### PR TITLE
Update spa-services.md

### DIFF
--- a/aspnetcore/client-side/spa-services.md
+++ b/aspnetcore/client-side/spa-services.md
@@ -221,7 +221,7 @@ Tip: Routes are evaluated in the order in which they're configured. Consequently
 
 ## Creating a new project
 
-JavaScriptServices provides pre-configured application templates. SpaServices is used in these templates, in conjunction with different frameworks and libraries such as Angular, React and Redux.
+JavaScriptServices provides pre-configured application templates. SpaServices is used in these templates, in conjunction with different frameworks and libraries such as Angular, React, and Redux.
 
 These templates can be installed via the .NET Core CLI by running the following command:
 


### PR DESCRIPTION
Remove unsupported Spa Templates from the list of available spa templates.

Per [announcement 289](https://github.com/aspnet/Announcements/issues/289) the spa templates of aurelia, knockout and vue are no longer supported.  