### PR TITLE
Add OS tabs to user secrets doc

### DIFF
--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -53,16 +53,19 @@ The Secret Manager tool abstracts away the implementation details, such as where
 # [Windows](#tab/windows)
 
 File system path:
+
 `%APPDATA%\Microsoft\UserSecrets\<user_secrets_id>\secrets.json`
 
 # [macOS](#tab/macos)
 
 File system path:
+
 `~/.microsoft/usersecrets/<user_secrets_id>/secrets.json`
 
 # [Linux](#tab/linux)
 
 File system path:
+
 `~/.microsoft/usersecrets/<user_secrets_id>/secrets.json`
 
 ---


### PR DESCRIPTION
Introduce tabs to [https://docs.microsoft.com/aspnet/core/security/app-secrets](https://docs.microsoft.com/aspnet/core/security/app-secrets), so that content corresponding to the reader's OS is visible by default.

[Internal Review Page](https://review.docs.microsoft.com/aspnet/core/security/app-secrets?branch=pr-en-us-6460)