### PR TITLE
Update Authorization Section

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to migrate an ASP.NET Core 2.2 project to ASP.NET Core 3.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/17/2019
+ms.date: 08/26/2019
 uid: migration/22-to-30
 ---
 # Migrate from ASP.NET Core 2.2 to 3.0
@@ -283,7 +283,7 @@ public class HomeController : ControllerBase
 
 If the app uses an `AuthorizeFilter` as a global filter in MVC, we recommend refactoring the code to provide a policy in the call to `AddAuthorization`.
 
-The `DefaultPolicy` is initially configured to require authentication, so no additional configuration is required. In the following example, MVC endpoints are marked as `RequireAuthorization` so that all requests must be authorized based on the `DefaultPolicy`, but the `HomeController` allows access without the user signing into the app due to `[AllowAnonymous]`:
+The `DefaultPolicy` is initially configured to require authentication, so no additional configuration is required. In the following example, MVC endpoints are marked as `RequireAuthorization` so that all requests must be authorized based on the `DefaultPolicy`. However, the `HomeController` allows access without the user signing into the app due to `[AllowAnonymous]`:
 
 ```csharp
 public void Configure(IApplicationBuilder app)
@@ -346,9 +346,9 @@ public class HomeController : ControllerBase
 }
 ```
 
-Alternatively, all endpoints can be configured to require authoriztion without `[Authorize]` nor `RequireAuthorization` by configuring a `FallbackPolicy`. The `FallbackPolicy` is different from the `DefaultPolicy` in that the `DefaultPolicy` is triggered by `[Authorize]` or `RequireAuthorization`, whereas the `FallbackPolicy` is triggered when no other policy is set. `FallbackPolicy` is initially configured to allow requests without authorization.
+Alternatively, all endpoints can be configured to require authorization without `[Authorize]` or `RequireAuthorization` by configuring a `FallbackPolicy`. The `FallbackPolicy` is different from the `DefaultPolicy`. The `DefaultPolicy` is triggered by `[Authorize]` or `RequireAuthorization`, while the `FallbackPolicy` is triggered when no other policy is set. `FallbackPolicy` is initially configured to allow requests without authorization.
 
-The following example is the same as the `DefaultPolicy` example above, but uses the `FallbackPolicy` to always require authentication on all endpoints except when `[AllowAnonymous]` is specified:
+The following example is the same as the preceding `DefaultPolicy` example but uses the `FallbackPolicy` to always require authentication on all endpoints except when `[AllowAnonymous]` is specified:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -387,7 +387,7 @@ public class HomeController : ControllerBase
 
 Authorization by middleware works without the framework having any specific knowledge of authorization. For instance, [health checks](xref:host-and-deploy/health-checks) has no specific knowledge of authorization, but health checks can have a configurable authorization policy applied by the middleware.
 
-Additionally, each endpoint can customize its authorization needs. In the following example, `UseAuthorization` processes authorization with the `DefaultPolicy`, but the `/healthz` health check endpoint requires the user to be in the `admin` role:
+Additionally, each endpoint can customize its authorization requirements. In the following example, `UseAuthorization` processes authorization with the `DefaultPolicy`, but the `/healthz` health check endpoint requires an `admin` user:
 
 ```csharp
 public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
Fixes #13942 - Describe the differences between `DefaultPolicy` and `FallbackPolicy`, their relationship with `[Authorize]` and `IEndpointConventionBuilder.RequireAuthoriztion()`. Previously, the docs suggested `app.UseAuthorization(new AuthorizationPolicyBuilder().Build()));` which is an overload that no longer exists.