### PR TITLE
Point tutorial links to samples folder

### DIFF
--- a/aspnetcore/data/ef-rp/intro/samples/cu/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu/Pages/Index.cshtml
@@ -27,7 +27,7 @@
         <h2>Download it</h2>
         <p>You can download the completed project from GitHub.</p>
         <p><a class="btn btn-default" 
-              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
             See project source code &raquo;</a></p>
     </div>
 </div>

--- a/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part3-sorting/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part3-sorting/Pages/Index.cshtml
@@ -27,7 +27,7 @@
         <h2>Download it</h2>
         <p>You can download the completed project from GitHub.</p>
         <p><a class="btn btn-default" 
-              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
             See project source code &raquo;</a></p>
     </div>
 </div>

--- a/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part5-complex/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part5-complex/Pages/Index.cshtml
@@ -27,7 +27,7 @@
         <h2>Download it</h2>
         <p>You can download the completed project from GitHub.</p>
         <p><a class="btn btn-default" 
-              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
             See project source code &raquo;</a></p>
     </div>
 </div>

--- a/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part6-related/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part6-related/Pages/Index.cshtml
@@ -27,7 +27,7 @@
         <h2>Download it</h2>
         <p>You can download the completed project from GitHub.</p>
         <p><a class="btn btn-default" 
-              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
             See project source code &raquo;</a></p>
     </div>
 </div>

--- a/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part7/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part7/Pages/Index.cshtml
@@ -27,7 +27,7 @@
         <h2>Download it</h2>
         <p>You can download the completed project from GitHub.</p>
         <p><a class="btn btn-default" 
-              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
             See project source code &raquo;</a></p>
     </div>
 </div>

--- a/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part8/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part8/Pages/Index.cshtml
@@ -27,7 +27,7 @@
         <h2>Download it</h2>
         <p>You can download the completed project from GitHub.</p>
         <p><a class="btn btn-default" 
-              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+              href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
             See project source code &raquo;</a></p>
     </div>
 </div>

--- a/aspnetcore/data/ef-rp/intro/samples/cu21/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu21/Pages/Index.cshtml
@@ -31,7 +31,7 @@
         <p>You can download the completed project from GitHub.</p>
         <p>
             <a class="btn btn-default"
-               href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+               href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
                 See project source code &raquo;
             </a>
         </p>

--- a/aspnetcore/data/ef-rp/intro/samples/cu21snapshots/Part-3-Sorting/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu21snapshots/Part-3-Sorting/Pages/Index.cshtml
@@ -31,7 +31,7 @@
         <p>You can download the completed project from GitHub.</p>
         <p>
             <a class="btn btn-default"
-               href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+               href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
                 See project source code &raquo;
             </a>
         </p>

--- a/aspnetcore/data/ef-rp/intro/samples/cu21snapshots/Part-4-Migrations/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu21snapshots/Part-4-Migrations/Pages/Index.cshtml
@@ -31,7 +31,7 @@
         <p>You can download the completed project from GitHub.</p>
         <p>
             <a class="btn btn-default"
-               href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+               href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
                 See project source code &raquo;
             </a>
         </p>

--- a/aspnetcore/data/ef-rp/intro/samples/cu21snapshots/Part-5/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu21snapshots/Part-5/Pages/Index.cshtml
@@ -31,7 +31,7 @@
         <p>You can download the completed project from GitHub.</p>
         <p>
             <a class="btn btn-default"
-               href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final">
+               href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/">
                 See project source code &raquo;
             </a>
         </p>

--- a/aspnetcore/data/ef-rp/intro/samples/cu30snapshots/1-intro/Pages/Index.cshtml
+++ b/aspnetcore/data/ef-rp/intro/samples/cu30snapshots/1-intro/Pages/Index.cshtml
@@ -35,7 +35,7 @@
                     You can download the completed project from GitHub.
                 </p>
                 <p>
-                    <a href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu-final" class="stretched-link">See project source code</a>
+                    <a href="https://github.com/aspnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/" class="stretched-link">See project source code</a>
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Fixes #14286

This might be a short-term fix ... it at least resolves the 404. For a long-term solution, I recommend renaming the folders for the samples and snapshot folders by convention. @Rick-Anderson Plz close if you want to handle this differently ... I'm just trying to quickly resolve the 404 here.

Thanks @jheaden! 🏍