### PR TITLE
Add warning about dotnet pack and static assets

### DIFF
--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -86,8 +86,7 @@ To include companion assets as part of an RCL, create a *wwwroot* folder in the 
 
 When packing an RCL, all companion assets in the *wwwroot* folder are automatically included in the package.
 
-> [!WARNING]
-> Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack` for static assets to be served from the packaged library.
+Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack` for static assets to be served from the packaged library.
 
 ### Exclude static assets
 

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -86,6 +86,9 @@ To include companion assets as part of an RCL, create a *wwwroot* folder in the 
 
 When packing an RCL, all companion assets in the *wwwroot* folder are automatically included in the package.
 
+> [!WARNING]
+> You must use the `dotnet pack` command rather than the NuGet.exe version `nuget pack` in order for static assets to be properly served from the packaged library.
+
 ### Exclude static assets
 
 To exclude static assets, add the desired exclusion path to the `$(DefaultItemExcludes)` property group in the project file. Separate entries with a semicolon (`;`).

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -86,7 +86,7 @@ To include companion assets as part of an RCL, create a *wwwroot* folder in the 
 
 When packing an RCL, all companion assets in the *wwwroot* folder are automatically included in the package.
 
-Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack` for static assets to be served from the packaged library.
+Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack`.
 
 ### Exclude static assets
 

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -87,7 +87,7 @@ To include companion assets as part of an RCL, create a *wwwroot* folder in the 
 When packing an RCL, all companion assets in the *wwwroot* folder are automatically included in the package.
 
 > [!WARNING]
-> You must use the `dotnet pack` command rather than the NuGet.exe version `nuget pack` in order for static assets to be properly served from the packaged library.
+> Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack` for static assets to be served from the packaged library.
 
 ### Exclude static assets
 


### PR DESCRIPTION
Fixes #13951

I chased my tail for a while trying to find out why my static assets wouldn't serve from my Razor Class Library's NuGet package -- it was due to using `nuget pack` instead of `dotnet pack`.  This warning would've alerted me immediately to the issue.  Thankfully I found it via a comment at the bottom of the doc page.