### PR TITLE
Expand `OwningComponentBase` docs

### DIFF
--- a/aspnetcore/blazor/dependency-injection.md
+++ b/aspnetcore/blazor/dependency-injection.md
@@ -199,11 +199,12 @@ There are two versions of the `OwningComponentBase` type:
 
     ```razor
     @page "/preferences"
+    @using Microsoft.Extensions.DependencyInjection
     @inherits OwningComponentBase
 
     <h1>User (@UserService.Name)</h1>
     <ul>
-        @foreach (var setting in SettingService)
+        @foreach (var setting in SettingService.GetSettings())
         {
             <li>@setting.SettingName: @setting.SettingValue</li>
         }
@@ -211,9 +212,8 @@ There are two versions of the `OwningComponentBase` type:
 
     @code {
         private IUserService UserService { get; set; }
-
-        private IPlayerService SettingService { get; set; }
-
+        private ISettingService SettingService { get; set; }
+        
         protected override void OnInitialized()
         {
             UserService = ScopedServices.GetRequiredService<IUserService>();


### PR DESCRIPTION
This beefs up `OwningComponentBase` docs in *blazor/dependency-injection*, explaining the uses of `OwningComponentBase` and `OwningComponentBase<T>`, as well as commenting on the specific case of `DbContext` usage, which is a common case for DI woes in Blazor.

Fixes #14316 