### PR TITLE
Add include for localized comments

### DIFF
--- a/aspnetcore/data/ef-rp/update-related-data.md
+++ b/aspnetcore/data/ef-rp/update-related-data.md
@@ -44,6 +44,8 @@ Update *Pages/Courses/Create.cshtml.cs* with the following code:
 
 [!code-csharp[](intro/samples/cu30/Pages/Courses/Create.cshtml.cs?highlight=7,18,27-41)]
 
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
+
 The preceding code:
 
 * Derives from `DepartmentNamePageModel`.

--- a/aspnetcore/fundamentals/configuration/options.md
+++ b/aspnetcore/fundamentals/configuration/options.md
@@ -318,6 +318,8 @@ catch (OptionsValidationException e)
 }
 ```
 
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
+
 The preceding example sets the named options instance to `optionalOptionsName`. The default options instance is `Options.DefaultName`.
 
 Validation runs when the options instance is created. An options instance is guaranteed to pass validation the first time it's accessed.

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -411,6 +411,8 @@ public class Startup
 }
 ```
 
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
+
 Use the [UseStartup(IWebHostBuilder, String)](/dotnet/api/microsoft.aspnetcore.hosting.hostingabstractionswebhostbuilderextensions.usestartup) overload that accepts an assembly name:
 
 ```csharp

--- a/aspnetcore/fundamentals/http-requests.md
+++ b/aspnetcore/fundamentals/http-requests.md
@@ -91,6 +91,7 @@ Typed clients:
 A typed client accepts an `HttpClient` parameter in its constructor:
 
 [!code-csharp[](http-requests/samples/3.x/HttpClientFactorySample/GitHub/GitHubService.cs?name=snippet1&highlight=5)]
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 In the preceding code:
 

--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -220,6 +220,7 @@ Localization is configured in the `Startup.ConfigureServices` method:
 The current culture on a request is set in the localization [Middleware](xref:fundamentals/middleware/index). The localization middleware is enabled in the `Startup.Configure` method. The localization middleware must be configured before any middleware which might check the request culture (for example, `app.UseMvcWithDefaultRoute()`).
 
 [!code-csharp[](localization/sample/Localization/Startup.cs?name=snippet2)]
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 `UseRequestLocalization` initializes a `RequestLocalizationOptions` object. On every request the list of `RequestCultureProvider` in the `RequestLocalizationOptions` is enumerated and the first provider that can successfully determine the request culture is used. The default providers come from the `RequestLocalizationOptions` class:
 

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -54,6 +54,7 @@ When a delegate doesn't pass a request to the next delegate, it's called *short-
 <xref:Microsoft.AspNetCore.Builder.RunExtensions.Run*> delegates don't receive a `next` parameter. The first `Run` delegate is always terminal and terminates the pipeline. `Run` is a convention. Some middleware components may expose `Run[Middleware]` methods that run at the end of the pipeline:
 
 [!code-csharp[](index/snapshot/Chain/Startup.cs?highlight=12-15)]
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 In the preceding example, the `Run` delegate writes `"Hello from 2nd delegate."` to the response and then terminates the pipeline. If another `Use` or `Run` delegate is added after the `Run` delegate, it's not called.
 

--- a/aspnetcore/fundamentals/middleware/request-response.md
+++ b/aspnetcore/fundamentals/middleware/request-response.md
@@ -30,6 +30,7 @@ Streams aren't being removed from the framework. Streams continue to be used thr
 Suppose the goal is to create a middleware that reads the entire request body as a list of strings, splitting on new lines. A simple stream implementation might look like the following example:
 
 [!code-csharp[](request-response/samples/3.x/RequestResponseSample/Startup.cs?name=GetListOfStringsFromStream)]
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 This code works, but there are some issues:
 

--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -105,6 +105,7 @@ The following markup references *MyStaticFiles/images/banner1.svg*:
 A [StaticFileOptions](/dotnet/api/microsoft.aspnetcore.builder.staticfileoptions) object can be used to set HTTP response headers. In addition to configuring static file serving from the [web root](xref:fundamentals/index#web-root), the following code sets the `Cache-Control` header:
 
 [!code-csharp[](static-files/samples/1x/StartupAddHeader.cs?name=snippet_ConfigureMethod)]
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 The [HeaderDictionaryExtensions.Append](/dotnet/api/microsoft.aspnetcore.http.headerdictionaryextensions.append) method exists in the [Microsoft.AspNetCore.Http](https://www.nuget.org/packages/Microsoft.AspNetCore.Http/) package.
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -53,6 +53,7 @@ In *Startup.cs*:
 * Each gRPC service is added to the routing pipeline through the `MapGrpcService` method.
 
 [!code-csharp[](~/tutorials/grpc/grpc-start/sample/GrpcGreeter/Startup.cs?name=snippet&highlight=7,24)]
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 ASP.NET Core middlewares and features share the routing pipeline, therefore an app can be configured to serve additional request handlers. The additional request handlers, such as MVC controllers, work in parallel with the configured gRPC services.
 

--- a/aspnetcore/grpc/basics.md
+++ b/aspnetcore/grpc/basics.md
@@ -27,6 +27,7 @@ For example, consider the *greet.proto* file used in [Get started with gRPC serv
 * `SayHello` sends a `HelloRequest` message and receives a `HelloReply` message:
 
 [!code-protobuf[](~/tutorials/grpc/grpc-start/sample/GrpcGreeter/Protos/greet.proto)]
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 ## Add a .proto file to a C\# app
 

--- a/aspnetcore/includes/code-comments-loc.md
+++ b/aspnetcore/includes/code-comments-loc.md
@@ -1,0 +1,1 @@
+If you would like to see code comments translated to languages other than English, let us know in [this GitHub discussion issue](https://github.com/MicrosoftDocs/feedback/issues/2515).

--- a/aspnetcore/mvc/advanced/custom-model-binding.md
+++ b/aspnetcore/mvc/advanced/custom-model-binding.md
@@ -55,6 +55,7 @@ When creating your own custom model binder, you can implement your own `IModelBi
 The following example shows how to use `ByteArrayModelBinder` to convert a base64-encoded string to a `byte[]` and save the result to a file:
 
 [!code-csharp[](custom-model-binding/samples/3.x/CustomModelBindingSample/Controllers/ImageController.cs?name=snippet_Post)]
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 You can POST a base64-encoded string to this api method using a tool like [Postman](https://www.getpostman.com/):
 

--- a/aspnetcore/security/data-protection/implementation/key-management.md
+++ b/aspnetcore/security/data-protection/implementation/key-management.md
@@ -53,6 +53,8 @@ services.AddDataProtection()
        .SetDefaultKeyLifetime(TimeSpan.FromDays(14));
 ```
 
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
+
 An administrator can also change the default system-wide, though an explicit call to `SetDefaultKeyLifetime` will override any system-wide policy. The default key lifetime cannot be shorter than 7 days.
 
 ## Automatic key ring refresh

--- a/aspnetcore/security/data-protection/implementation/key-management.md
+++ b/aspnetcore/security/data-protection/implementation/key-management.md
@@ -53,8 +53,6 @@ services.AddDataProtection()
        .SetDefaultKeyLifetime(TimeSpan.FromDays(14));
 ```
 
-[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
-
 An administrator can also change the default system-wide, though an explicit call to `SetDefaultKeyLifetime` will override any system-wide policy. The default key lifetime cannot be shorter than 7 days.
 
 ## Automatic key ring refresh
@@ -71,6 +69,8 @@ Any operation which modifies the key ring (creating a new key explicitly or perf
 The sample below demonstrates using the `IKeyManager` interface to inspect and manipulate the key ring, including revoking existing keys and generating a new key manually.
 
 [!code-csharp[](key-management/samples/key-management.cs)]
+
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
 
 ## Key storage
 

--- a/aspnetcore/security/data-protection/implementation/key-storage-providers.md
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers.md
@@ -139,6 +139,8 @@ To configure the EF Core provider, call the [PersistKeysToDbContext\<TContext>](
 
 [!code-csharp[Main](key-storage-providers/sample/Startup.cs?name=snippet&highlight=13-20)]
 
+[!INCLUDE[about the series](~/includes/code-comments-loc.md)]
+
 The generic parameter, `TContext`, must inherit from [DbContext](/dotnet/api/microsoft.entityframeworkcore.dbcontext) and implement [IDataProtectionKeyContext](/dotnet/api/microsoft.aspnetcore.dataprotection.entityframeworkcore.idataprotectionkeycontext):
 
 [!code-csharp[Main](key-storage-providers/sample/MyKeysContext.cs)]


### PR DESCRIPTION
Part of work with loc to find out how important localized comments are.  If you know a doc with lots of code comments, please add the include.

The two routing docs have massive useful code comments, but those are in PR now so avoid that to prevent merge conflicts. I'll handle them.

See related PR https://github.com/dotnet/docs/pull/17129
cc @guardrex 