### PR TITLE
Clarify startup method conventions

### DIFF
--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -860,7 +860,7 @@ public static IWebHostBuilder CreateWebHostBuilder(string[] args)
 
 ### Startup method conventions
 
-[Configure](/dotnet/api/microsoft.aspnetcore.hosting.startupbase.configure) and [ConfigureServices](/dotnet/api/microsoft.aspnetcore.hosting.startupbase.configureservices) support environment-specific versions of the form `Configure<EnvironmentName>` and `Configure<EnvironmentName>Services`. This approach is useful when the app requires configuring startup for several environments with many code differences per environment.
+[Configure](/dotnet/api/microsoft.aspnetcore.hosting.startupbase.configure) and [ConfigureServices](/dotnet/api/microsoft.aspnetcore.hosting.startupbase.configureservices) support environment-specific versions of the form `Configure<EnvironmentName>` and `Configure<EnvironmentName>Services`. If a matching Configure{EnvironmentName}Services method is found, it is called before ConfigureServices. This approach is useful when the app requires configuring startup for several environments with many code differences per environment.
 
 [!code-csharp[](environments/sample/EnvironmentsSample/Startup.cs?name=snippet_all&highlight=15,42)]
 


### PR DESCRIPTION
Startup _method_ is called **as well as** the default _method_, unlike
Startup _class_ is called **instead of** the Startup _class_.

Yeah? This is what I found while testing startup methods



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->