### PR TITLE
File uploads example contains a compilation error

### DIFF
--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -264,7 +264,7 @@ public async Task<IActionResult> OnPostUploadAsync(List<IFormFile> files)
     // Process uploaded files
     // Don't rely on or trust the FileName property without validation.
 
-    return Ok(new { count = files.Count, size, filePath });
+    return Ok(new { count = files.Count, size });
 }
 ```
 

--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -5,7 +5,7 @@ description: How to use model binding and streaming to upload files in ASP.NET C
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/11/2020
+ms.date: 02/25/2020
 uid: mvc/models/file-uploads
 ---
 # Upload files in ASP.NET Core
@@ -993,7 +993,7 @@ public async Task<IActionResult> OnPostUploadAsync(List<IFormFile> files)
     // Process uploaded files
     // Don't rely on or trust the FileName property without validation.
 
-    return Ok(new { count = files.Count, size, filePath });
+    return Ok(new { count = files.Count, size });
 }
 ```
 


### PR DESCRIPTION
`OnPostUploadAsync` contains a compilation error by trying to reference `filePath` outside the scope it was declared in.

Fixes #17114 

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->