### PR TITLE
Manage table 1st column width in gRPC topic

### DIFF
--- a/aspnetcore/grpc/configuration.md
+++ b/aspnetcore/grpc/configuration.md
@@ -5,7 +5,7 @@ description: Learn how to configure gRPC for .NET apps.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: jamesnk
 ms.custom: mvc
-ms.date: 09/05/2019
+ms.date: 02/26/2020
 uid: grpc/configuration
 ---
 # gRPC for .NET configuration
@@ -20,7 +20,7 @@ gRPC services are configured with `AddGrpc` in *Startup.cs*. The following table
 | `MaxReceiveMessageSize` | 4 MB | The maximum message size in bytes that can be received by the server. If the server receives a message that exceeds this limit, it throws an exception. Increasing this value allows the server to receive larger messages, but can negatively impact memory consumption. |
 | `EnableDetailedErrors` | `false` | If `true`, detailed exception messages are returned to clients when an exception is thrown in a service method. The default is `false`. Setting `EnableDetailedErrors` to `true` can leak sensitive information. |
 | `CompressionProviders` | gzip | A collection of compression providers used to compress and decompress messages. Custom compression providers can be created and added to the collection. The default configured providers support **gzip** compression. |
-| `ResponseCompressionAlgorithm` | `null` | The compression algorithm used to compress messages sent from the server. The algorithm must match a compression provider in `CompressionProviders`. For the algorithm to compress a response, the client must indicate it supports the algorithm by sending it in the **grpc-accept-encoding** header. |
+| <code style="word-break:normal">ResponseCompressionAlgorithm</code> | `null` | The compression algorithm used to compress messages sent from the server. The algorithm must match a compression provider in `CompressionProviders`. For the algorithm to compress a response, the client must indicate it supports the algorithm by sending it in the **grpc-accept-encoding** header. |
 | `ResponseCompressionLevel` | `null` | The compress level used to compress messages sent from the server. |
 | `Interceptors` | None | A collection of interceptors that are run with each gRPC call. Interceptors are run in the order they are registered. Globally configured interceptors are run before interceptors configured for a single service. For more information about gRPC interceptors, see [gRPC Interceptors vs. Middleware](xref:grpc/migration#grpc-interceptors-vs-middleware). |
 
@@ -42,7 +42,7 @@ gRPC client configuration is set on `GrpcChannelOptions`. The following table de
 | `DisposeHttpClient` | `false` | If `true`, and an `HttpClient` is specified, then the `HttpClient` instance will be disposed when the `GrpcChannel` is disposed. |
 | `LoggerFactory` | `null` | The `LoggerFactory` used by the client to log information about gRPC calls. A `LoggerFactory` instance can be resolved from dependency injection or created using `LoggerFactory.Create`. For examples of configuring logging, see <xref:grpc/diagnostics#grpc-client-logging>. |
 | `MaxSendMessageSize` | `null` | The maximum message size in bytes that can be sent from the client. Attempting to send a message that exceeds the configured maximum message size results in an exception. |
-| `MaxReceiveMessageSize` | 4 MB | The maximum message size in bytes that can be received by the client. If the client receives a message that exceeds this limit, it throws an exception. Increasing this value allows the client to receive larger messages, but can negatively impact memory consumption. |
+| <code style="word-break:normal">MaxReceiveMessageSize</code> | 4 MB | The maximum message size in bytes that can be received by the client. If the client receives a message that exceeds this limit, it throws an exception. Increasing this value allows the client to receive larger messages, but can negatively impact memory consumption. |
 | `Credentials` | `null` | A `ChannelCredentials` instance. Credentials are used to add authentication metadata to gRPC calls. |
 | `CompressionProviders` | gzip | A collection of compression providers used to compress and decompress messages. Custom compression providers can be created and added to the collection. The default configured providers support **gzip** compression. |
 

--- a/aspnetcore/grpc/configuration.md
+++ b/aspnetcore/grpc/configuration.md
@@ -14,7 +14,7 @@ uid: grpc/configuration
 
 gRPC services are configured with `AddGrpc` in *Startup.cs*. The following table describes options for configuring gRPC services:
 
-| Option | Default Value | Description |
+| `Option            ` | `Default Value   ` | Description |
 | ------ | ------------- | ----------- |
 | `MaxSendMessageSize` | `null` | The maximum message size in bytes that can be sent from the server. Attempting to send a message that exceeds the configured maximum message size results in an exception. |
 | `MaxReceiveMessageSize` | 4 MB | The maximum message size in bytes that can be received by the server. If the server receives a message that exceeds this limit, it throws an exception. Increasing this value allows the server to receive larger messages, but can negatively impact memory consumption. |

--- a/aspnetcore/grpc/configuration.md
+++ b/aspnetcore/grpc/configuration.md
@@ -14,7 +14,7 @@ uid: grpc/configuration
 
 gRPC services are configured with `AddGrpc` in *Startup.cs*. The following table describes options for configuring gRPC services:
 
-| `Option            ` | `Default Value   ` | Description |
+| Option    | Default Value | Description |
 | ------ | ------------- | ----------- |
 | `MaxSendMessageSize` | `null` | The maximum message size in bytes that can be sent from the server. Attempting to send a message that exceeds the configured maximum message size results in an exception. |
 | `MaxReceiveMessageSize` | 4 MB | The maximum message size in bytes that can be received by the server. If the server receives a message that exceeds this limit, it throws an exception. Increasing this value allows the server to receive larger messages, but can negatively impact memory consumption. |


### PR DESCRIPTION
Fixes #17124

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/grpc/configuration?view=aspnetcore-3.0&branch=pr-en-us-17133#configure-services-options)

Is everyone cool with our HTML hack approach on this one? It 🤞 *should* 🍀 work. Applying this to the longest entry should set the column width to accommodate all entries in that column of the table. Can someone check the internal build topic to confirm?

... also wondering in passing if they chose the best style in this case. Perhaps, `<code>` in a table cell should have this style set everywhere. 🤔