### PR TITLE
Add ms.technology metadata for the What's New pages

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -84,7 +84,8 @@
         "signalr/**/**.md": "aspnetcore-signalr",
         "test/**/**.md": "aspnetcore-test",
         "tutorials/**/**.md": "aspnetcore-tutorials",
-        "web-api/**/**.md": "aspnetcore-webapi"
+        "web-api/**/**.md": "aspnetcore-webapi",
+        "whats-new/**/**.md": "aspnetcore-whatsnew"
       },
       "ms.topic": {
         "getting-started/**/**.md": "tutorial",


### PR DESCRIPTION
I've also submitted the metadata whitelisting request here: https://ceapex.visualstudio.com/Engineering/_workitems/edit/182170