### PR TITLE
Add Blazor label to Blazor security topic issues

### DIFF
--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -36,7 +36,6 @@
           "(?i).*master\/aspnetcore\/tutorials\/grpc*.*": {
             "labels-add": "gRPC"
           },
-          
           "(?i).*master\/aspnetcore\/tutorials\/signalr*.*": {
             "labels-add": "SignalR"
           }

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -15,9 +15,6 @@
           "(?i).*master\/aspnetcore\/blazor.*": {
             "labels-add": "Blazor"
           },
-          "(?i).*master\/aspnetcore\/grpc.*": {
-            "labels-add": "gRPC"
-          },
           "(?i).*master\/aspnetcore\/host-and-deploy\/blazor.*": {
             "labels-add": "Blazor"
           },
@@ -27,14 +24,17 @@
           "(?i).*master\/aspnetcore\/security\/blazor.*": {
             "labels-add": "Blazor"
           },
-          "(?i).*master\/aspnetcore\/signalr.*": {
-            "labels-add": "SignalR"
-          },
           "(?i).*master\/aspnetcore\/tutorials\/*blazor*.*": {
             "labels-add": "Blazor"
           },
+          "(?i).*master\/aspnetcore\/grpc.*": {
+            "labels-add": "gRPC"
+          },
           "(?i).*master\/aspnetcore\/tutorials\/grpc*.*": {
             "labels-add": "gRPC"
+          },
+          "(?i).*master\/aspnetcore\/signalr.*": {
+            "labels-add": "SignalR"
           },
           "(?i).*master\/aspnetcore\/tutorials\/signalr*.*": {
             "labels-add": "SignalR"

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -15,27 +15,28 @@
           "(?i).*master\/aspnetcore\/blazor.*": {
             "labels-add": "Blazor"
           },
-          "(?i).*master\/aspnetcore\/mvc\/views\/tag-helpers\/built-in\/component.md": {
-            "labels-add": "Blazor"
+          "(?i).*master\/aspnetcore\/grpc.*": {
+            "labels-add": "gRPC"
           },
           "(?i).*master\/aspnetcore\/host-and-deploy\/blazor.*": {
+            "labels-add": "Blazor"
+          },
+          "(?i).*master\/aspnetcore\/mvc\/views\/tag-helpers\/built-in\/component.md": {
             "labels-add": "Blazor"
           },
           "(?i).*master\/aspnetcore\/security\/*blazor*.*": {
             "labels-add": "Blazor"
           },
+          "(?i).*master\/aspnetcore\/signalr.*": {
+            "labels-add": "SignalR"
+          },
           "(?i).*master\/aspnetcore\/tutorials\/*blazor*.*": {
             "labels-add": "Blazor"
-          },
-          "(?i).*master\/aspnetcore\/grpc.*": {
-            "labels-add": "gRPC"
           },
           "(?i).*master\/aspnetcore\/tutorials\/grpc*.*": {
             "labels-add": "gRPC"
           },
-          "(?i).*master\/aspnetcore\/signalr.*": {
-            "labels-add": "SignalR"
-          },
+          
           "(?i).*master\/aspnetcore\/tutorials\/signalr*.*": {
             "labels-add": "SignalR"
           }

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -18,6 +18,9 @@
           "(?i).*master\/aspnetcore\/host-and-deploy\/blazor.*": {
             "labels-add": "Blazor"
           },
+          "(?i).*master\/aspnetcore\/security\/*blazor*.*": {
+            "labels-add": "Blazor"
+          },
           "(?i).*master\/aspnetcore\/tutorials\/*blazor*.*": {
             "labels-add": "Blazor"
           },

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -24,7 +24,7 @@
           "(?i).*master\/aspnetcore\/mvc\/views\/tag-helpers\/built-in\/component.md": {
             "labels-add": "Blazor"
           },
-          "(?i).*master\/aspnetcore\/security\/*blazor*.*": {
+          "(?i).*master\/aspnetcore\/security\/blazor.*": {
             "labels-add": "Blazor"
           },
           "(?i).*master\/aspnetcore\/signalr.*": {

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -15,6 +15,9 @@
           "(?i).*master\/aspnetcore\/blazor.*": {
             "labels-add": "Blazor"
           },
+          "(?i).*master\/aspnetcore\/mvc\/views\/tag-helpers\/built-in\/component.md": {
+            "labels-add": "Blazor"
+          },
           "(?i).*master\/aspnetcore\/host-and-deploy\/blazor.*": {
             "labels-add": "Blazor"
           },

--- a/.ghal.rules.json
+++ b/.ghal.rules.json
@@ -18,9 +18,6 @@
           "(?i).*master\/aspnetcore\/host-and-deploy\/blazor.*": {
             "labels-add": "Blazor"
           },
-          "(?i).*master\/aspnetcore\/mvc\/views\/tag-helpers\/built-in\/component.md": {
-            "labels-add": "Blazor"
-          },
           "(?i).*master\/aspnetcore\/security\/blazor.*": {
             "labels-add": "Blazor"
           },


### PR DESCRIPTION
I started the Blazor security topic work this morning and remembered that the "Blazor" label isn't applied to the ones that open from that neck of the woods. Is it ok to add that label to issues that come from those topics? We're about to have a whole slew of new reference topics there, which I think will generate a number of new issues in the future.

**Additional**: ~I added the upcoming Blazor Components TH topic to this in advance of that topic being set up. It will happen fairly soon-ish. That ok? If not, I can add it later when that topic goes up. :ear:~ **HELD** until that topic is created.