### PR TITLE
Fix typo in "Importing Shared Directives" section.

### DIFF
--- a/aspnetcore/mvc/views/layout.md
+++ b/aspnetcore/mvc/views/layout.md
@@ -103,7 +103,7 @@ The body and every section in a Razor page must be either rendered or ignored.
 
 ## Importing Shared Directives
 
-Views and pages can use Razor directives to importing namespaces and use [dependency injection](dependency-injection.md). Directives shared by many views may be specified in a common *_ViewImports.cshtml* file. The `_ViewImports` file supports the following directives:
+Views and pages can use Razor directives to import namespaces and use [dependency injection](dependency-injection.md). Directives shared by many views may be specified in a common *_ViewImports.cshtml* file. The `_ViewImports` file supports the following directives:
 
 * `@addTagHelper`
 * `@removeTagHelper`


### PR DESCRIPTION
Fix minor typo in the `Importing Shared Directives` section. The following:

> directives to importing namespaces

...should read:

> directives to import namespaces