### PR TITLE
Update CRA documentation link

### DIFF
--- a/aspnetcore/client-side/spa/react.md
+++ b/aspnetcore/client-side/spa/react.md
@@ -49,7 +49,7 @@ The project template creates an ASP.NET Core app and a React app. The ASP.NET Co
 
 ## Add pages, images, styles, modules, etc.
 
-The *ClientApp* directory is a standard CRA React app. See the official [CRA documentation](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md) for more information.
+The *ClientApp* directory is a standard CRA React app. See the official [CRA documentation](https://create-react-app.dev/docs/getting-started/) for more information.
 
 There are slight differences between the React app created by this template and the one created by CRA itself; however, the app's capabilities are unchanged. The app created by the template contains a [Bootstrap](https://getbootstrap.com/)-based layout and a basic routing example.
 


### PR DESCRIPTION
The CRA github repo was probably restructured, which makes the CRA documentation link point to a "Learn about making a Progressive Web App" readme file.
This change will make it point to the official docs: https://create-react-app.dev/docs/getting-started/



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->