### PR TITLE
Fix misleading typo in docs on UseWhen

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -209,7 +209,7 @@ The following table shows the requests and responses from `http://localhost:1234
 | localhost:1234                | Hello from non-Map delegate. |
 | localhost:1234/?branch=master | Branch used = master         |
 
-<xref:Microsoft.AspNetCore.Builder.UseWhenExtensions.UseWhen*> also branches the request pipeline based on the result of the given predicate. Unlike with `MapWhen`, this branch is rejoined to the main pipeline if it does short-circuit or contain a terminal middleware:
+<xref:Microsoft.AspNetCore.Builder.UseWhenExtensions.UseWhen*> also branches the request pipeline based on the result of the given predicate. Unlike with `MapWhen`, this branch is rejoined to the main pipeline if it does not short-circuit or contain a terminal middleware:
 
 [!code-csharp[](index/snapshot/Chain/StartupUseWhen.cs?highlight=23-24)]
 

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -209,7 +209,7 @@ The following table shows the requests and responses from `http://localhost:1234
 | localhost:1234                | Hello from non-Map delegate. |
 | localhost:1234/?branch=master | Branch used = master         |
 
-<xref:Microsoft.AspNetCore.Builder.UseWhenExtensions.UseWhen*> also branches the request pipeline based on the result of the given predicate. Unlike with `MapWhen`, this branch is rejoined to the main pipeline if it does not short-circuit or contain a terminal middleware:
+<xref:Microsoft.AspNetCore.Builder.UseWhenExtensions.UseWhen*> also branches the request pipeline based on the result of the given predicate. Unlike with `MapWhen`, this branch is rejoined to the main pipeline if it doesn't short-circuit or contain a terminal middleware:
 
 [!code-csharp[](index/snapshot/Chain/StartupUseWhen.cs?highlight=23-24)]
 


### PR DESCRIPTION
Fixes dotnet/aspnetcore#19586

See https://github.com/dotnet/aspnetcore/issues/19586#issuecomment-595995998 for description as to why this appears to be a typo. This appears to have been a typo. There's a missing 'not' 😄.