### PR TITLE
Update Book.cs. Fix type

### DIFF
--- a/aspnetcore/tutorials/first-mongo-app/samples/3.x/SampleApp/Models/Book.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/3.x/SampleApp/Models/Book.cs
@@ -18,6 +18,7 @@ namespace BooksApi.Models
         public string BookName { get; set; }
         #endregion
 
+        [BsonRepresentation(BsonType.Double)]
         public decimal Price { get; set; }
 
         public string Category { get; set; }


### PR DESCRIPTION
```
db.Books.insertMany([{'Name':'Design Patterns','Price':54.93,'Category':'Computers','Author':'Ralph Johnson'}, {'Name':'Clean Code','Price':43.15,'Category':'Computers','Author':'Robert C. Martin'}])
```
'Price' type is 'Double'

so update book.cs 