### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -50,7 +50,7 @@ Get started with Blazor:
 
    1\. Install [Visual Studio Code](https://code.visualstudio.com/).
 
-   2\. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp).
+   2\. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
    3\. For a Blazor WebAssembly experience, execute the following command in a command shell:
 

--- a/aspnetcore/includes/net-core-prereqs-vsc-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-vsc-2.2.md
@@ -1,5 +1,5 @@
 * [Visual Studio Code](https://code.visualstudio.com/download)
-* [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download/all)
 
 The Visual Studio Code instructions use the .NET Core CLI for ASP.NET Core development functions such as project creation. You can follow these instructions on any platform (macOS, Linux, or Windows) and with any code editor. Minor changes may be required if you use something other than Visual Studio Code.

--- a/aspnetcore/includes/net-core-prereqs-vsc-3.0.md
+++ b/aspnetcore/includes/net-core-prereqs-vsc-3.0.md
@@ -1,5 +1,5 @@
 * [Visual Studio Code](https://code.visualstudio.com/download)
-* [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [!INCLUDE [](~/includes/3.0-SDK.md)]
 
 The Visual Studio Code instructions use the .NET Core CLI for ASP.NET Core development functions such as project creation. You can follow these instructions on any platform (macOS, Linux, or Windows) and with any code editor. Minor changes may be required if you use something other than Visual Studio Code.

--- a/aspnetcore/includes/net-core-prereqs-vsc-3.1.md
+++ b/aspnetcore/includes/net-core-prereqs-vsc-3.1.md
@@ -1,5 +1,5 @@
 * [Visual Studio Code](https://code.visualstudio.com/download)
-* [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [!INCLUDE [.NET Core 3.1 SDK](~/includes/3.1-SDK.md)]
 
 The Visual Studio Code instructions use the .NET Core CLI for ASP.NET Core development functions such as project creation. You can follow these instructions on any platform (macOS, Linux, or Windows) and with any code editor. Minor changes may be required if you use something other than Visual Studio Code.

--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -39,7 +39,7 @@ In this tutorial, you learn how to:
 
 * [.NET Core SDK 3.0 or later](https://www.microsoft.com/net/download/all)
 * [Visual Studio Code](https://code.visualstudio.com/download)
-* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [MongoDB](https://docs.mongodb.com/manual/administration/install-community/)
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
@@ -389,7 +389,7 @@ In this tutorial, you learn how to:
 
 * [.NET Core SDK 2.2](https://www.microsoft.com/net/download/all)
 * [Visual Studio Code](https://code.visualstudio.com/download)
-* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [MongoDB](https://docs.mongodb.com/manual/administration/install-community/)
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)

--- a/aspnetcore/tutorials/publish-to-azure-webapp-using-vscode.md
+++ b/aspnetcore/tutorials/publish-to-azure-webapp-using-vscode.md
@@ -26,7 +26,7 @@ and deploy it within Visual Studio Code.
 - Open a [free Azure account](https://azure.microsoft.com/free/dotnet/) if you don't have one.
 - Install [.NET Core SDK](https://dotnet.microsoft.com/download)
 - Install [Visual Studio Code](https://code.visualstudio.com/Download)
-  - Install the [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) to Visual Studio Code
+  - Install the [C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) to Visual Studio Code
   - Install the [Azure App Service Extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice)
   to Visual Studio Code and configure it before proceeding
 

--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -39,7 +39,7 @@ In this tutorial, you learn how to:
 
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [.NET Core SDK 3.0 or later](https://www.microsoft.com/net/download/all)
-* [C# for Visual Studio Code version 1.17.1 or later](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [C# for Visual Studio Code version 1.17.1 or later](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [Node.js](https://nodejs.org/) with [npm](https://www.npmjs.com/)
 
 ---
@@ -296,7 +296,7 @@ Confirm that the app works with the following steps.
 
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download/all)
-* [C# for Visual Studio Code version 1.17.1 or later](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)
+* [C# for Visual Studio Code version 1.17.1 or later](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [Node.js](https://nodejs.org/) with [npm](https://www.npmjs.com/)
 
 ---


### PR DESCRIPTION
[C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) has been renamed from `ms-vscode.csharp` to `ms-dotnettools.csharp`, this PR corrects to new correct uris.