### PR TITLE
Fixes NGINX as a WebSocket Proxy header

### DIFF
--- a/aspnetcore/host-and-deploy/blazor/server.md
+++ b/aspnetcore/host-and-deploy/blazor/server.md
@@ -106,7 +106,7 @@ For SignalR WebSockets to function properly, set the proxy's `Upgrade` and `Conn
 
 ```
 proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection $connection_upgrade;
+proxy_set_header Connection "Upgrade";
 ```
 
 For more information, see [NGINX as a WebSocket Proxy](https://www.nginx.com/blog/websocket-nginx/).


### PR DESCRIPTION
Run nginx -t command error with **proxy_set_header Connection $connection_upgrade;**
Changed to **proxy_set_header Connection "Upgrade";** according to official documentation



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->