### PR TITLE
Replace AddMvc method reference with AddControllers

### DIFF
--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -342,7 +342,7 @@ To satisfy the preceding requirements, make the following changes:
 
 1. JSON.NET has been removed from ASP.NET shared framework. Add a package reference to [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://nuget.org/packages/Microsoft.AspNetCore.Mvc.NewtonsoftJson).
 
-1. In `Startup.ConfigureServices`, chain the following highlighted code on to the `AddMvc` method call:
+1. In `Startup.ConfigureServices`, chain the following highlighted code on to the `AddControllers` method call:
 
    [!code-csharp[](first-mongo-app/samples/3.x/SampleApp/Startup.cs?name=snippet_ConfigureServices&highlight=12)]
 


### PR DESCRIPTION
The `AddMvc` method should be replaced with `AddControllers` in ASP.NET Core 3.0+.