### PR TITLE
Blazor WebAssembly auth documentation

### DIFF
--- a/aspnetcore/includes/blazor-security/app-component.md
+++ b/aspnetcore/includes/blazor-security/app-component.md
@@ -1,0 +1,25 @@
+The `App` component (*App.razor*) is similar to the `App` component found in Blazor Server apps:
+
+* The `CascadingAuthenticationState` component manages exposing the `AuthenticationState` to the rest of the app.
+* The `AuthorizeRouteView` component makes sure that the current user is authorized to access a given page or otherwise renders the `RedirectToLogin` component.
+* The `RedirectToLogin` component manages redirecting unauthorized users to the login page.
+
+```razor
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(Program).Assembly">
+        <Found Context="routeData">
+            <AuthorizeRouteView RouteData="@routeData" 
+                DefaultLayout="@typeof(MainLayout)">
+                <NotAuthorized>
+                    <RedirectToLogin />
+                </NotAuthorized>
+            </AuthorizeRouteView>
+        </Found>
+        <NotFound>
+            <LayoutView Layout="@typeof(MainLayout)">
+                <p>Sorry, there's nothing at this address.</p>
+            </LayoutView>
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>
+```

--- a/aspnetcore/includes/blazor-security/authentication-component.md
+++ b/aspnetcore/includes/blazor-security/authentication-component.md
@@ -1,0 +1,18 @@
+The page produced by the `Authentication` component (*Pages/Authentication.razor*) defines the routes required for handling different authentication stages.
+
+The `RemoteAuthenticatorView` component:
+
+* Is provided by the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package.
+* Manages performing the appropriate actions at each stage of authentication.
+
+```razor
+@page "/authentication/{action}"
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+
+<RemoteAuthenticatorView Action="@Action" />
+
+@code {
+    [Parameter]
+    public string Action { get; set; }
+}
+```

--- a/aspnetcore/includes/blazor-security/fetchdata-component.md
+++ b/aspnetcore/includes/blazor-security/fetchdata-component.md
@@ -46,4 +46,4 @@ If the request failed because the token couldn't be provisioned without user int
 }
 ```
 
-For more information, see [Save app state before an authentication operation](xref:security/blazor/webassembly/additional-scnearios#save-app-state-before-an-authentication-operation).
+For more information, see [Save app state before an authentication operation](xref:security/blazor/webassembly/additional-scenarios#save-app-state-before-an-authentication-operation).

--- a/aspnetcore/includes/blazor-security/fetchdata-component.md
+++ b/aspnetcore/includes/blazor-security/fetchdata-component.md
@@ -1,0 +1,49 @@
+The `FetchData` component shows how to:
+
+* Provision an access token.
+* Use the access token to call a protected resource API in the *Server* app.
+
+The `@attribute [Authorize]` directive indicates to the Blazor WebAssembly authorization system that the user must be authorized in order to visit this component. The presence of the attribute in the *Client* app doesn't prevent the API on the server from being called without proper credentials. The *Server* app also must use `[Authorize]` on the appropriate endpoints to correctly protect them.
+
+`AuthenticationService.RequestAccessToken();` takes care of requesting an access token that can be added to the request to call the API. If the token is cached or the service is able to provision a new access token without user interaction, the token request succeeds. Otherwise, the token request fails.
+
+In order to obtain the actual token to include in the request, the app must check that the request succeeded by calling `tokenResult.TryGetToken(out var token)`. 
+
+If the request was successful, the token variable is populated with the access token. The `Value` property of the token exposes the literal string to include in the `Authorization` request header.
+
+If the request failed because the token couldn't be provisioned without user interaction, the token result contains a redirect URL. Navigating to this URL takes the user to the login page and back to the current page after a successful authentication.
+
+```razor
+@page "/fetchdata"
+...
+@attribute [Authorize]
+
+...
+
+@code {
+    private WeatherForecast[] forecasts;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var httpClient = new HttpClient();
+        httpClient.BaseAddress = new Uri(Navigation.BaseUri);
+
+        var tokenResult = await AuthenticationService.RequestAccessToken();
+
+        if (tokenResult.TryGetToken(out var token))
+        {
+            httpClient.DefaultRequestHeaders.Add("Authorization", 
+                $"Bearer {token.Value}");
+            forecasts = await httpClient.GetJsonAsync<WeatherForecast[]>(
+                "WeatherForecast");
+        }
+        else
+        {
+            Navigation.NavigateTo(tokenResult.RedirectUrl);
+        }
+
+    }
+}
+```
+
+For more information, see [Save app state before an authentication operation](xref:security/blazor/webassembly/additional-scnearios#save-app-state-before-an-authentication-operation).

--- a/aspnetcore/includes/blazor-security/index-page.md
+++ b/aspnetcore/includes/blazor-security/index-page.md
@@ -1,0 +1,6 @@
+The Index page (*wwwroot/index.html*) page includes a script that defines the `AuthenticationService` in JavaScript. `AuthenticationService` handles the low-level details of the the OIDC protocol. The app internally calls methods defined in the script to perform the authentication operations.
+
+```html
+<script src="_content/Microsoft.Authentication.WebAssembly.Msal/
+    AuthenticationService.js"></script>
+```

--- a/aspnetcore/includes/blazor-security/logindisplay-component.md
+++ b/aspnetcore/includes/blazor-security/logindisplay-component.md
@@ -1,0 +1,33 @@
+The `LoginDisplay` component (*Shared/LoginDisplay.razor*) is rendered in the `MainLayout` component (*Shared/MainLayout.razor*) and manages the following behaviors:
+
+* For authenticated users:
+  * Displays the current username.
+  * Offers a button to log out of the app.
+* For anonymous users, offers the option to log in.
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+@inject NavigationManager Navigation
+@inject SignOutSessionStateManager SignOutManager
+
+<AuthorizeView>
+    <Authorized>
+        Hello, @context.User.Identity.Name!
+        <button class="nav-link btn btn-link" @onclick="BeginSignOut">
+            Log out
+        </button>
+    </Authorized>
+    <NotAuthorized>
+        <a href="authentication/login">Log in</a>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private async Task BeginSignOut(MouseEventArgs args)
+    {
+        await SignOutManager.SetSignOutState();
+        Navigation.NavigateTo("authentication/logout");
+    }
+}
+```

--- a/aspnetcore/includes/blazor-security/redirecttologin-component.md
+++ b/aspnetcore/includes/blazor-security/redirecttologin-component.md
@@ -1,0 +1,15 @@
+The `RedirectToLogin` component (*Shared/RedirectToLogin.razor*):
+
+* Manages redirecting unauthorized users to the login page.
+* Preserves the current URL that the user is attempting to access so that they can be returned to that page if authentication is successful.
+
+```razor
+@inject NavigationManager Navigation
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+@code {
+    protected override void OnInitialized()
+    {
+        Navigation.NavigateTo($"authentication/login?returnUrl={Navigation.Uri}");
+    }
+}
+```

--- a/aspnetcore/includes/blazor-security/troubleshoot.md
+++ b/aspnetcore/includes/blazor-security/troubleshoot.md
@@ -1,0 +1,6 @@
+## Troubleshoot
+
+Because ID tokens and access tokens can persist across login attempts, clear browser cookies using the browser's developer console after every update to:
+
+* The app's authentication code or configuration settings.
+* The app's configuration OIDC-compliant provider (for example, Azure Active Directory).

--- a/aspnetcore/includes/blazorwasm-3.2-template-article-notice.md
+++ b/aspnetcore/includes/blazorwasm-3.2-template-article-notice.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> The guidance in this article applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template, see <xref:blazor/get-started>.

--- a/aspnetcore/includes/blazorwasm-3.2-template-section-notice.md
+++ b/aspnetcore/includes/blazorwasm-3.2-template-section-notice.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> The guidance in this section applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template, see <xref:blazor/get-started>.

--- a/aspnetcore/security/blazor/index.md
+++ b/aspnetcore/security/blazor/index.md
@@ -506,6 +506,8 @@ In Blazor WebAssembly apps, authorization checks can be bypassed because all cli
 
 **Always perform authorization checks on the server within any API endpoints accessed by your client-side app.**
 
+For more information, see the articles under <xref:security/blazor/webassembly/index>.
+
 ## Troubleshoot errors
 
 Common errors:

--- a/aspnetcore/security/blazor/webassembly/additional-scenarios.md
+++ b/aspnetcore/security/blazor/webassembly/additional-scenarios.md
@@ -7,7 +7,7 @@ ms.author: riande
 ms.custom: mvc
 ms.date: 03/09/2020
 no-loc: [Blazor, SignalR]
-uid: security/blazor/webassembly/additional-scnearios
+uid: security/blazor/webassembly/additional-scenarios
 ---
 # ASP.NET Core Blazor WebAssembly additional security scenarios
 
@@ -19,26 +19,34 @@ By [Javier Calvarro Nelson](https://github.com/javiercn)
 
 ## Handle token request errors
 
-When a single page app authenticates a user using Open ID Connect, the authentication state is kept locally within the single page app and in the Identity Provider in the form of a session cookie that is set as a result of the user introducing their credentials.
+When a single page app (SPA) authenticates a user using Open ID Connect (OIDC), the authentication state is maintained locally within the SPA and in the Identity Provider (IP) in the form of a session cookie that's set as a result of the user providing their credentials.
 
-The tokens that the Identity Provider emits for the user typically are valid for short periods of time, about one hour normally, so the client app needs to regularly fetch new tokens. Otherwise, you would be logged-out after the tokens granted expired. In the majority of cases Open ID Connect clients are able to provision new tokens without requiring the user to authenticate again thanks to the authentication state or "session" that is kept within the Identity Provider.
+The tokens that the IP emits for the user typically are valid for short periods of time, about one hour normally, so the client app must regularly fetch new tokens. Otherwise, the user would be logged-out after the granted tokens expire. In most cases, OIDC clients are able to provision new tokens without requiring the user to authenticate again thanks to the authentication state or "session" that is kept within the IP.
 
-There are however, some cases in which the client can't get a token without user interaction, for example, when for some reason the user explicitly logged out from the identity provider. (For example if you visited `https://login.microsoftonline.com` and logged out). In those scenarios, the app doesn't know immediately that the user logged out, and any token that it might have received might no longer be valid or it won't be able to provision a new one without user interaction once the current one expires.
+There are some cases in which the client can't get a token without user interaction, for example, when for some reason the user explicitly logs out from the IP. This scenario occurs if a user visits `https://login.microsoftonline.com` and logs out. In these scenarios, the app doesn't know immediately that the user has logged out. Any token that the client holds might no longer be valid. Also, the client isn't able to provision a new token without user interaction after the current token expires.
 
-This is not something specific to token based authentication, but it is part of the nature of single page apps. A single page app using cookies would also fail to call a server API if the authentication cookie got removed.
+These scenarios aren't specific to token-based authentication. They are part of the nature of SPAs. An SPA using cookies also fails to call a server API if the authentication cookie is removed.
 
-For this reason, when we are performing API calls to protected resources we need to be aware of the fact that provision a new access token to call the API might require the user authenticating again and that, even if we have a token that seems to be valid, the call to the server might fail because the token got revoked by the user.
+When an app performs API calls to protected resources, you must be aware of the following:
 
-When we request a token there are two possible outcomes:
-* The request succeeds and we have a valid token.
-* The request fails and we need to authenticate again to get a new token.
+* To provision a new access token to call the API, the user might be required to authenticate again.
+* Even if the client has a token that seems to be valid, the call to the server might fail because the token was revoked by the user.
 
-When a token request fails, we need to decide whether we want to save any current state before we perform a redirection. We can do several things with increasing levels of complexity:
-* We can store the current page state in session storage and during `OnInitializeAsync` check if it is there to restore before we continue when we return to the current page after a successful authentication.
-* We can add a query string parameter and use that as a way to signal the app that it needs to re-hydrate the previously saved state.
-* We can add a query string parameter with a unique identifier to store things in session storage without risking collisions with other items.
+When the app requests a token, there are two possible outcomes:
 
-The example below shows how you can preserve the state before you redirect to the login page and how you recover the previous state afterwards using the second option.
+* The request succeeds, and the app has a valid token.
+* The request fails, and the app must authenticate the user again to obtain a new token.
+
+When a token request fails, you need to decide whether you want to save any current state before you perform a redirection. Several approaches exist with increasing levels of complexity:
+
+* Store the current page state in session storage. During `OnInitializeAsync`, check if state can be restored before continuing.
+* Add a query string parameter and use that as a way to signal the app that it needs to re-hydrate the previously saved state.
+* Add a query string parameter with a unique identifier to store data in session storage without risking collisions with other items.
+
+The following example shows how to:
+
+* Preserve state before redirecting to the login page.
+* Recover the previous state afterward authentication using the query string parameter.
 
 ```razor
 <EditForm Model="User" @onsubmit="OnSaveAsync">
@@ -62,6 +70,7 @@ The example below shows how you can preserve the state before you redirect to th
     protected async override Task OnInitializedAsync()
     {
         var currentQuery = new Uri(Navigation.Uri).Query;
+
         if (currentQuery.Contains("state=resumeSavingProfile"))
         {
             User = await JS.InvokeAsync<Profile>("sessionStorage.getState", 
@@ -100,7 +109,9 @@ The example below shows how you can preserve the state before you redirect to th
 
 ## Save app state before an authentication operation
 
-During an authentication operation there are cases where you want to save the app state before the browser gets redirected to the Identity provider. This can be the case when you are using something like a state container and you want to restore the state after the authentication succeeds. In those scenarios, you can use a custom authentication state object to preserve your app specific state or a reference to it and restore that state once the authentication operation completes successfully:
+During an authentication operation, there are cases where you want to save the app state before the browser is redirected to the IP. This can be the case when you are using something like a state container and you want to restore the state after the authentication succeeds. You can use a custom authentication state object to preserve app-specific state or a reference to it and restore that state once the authentication operation successfully completes.
+
+`Authentication` component (*Pages/Authentication.razor*):
 
 ```razor
 @page "/authentication/{action}"
@@ -146,9 +157,7 @@ During an authentication operation there are cases where you want to save the ap
 
 ## Request additional access tokens
 
-Most apps only require an access token to talk to the protected resources that they work with, but in some scenarios a given app might need more than one token to talk to two or more resources. In these scenarios, the `IAccessTokenProvider.RequestToken` method provides an overload that allows you to provision a token with a given set of scopes.
-
-For example:
+Most apps only require an access token to interact with the protected resources that they use. In some scenarios, an app might require more than one token in order to interact with two or more resources. The `IAccessTokenProvider.RequestToken` method provides an overload that allows an app to provision a token with a given set of scopes, as seen in the following example:
 
 ```csharp
 var tokenResult = await AuthenticationService.RequestAccessToken(
@@ -161,7 +170,7 @@ var tokenResult = await AuthenticationService.RequestAccessToken(
 
 ## Customize app routes
 
-By default, the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package uses the routes shown in the following table for representing different authentication states.
+By default, the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` library uses the routes shown in the following table for representing different authentication states.
 
 | Route                            | Purpose |
 | -------------------------------- | ------- |
@@ -170,12 +179,16 @@ By default, the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` pac
 | `authentication/login-failed`    | Displays error messages when the sign-in operation fails for some reason. |
 | `authentication/logout`          | Triggers a sign-out operation. |
 | `authentication/logout-callback` | Handles the result of a sign-out operation. |
-| `authentication/logout-failed  ` | Displays error messages when the sign-out operation fails for some reason. |
+| `authentication/logout-failed`   | Displays error messages when the sign-out operation fails for some reason. |
 | `authentication/logged-out`      | Indicates that the user has successfully logout. |
 | `authentication/profile`         | Triggers an operation to edit the user profile. |
 | `authentication/register`        | Triggers an operation to register a new user. |
 
-All these paths are configurable in `RemoteAuthenticationOptions<TProviderOptions>.AuthenticationPaths` if you want to change the paths your app uses for any of the operations described above, you need to change the path in the options as well as making sure that you have a route that handles that path. For example, you can change all the paths to be prefixed by security instead as shown below:
+The routes shown in the preceding table are configurable via `RemoteAuthenticationOptions<TProviderOptions>.AuthenticationPaths`. When setting options to provide custom routes, confirm that the app has a route that handles each path.
+
+In the following example, all the paths are prefixed with `/security`.
+
+`Authentication` component (*Pages/Authentication.razor*):
 
 ```razor
 @page "/security/{action}"
@@ -188,6 +201,8 @@ All these paths are configurable in `RemoteAuthenticationOptions<TProviderOption
     public string Action { get; set; }
 }
 ```
+
+`Program.Main` (*Program.cs*):
 
 ```csharp
 builder.Services.AddApiAuthorization(options => { 
@@ -203,9 +218,7 @@ builder.Services.AddApiAuthorization(options => {
 });
 ```
 
-If you plan to have completely different paths, you can do so as described above and simply render the RemoteAuthenticatorView with an explicit action parameter.
-
-For example:
+If the requirement calls for completely different paths, set the routes as described previously and render the `RemoteAuthenticatorView` with an explicit action parameter:
 
 ```razor
 @page "/register"
@@ -213,11 +226,13 @@ For example:
 <RemoteAuthenticatorView Action="@RemoteAuthenticationActions.Register" />
 ```
 
-This also means you can break the UI into different pages if you choose to do so.
+You're allowed to break the UI into different pages if you choose to do so.
 
 ## Customize the authentication user interface
 
-`RemoteAuthenticatorView` includes a default set of UI pieces for each authentication state. You can customize each state by passing in your own `RenderFragment`. To customize the text that gets displayed during the initial login process you can change the `RemoteAuthenticatorView` as follows:
+`RemoteAuthenticatorView` includes a default set of UI pieces for each authentication state. Each state can be customized by passing in a custom `RenderFragment`. To customize the displayed text during the initial login process, can change the `RemoteAuthenticatorView` as follows.
+
+`Authentication` component (*Pages/Authentication.razor*):
 
 ```razor
 @page "/security/{action}"
@@ -235,7 +250,7 @@ This also means you can break the UI into different pages if you choose to do so
 }
 ```
 
-The remote authenticator view has one fragment that can be used per authentication route shown in the following table.
+The `RemoteAuthenticatorView` has one fragment that can be used per authentication route shown in the following table.
 
 | Route                            | Fragment             |
 | -------------------------------- | -------------------- |

--- a/aspnetcore/security/blazor/webassembly/additional-scnearios.md
+++ b/aspnetcore/security/blazor/webassembly/additional-scnearios.md
@@ -1,0 +1,250 @@
+---
+title: ASP.NET Core Blazor WebAssembly additional security scenarios
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/additional-scnearios
+---
+# ASP.NET Core Blazor WebAssembly additional security scenarios
+
+By [Javier Calvarro Nelson](https://github.com/javiercn)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+## Handle token request errors
+
+When a single page app authenticates a user using Open ID Connect, the authentication state is kept locally within the single page app and in the Identity Provider in the form of a session cookie that is set as a result of the user introducing their credentials.
+
+The tokens that the Identity Provider emits for the user typically are valid for short periods of time, about one hour normally, so the client app needs to regularly fetch new tokens. Otherwise, you would be logged-out after the tokens granted expired. In the majority of cases Open ID Connect clients are able to provision new tokens without requiring the user to authenticate again thanks to the authentication state or "session" that is kept within the Identity Provider.
+
+There are however, some cases in which the client can't get a token without user interaction, for example, when for some reason the user explicitly logged out from the identity provider. (For example if you visited `https://login.microsoftonline.com` and logged out). In those scenarios, the app doesn't know immediately that the user logged out, and any token that it might have received might no longer be valid or it won't be able to provision a new one without user interaction once the current one expires.
+
+This is not something specific to token based authentication, but it is part of the nature of single page apps. A single page app using cookies would also fail to call a server API if the authentication cookie got removed.
+
+For this reason, when we are performing API calls to protected resources we need to be aware of the fact that provision a new access token to call the API might require the user authenticating again and that, even if we have a token that seems to be valid, the call to the server might fail because the token got revoked by the user.
+
+When we request a token there are two possible outcomes:
+* The request succeeds and we have a valid token.
+* The request fails and we need to authenticate again to get a new token.
+
+When a token request fails, we need to decide whether we want to save any current state before we perform a redirection. We can do several things with increasing levels of complexity:
+* We can store the current page state in session storage and during `OnInitializeAsync` check if it is there to restore before we continue when we return to the current page after a successful authentication.
+* We can add a query string parameter and use that as a way to signal the app that it needs to re-hydrate the previously saved state.
+* We can add a query string parameter with a unique identifier to store things in session storage without risking collisions with other items.
+
+The example below shows how you can preserve the state before you redirect to the login page and how you recover the previous state afterwards using the second option.
+
+```razor
+<EditForm Model="User" @onsubmit="OnSaveAsync">
+    <label>User
+        <InputText @bind-Value="User.Name" />
+    </label>
+    <label>Last name
+        <InputText @bind-Value="User.LastName" />
+    </label>
+</EditForm>
+
+@code {
+    public class Profile
+    {
+        public string Name { get; set; }
+        public string LastName { get; set; }
+    }
+
+    public Profile User { get; set; } = new Profile();
+
+    protected async override Task OnInitializedAsync()
+    {
+        var currentQuery = new Uri(Navigation.Uri).Query;
+        if (currentQuery.Contains("state=resumeSavingProfile"))
+        {
+            User = await JS.InvokeAsync<Profile>("sessionStorage.getState", 
+                "resumeSavingProfile");
+        }
+    }
+
+    public async Task OnSaveAsync()
+    {
+        var httpClient = new HttpClient();
+        httpClient.BaseAddress = new Uri(Navigation.BaseUri);
+
+        var resumeUri = Navigation.Uri + $"?state=resumeSavingProfile";
+
+        var tokenResult = await AuthenticationService.RequestAccessToken(
+            new AccessTokenRequestOptions
+            {
+                ReturnUrl = resumeUri
+            });
+
+        if (tokenResult.TryGetToken(out var token))
+        {
+            httpClient.DefaultRequestHeaders.Add("Authorization", 
+                $"Bearer {token.Value}");
+            await httpClient.PostJsonAsync("Save", User);
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("sessionStorage.setState", 
+                "resumeSavingProfile", User);
+            Navigation.NavigateTo(tokenResult.RedirectUrl);
+        }
+    }
+}
+```
+
+## Save app state before an authentication operation
+
+During an authentication operation there are cases where you want to save the app state before the browser gets redirected to the Identity provider. This can be the case when you are using something like a state container and you want to restore the state after the authentication succeeds. In those scenarios, you can use a custom authentication state object to preserve your app specific state or a reference to it and restore that state once the authentication operation completes successfully:
+
+```razor
+@page "/authentication/{action}"
+@inject JSRuntime JS
+@inject StateContainer State
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+
+<RemoteAuthenticatorViewCore Action="@Action" 
+    AuthenticationState="AuthenticationState" OnLoginSucceded="RestoreState" 
+    OnLogoutSucceded="RestoreState" />
+
+@code {
+    [Parameter]
+    public string Action { get; set; }
+
+    public class ApplicationAuthenticationState : RemoteAuthenticationState
+    {
+        public string Id { get; set; }
+    }
+
+    protected async override Task OnInitializedAsync()
+    {
+        if (RemoteAuthenticationActions.IsAction(RemoteAuthenticationActions.LogIn, 
+            Action))
+        {
+            AuthenticationState.Id = Guid.NewGuid().ToString();
+            await JS.InvokeVoidAsync("sessionStorage.setKey", 
+                AuthenticationState.Id, State.Store());
+        }
+    }
+
+    public async Task RestoreState(ApplicationAuthenticationState state)
+    {
+        var stored = await JS.InvokeAsync<string>("sessionStorage.getKey", 
+            state.Id);
+        State.FromStore(stored);
+    }
+
+    public ApplicationAuthenticationState AuthenticationState { get; set; } = 
+        new ApplicationAuthenticationState();
+}
+```
+
+## Request additional access tokens
+
+Most apps only require an access token to talk to the protected resources that they work with, but in some scenarios a given app might need more than one token to talk to two or more resources. In these scenarios, the `IAccessTokenProvider.RequestToken` method provides an overload that allows you to provision a token with a given set of scopes.
+
+For example:
+
+```csharp
+var tokenResult = await AuthenticationService.RequestAccessToken(
+    new AccessTokenRequestOptions
+    {
+        Scopes = new[] { "https://graph.microsoft.com/Mail.Send", 
+            "https://graph.microsoft.com/User.Read" }
+    });
+```
+
+## Customize app routes
+
+By default, the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package uses the routes shown in the following table for representing different authentication states.
+
+| Route                            | Purpose |
+| -------------------------------- | ------- |
+| `authentication/login`           | Triggers a sign-in operation. |
+| `authentication/login-callback`  | Handles the result of any sign-in operation. |
+| `authentication/login-failed`    | Displays error messages when the sign-in operation fails for some reason. |
+| `authentication/logout`          | Triggers a sign-out operation. |
+| `authentication/logout-callback` | Handles the result of a sign-out operation. |
+| `authentication/logout-failed  ` | Displays error messages when the sign-out operation fails for some reason. |
+| `authentication/logged-out`      | Indicates that the user has successfully logout. |
+| `authentication/profile`         | Triggers an operation to edit the user profile. |
+| `authentication/register`        | Triggers an operation to register a new user. |
+
+All these paths are configurable in `RemoteAuthenticationOptions<TProviderOptions>.AuthenticationPaths` if you want to change the paths your app uses for any of the operations described above, you need to change the path in the options as well as making sure that you have a route that handles that path. For example, you can change all the paths to be prefixed by security instead as shown below:
+
+```razor
+@page "/security/{action}"
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+
+<RemoteAuthenticatorView Action="@Action" />
+
+@code{
+    [Parameter]
+    public string Action { get; set; }
+}
+```
+
+```csharp
+builder.Services.AddApiAuthorization(options => { 
+    options.AuthenticationPaths.LogInPath = "security/login";
+    options.AuthenticationPaths.LogInCallbackPath = "security/login-callback";
+    options.AuthenticationPaths.LogInFailedPath = "security/login-failed";
+    options.AuthenticationPaths.LogOutPath = "security/logout";
+    options.AuthenticationPaths.LogOutCallbackPath = "security/logout-callback";
+    options.AuthenticationPaths.LogOutFailedPath = "security/logout-failed";
+    options.AuthenticationPaths.LogOutSucceededPath = "security/logged-out";
+    options.AuthenticationPaths.ProfilePath = "security/profile";
+    options.AuthenticationPaths.RegisterPath = "security/register";
+});
+```
+
+If you plan to have completely different paths, you can do so as described above and simply render the RemoteAuthenticatorView with an explicit action parameter.
+
+For example:
+
+```razor
+@page "/register"
+
+<RemoteAuthenticatorView Action="@RemoteAuthenticationActions.Register" />
+```
+
+This also means you can break the UI into different pages if you choose to do so.
+
+## Customize the authentication user interface
+
+`RemoteAuthenticatorView` includes a default set of UI pieces for each authentication state. You can customize each state by passing in your own `RenderFragment`. To customize the text that gets displayed during the initial login process you can change the `RemoteAuthenticatorView` as follows:
+
+```razor
+@page "/security/{action}"
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+
+<RemoteAuthenticatorView Action="@Action">
+    <LoggingIn>
+        You are about to be redirected to https://login.microsoftonline.com.
+    </LoggingIn>
+</RemoteAuthenticatorView>
+
+@code{
+    [Parameter]
+    public string Action { get; set; }
+}
+```
+
+The remote authenticator view has one fragment that can be used per authentication route shown in the following table.
+
+| Route                            | Fragment             |
+| -------------------------------- | -------------------- |
+| `authentication/login`           | `<LoggingIn>`        |
+| `authentication/login-callback`  | `<CompletingLogIn>`  |
+| `authentication/login-failed`    | `<LogInFailed>`      |
+| `authentication/logout`          | `<LoggingOut>`       |
+| `authentication/logout-callback` | `<CompletingLogOut>` |
+| `authentication/logout-failed`   | `<LogOutFailed>`     |
+| `authentication/logged-out`      | `<LogOutSucceeded>`  |
+| `authentication/profile`         | `<UserProfile>`      |
+| `authentication/register`        | `<Registering>`      |

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -1,0 +1,261 @@
+---
+title: Secure an ASP.NET Core Blazor WebAssembly hosted app with Azure Active Directory B2C
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/hosted-with-azure-active-directory-b2c
+---
+# Secure an ASP.NET Core Blazor WebAssembly hosted app with Azure Active Directory B2C
+
+By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+This article describes how to create a Blazor WebAssembly standalone app that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication.
+
+## Register apps in AAD B2C and create solution
+
+### Create a tenant
+
+Follow the guidance in [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant) to create an AAD B2C tenant and record the following information:
+
+* AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash)
+* AAD B2C Tenant domain (for example, `contoso.onmicrosoft.com`)
+
+### Register a server API app
+
+Follow the guidance in [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications) to register an AAD app for the *Server API app* in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+
+1. Select **New registration**.
+1. Provide a **Name** for the app (for example, **Blazor Server AAD B2C**).
+1. For **Supported account types**, select **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.** (multi-tenant) for this experience.
+1. The *Server API app* doesn't require a **Redirect URI** in this scenario, so leave the drop down set to **Web** and don't enter a redirect URI.
+1. Confirm that **Permissions** > **Grant admin concent to openid and offline_access permissions** is enabled.
+1. Select **Register**.
+
+In **Expose an API**:
+
+1. Select **Add a scope**.
+1. Select **Save and continue**.
+1. Provide a **Scope name** (for example, `API.Access`).
+1. Provide an **Admin consent display name** (for example, `Access API`).
+1. Provide an **Admin consent description** (for example, `Allows the app to access server app API endpoints.`).
+1. Confirm that the **State** is set to **Enabled**.
+1. Select **Add scope**.
+
+Record the following information:
+
+* *Server API app* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
+* Directory ID (Tenant ID) (for example, `222222222-2222-2222-2222-222222222222`)
+* *Server API app* App ID URI (for example, `https://contoso.onmicrosoft.com/11111111-1111-1111-1111-111111111111`, the Azure portal might default the value to the Client ID)
+* Default scope (for example, `API.Access`)
+
+### Register a client app
+
+Follow the guidance in [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications) again to register an AAD app for the *Client app* in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+
+1. Select **New registration**.
+1. Provide a **Name** for the app (for example, **Blazor Client AAD B2C**).
+1. For **Supported account types**, select **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.** (multi-tenant) for this experience.
+1. Leave the **Redirect URI** drop down set to **Web**, and provide a redirect URI of `https://localhost:5001/authentication/login-callback`.
+1. Confirm that **Permissions** > **Grant admin concent to openid and offline_access permissions** is enabled.
+1. Select **Register**.
+
+In **Authentication** > **Platform configurations** > **Web**:
+
+1. Confirm the **Redirect URI** of `https://localhost:5001/authentication/login-callback` is present.
+1. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.
+1. The remaining defaults for the app are acceptable for this experience.
+1. Select the **Save** button.
+
+In **API permissions**:
+
+1. Confirm that the app has **Microsoft Graph** > **User.Read** permission.
+1. Select **Add a permission** followed by **My APIs**.
+1. Select the *Server API app* from the **Name** column (for example, **Blazor Server AAD B2C**).
+1. Open the **API** list.
+1. Enable access to the API (for example, `API.Access`).
+1. Select **Add permissions**.
+1. Select the **Grant admin content for {TENANT NAME}** button. Select **Yes** to confirm.
+
+In **Home** > **Azure AD B2C** > **User flows**:
+
+[Create a sign-up and sign-in user flow](/azure/active-directory-b2c/tutorial-create-user-flows)
+
+Record the following information:
+
+* Record the *Client app* Application ID (Client ID) (for example, `33333333-3333-3333-3333-333333333333`).
+* Record the sign-up and sign-in user flow name created for the app (for example, `B2C_1_signupsignin`).
+
+### Create the app
+
+Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+
+```dotnetcli
+dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{DOMAIN}" -ho -ssp "{SIGN UP OR SIGN IN POLICY}" --tenant-id "{TENANT ID}"
+```
+
+To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+## Server app configuration
+
+*This section pertains to the solution's **Server** app.*
+
+### Authentication package
+
+The support for authenticating and authorizing calls to ASP.NET Core Web APIs is provided by the `Microsoft.AspNetCore.Authentication.AzureAD.UI`:
+
+```xml
+<PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" 
+    Version="3.1.0" />
+```
+
+### Authentication service support
+
+The `AddAuthentication` method sets up authentication services within the app and configures the JWT Bearer handler as the default authentication method. The `AddAzureADBearer` method sets up the specific parameters in the JWT Bearer handler required to validate tokens emitted by the Azure Active Directory:
+
+```csharp
+services.AddAuthentication(AzureADDefaults.BearerAuthenticationScheme)
+    .AddAzureADBearer(options => Configuration.Bind("AzureAd", options));
+```
+
+`UseAuthentication` and `UseAuthorization` ensure that:
+
+* The app attempts to parse and validate tokens on incoming requests.
+* Any request attempting to access a protected resource without proper credentials fails.
+
+```csharp
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+### App settings
+
+The *appsettings.json* file contains the options to configure the JWT bearer handler used to validate access tokens.
+
+```json
+{
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "ClientId": "{API CLIENT ID}",
+    "Domain": "{DOMAIN}",
+    "SignUpSignInPolicyId": "{SIGN UP OR SIGN IN POLICY}"
+  }
+}
+```
+
+### WeatherForecast controller
+
+The WeatherForecast controller (*Controllers/WeatherForecastController.cs*) exposes a protected API with the `[Authorize]` attribute applied to the controller. It's **important** to understand that:
+
+* The `[Authorize]` attribute in this API controller is the only thing that protect this API from unauthorized access.
+* The `[Authorize]` attribute used in the Blazor WebAssembly app only serves as a hint to the app that the user should be authorized for the app to work correctly.
+
+```csharp
+[Authorize]
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    [HttpGet]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        ...
+    }
+}
+```
+
+## Client app configuration
+
+*This section pertains to the solution's **Client** app.*
+
+### Authentication package
+
+When an app is created to use an Individual B2C Account (`IndividualB2C`), the app automatically receives a package reference for the [Microsoft Authentication Library](/azure/active-directory/develop/msal-overview) (`Microsoft.Authentication.WebAssembly.Msal`). The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+
+If adding authentication to an app, manually add the package to the app's project file:
+
+```xml
+<PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" 
+    Version="{VERSION}" />
+```
+
+Replace `{VERSION}` in the preceding package reference with the version of the `Microsoft.AspNetCore.Blazor.Templates` package shown in the <xref:blazor/get-started> article.
+
+The `Microsoft.Authentication.WebAssembly.Msal` package transitively adds the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package to the app.
+
+### Authentication service support
+
+Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+
+*Program.cs*:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    var authentication = options.ProviderOptions.Authentication;
+    authentication.Authority = 
+        "{AAD B2C INSTANCE}{DOMAIN}/{SIGN UP OR SIGN IN POLICY}";
+    authentication.ClientId = "{CLIENT ID}";
+    authentication.ValidateAuthority = false;
+    options.ProviderOptions.DefaultAccessTokenScopes.Add(
+        "{APP ID URI}/{DEFAULT SCOPE}");
+});
+```
+
+The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Azure Portal AAD configuration when you register the app.
+
+The Blazor WebAssembly template automatically configures the app to request an access token for a secure API for the default scope provided to the `dotnet new` command (`{APP ID URI}/{DEFAULT SCOPE}`).
+
+The default access token scopes represent the list of access token scopes that are:
+
+* Included by default in the sign in request.
+* Used to provision an access token immediately after authentication.
+
+All scopes must belong to the same app per Azure Active Directory rules. Additional scopes can be added for additional API apps as needed:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    ...
+    options.ProviderOptions.DefaultAccessTokenScopes.Add(
+        "{APP ID URI}/{SCOPE}");
+});
+```
+
+### Index page
+
+[!INCLUDE[](~/includes/blazor-security/index-page.md)]
+
+### App component
+
+[!INCLUDE[](~/includes/blazor-security/app-component.md)]
+
+### RedirectToLogin component
+
+[!INCLUDE[](~/includes/blazor-security/redirecttologin-component.md)]
+
+### LoginDisplay component
+
+[!INCLUDE[](~/includes/blazor-security/logindisplay-component.md)]
+
+### Authentication component
+
+[!INCLUDE[](~/includes/blazor-security/authentication-component.md)]
+
+### FetchData component
+
+[!INCLUDE[](~/includes/blazor-security/fetchdata-component.md)]
+
+[!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
+
+## Additional resources
+
+* <xref:security/authentication/azure-ad-b2c>
+* [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant)

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
@@ -1,0 +1,258 @@
+---
+title: Secure an ASP.NET Core Blazor WebAssembly hosted app with Azure Active Directory
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/hosted-with-azure-active-directory
+---
+# Secure an ASP.NET Core Blazor WebAssembly hosted app with Azure Active Directory
+
+By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+
+
+This article describes how to create a [Blazor WebAssembly hosted app](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) for authentication.
+
+## Register apps in AAD B2C and create solution
+
+### Create a tenant
+
+Follow the guidance in [Quickstart: Set up a tenant](/azure/active-directory/develop/quickstart-create-new-tenant) to create a tenant in AAD.
+
+### Register a server API app
+
+Follow the guidance in [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app) and subsequent Azure AAD topics to register an AAD app for the *Server API app* in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+
+1. Select **New registration**.
+1. Provide a **Name** for the app (for example, **Blazor Server AAD**).
+1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** (single tenant) for this experience.
+1. The *Server API app* doesn't require a **Redirect URI** in this scenario, so leave the drop down set to **Web** and don't enter a redirect URI.
+1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
+1. Select **Register**.
+
+In **API permissions**, remove the **Microsoft Graph** > **User.Read** permission, as the app doesn't require sign in or uer profile access.
+
+In **Expose an API**:
+
+1. Select **Add a scope**.
+1. Select **Save and continue**.
+1. Provide a **Scope name** (for example, `API.Access`).
+1. Provide an **Admin consent display name** (for example, `Access API`).
+1. Provide an **Admin consent description** (for example, `Allows the app to access server app API endpoints.`).
+1. Confirm that the **State** is set to **Enabled**.
+1. Select **Add scope**.
+
+Record the following information:
+
+* *Server API app* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
+* Directory ID (Tenant ID) (for example, `222222222-2222-2222-2222-222222222222`)
+* AAD Tenant domain (for example, `contoso.onmicrosoft.com`)
+* Default scope (for example, `API.Access`)
+
+### Register a client app
+
+Follow the guidance in [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app) and subsequent Azure AAD topics to register a AAD app for the *Client app* in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+
+1. Select **New registration**.
+1. Provide a **Name** for the app (for example, **Blazor Client AAD**).
+1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** (single tenant) for this experience.
+1. Leave the **Redirect URI** drop down set to **Web**, and provide a redirect URI of `https://localhost:5001/authentication/login-callback`.
+1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
+1. Select **Register**.
+
+In **Authentication** > **Platform configurations** > **Web**:
+
+1. Confirm the **Redirect URI** of `https://localhost:5001/authentication/login-callback` is present.
+1. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.
+1. The remaining defaults for the app are acceptable for this experience.
+1. Select the **Save** button.
+
+In **API permissions**:
+
+1. Confirm that the app has **Microsoft Graph** > **User.Read** permission.
+1. Select **Add a permission** followed by **My APIs**.
+1. Select the *Server API app* from the **Name** column (for example, **Blazor Server AAD**).
+1. Open the **API** list.
+1. Enable access to the API (for example, `API.Access`).
+1. Select **Add permissions**.
+1. Select the **Grant admin content for {TENANT NAME}** button. Select **Yes** to confirm.
+
+Record the *Client app* Application ID (Client ID) (for example, `33333333-3333-3333-3333-333333333333`).
+
+### Create the app
+
+Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+
+```dotnetcli
+dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP CLIENT ID}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{DOMAIN}" -ho --tenant-id "{TENANT ID}"
+```
+
+To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+> [!NOTE]
+> See the [Authentication service support](#Authentication service support) section for an important configuration change to the default access token scope. The value provided by the Blazor WebAssembly template must be manually changed after the *Client app* is created from the template.
+
+## Server app configuration
+
+*This section pertains to the solution's **Server** app.*
+
+### Authentication package
+
+The support for authenticating and authorizing calls to ASP.NET Core Web APIs is provided by the `Microsoft.AspNetCore.Authentication.AzureAD.UI`:
+
+```xml
+<PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" 
+    Version="3.1.0" />
+```
+
+### Authentication service support
+
+The `AddAuthentication` method sets up authentication services within the app and configures the JWT Bearer handler as the default authentication method. The `AddAzureADBearer` method sets up the specific parameters in the JWT Bearer handler required to validate tokens emitted by the Azure Active Directory:
+
+```csharp
+services.AddAuthentication(AzureADDefaults.BearerAuthenticationScheme)
+    .AddAzureADBearer(options => Configuration.Bind("AzureAd", options));
+```
+
+`UseAuthentication` and `UseAuthorization` ensure that:
+
+* The app attempts to parse and validate tokens on incoming requests.
+* Any request attempting to access a protected resource without proper credentials fails.
+
+```csharp
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+### App settings
+
+The *appsettings.json* file contains the options to configure the JWT bearer handler used to validate access tokens.
+
+```json
+{
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "Domain": "{DOMAIN}",
+    "TenantId": "{TENANT ID}",
+    "ClientId": "{API CLIENT ID}",
+  }
+}
+```
+
+### WeatherForecast controller
+
+The WeatherForecast controller (*Controllers/WeatherForecastController.cs*) exposes a protected API with the `[Authorize]` attribute applied to the controller. It's **important** to understand that:
+
+* The `[Authorize]` attribute in this API controller is the only thing that protect this API from unauthorized access.
+* The `[Authorize]` attribute used in the Blazor WebAssembly app only serves as a hint to the app that the user should be authorized for the app to work correctly.
+
+```csharp
+[Authorize]
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
+{
+    [HttpGet]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        ...
+    }
+}
+```
+
+## Client app configuration
+
+*This section pertains to the solution's **Client** app.*
+
+### Authentication package
+
+When an app is created to use Work or School Accounts (`SingleOrg`), the app automatically receives a package reference for the [Microsoft Authentication Library](/azure/active-directory/develop/msal-overview) (`Microsoft.Authentication.WebAssembly.Msal`). The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+
+If adding authentication to an app, manually add the package to the app's project file:
+
+```xml
+<PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" 
+    Version="{VERSION}" />
+```
+
+Replace `{VERSION}` in the preceding package reference with the version of the `Microsoft.AspNetCore.Blazor.Templates` package shown in the <xref:blazor/get-started> article.
+
+The `Microsoft.Authentication.WebAssembly.Msal` package transitively adds the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package to the app.
+
+### Authentication service support
+
+Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+
+*Program.cs*:
+
+When the *Client app* is generated, the default access token scope is of the format `api://{SERVER API APP CLIENT ID}/{DEFAULT SCOPE}`. **Remove the `api://` portion of the scope value.** This issue will be addressed in a future preview release.
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    var authentication = options.ProviderOptions.Authentication;
+    authentication.Authority = "https://login.microsoftonline.com/{TENANT ID}";
+    authentication.ClientId = "{CLIENT ID}";
+    options.ProviderOptions.DefaultAccessTokenScopes.Add(
+        "{SERVER API APP CLIENT ID}/{DEFAULT SCOPE}");
+});
+```
+
+> [!NOTE]
+> The default access token scope must be in the format `{SERVER API APP CLIENT ID}/{DEFAULT SCOPE}` (for example, `11111111-1111-1111-1111-111111111111/API.Access`). If a scheme or scheme and host is provided to the scope setting (as shown in the Azure Portal), the *Client app* throws an unhandled exception when it receives a *401 Unauthorized* response from the *Server API app*.
+
+The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Azure Portal AAD configuration when you register the app.
+
+The default access token scopes represent the list of access token scopes that are:
+
+* Included by default in the sign in request.
+* Used to provision an access token immediately after authentication.
+
+All scopes must belong to the same app per Azure Active Directory rules. Additional scopes can be added for additional API apps as needed:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    ...
+    options.ProviderOptions.DefaultAccessTokenScopes.Add(
+        "{SERVER API APP CLIENT ID}/{SCOPE}");
+});
+```
+
+### Index page
+
+[!INCLUDE[](~/includes/blazor-security/index-page.md)]
+
+### App component
+
+[!INCLUDE[](~/includes/blazor-security/app-component.md)]
+
+### RedirectToLogin component
+
+[!INCLUDE[](~/includes/blazor-security/redirecttologin-component.md)]
+
+### LoginDisplay component
+
+[!INCLUDE[](~/includes/blazor-security/logindisplay-component.md)]
+
+### Authentication component
+
+[!INCLUDE[](~/includes/blazor-security/authentication-component.md)]
+
+### FetchData component
+
+[!INCLUDE[](~/includes/blazor-security/fetchdata-component.md)]
+
+[!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
+
+## Additional resources
+
+* <xref:security/authentication/azure-active-directory/index>

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -95,21 +95,21 @@ The <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.Ad
 
 ### WeatherForecastController
 
-In the *Controllers/WeatherForecastController.cs* file, the [`[Authorize]`](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) attribute is applied to the class. The attribute indicates that the user must be authorized based on the default policy to access the resource. The default authorization policy is configured to use the default authentication scheme, which is set up by <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.AddIdentityServerJwt%2A> to the policy scheme that was mentioned earlier. <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerHandler> is configured as the default handler for requests to the app by the helper method.
+In the `WeatherForecastController` (*Controllers/WeatherForecastController.cs*), the [`[Authorize]`](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) attribute is applied to the class. The attribute indicates that the user must be authorized based on the default policy to access the resource. The default authorization policy is configured to use the default authentication scheme, which is set up by <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.AddIdentityServerJwt%2A> to the policy scheme that was mentioned earlier. The helper method configures <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerHandler> as the default handler for requests to the app.
 
 ### ApplicationDbContext
 
-In the *Data/ApplicationDbContext.cs* file, the same <xref:Microsoft.EntityFrameworkCore.DbContext> is used in Identity with the exception that it extends <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> to include the schema for IdentityServer. <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> is a more derived class from <xref:Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext>.
+In the `ApplicationDbContext` (*Data/ApplicationDbContext.cs*), the same <xref:Microsoft.EntityFrameworkCore.DbContext> is used in Identity with the exception that it extends <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> to include the schema for IdentityServer. <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> is derived from <xref:Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext>.
 
-To gain full control of the database schema, inherit from one of the available Identity <xref:Microsoft.EntityFrameworkCore.DbContext> classes and configure the context to include the Identity schema by calling `builder.ConfigurePersistedGrantContext(_operationalStoreOptions.Value)` on the `OnModelCreating` method.
+To gain full control of the database schema, inherit from one of the available Identity <xref:Microsoft.EntityFrameworkCore.DbContext> classes and configure the context to include the Identity schema by calling `builder.ConfigurePersistedGrantContext(_operationalStoreOptions.Value)` in the `OnModelCreating` method.
 
 ### OidcConfigurationController
 
-In the *Controllers/OidcConfigurationController.cs* file, notice the endpoint that's provisioned to serve the OIDC parameters that the client needs to use.
+In the `OidcConfigurationController` (*Controllers/OidcConfigurationController.cs*), the client endpoint is provisioned to serve OIDC parameters.
 
-### appsettings.json
+### App settings files
 
-In the *appsettings.json* file of the project root, there's a new `IdentityServer` section that describes the list of configured clients. In the following example, there's a single client. The client name corresponds to the app name and is mapped by convention to the OAuth `ClientId` parameter. The profile indicates the app type being configured. It's used internally to drive conventions that simplify the configuration process for the server. <!-- There are several profiles available, as explained in the [Application profiles](#application-profiles) section. -->
+In the app settings file (*appsettings.json*) at the project root, the `IdentityServer` section describes the list of configured clients. In the following example, there's a single client. The client name corresponds to the app name and is mapped by convention to the OAuth `ClientId` parameter. The profile indicates the app type being configured. The profile is used internally to drive conventions that simplify the configuration process for the server. <!-- There are several profiles available, as explained in the [Application profiles](#application-profiles) section. -->
 
 ```json
 "IdentityServer": {
@@ -121,9 +121,7 @@ In the *appsettings.json* file of the project root, there's a new `IdentityServe
 }
 ```
 
-### appsettings.Development.json
-
-In the *appsettings.Development.json* file of the project root, there's an `IdentityServer` section that describes the key used to sign tokens. <!-- When deploying to production, a key needs to be provisioned and deployed alongside the app, as explained in the [Deploy to production](#deploy-to-production) section. -->
+In the Development environment app settings file (*appsettings.Development.json*) at the project root, the `IdentityServer` section describes the key used to sign tokens. <!-- When deploying to production, a key needs to be provisioned and deployed alongside the app, as explained in the [Deploy to production](#deploy-to-production) section. -->
 
 ```json
 "IdentityServer": {

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -1,7 +1,7 @@
 ---
 title: Secure an ASP.NET Core Blazor WebAssembly hosted app with Identity Server
 author: guardrex
-description: 
+description: To create a new Blazor hosted app with authentication from within Visual Studio that uses an [IdentityServer](https://identityserver.io/) backend
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
@@ -17,15 +17,15 @@ By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https
 
 [!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
 
-To create a new Blazor hosted application with authentication from within Visual Studio:
+To create a new Blazor hosted app in Visual Studio that uses [IdentityServer](https://identityserver.io/) to authenticate users and API calls:
 
-1. Use Visual Studio to create a new **Blazor WebAssembly** app.
+1. Use Visual Studio to create a new **Blazor WebAssembly** app. For more information, see <xref:blazor/get-started>.
 1. In the **Create a new Blazor app** dialog, select **Change** in the **Authentication** section.
 1. Select **Individual User Accounts** followed by **OK**.
 1. Select the **ASP.NET Core hosted** checkbox in the **Advanced** section.
 1. Select the **Create** button.
 
-To create this project from a command shell, execute the following command:
+To create the app in a command shell, execute the following command:
 
 ```dotnetcli
 dotnet new blazorwasm -au Individual -ho
@@ -41,7 +41,7 @@ The following sections describe additions to the project when authentication sup
 
 The `Startup` class has the following additions:
 
-* Inside the `Startup.ConfigureServices` method:
+* In `Startup.ConfigureServices`:
 
   * Identity with the default UI:
 
@@ -54,21 +54,21 @@ The `Startup` class has the following additions:
         .AddEntityFrameworkStores<ApplicationDbContext>();
     ```
 
-  * IdentityServer with an additional `AddApiAuthorization` helper method that sets up some default ASP.NET Core conventions on top of IdentityServer:
+  * IdentityServer with an additional <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method that sets up some default ASP.NET Core conventions on top of IdentityServer:
 
     ```csharp
     services.AddIdentityServer()
         .AddApiAuthorization<ApplicationUser, ApplicationDbContext>();
     ```
 
-  * Authentication with an additional `AddIdentityServerJwt` helper method that configures the app to validate JWT tokens produced by IdentityServer:
+  * Authentication with an additional <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.AddIdentityServerJwt%2A> helper method that configures the app to validate JWT tokens produced by IdentityServer:
 
     ```csharp
     services.AddAuthentication()
         .AddIdentityServerJwt();
     ```
 
-* Inside the `Startup.Configure` method:
+* In `Startup.Configure`:
 
   * The authentication middleware that is responsible for validating the request credentials and setting the user on the request context:
 
@@ -76,7 +76,7 @@ The `Startup` class has the following additions:
     app.UseAuthentication();
     ```
 
-  * The IdentityServer middleware that exposes the Open ID Connect endpoints:
+  * The IdentityServer middleware that exposes the Open ID Connect (OIDC) endpoints:
 
     ```csharp
     app.UseIdentityServer();
@@ -84,25 +84,28 @@ The `Startup` class has the following additions:
 
 ### AddApiAuthorization
 
-This helper method configures IdentityServer to use our supported configuration. IdentityServer is a powerful and extensible framework for handling app security concerns. At the same time, that exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided to you that are considered a good starting point. Once your authentication needs change, the full power of IdentityServer is still available to customize authentication to suit your needs.
+The <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method configures [IdentityServer](https://identityserver.io/) for ASP.NET Core scenarios. IdentityServer is a powerful and extensible framework for handling app security concerns. IdentityServer exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided that we consider a good starting point. Once your authentication needs change, the full power of IdentityServer is still available to customize authentication to suit an app's requirements.
 
 ### AddIdentityServerJwt
 
-This helper method configures a policy scheme for the app as the default authentication handler. The policy is configured to let Identity handle all requests routed to any subpath in the Identity URL space "/Identity". The `JwtBearerHandler` handles all other requests. Additionally, this method registers an `{APPLICATION NAME}API` API resource with IdentityServer with a default scope of `{APPLICATION NAME}API` and configures the JWT Bearer token middleware to validate tokens issued by IdentityServer for the app.
+The <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.AddIdentityServerJwt%2A> helper method configures a policy scheme for the app as the default authentication handler. The policy is configured to allow Identity to handle all requests routed to any subpath in the Identity URL space `/Identity`. The <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerHandler> handles all other requests. Additionally, this method:
+
+* Registers an `{APPLICATION NAME}API` API resource with IdentityServer with a default scope of `{APPLICATION NAME}API`.
+* Configures the JWT Bearer Token Middleware to validate tokens issued by IdentityServer for the app.
 
 ### WeatherForecastController
 
-In the *Controllers\WeatherForecastController.cs* file, notice the `[Authorize]` attribute applied to the class that indicates that the user needs to be authorized based on the default policy to access the resource. The default authorization policy happens to be configured to use the default authentication scheme, which is set up by `AddIdentityServerJwt` to the policy scheme that was mentioned above, making the `JwtBearerHandler` configured by such helper method the default handler for requests to the app.
+In the *Controllers/WeatherForecastController.cs* file, the [`[Authorize]`](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) attribute is applied to the class. The attribute indicates that the user must be authorized based on the default policy to access the resource. The default authorization policy is configured to use the default authentication scheme, which is set up by <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.AddIdentityServerJwt%2A> to the policy scheme that was mentioned earlier. <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerHandler> is configured as the default handler for requests to the app by the helper method.
 
 ### ApplicationDbContext
 
-In the *Data\ApplicationDbContext.cs* file, notice the same `DbContext` is used in Identity with the exception that it extends `ApiAuthorizationDbContext` (a more derived class from `IdentityDbContext`) to include the schema for IdentityServer.
+In the *Data/ApplicationDbContext.cs* file, the same <xref:Microsoft.EntityFrameworkCore.DbContext> is used in Identity with the exception that it extends <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> to include the schema for IdentityServer. <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> is a more derived class from <xref:Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext>.
 
-To gain full control of the database schema, inherit from one of the available Identity `DbContext` classes and configure the context to include the Identity schema by calling `builder.ConfigurePersistedGrantContext(_operationalStoreOptions.Value)` on the `OnModelCreating` method.
+To gain full control of the database schema, inherit from one of the available Identity <xref:Microsoft.EntityFrameworkCore.DbContext> classes and configure the context to include the Identity schema by calling `builder.ConfigurePersistedGrantContext(_operationalStoreOptions.Value)` on the `OnModelCreating` method.
 
 ### OidcConfigurationController
 
-In the *Controllers\OidcConfigurationController.cs* file, notice the endpoint that's provisioned to serve the OIDC parameters that the client needs to use.
+In the *Controllers/OidcConfigurationController.cs* file, notice the endpoint that's provisioned to serve the OIDC parameters that the client needs to use.
 
 ### appsettings.json
 
@@ -134,7 +137,7 @@ In the *appsettings.Development.json* file of the project root, there's an `Iden
 
 ### Authentication package
 
-When an app is created to use Individual User Accounts, the app automatically receives a package reference for the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package in the app's project file. The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+When an app is created to use Individual User Accounts (`Individual`), the app automatically receives a package reference for the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package in the app's project file. The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
 
 If adding authentication to an app, manually add the package to the app's project file:
 
@@ -148,13 +151,13 @@ Replace `{VERSION}` in the preceding package reference with the version of the `
 
 ### API authorization support
 
-The support for authenticating users is plugged into the service container by the extension method provided inside the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package. This method sets up all the services needed for the application to interact with the existing authorization system.
+The support for authenticating users is plugged into the service container by the extension method provided inside the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package. This method sets up all the services needed for the app to interact with the existing authorization system.
 
 ```csharp
 builder.Services.AddApiAuthorization();
 ```
 
-By default, it loads the configuration for the application by convention from `_configuration/{client-id}`. The client ID used by convention is the application assembly name. This url can be changed to point to a separate endpoint by calling the overload with options.
+By default, it loads the configuration for the app by convention from `_configuration/{client-id}`. By convention, the client ID is set to the app's assembly name. This URL can be changed to point to a separate endpoint by calling the overload with options.
 
 ### Index page
 
@@ -175,7 +178,7 @@ The `LoginDisplay` component (*Shared/LoginDisplay.razor*) is rendered in the `M
 * For authenticated users:
   * Displays the current user name.
   * Offers a link to the user profile page in ASP.NET Core Identity.
-  * Offers a button to log out of the application.
+  * Offers a button to log out of the app.
 * For anonymous users:
   * Offers the option to register.
   * Offers the option to log in.
@@ -199,7 +202,7 @@ The `LoginDisplay` component (*Shared/LoginDisplay.razor*) is rendered in the `M
     </NotAuthorized>
 </AuthorizeView>
 
-@code{
+@code {
     private async Task BeginSignOut(MouseEventArgs args)
     {
         await SignOutManager.SetSignOutState();

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -1,0 +1,219 @@
+---
+title: Secure an ASP.NET Core Blazor WebAssembly hosted app with Identity Server
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/hosted-with-identity-server
+---
+# Secure an ASP.NET Core Blazor WebAssembly hosted app with Identity Server
+
+By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+To create a new Blazor hosted application with authentication from within Visual Studio:
+
+1. Use Visual Studio to create a new **Blazor WebAssembly** app.
+1. In the **Create a new Blazor app** dialog, select **Change** in the **Authentication** section.
+1. Select **Individual User Accounts** followed by **OK**.
+1. Select the **ASP.NET Core hosted** checkbox in the **Advanced** section.
+1. Select the **Create** button.
+
+To create this project from a command shell, execute the following command:
+
+```dotnetcli
+dotnet new blazorwasm -au Individual -ho
+```
+
+To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+## Server app configuration
+
+The following sections describe additions to the project when authentication support is included.
+
+### Startup class
+
+The `Startup` class has the following additions:
+
+* Inside the `Startup.ConfigureServices` method:
+
+  * Identity with the default UI:
+
+    ```csharp
+    services.AddDbContext<ApplicationDbContext>(options =>
+        options.UseSqlite(Configuration.GetConnectionString("DefaultConnection")));
+
+    services.AddDefaultIdentity<ApplicationUser>()
+        .AddDefaultUI(UIFramework.Bootstrap4)
+        .AddEntityFrameworkStores<ApplicationDbContext>();
+    ```
+
+  * IdentityServer with an additional `AddApiAuthorization` helper method that sets up some default ASP.NET Core conventions on top of IdentityServer:
+
+    ```csharp
+    services.AddIdentityServer()
+        .AddApiAuthorization<ApplicationUser, ApplicationDbContext>();
+    ```
+
+  * Authentication with an additional `AddIdentityServerJwt` helper method that configures the app to validate JWT tokens produced by IdentityServer:
+
+    ```csharp
+    services.AddAuthentication()
+        .AddIdentityServerJwt();
+    ```
+
+* Inside the `Startup.Configure` method:
+
+  * The authentication middleware that is responsible for validating the request credentials and setting the user on the request context:
+
+    ```csharp
+    app.UseAuthentication();
+    ```
+
+  * The IdentityServer middleware that exposes the Open ID Connect endpoints:
+
+    ```csharp
+    app.UseIdentityServer();
+    ```
+
+### AddApiAuthorization
+
+This helper method configures IdentityServer to use our supported configuration. IdentityServer is a powerful and extensible framework for handling app security concerns. At the same time, that exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided to you that are considered a good starting point. Once your authentication needs change, the full power of IdentityServer is still available to customize authentication to suit your needs.
+
+### AddIdentityServerJwt
+
+This helper method configures a policy scheme for the app as the default authentication handler. The policy is configured to let Identity handle all requests routed to any subpath in the Identity URL space "/Identity". The `JwtBearerHandler` handles all other requests. Additionally, this method registers an `{APPLICATION NAME}API` API resource with IdentityServer with a default scope of `{APPLICATION NAME}API` and configures the JWT Bearer token middleware to validate tokens issued by IdentityServer for the app.
+
+### WeatherForecastController
+
+In the *Controllers\WeatherForecastController.cs* file, notice the `[Authorize]` attribute applied to the class that indicates that the user needs to be authorized based on the default policy to access the resource. The default authorization policy happens to be configured to use the default authentication scheme, which is set up by `AddIdentityServerJwt` to the policy scheme that was mentioned above, making the `JwtBearerHandler` configured by such helper method the default handler for requests to the app.
+
+### ApplicationDbContext
+
+In the *Data\ApplicationDbContext.cs* file, notice the same `DbContext` is used in Identity with the exception that it extends `ApiAuthorizationDbContext` (a more derived class from `IdentityDbContext`) to include the schema for IdentityServer.
+
+To gain full control of the database schema, inherit from one of the available Identity `DbContext` classes and configure the context to include the Identity schema by calling `builder.ConfigurePersistedGrantContext(_operationalStoreOptions.Value)` on the `OnModelCreating` method.
+
+### OidcConfigurationController
+
+In the *Controllers\OidcConfigurationController.cs* file, notice the endpoint that's provisioned to serve the OIDC parameters that the client needs to use.
+
+### appsettings.json
+
+In the *appsettings.json* file of the project root, there's a new `IdentityServer` section that describes the list of configured clients. In the following example, there's a single client. The client name corresponds to the app name and is mapped by convention to the OAuth `ClientId` parameter. The profile indicates the app type being configured. It's used internally to drive conventions that simplify the configuration process for the server. <!-- There are several profiles available, as explained in the [Application profiles](#application-profiles) section. -->
+
+```json
+"IdentityServer": {
+  "Clients": {
+    "BlazorApplicationWithAuthentication.Client": {
+      "Profile": "IdentityServerSPA"
+    }
+  }
+}
+```
+
+### appsettings.Development.json
+
+In the *appsettings.Development.json* file of the project root, there's an `IdentityServer` section that describes the key used to sign tokens. <!-- When deploying to production, a key needs to be provisioned and deployed alongside the app, as explained in the [Deploy to production](#deploy-to-production) section. -->
+
+```json
+"IdentityServer": {
+  "Key": {
+    "Type": "Development"
+  }
+}
+```
+
+## Client app configuration
+
+### Authentication package
+
+When an app is created to use Individual User Accounts, the app automatically receives a package reference for the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package in the app's project file. The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+
+If adding authentication to an app, manually add the package to the app's project file:
+
+```xml
+<PackageReference 
+    Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" 
+    Version="{VERSION}" />
+```
+
+Replace `{VERSION}` in the preceding package reference with the version of the `Microsoft.AspNetCore.Blazor.Templates` package shown in the <xref:blazor/get-started> article.
+
+### API authorization support
+
+The support for authenticating users is plugged into the service container by the extension method provided inside the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package. This method sets up all the services needed for the application to interact with the existing authorization system.
+
+```csharp
+builder.Services.AddApiAuthorization();
+```
+
+By default, it loads the configuration for the application by convention from `_configuration/{client-id}`. The client ID used by convention is the application assembly name. This url can be changed to point to a separate endpoint by calling the overload with options.
+
+### Index page
+
+[!INCLUDE[](~/includes/blazor-security/index-page.md)]
+
+### App component
+
+[!INCLUDE[](~/includes/blazor-security/app-component.md)]
+
+### RedirectToLogin component
+
+[!INCLUDE[](~/includes/blazor-security/redirecttologin-component.md)]
+
+### LoginDisplay component
+
+The `LoginDisplay` component (*Shared/LoginDisplay.razor*) is rendered in the `MainLayout` component (*Shared/MainLayout.razor*) and manages the following behaviors:
+
+* For authenticated users:
+  * Displays the current user name.
+  * Offers a link to the user profile page in ASP.NET Core Identity.
+  * Offers a button to log out of the application.
+* For anonymous users:
+  * Offers the option to register.
+  * Offers the option to log in.
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+@inject NavigationManager Navigation
+@inject SignOutSessionStateManager SignOutManager
+
+<AuthorizeView>
+    <Authorized>
+        <a href="authentication/profile">Hello, @context.User.Identity.Name!</a>
+        <button class="nav-link btn btn-link" @onclick="BeginSignOut">
+            Log out
+        </button>
+    </Authorized>
+    <NotAuthorized>
+        <a href="authentication/register">Register</a>
+        <a href="authentication/login">Log in</a>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code{
+    private async Task BeginSignOut(MouseEventArgs args)
+    {
+        await SignOutManager.SetSignOutState();
+        Navigation.NavigateTo("authentication/logout");
+    }
+}
+```
+
+### Authentication component
+
+[!INCLUDE[](~/includes/blazor-security/authentication-component.md)]
+
+### FetchData component
+
+[!INCLUDE[](~/includes/blazor-security/fetchdata-component.md)]
+
+[!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]

--- a/aspnetcore/security/blazor/webassembly/index.md
+++ b/aspnetcore/security/blazor/webassembly/index.md
@@ -1,0 +1,48 @@
+---
+title: Secure ASP.NET Core Blazor WebAssembly
+author: guardrex
+description: Learn how to secure Blazor WebAssemlby apps as Single Page Applications (SPAs).
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/index
+---
+# Secure ASP.NET Core Blazor WebAssembly
+
+By [Javier Calvarro Nelson](https://github.com/javiercn)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+Blazor WebAssembly apps are secured in the same manner as Single Page Applications (SPAs). There are several approaches for authenticating users to SPAs, but the most common and comprehensive approach is to use an implementation based on the [oAuth 2.0 protocol](https://oauth.net/), such as [Open ID Connect (OIDC)](https://openid.net/connect/).
+
+## Authentication library
+
+Blazor WebAssembly supports authenticating and authorizing apps using OIDC via the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` library. The library provides a set of primitives for seamlessly authenticating against ASP.NET Core backends. The library integrates ASP.NET Core Identity with API authorization support built on top of [Identity Server](https://identityserver.io/). The library can authenticate against any third-party Identity Provider (IP) that supports OIDC, which are called OpenID Providers (OP).
+
+The authentication support in Blazor WebAssembly is built on top of the *oidc-client.js* library, which is used to handle the underlying authentication protocol details.
+
+Other options for authenticating SPAs exist, such as the use of SameSite cookies. However, the engineering design of Blazor WebAssembly is settled on oAuth and OIDC as the best option for authentication in Blazor WebAssembly apps. [Token-based authentication](xref:security/anti-request-forgery#token-based-authentication) based on [JSON Web Tokens (JWTs)](https://self-issued.info/docs/draft-ietf-oauth-json-web-token.html) was chosen over [cookie-based authentication](xref:security/anti-request-forgery#cookie-based-authentication) for functional and security reasons:
+
+* Using a token-based protocol offers a smaller attack surface area, as the tokens aren't sent in all requests.
+* Server endpoints don't require protection against [Cross-Site Request Forgery (CSRF)](xref:security/anti-request-forgery) because the tokens are sent explicitly. This allows you to host Blazor WebAssembly apps alongside MVC or Razor pages apps.
+* Tokens have narrower permissions than cookies. For example, tokens can't be used to manage the user account or change a user's password unless such functionality is explicitly implemented.
+* Tokens have a short lifetime, one hour by default, which limits the attack window. Tokens can also be revoked at any time.
+* Self-contained JWTs offer guarantees to the client and server about the authentication process. For example, a client has the means to detect and validate that the tokens it receives are legitimate and were emitted as part a given authentication process. If a third party attempts to switch a token in the middle of the authentication process, the client can detect the switched token and avoid using it.
+* Tokens with oAuth and OIDC don't rely on the user agent behaving correctly to ensure that the app is secure.
+* Token-based protocols, such as oAuth and OIDC, allow for authenticating and authorizing hosted and standalone apps with the same set of security characteristics.
+
+## Authentication process with OIDC
+
+The `Microsoft.AspNetCore.Components.WebAssembly.Authentication` library offers several primitives to implement authentication and authorization using OIDC. In broad terms, authentication works as follows:
+
+* When an anonymous user selects the login button or requests a page with the [`[Authorize]`](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) attribute applied, the user is redirected to the app's login page (`/authentication/login`).
+* In the login page, the authentication library prepares for a redirect to the authorization endpoint. The authorization endpoint is outside of the Blazor WebAssembly app and can be hosted at a separate origin. The endpoint is responsible for determining whether the user is authenticated and for issuing one or more tokens in response. The authentication library provides a login callback to receive the authentication response.
+  * If the user isn't authenticated, the user is redirected to the underlying authentication system, which is usually ASP.NET Core Identity.
+  * If the user was already authenticated, the authorization endpoint generates the appropriate tokens and redirects the browser back to the login callback endpoint (`/authentication/login-callback`).
+* When the Blazor WebAssembly app loads the login callback endpoint (`/authentication/login-callback`), the authentication response is processed.
+  * If the authentication process completes successfully, the user is authenticated and optionally sent back to the original protected URL that the user requested.
+  * If the authentication process fails for any reason, the user is sent to the login failed page (`/authentication/login-failed`), and an error is displayed.

--- a/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
@@ -1,0 +1,80 @@
+---
+title: Secure an ASP.NET Core Blazor WebAssembly standalone app with the Authentication library
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/standalone-with-authentication-library
+---
+# Secure an ASP.NET Core Blazor WebAssembly standalone app with the Authentication library
+
+By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+To create a Blazor WebAssembly standalone app that uses `Microsoft.AspNetCore.Components.WebAssembly.Authentication` library, execute the following command in a command shell:
+
+```dotnetcli
+dotnet new blazorwasm -au Individual
+```
+
+To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+In Visual Studio, [create a Blazor WebAssembly app](xref:blazor/get-started). Set **Authentication** to **Individual User Accounts** with the **Store user accounts in-app** option.
+
+## Authentication package
+
+When an app is created to use Individual User Accounts, the app automatically receives a package reference for the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package in the app's project file. The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+
+If adding authentication to an app, manually add the package to the app's project file:
+
+```xml
+<PackageReference 
+    Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" 
+    Version="{VERSION}" />
+```
+
+Replace `{VERSION}` in the preceding package reference with the version of the `Microsoft.AspNetCore.Blazor.Templates` package shown in the <xref:blazor/get-started> article.
+
+## Authentication service support
+
+Support for authenticating users is registered in the service container with the `AddOidcAuthentication` extension method provided by the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+
+*Program.cs*:
+
+```csharp
+builder.Services.AddOidcAuthentication(options =>
+{
+    options.ProviderOptions.Authority = "{AUTHORITY}";
+    options.ProviderOptions.ClientId = "{CLIENT ID}";
+});
+```
+
+Authentication support for standalone apps is offered using Open ID Connect (OIDC). The `AddOidcAuthentication` method accepts a callback to configure the parameters required to authenticate an app using OIDC. The values required for configuring the app can be obtained from the IP, such as Google, Microsoft, or other OIDC-compliant provider. Obtain the values when you register the app, which typically occurs in their online portal.
+
+## Index page
+
+[!INCLUDE[](~/includes/blazor-security/index-page.md)]
+
+## App component
+
+[!INCLUDE[](~/includes/blazor-security/app-component.md)]
+
+## RedirectToLogin component
+
+[!INCLUDE[](~/includes/blazor-security/redirecttologin-component.md)]
+
+## LoginDisplay component
+
+[!INCLUDE[](~/includes/blazor-security/logindisplay-component.md)]
+
+## Authentication component
+
+[!INCLUDE[](~/includes/blazor-security/authentication-component.md)]
+
+[!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -1,0 +1,119 @@
+---
+title: Secure an ASP.NET Core Blazor WebAssembly standalone app with Azure Active Directory B2C
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/standalone-with-azure-active-directory-b2c
+---
+# Secure an ASP.NET Core Blazor WebAssembly standalone app with Azure Active Directory B2C
+
+By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+To create a Blazor WebAssembly standalone app that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication:
+
+1. Follow the guidance in the following topics to create a tenant and register a web app in the Azure Portal:
+
+   * [Create an AAD B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant) &ndash; Record the following information:
+
+     1\. AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash)<br>
+     2\. AAD B2C Tenant domain (for example, `contoso.onmicrosoft.com`)
+
+   * [Register a web application](/azure/active-directory-b2c/tutorial-register-applications) &ndash; Make the following selections during app registration:
+
+     1\. Set **Web App / Web API** to **Yes**.<br>
+     2\. Set **Allow implicit flow** to **Yes**.<br>
+     3\. Add a **Reply URL** of `https://localhost:5001/authentication/login-callback`.
+
+     Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
+
+   * [Create user flows](/azure/active-directory-b2c/tutorial-create-user-flows) & ndash; Create a sign-up and sign-in user flow.
+
+     Record the sign-up and sign-in user flow name created for the app (for example, `B2C_1_signupsignin`).
+
+1. Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+
+   ```dotnetcli
+   dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --client-id "{CLIENT ID}" --domain "{DOMAIN}" -ssp "{SIGN UP OR SIGN IN POLICY}"
+   ```
+
+   To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+## Authentication package
+
+When an app is created to use an Individual B2C Account (`IndividualB2C`), the app automatically receives a package reference for the [Microsoft Authentication Library](/azure/active-directory/develop/msal-overview) (`Microsoft.Authentication.WebAssembly.Msal`). The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+
+If adding authentication to an app, manually add the package to the app's project file:
+
+```xml
+<PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" 
+    Version="{VERSION}" />
+```
+
+Replace `{VERSION}` in the preceding package reference with the version of the `Microsoft.AspNetCore.Blazor.Templates` package shown in the <xref:blazor/get-started> article.
+
+The `Microsoft.Authentication.WebAssembly.Msal` package transitively adds the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package to the app.
+
+## Authentication service support
+
+Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+
+*Program.cs*:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    var authentication = options.ProviderOptions.Authentication;
+    authentication.Authority = 
+        "{AAD B2C INSTANCE}{DOMAIN}/{SIGN UP OR SIGN IN POLICY}";
+    authentication.ClientId = "{CLIENT ID}";
+    authentication.ValidateAuthority = false;
+});
+```
+
+The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Azure Portal AAD configuration when you register the app.
+
+The Blazor WebAssembly template doesn't automatically configure the app to request an access token for a secure API. To provision a token as part of the sign-in flow, add the scope to the default access token scopes of the `MsalProviderOptions`:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    ...
+    options.ProviderOptions.DefaultAccessTokenScopes.Add(
+        "{API ID URI}/{SCOPE}");
+});
+```
+
+## Index page
+
+[!INCLUDE[](~/includes/blazor-security/index-page.md)]
+
+## App component
+
+[!INCLUDE[](~/includes/blazor-security/app-component.md)]
+
+## RedirectToLogin component
+
+[!INCLUDE[](~/includes/blazor-security/redirecttologin-component.md)]
+
+## LoginDisplay component
+
+[!INCLUDE[](~/includes/blazor-security/logindisplay-component.md)]
+
+## Authentication component
+
+[!INCLUDE[](~/includes/blazor-security/authentication-component.md)]
+
+[!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
+
+## Additional resources
+
+* <xref:security/authentication/azure-ad-b2c>
+* [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
@@ -1,0 +1,122 @@
+---
+title: Secure an ASP.NET Core Blazor WebAssembly standalone app with Azure Active Directory
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/standalone-with-azure-active-directory
+---
+# Secure an ASP.NET Core Blazor WebAssembly standalone app with Azure Active Directory
+
+By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+To create a Blazor WebAssembly standalone app that uses [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) for authentication:
+
+[Create an AAD tenant and web application](/azure/active-directory/develop/v2-overview):
+
+Register a AAD app in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+
+1. Provide a **Name** for the app (for example, **Blazor Client AAD**).
+1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** for this experience.
+1. Leave the **Redirect URI** drop down set to **Web**, and provide a redirect URI of `https://localhost:5001/authentication/login-callback`.
+1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
+1. Select **Register**.
+
+In **Authentication** > **Platform configurations** > **Web**:
+
+1. Confirm the **Redirect URI** of `https://localhost:5001/authentication/login-callback` is present.
+1. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.
+1. The remaining defaults for the app are acceptable for this experience.
+1. Select the **Save** button.
+
+Record the following information:
+
+* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
+* Directory ID (Tenant ID) (for example, `22222222-2222-2222-2222-222222222222`)
+
+Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+
+```dotnetcli
+dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" --tenant-id "{TENANT ID}"
+```
+
+To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+## Authentication package
+
+When an app is created to use Work or School Accounts (`SingleOrg`), the app automatically receives a package reference for the [Microsoft Authentication Library](/azure/active-directory/develop/msal-overview) (`Microsoft.Authentication.WebAssembly.Msal`). The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+
+If adding authentication to an app, manually add the package to the app's project file:
+
+```xml
+<PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" 
+    Version="{VERSION}" />
+```
+
+Replace `{VERSION}` in the preceding package reference with the version of the `Microsoft.AspNetCore.Blazor.Templates` package shown in the <xref:blazor/get-started> article.
+
+The `Microsoft.Authentication.WebAssembly.Msal` package transitively adds the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package to the app.
+
+## Authentication service support
+
+Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+
+*Program.cs*:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    var authentication = options.ProviderOptions.Authentication;
+    authentication.Authority = "https://login.microsoftonline.com/{TENANT ID}";
+    authentication.ClientId = "{CLIENT ID}";
+});
+```
+
+The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Azure Portal AAD configuration when you register the app.
+
+The Blazor WebAssembly template doesn't automatically configure the app to request an access token for a secure API. To provision a token as part of the sign-in flow, add the scope to the default access token scopes of the `MsalProviderOptions`:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    ...
+    options.ProviderOptions.DefaultAccessTokenScopes.Add(
+        "{SERVER API APP CLIENT ID}/{DEFAULT SCOPE}");
+});
+```
+
+> [!NOTE]
+> The default access token scope must be in the format `{SERVER API APP CLIENT ID}/{DEFAULT SCOPE}` (for example, `11111111-1111-1111-1111-111111111111/API.Access`). If a scheme or scheme and host is provided to the scope setting (as shown in the Azure Portal), the *Client app* throws an unhandled exception when it receives a *401 Unauthorized* response from the *Server API app*.
+
+## Index page
+
+[!INCLUDE[](~/includes/blazor-security/index-page.md)]
+
+## App component
+
+[!INCLUDE[](~/includes/blazor-security/app-component.md)]
+
+## RedirectToLogin component
+
+[!INCLUDE[](~/includes/blazor-security/redirecttologin-component.md)]
+
+## LoginDisplay component
+
+[!INCLUDE[](~/includes/blazor-security/logindisplay-component.md)]
+
+## Authentication component
+
+[!INCLUDE[](~/includes/blazor-security/authentication-component.md)]
+
+[!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
+
+## Additional resources
+
+* <xref:security/authentication/azure-active-directory/index>

--- a/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
@@ -1,0 +1,111 @@
+---
+title: Secure an ASP.NET Core Blazor WebAssembly standalone app with Microsoft Accounts
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/09/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/webassembly/standalone-with-microsoft-accounts
+---
+# Secure an ASP.NET Core Blazor WebAssembly standalone app with Microsoft Accounts
+
+By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
+
+[!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
+
+To create a Blazor WebAssembly standalone app that uses [Microsoft Accounts with Azure Active Directory (AAD)](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal) for authentication:
+
+1. [Create an AAD tenant and web application](/azure/active-directory/develop/v2-overview)
+
+   Register a AAD app in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+
+   1\. Provide a **Name** for the app (for example, **Blazor Client AAD**).<br>
+   2\. In **Supported account types**, select **Accounts in any organizational directory**.<br>
+   3\. Leave the **Redirect URI** drop down set to **Web**, and provide a redirect URI of `https://localhost:5001/authentication/login-callback`.<br>
+   4\. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.<br>
+   5\. Select **Register**.
+
+   In **Authentication** > **Platform configurations** > **Web**:
+
+   1\. Confirm the **Redirect URI** of `https://localhost:5001/authentication/login-callback` is present.<br>
+   2\. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.<br>
+   3\. The remaining defaults for the app are acceptable for this experience.<br>
+   4\. Select the **Save** button.
+
+   Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
+
+1. Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+
+   ```dotnetcli
+   dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" --tenant-id "common"
+   ```
+
+   To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+After creating the app, you should be able to:
+
+* Log into the app using a Microsoft Account.
+* Request access tokens for Microsoft APIs using the same approach as for standalone Blazor apps provided that you have configured the app correctly. For more information, see [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis).
+
+## Authentication package
+
+When an app is created to use Work or School Accounts (`SingleOrg`), the app automatically receives a package reference for the [Microsoft Authentication Library](/azure/active-directory/develop/msal-overview) (`Microsoft.Authentication.WebAssembly.Msal`). The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+
+If adding authentication to an app, manually add the package to the app's project file:
+
+```xml
+<PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" 
+    Version="{VERSION}" />
+```
+
+Replace `{VERSION}` in the preceding package reference with the version of the `Microsoft.AspNetCore.Blazor.Templates` package shown in the <xref:blazor/get-started> article.
+
+The `Microsoft.Authentication.WebAssembly.Msal` package transitively adds the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package to the app.
+
+## Authentication service support
+
+Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+
+*Program.cs*:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    var authentication = options.ProviderOptions.Authentication;
+    authentication.Authority = "{AUTHORITY}";
+    authentication.ClientId = "{CLIENT ID}";
+});
+```
+
+The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Microsoft Accounts configuration when you register the app.
+
+## Index page
+
+[!INCLUDE[](~/includes/blazor-security/index-page.md)]
+
+## App component
+
+[!INCLUDE[](~/includes/blazor-security/app-component.md)]
+
+## RedirectToLogin component
+
+[!INCLUDE[](~/includes/blazor-security/redirecttologin-component.md)]
+
+## LoginDisplay component
+
+[!INCLUDE[](~/includes/blazor-security/logindisplay-component.md)]
+
+## Authentication component
+
+[!INCLUDE[](~/includes/blazor-security/authentication-component.md)]
+
+[!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
+
+## Additional resources
+
+* [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal)
+* [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -346,7 +346,7 @@
                 - name: Hosted with AAD B2C
                   uid: security/blazor/webassembly/hosted-with-azure-active-directory-b2c
                 - name: Additional scenarios
-                  uid: security/blazor/webassembly/additional-scnearios
+                  uid: security/blazor/webassembly/additional-scenarios
             - name: Blazor Server
               uid: security/blazor/server
             - name: Content Security Policy
@@ -1125,7 +1125,7 @@
             - name: Hosted with AAD B2C
               uid: security/blazor/webassembly/hosted-with-azure-active-directory-b2c
             - name: Additional scenarios
-              uid: security/blazor/webassembly/additional-scnearios
+              uid: security/blazor/webassembly/additional-scenarios
         - name: Blazor Server
           uid: security/blazor/server
         - name: Content Security Policy

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -327,8 +327,30 @@
           items:
             - name: Overview
               uid: security/blazor/index
+            - name: Blazor WebAssembly
+              items:
+                - name: Overview
+                  uid: security/blazor/webassembly/index
+                - name: Standalone with Authentication library
+                  uid: security/blazor/webassembly/standalone-with-authentication-library
+                - name: Standalone with Microsoft Accounts
+                  uid: security/blazor/webassembly/standalone-with-microsoft-accounts
+                - name: Standalone with AAD
+                  uid: security/blazor/webassembly/standalone-with-azure-active-directory
+                - name: Standalone with AAD B2C
+                  uid: security/blazor/webassembly/standalone-with-azure-active-directory-b2c
+                - name: Hosted with Identity Server
+                  uid: security/blazor/webassembly/hosted-with-identity-server
+                - name: Hosted with AAD
+                  uid: security/blazor/webassembly/hosted-with-azure-active-directory
+                - name: Hosted with AAD B2C
+                  uid: security/blazor/webassembly/hosted-with-azure-active-directory-b2c
+                - name: Additional scenarios
+                  uid: security/blazor/webassembly/additional-scnearios
             - name: Blazor Server
               uid: security/blazor/server
+            - name: Content Security Policy
+              uid: security/blazor/content-security-policy
         - name: State management
           uid: blazor/state-management
         - name: Handle errors
@@ -1084,8 +1106,30 @@
       items:
         - name: Overview
           uid: security/blazor/index
+        - name: Blazor WebAssembly
+          items:
+            - name: Overview
+              uid: security/blazor/webassembly/index
+            - name: Standalone with Authentication library
+              uid: security/blazor/webassembly/standalone-with-authentication-library
+            - name: Standalone with Microsoft Accounts
+              uid: security/blazor/webassembly/standalone-with-microsoft-accounts
+            - name: Standalone with AAD
+              uid: security/blazor/webassembly/standalone-with-azure-active-directory
+            - name: Standalone with AAD B2C
+              uid: security/blazor/webassembly/standalone-with-azure-active-directory-b2c
+            - name: Hosted with Identity Server
+              uid: security/blazor/webassembly/hosted-with-identity-server
+            - name: Hosted with AAD
+              uid: security/blazor/webassembly/hosted-with-azure-active-directory
+            - name: Hosted with AAD B2C
+              uid: security/blazor/webassembly/hosted-with-azure-active-directory-b2c
+            - name: Additional scenarios
+              uid: security/blazor/webassembly/additional-scnearios
         - name: Blazor Server
           uid: security/blazor/server
+        - name: Content Security Policy
+          uid: security/blazor/content-security-policy
 - name: Performance
   items:
     - name: Overview

--- a/aspnetcore/whats-new/2020-02.md
+++ b/aspnetcore/whats-new/2020-02.md
@@ -30,7 +30,7 @@ This article lists some of the significant changes to docs during this period.
   - Split Blazor JS Interop topic
   - Split Razor Components topic
 - [Create and use ASP.NET Core Razor components](../blazor/components.md) - Blazor binding content and layout updates
-- [ASP.NET Core Blazor JavaScript interop](../blazor/javascript-interop.md) - Add content for performing large data transfers in Blazor Server apps
+- [ASP.NET Core Blazor advanced scenarios](../blazor/advanced-scenarios.md) - Add content for performing large data transfers in Blazor Server apps
 
 ## Fundamentals
 


### PR DESCRIPTION
Fixes  #17144

Internal Review Topics

* [Overview](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/index?view=aspnetcore-3.1&branch=pr-en-us-17260)
* [Standalone w/Auth Lib](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/standalone-with-authentication-library?view=aspnetcore-3.1&branch=pr-en-us-17260)
* [Standalone w/AAD](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/standalone-with-azure-active-directory?view=aspnetcore-3.1&branch=pr-en-us-17260)
* [Standalone w/AAD B2C](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/standalone-with-azure-active-directory-b2c?view=aspnetcore-3.1&branch=pr-en-us-17260)
* [Standalone w/MS Accts](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/standalone-with-microsoft-accounts?view=aspnetcore-3.1&branch=pr-en-us-17260)
* [Hosted w/AAD](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/hosted-with-azure-active-directory?view=aspnetcore-3.1&branch=pr-en-us-17260)
* [Hosted w/AAD B2C](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/hosted-with-azure-active-directory-b2c?view=aspnetcore-3.1&branch=pr-en-us-17260)
* [Hosted w/Identity Server](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/hosted-with-identity-server?view=aspnetcore-3.1&branch=pr-en-us-17260)
* [Additional Scenarios](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/additional-scnearios?view=aspnetcore-3.1&branch=pr-en-us-17260)

Notes

* A bit rough ... *rough, rough* 🐕 ... I'll UE pass these topics again later. I didn't have time to test the guidance in *Hosted with Identity Server* topic. Will endeavor to do so in the future.
* Hosted AAD vs. AAD B2C
  * The API ID URI *works as expected* for AAD B2C.
  * The only way API ID URI works for AAD (for *Floridians??* :smile:) is if the scheme and host aren't part of the scope name added to `DefaultAccessTokenScopes`.
  * The Azure Portal does **not** allow me to set/edit the API ID URI. It insists on `https://{DOMAIN}/`, where `{DOMAIN}` is locked into the tenant domain. It recommends the {API CLIENT ID} at the end, which can be changed. I wasn't able to set/use an API ID URI that starts with `api://` for AAD. Even in the AAD B2C case, I can only use the `http://{DOMAIN}/{CLIENT ID}` version. *There's some strange stuff going on in the Azure Portal* 👽.
  * I can comment out the AAD steps and **only cross-link to their docs** for now to sidestep this issue. I can come back later, confer with Azure AAD :cat2: to figure it out, and revert back to full instructions after I resolve it. :ear: If we do that tho, readers may hit any number of 💥:cry: scenarios trying to follow their docs, especially this issue with the scope. If they get the same portal+behavior that I'm getting, it took me *HOURS* to figure out how to make it work.
  * Finally, I don't use the B2C area of the portal to configure the Hosted B2C setup. I go with the AAD area of the portal for it. You can't expose the API in the B2C area. Also, they have a link in my version of the portal that cross-links the AAD app registration process in the B2C area, so I think the direction that I took is the direction that they're taking with the portal.
* There are section links in the *Hosted with Identity Server* topic that don't exist. I've commented them out for now ...
  * In *appsettings.json*: `There are several profiles available, as explained in the [Application profiles](#application-profiles) section.`
  * In *appsettings.Development.json*: `When deploying to production, a key needs to be provisioned and deployed alongside the app, as explained in the [Deploy to production](#deploy-to-production) section.`