### PR TITLE
Improve Blazor tutorial guidance

### DIFF
--- a/aspnetcore/tutorials/build-your-first-blazor-app.md
+++ b/aspnetcore/tutorials/build-your-first-blazor-app.md
@@ -5,7 +5,7 @@ description: Build a Blazor app step-by-step.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/13/2020
+ms.date: 03/13/2020
 no-loc: [Blazor]
 uid: tutorials/first-blazor-app
 ---
@@ -17,9 +17,9 @@ By [Daniel Roth](https://github.com/danroth27) and [Luke Latham](https://github.
 
 This tutorial shows you how to build and modify a Blazor app.
 
-Follow the guidance in the <xref:blazor/get-started> article to create a Blazor project for this tutorial. Name the project *ToDoList*.
-
 ## Build components
+
+1. Follow the guidance in the <xref:blazor/get-started> article to create a Blazor project for this tutorial. Name the project *ToDoList*.
 
 1. Browse to each of the app's three pages in the *Pages* folder: Home, Counter, and Fetch data. These pages are implemented by the Razor component files *Index.razor*, *Counter.razor*, and *FetchData.razor*.
 
@@ -126,14 +126,14 @@ An [`@foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop is u
 
 Add a new component to the app that implements a simple todo list.
 
-1. Add an empty file named *Todo.razor* to the app in the *Pages* folder:
+1. Add a new `Todo` Razor component to the app in the *Pages* folder. In Visual Studio, right-click the **Pages** folder and select **Add** > **New Item** > **Razor Component**. Name the component's file *Todo.razor*. In other development environments, add a blank file to the **Pages** folder named *Todo.razor*.
 
 1. Provide the initial markup for the component:
 
    ```razor
    @page "/todo"
 
-   <h1>Todo</h1>
+   <h3>Todo</h3>
    ```
 
 1. Add the `Todo` component to the navigation bar.

--- a/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/ToDo.razor
+++ b/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/ToDo.razor
@@ -1,6 +1,6 @@
 @page "/todo"
 
-<h1>Todo (@todos.Count(todo => !todo.IsDone))</h1>
+<h3>Todo (@todos.Count(todo => !todo.IsDone))</h3>
 
 <ul>
     @foreach (var todo in todos)

--- a/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/ToDo5.razor
+++ b/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/ToDo5.razor
@@ -1,6 +1,6 @@
 @page "/todo"
 
-<h1>Todo</h1>
+<h3>Todo</h3>
 
 <ul>
     @foreach (var todo in todos)

--- a/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/ToDo8.razor
+++ b/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/ToDo8.razor
@@ -1,6 +1,6 @@
 @page "/todo"
 
-<h1>Todo</h1>
+<h3>Todo</h3>
 
 <ul>
     @foreach (var todo in todos)

--- a/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/Todo4.razor
+++ b/aspnetcore/tutorials/build-your-first-blazor-app/samples_snapshot/3.x/Todo4.razor
@@ -1,6 +1,6 @@
 @page "/todo"
 
-<h1>Todo</h1>
+<h3>Todo</h3>
 
 <ul>
     @foreach (var todo in todos)


### PR DESCRIPTION
Fixes #17235 

@JMackey1 - The namespace for the app should have sufficed there. I think you may have accidentally created your `TodoItem` class in the *wwwroot* folder. There's no need to add a namespace if the class is created in the root of the project with either no namespace or a namespace that matches the app's namespace. Otherwise, I've reacted to your feedback on this PR. Thanks again for commenting on the topic.

@danroth27 @mkArtakMSFT Let me *beat a dead* 🐴 here for a sec (*poor horse!*). VS *correctly* uppercases the word "Component" when referring to a "Razor Component." I still cringe when I see it all across our docs as "Razor component" because the word "component" is part of the formal, specific, named entity ... part of the **_proper noun_**. I still suggest using "Razor Component" across the docs to align with every style manual out there, including Chicago.