### PR TITLE
Blazor Razor syntax remark improvements

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -80,8 +80,6 @@ For information on setting an app's base path, see <xref:host-and-deploy/blazor/
 
 Components can include other components by declaring them using HTML element syntax. The markup for using a component looks like an HTML tag where the name of the tag is the component type.
 
-Attribute binding is case sensitive. For example, `@bind` is valid, and `@Bind` is invalid.
-
 The following markup in *Index.razor* renders a `HeadingComponent` instance:
 
 ```razor

--- a/aspnetcore/blazor/data-binding.md
+++ b/aspnetcore/blazor/data-binding.md
@@ -5,7 +5,7 @@ description: Learn about data binding scenarios for components and DOM elements 
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/24/2020
+ms.date: 03/16/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/data-binding
 ---
@@ -13,7 +13,9 @@ uid: blazor/data-binding
 
 By [Luke Latham](https://github.com/guardrex) and [Daniel Roth](https://github.com/danroth27)
 
-Data binding to both components and DOM elements is accomplished with the [`@bind`](xref:mvc/views/razor#bind) attribute. The following example binds a `CurrentValue` property to the text box's value:
+Razor components provide data binding scenarios via an HTML element attribute named [`@bind`](xref:mvc/views/razor#bind) with a field, property, or Razor expression value.
+
+The following example binds the `CurrentValue` property to the text box's value:
 
 ```razor
 <input @bind="CurrentValue" />
@@ -70,6 +72,8 @@ Use `@bind-{ATTRIBUTE}` with `@bind-{ATTRIBUTE}:event` syntax to bind element at
     private string _paragraphStyle = "color:red";
 }
 ```
+
+Attribute binding is case sensitive. For example, `@bind` is valid, and `@Bind` is invalid.
 
 ## Unparsable values
 

--- a/aspnetcore/blazor/data-binding.md
+++ b/aspnetcore/blazor/data-binding.md
@@ -1,7 +1,7 @@
 ---
 title: ASP.NET Core Blazor data binding
 author: guardrex
-description: Learn about data binding scenarios for components and DOM elements in Blazor apps.
+description: Learn about data binding features for components and DOM elements in Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
@@ -13,7 +13,7 @@ uid: blazor/data-binding
 
 By [Luke Latham](https://github.com/guardrex) and [Daniel Roth](https://github.com/danroth27)
 
-Razor components provide data binding scenarios via an HTML element attribute named [`@bind`](xref:mvc/views/razor#bind) with a field, property, or Razor expression value.
+Razor components provide data binding features via an HTML element attribute named [`@bind`](xref:mvc/views/razor#bind) with a field, property, or Razor expression value.
 
 The following example binds the `CurrentValue` property to the text box's value:
 

--- a/aspnetcore/blazor/event-handling.md
+++ b/aspnetcore/blazor/event-handling.md
@@ -1,7 +1,7 @@
 ---
 title: ASP.NET Core Blazor event handling
 author: guardrex
-description: Learn about Blazor's event handling scenarios, including event argument types, event callbacks, and managing default browser events.
+description: Learn about Blazor's event handling features, including event argument types, event callbacks, and managing default browser events.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
@@ -13,7 +13,7 @@ uid: blazor/event-handling
 
 By [Luke Latham](https://github.com/guardrex) and [Daniel Roth](https://github.com/danroth27)
 
-Razor components provide event handling scenarios. For an HTML element attribute named [`@on{EVENT}`](xref:mvc/views/razor#onevent) (for example, `@onclick`) with a delegate-typed value, a Razor component treats the attribute's value as an event handler.
+Razor components provide event handling features. For an HTML element attribute named [`@on{EVENT}`](xref:mvc/views/razor#onevent) (for example, `@onclick`) with a delegate-typed value, a Razor component treats the attribute's value as an event handler.
 
 The following code calls the `UpdateHeading` method when the button is selected in the UI:
 

--- a/aspnetcore/blazor/event-handling.md
+++ b/aspnetcore/blazor/event-handling.md
@@ -5,7 +5,7 @@ description: Learn about Blazor's event handling scenarios, including event argu
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/12/2020
+ms.date: 03/16/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/event-handling
 ---
@@ -13,7 +13,7 @@ uid: blazor/event-handling
 
 By [Luke Latham](https://github.com/guardrex) and [Daniel Roth](https://github.com/danroth27)
 
-Razor components provide event handling features. For an HTML element attribute named `on{EVENT}` (for example, `onclick` and `onsubmit`) with a delegate-typed value, Razor components treats the attribute's value as an event handler. The attribute's name is always formatted [`@on{EVENT}`](xref:mvc/views/razor#onevent).
+Razor components provide event handling scenarios. For an HTML element attribute named [`@on{EVENT}`](xref:mvc/views/razor#onevent) (for example, `@onclick`) with a delegate-typed value, a Razor component treats the attribute's value as an event handler.
 
 The following code calls the `UpdateHeading` method when the button is selected in the UI:
 


### PR DESCRIPTION
Fixes #17119

* Nits on how we lead into binding and event handling.
* There's an out-of-place remark in the *Components* topic. I move it to the *Binding* topic.
* I kill off 🔪 the "to both components and DOM elements" phrase in the opening sentence of the *Binding* topic. There are **only** components and DOM elements under discussion, so it's not really explaining anything. Also, the concept is well covered down in the topic.
* We've been instructed to use the word *scenario* over *feature*. I don't fully understand it, but that's the word.