### PR TITLE
Replace www.microsoft.com/net links

### DIFF
--- a/aspnetcore/azure/devops/tools-and-downloads.md
+++ b/aspnetcore/azure/devops/tools-and-downloads.md
@@ -22,7 +22,7 @@ The following subscriptions are required:
 The following tools are required:
 
 * [Git](https://git-scm.com/downloads) &mdash; A fundamental understanding of Git is recommended for this guide. Review the [Git documentation](https://git-scm.com/doc), specifically [git remote](https://git-scm.com/docs/git-remote) and [git push](https://git-scm.com/docs/git-push).
-* [.NET Core SDK](https://www.microsoft.com/net/download/) &mdash; Version 2.1.300 or later is required to build and run the sample app. If Visual Studio is installed with the **.NET Core cross-platform development** workload, the .NET Core SDK is already installed.
+* [.NET Core SDK](https://dotnet.microsoft.com/download/) &mdash; Version 2.1.300 or later is required to build and run the sample app. If Visual Studio is installed with the **.NET Core cross-platform development** workload, the .NET Core SDK is already installed.
 
     Verify your .NET Core SDK installation. Open a command shell, and run the following command:
 

--- a/aspnetcore/data/ef-mvc/intro.md
+++ b/aspnetcore/data/ef-mvc/intro.md
@@ -38,7 +38,7 @@ In this tutorial, you:
 
 ## Prerequisites
 
-* [.NET Core SDK 2.2](https://www.microsoft.com/net/download)
+* [.NET Core SDK 2.2](https://dotnet.microsoft.com/download)
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the following workloads:
   * **ASP.NET and web development** workload
   * **.NET Core cross-platform development** workload

--- a/aspnetcore/fundamentals/metapackage-app.md
+++ b/aspnetcore/fundamentals/metapackage-app.md
@@ -101,8 +101,8 @@ The `Microsoft.AspNetCore.App` [metapackage](/dotnet/core/packages#metapackages)
 
 To update ASP.NET Core:
 
-* On development machines and build servers: Download and install the [.NET Core SDK](https://www.microsoft.com/net/download).
-* On deployment servers: Download and install the [.NET Core runtime](https://www.microsoft.com/net/download).
+* On development machines and build servers: Download and install the [.NET Core SDK](https://dotnet.microsoft.com/download).
+* On deployment servers: Download and install the [.NET Core runtime](https://dotnet.microsoft.com/download).
 
  Applications will roll forward to the latest installed version on application restart. It's not necessary to update the `Microsoft.AspNetCore.App` version number in the project file. For more information, see [Framework-dependent apps roll forward](/dotnet/core/versions/selection#framework-dependent-apps-roll-forward).
 

--- a/aspnetcore/fundamentals/metapackage.md
+++ b/aspnetcore/fundamentals/metapackage.md
@@ -88,6 +88,6 @@ Any dependencies of the preceding packages that otherwise aren't dependencies of
 
 We recommend migrating to the `Microsoft.AspNetCore.App` metapackage for 2.1 and later. To keep using the `Microsoft.AspNetCore.All` metapackage and ensure the latest patch version is deployed:
 
-* On development machines and build servers: Install the latest [.NET Core SDK](https://www.microsoft.com/net/download).
-* On deployment servers: Install the latest [.NET Core runtime](https://www.microsoft.com/net/download).
+* On development machines and build servers: Install the latest [.NET Core SDK](https://dotnet.microsoft.com/download).
+* On deployment servers: Install the latest [.NET Core runtime](https://dotnet.microsoft.com/download).
  Your app will roll forward to the latest installed version on an application restart.

--- a/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
+++ b/aspnetcore/host-and-deploy/azure-iis-errors-reference.md
@@ -155,7 +155,7 @@ Troubleshooting:
 
 * Open **Programs & Features** or **Apps & features** and confirm that **Windows Server Hosting** is installed. If **Windows Server Hosting** isn't present in the list of installed programs, download and install the .NET Core Hosting Bundle.
 
-  [Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+  [Current .NET Core Hosting Bundle installer (direct download)](https://dotnet.microsoft.com/permalink/dotnetcore-current-windows-runtime-bundle-installer)
 
   For more information, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
 
@@ -193,7 +193,7 @@ Troubleshooting:
 
 * An FDD may have been deployed without installing the .NET Core runtime on the hosting system. If the .NET Core runtime hasn't been installed, run the **.NET Core Hosting Bundle installer** on the system.
 
-  [Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+  [Current .NET Core Hosting Bundle installer (direct download)](https://dotnet.microsoft.com/permalink/dotnetcore-current-windows-runtime-bundle-installer)
 
   For more information, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
 
@@ -433,7 +433,7 @@ Troubleshooting:
 
 * Open **Programs & Features** or **Apps & features** and confirm that **Windows Server Hosting** is installed. If **Windows Server Hosting** isn't present in the list of installed programs, download and install the .NET Core Hosting Bundle.
 
-  [Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+  [Current .NET Core Hosting Bundle installer (direct download)](https://dotnet.microsoft.com/permalink/dotnetcore-current-windows-runtime-bundle-installer)
 
   For more information, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
 
@@ -469,7 +469,7 @@ Troubleshooting:
 
 * An FDD may have been deployed without installing the .NET Core runtime on the hosting system. If the .NET Core runtime hasn't been installed, run the **.NET Core Hosting Bundle installer** on the system.
 
-  [Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+  [Current .NET Core Hosting Bundle installer (direct download)](https://dotnet.microsoft.com/permalink/dotnetcore-current-windows-runtime-bundle-installer)
 
   For more information, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle).
 

--- a/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
+++ b/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
@@ -38,7 +38,7 @@ The sample Dockerfile uses the [Docker multi-stage build feature](https://docs.d
 ## Prerequisites
 ::: moniker range="< aspnetcore-3.0"
 
-* [.NET Core 2.2 SDK](https://www.microsoft.com/net/core)
+* [.NET Core 2.2 SDK](https://dotnet.microsoft.com/download/dotnet-core)
 ::: moniker-end
 
 ::: moniker range=">= aspnetcore-3.0"

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -237,7 +237,7 @@ Install the *.NET Core Hosting Bundle* on the hosting system. The bundle install
 
 Download the installer using the following link:
 
-[Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+[Current .NET Core Hosting Bundle installer (direct download)](https://dotnet.microsoft.com/permalink/dotnetcore-current-windows-runtime-bundle-installer)
 
 ### Earlier versions of the installer
 
@@ -844,7 +844,7 @@ Install the *.NET Core Hosting Bundle* on the hosting system. The bundle install
 
 Download the installer using the following link:
 
-[Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+[Current .NET Core Hosting Bundle installer (direct download)](https://dotnet.microsoft.com/permalink/dotnetcore-current-windows-runtime-bundle-installer)
 
 ### Earlier versions of the installer
 
@@ -1420,7 +1420,7 @@ Install the *.NET Core Hosting Bundle* on the hosting system. The bundle install
 
 Download the installer using the following link:
 
-[Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+[Current .NET Core Hosting Bundle installer (direct download)](https://dotnet.microsoft.com/permalink/dotnetcore-current-windows-runtime-bundle-installer)
 
 ### Earlier versions of the installer
 

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -243,8 +243,8 @@ Download the installer using the following link:
 
 To obtain an earlier version of the installer:
 
-1. Navigate to the [.NET download archives](https://www.microsoft.com/net/download/archives).
-1. Under **.NET Core**, select the .NET Core version.
+1. Navigate to the [Download .NET Core](https://dotnet.microsoft.com/download/dotnet-core) page.
+1. Click on the desired .NET Core version.
 1. In the **Run apps - Runtime** column, find the row of the .NET Core runtime version desired.
 1. Download the installer using the **Runtime & Hosting Bundle** link.
 

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -850,8 +850,8 @@ Download the installer using the following link:
 
 To obtain an earlier version of the installer:
 
-1. Navigate to the [.NET download archives](https://www.microsoft.com/net/download/archives).
-1. Under **.NET Core**, select the .NET Core version.
+1. Navigate to the [Download .NET Core](https://dotnet.microsoft.com/download/dotnet-core) page.
+1. Click on the desired .NET Core version.
 1. In the **Run apps - Runtime** column, find the row of the .NET Core runtime version desired.
 1. Download the installer using the **Runtime & Hosting Bundle** link.
 
@@ -1426,8 +1426,8 @@ Download the installer using the following link:
 
 To obtain an earlier version of the installer:
 
-1. Navigate to the [.NET download archives](https://www.microsoft.com/net/download/archives).
-1. Under **.NET Core**, select the .NET Core version.
+1. Navigate to the [Download .NET Core](https://dotnet.microsoft.com/download/dotnet-core) page.
+1. Click on the desired .NET Core version.
 1. In the **Run apps - Runtime** column, find the row of the .NET Core runtime version desired.
 1. Download the installer using the **Runtime & Hosting Bundle** link.
 

--- a/aspnetcore/includes/2.1-SDK.md
+++ b/aspnetcore/includes/2.1-SDK.md
@@ -1,1 +1,1 @@
-[.NET Core 2.1 SDK or later](https://www.microsoft.com/net/download/all)
+[.NET Core 2.1 SDK or later](https://dotnet.microsoft.com/download/dotnet-core)

--- a/aspnetcore/includes/2.2-SDK.md
+++ b/aspnetcore/includes/2.2-SDK.md
@@ -1,1 +1,1 @@
-[.NET Core 2.2 SDK or later](https://www.microsoft.com/net/download/all)
+[.NET Core 2.2 SDK or later](https://dotnet.microsoft.com/download/dotnet-core)

--- a/aspnetcore/includes/net-core-prereqs-mac-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-mac-2.2.md
@@ -1,2 +1,2 @@
 * [Visual Studio for Mac version 8.0 or later](https://visualstudio.microsoft.com/downloads/)
-* [.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)

--- a/aspnetcore/includes/net-core-prereqs-vs2017-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-vs2017-2.2.md
@@ -1,5 +1,5 @@
 * [Visual Studio 2017 version 15.9 or later](https://visualstudio.microsoft.com/downloads/) with the **ASP.NET and web development** workload. You can use [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019), but some project creation steps differ from what's shown in the tutorial.
-* [.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)
 
 > [!WARNING]
 > If you use Visual Studio 2017, see [dotnet/sdk issue #3124](https://github.com/dotnet/sdk/issues/3124) for information about .NET Core SDK versions that don't work with Visual Studio.

--- a/aspnetcore/includes/net-core-prereqs-vs2019-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-vs2019-2.2.md
@@ -1,5 +1,5 @@
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
-* [.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)
 
 > [!WARNING]
 > If you use Visual Studio 2017, see [dotnet/sdk issue #3124](https://github.com/dotnet/sdk/issues/3124) for information about .NET Core SDK versions that don't work with Visual Studio.

--- a/aspnetcore/includes/net-core-prereqs-vsc-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-vsc-2.2.md
@@ -1,5 +1,5 @@
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
-* [.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)
 
 The Visual Studio Code instructions use the .NET Core CLI for ASP.NET Core development functions such as project creation. You can follow these instructions on any platform (macOS, Linux, or Windows) and with any code editor. Minor changes may be required if you use something other than Visual Studio Code.

--- a/aspnetcore/includes/net-core-prereqs-windows.md
+++ b/aspnetcore/includes/net-core-prereqs-windows.md
@@ -5,6 +5,6 @@
 
 ::: moniker range=">= aspnetcore-2.1"
 
-[.NET Core 2.1 SDK or later](https://www.microsoft.com/net/download/windows)
+[.NET Core 2.1 SDK or later](https://dotnet.microsoft.com/download)
 
 ::: moniker-end

--- a/aspnetcore/includes/net-core-sdk-download-link.md
+++ b/aspnetcore/includes/net-core-sdk-download-link.md
@@ -1,1 +1,1 @@
-[.NET Core SDK 2.0 or later](https://www.microsoft.com/net/download)
+[.NET Core SDK 2.0 or later](https://dotnet.microsoft.com/download)

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -14,7 +14,7 @@ This article serves as a reference guide for migrating ASP.NET apps to ASP.NET C
 
 ## Prerequisites
 
-[.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download)
+[.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download)
 
 ## Target frameworks
 

--- a/aspnetcore/migration/proper-to-2x/mvc2.md
+++ b/aspnetcore/migration/proper-to-2x/mvc2.md
@@ -15,7 +15,7 @@ This article serves as a reference guide for migrating ASP.NET applications to A
 
 ## Prerequisites
 
-Install **one** of the following from [.NET Downloads: Windows](https://www.microsoft.com/net/download/windows):
+Install **one** of the following from [.NET Downloads: Windows](https://dotnet.microsoft.com/download):
 
 * .NET Core SDK
 * Visual Studio for Windows

--- a/aspnetcore/release-notes/aspnetcore-3.0.md
+++ b/aspnetcore/release-notes/aspnetcore-3.0.md
@@ -177,7 +177,7 @@ In the preceding code, `DomainRestrictedRequirement` serves as a custom `IAuthor
 Individual Hub methods can be marked with the name of the policy the code checks at run-time. As clients attempt to call individual Hub methods, the `DomainRestrictedRequirement` handler runs and controls access to the methods. Based on the way the `DomainRestrictedRequirement` controls access:
 
 * All logged-in users can call the `SendMessage` method.
-* Only users who have logged in with a `@jabbr.net` email address can view users’ histories.
+* Only users who have logged in with a `@jabbr.net` email address can view users' histories.
 * Only `bob42@jabbr.net` can ban users from the chat room.
 
 ```csharp
@@ -509,7 +509,7 @@ ASP.NET Core 3.0 includes many improvements that reduce memory usage and improve
 
 ## ASP.NET Core 3.0 only runs on .NET Core 3.0
 
-As of ASP.NET Core 3.0, .NET Framework is no longer a supported target framework. Projects targeting .NET Framework can continue in a fully supported fashion using the [.NET Core 2.1 LTS release](https://www.microsoft.com/net/download/dotnet-core/2.1). Most ASP.NET Core 2.1.x related packages will be supported indefinitely, beyond the three-year LTS period for .NET Core 2.1.
+As of ASP.NET Core 3.0, .NET Framework is no longer a supported target framework. Projects targeting .NET Framework can continue in a fully supported fashion using the [.NET Core 2.1 LTS release](https://dotnet.microsoft.com/download/dotnet-core/2.1). Most ASP.NET Core 2.1.x related packages will be supported indefinitely, beyond the three-year LTS period for .NET Core 2.1.
 
 For migration information, see [Port your code from .NET Framework to .NET Core](/dotnet/core/porting/).
 
@@ -534,3 +534,4 @@ For a complete list of assemblies removed from the shared framework, see [Assemb
 ## Additional information
 For the complete list of changes, see the [ASP.NET Core 3.0 Release Notes](WHERE IS THIS????).
 -->
+ 

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -214,7 +214,7 @@ Enabling account confirmation on a site with users locks out all the existing us
 
 ## Prerequisites
 
-[.NET Core 2.2 SDK or later](https://www.microsoft.com/net/download/all)
+[.NET Core 2.2 SDK or later](https://dotnet.microsoft.com/download/dotnet-core)
 
 ## Create a web  app and scaffold Identity
 

--- a/aspnetcore/security/authentication/samples.md
+++ b/aspnetcore/security/authentication/samples.md
@@ -26,7 +26,7 @@ The [ASP.NET Core repository](https://github.com/dotnet/AspNetCore) contains the
 
 * Select a [branch](https://github.com/dotnet/AspNetCore). For example, `Tag:v3.0.0`
 * Clone or download the [ASP.NET Core repository](https://github.com/dotnet/AspNetCore).
-* Verify you have installed the [.NET Core SDK](https://www.microsoft.com/net/download/all) version matching the clone of the ASP.NET Core repository.
+* Verify you have installed the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core) version matching the clone of the ASP.NET Core repository.
 * Navigate to a sample in *AspNetCore/src/Security/samples* and run the sample with `dotnet run`.
 
 ::: moniker-end
@@ -47,7 +47,7 @@ The [ASP.NET Core repository](https://github.com/dotnet/AspNetCore) contains the
 
 * Select a [branch](https://github.com/dotnet/AspNetCore). For example, `release/2.2`
 * Clone or download the [ASP.NET Core repository](https://github.com/dotnet/AspNetCore).
-* Verify you have installed the [.NET Core SDK](https://www.microsoft.com/net/download/all) version matching the clone of the ASP.NET Core repository.
+* Verify you have installed the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core) version matching the clone of the ASP.NET Core repository.
 * Navigate to a sample in *AspNetCore/src/Security/samples* and run the sample with `dotnet run`.
 
 ::: moniker-end

--- a/aspnetcore/security/docker-https.md
+++ b/aspnetcore/security/docker-https.md
@@ -23,7 +23,7 @@ This sample requires [Docker 17.06](https://docs.docker.com/release-notes/docker
 
 ## Prerequisites
 
-The [.NET Core 2.2 SDK](https://www.microsoft.com/net/download) or later is required for some of the instructions in this document.
+The [.NET Core 2.2 SDK](https://dotnet.microsoft.com/download) or later is required for some of the instructions in this document.
 
 ## Certificates
 

--- a/aspnetcore/test/troubleshoot.md
+++ b/aspnetcore/test/troubleshoot.md
@@ -26,7 +26,7 @@ In the **New Project** dialog for ASP.NET Core, you may see the following warnin
 
 > Both 32-bit and 64-bit versions of the .NET Core SDK are installed. Only templates from the 64-bit versions installed at 'C:\\Program Files\\dotnet\\sdk\\' are displayed.
 
-This warning appears when both 32-bit (x86) and 64-bit (x64) versions of the [.NET Core SDK](https://www.microsoft.com/net/download/all) are installed. Common reasons both versions may be installed include:
+This warning appears when both 32-bit (x86) and 64-bit (x64) versions of the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core) are installed. Common reasons both versions may be installed include:
 
 * You originally downloaded the .NET Core SDK installer using a 32-bit machine but then copied it across and installed it on a 64-bit machine.
 * The 32-bit .NET Core SDK was installed by another application.

--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -31,20 +31,20 @@ In this tutorial, you learn how to:
 
 # [Visual Studio](#tab/visual-studio)
 
-* [.NET Core SDK 3.0 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 3.0 or later](https://dotnet.microsoft.com/download/dotnet-core)
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
 * [MongoDB](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/)
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-* [.NET Core SDK 3.0 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 3.0 or later](https://dotnet.microsoft.com/download/dotnet-core)
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [MongoDB](https://docs.mongodb.com/manual/administration/install-community/)
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
-* [.NET Core SDK 3.0 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 3.0 or later](https://dotnet.microsoft.com/download/dotnet-core)
 * [Visual Studio for Mac version 7.7 or later](https://visualstudio.microsoft.com/downloads/)
 * [MongoDB](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/)
 
@@ -381,20 +381,20 @@ In this tutorial, you learn how to:
 
 # [Visual Studio](#tab/visual-studio)
 
-* [.NET Core SDK 2.2](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2](https://dotnet.microsoft.com/download/dotnet-core)
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
 * [MongoDB](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/)
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-* [.NET Core SDK 2.2](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2](https://dotnet.microsoft.com/download/dotnet-core)
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [C# for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [MongoDB](https://docs.mongodb.com/manual/administration/install-community/)
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
-* [.NET Core SDK 2.2](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2](https://dotnet.microsoft.com/download/dotnet-core)
 * [Visual Studio for Mac version 7.7 or later](https://visualstudio.microsoft.com/downloads/)
 * [MongoDB](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/)
 

--- a/aspnetcore/tutorials/first-mongo-app/samples/3.x/SampleApp/readme.md
+++ b/aspnetcore/tutorials/first-mongo-app/samples/3.x/SampleApp/readme.md
@@ -23,7 +23,7 @@ In this tutorial, you learn how to:
 
 ## Prerequisites
 
-* [.NET Core SDK 3.0 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 3.0 or later](https://dotnet.microsoft.com/download/dotnet-core)
 * [Visual Studio 2019 Preview](https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=community&ch=pre&rel=16&utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019preview) with the **ASP.NET and web development** workload
 * [MongoDB](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-windows/)
 

--- a/aspnetcore/tutorials/publish-to-iis.md
+++ b/aspnetcore/tutorials/publish-to-iis.md
@@ -39,7 +39,7 @@ Install the *.NET Core Hosting Bundle* on the IIS server. The bundle installs th
 
 Download the installer using the following link:
 
-[Current .NET Core Hosting Bundle installer (direct download)](https://www.microsoft.com/net/permalink/dotnetcore-current-windows-runtime-bundle-installer)
+[Current .NET Core Hosting Bundle installer (direct download)](https://dotnet.microsoft.com/permalink/dotnetcore-current-windows-runtime-bundle-installer)
 
 1. Run the installer on the IIS server.
 

--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -32,13 +32,13 @@ In this tutorial, you learn how to:
 # [Visual Studio](#tab/visual-studio)
 
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
-* [.NET Core SDK 3.0 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 3.0 or later](https://dotnet.microsoft.com/download/dotnet-core)
 * [Node.js](https://nodejs.org/) with [npm](https://www.npmjs.com/)
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
 * [Visual Studio Code](https://code.visualstudio.com/download)
-* [.NET Core SDK 3.0 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 3.0 or later](https://dotnet.microsoft.com/download/dotnet-core)
 * [C# for Visual Studio Code version 1.17.1 or later](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [Node.js](https://nodejs.org/) with [npm](https://www.npmjs.com/)
 
@@ -289,13 +289,13 @@ Confirm that the app works with the following steps.
 # [Visual Studio](#tab/visual-studio)
 
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
-* [.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)
 * [Node.js](https://nodejs.org/) with [npm](https://www.npmjs.com/)
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
 * [Visual Studio Code](https://code.visualstudio.com/download)
-* [.NET Core SDK 2.2 or later](https://www.microsoft.com/net/download/all)
+* [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)
 * [C# for Visual Studio Code version 1.17.1 or later](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [Node.js](https://nodejs.org/) with [npm](https://www.npmjs.com/)
 


### PR DESCRIPTION
I'm looking at where we're getting the traffic from to the archives page given this issue (https://github.com/dotnet/website/issues/1070). This page was one of the sources.

While doing this, also noticed we had a couple of other links that could be updated. Let me know if you'd prefer a different target. For example, https://www.microsoft.com/net/download/all could go to the main download page instead of going to https://dotnet.microsoft.com/download/dotnet-core.