### PR TITLE
Surface plan for Blazor generic type constraints

### DIFF
--- a/aspnetcore/blazor/templated-components.md
+++ b/aspnetcore/blazor/templated-components.md
@@ -5,7 +5,7 @@ description: Learn how templated components can accept one or more UI templates 
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/12/2020
+ms.date: 03/18/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/templated-components
 ---
@@ -40,6 +40,9 @@ When using a templated component, the template parameters can be specified using
     </RowTemplate>
 </TableTemplate>
 ```
+
+> [!NOTE]
+> Generic type constraints will be supported in a future release. For more information, see [Allow generic type constraints (dotnet/aspnetcore #8433)](https://github.com/dotnet/aspnetcore/issues/8433).
 
 ## Template context parameters
 


### PR DESCRIPTION
Fixes #17348

I've opened [Blazor generic type constraints (dotnet/AspNetCore.Docs #17351)](https://github.com/dotnet/AspNetCore.Docs/issues/17351) on HOLD for 5.0 to revert this PR and supply feature coverage.

Thanks @ClaudioFriederich! 🚀