### PR TITLE
Add the Blazor WebAssembly version to INCLUDES

### DIFF
--- a/aspnetcore/includes/blazorwasm-3.2-template-article-notice.md
+++ b/aspnetcore/includes/blazorwasm-3.2-template-article-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> The guidance in this article applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template, see <xref:blazor/get-started>.
+> The guidance in this article applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview2.20160.5`), see <xref:blazor/get-started>.

--- a/aspnetcore/includes/blazorwasm-3.2-template-section-notice.md
+++ b/aspnetcore/includes/blazorwasm-3.2-template-section-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> The guidance in this section applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template, see <xref:blazor/get-started>.
+> The guidance in this section applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview2.20160.5`), see <xref:blazor/get-started>.


### PR DESCRIPTION
Fixes #17349

Going ahead with that plan ... Given that the version is applied to all topics by two INCLUDES files, this is an easy way to signal the latest package version across the topics. It will be easy/fast to update each preview release.

Thanks @tomidix! 🌴