### PR TITLE
fix #17358 by calling 'start()' in the JS sample

### DIFF
--- a/aspnetcore/signalr/javascript-client/sample/wwwroot/js/chat.js
+++ b/aspnetcore/signalr/javascript-client/sample/wwwroot/js/chat.js
@@ -39,6 +39,9 @@ connection.onclose(async () => {
     await start();
 });
 
+// Start the connection.
+start();
+
 /* this is here to show an alternative to start, with a then
 connection.start().then(function () {
     console.log("connected");


### PR DESCRIPTION
Turns out the JS version of the sample doesn't actually work because we don't call the `async function start()` we create.

Fixes https://github.com/dotnet/AspNetCore.Docs/issues/17358 (originally reported in dotnet/aspnetcore).