### PR TITLE
Add an XML linker config file to a library

### DIFF
--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -110,37 +110,7 @@ Include the `@using MyComponentLib1` directive in the top-level *_Import.razor* 
 
 An RCL can include static assets. The static assets are available to any app that consumes the library. For more information, see <xref:razor-pages/ui-class#create-an-rcl-with-static-assets>.
 
-## Add an XML linker configuration file to a library
 
-Embed the XML file into the library as an embedded resource.
-
-For example, create a *LinkerConfig.xml* file in the library that targets the `System.Linq.Queryable` type in the `System.Core` assembly:
-
-```xml
-<?xml version="1.0" encoding="utf-8" ?>
-<linker>
-  <assembly fullname="System.Core">
-    <type fullname="System.Linq.Queryable" preserve="all" />
-  </assembly>
-</linker>
-```
-
-For information on the IL linker format, see [Link xml file examples (mono/linker GitHub repository)](https://github.com/mono/linker#link-xml-file-examples).
-
-The library's project file has:
-
-* A package reference for [System.Linq.Dynamic.Core](https://www.nuget.org/packages/System.Linq.Dynamic.Core/).
-* The *LinkerConfig.xml* file specified as an embedded resource.
-
-```xml
-<ItemGroup>
-  <EmbeddedResource Include="LinkerConfig.xml">
-    <LogicalName>$(MSBuildProjectName).xml</LogicalName>
-  </EmbeddedResource>
-</ItemGroup>
-```
-
-For more information, see <xref:host-and-deploy/blazor/configure-linker>.
 
 ## Build, pack, and ship to NuGet
 
@@ -155,3 +125,4 @@ Upload the package to NuGet using the [dotnet nuget push](/dotnet/core/tools/dot
 ## Additional resources
 
 * <xref:razor-pages/ui-class>
+* [Add an XML linker configuration file to a library](xref:host-and-deploy/blazor/configure-linker#add-an-xml-linker-configuration-file-to-a-library)

--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -5,7 +5,7 @@ description: Discover how components can be included in Blazor apps from an exte
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/23/2020
+ms.date: 03/23/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/class-libraries
 ---
@@ -106,6 +106,42 @@ Welcome to your new app.
 
 Include the `@using MyComponentLib1` directive in the top-level *_Import.razor* file to make the library's components available to an entire project. Add the directive to an *_Import.razor* file at any level to apply the namespace to a single page or set of pages within a folder.
 
+## Create a Razor components class library with static assets
+
+An RCL can include static assets. The static assets are available to any app that consumes the library. For more information, see <xref:razor-pages/ui-class#create-an-rcl-with-static-assets>.
+
+## Add an XML linker configuration file to a library
+
+Embed the XML file into the library as an embedded resource.
+
+For example, create a *LinkerConfig.xml* file in the library that targets the `System.Linq.Queryable` type in the `System.Core` assembly:
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+  <assembly fullname="System.Core">
+    <type fullname="System.Linq.Queryable" preserve="all" />
+  </assembly>
+</linker>
+```
+
+For information on the IL linker format, see [Link xml file examples (mono/linker GitHub repository)](https://github.com/mono/linker#link-xml-file-examples).
+
+The library's project file has:
+
+* A package reference for [System.Linq.Dynamic.Core](https://www.nuget.org/packages/System.Linq.Dynamic.Core/).
+* The *LinkerConfig.xml* file specified as an embedded resource.
+
+```xml
+<ItemGroup>
+  <EmbeddedResource Include="LinkerConfig.xml">
+    <LogicalName>$(MSBuildProjectName).xml</LogicalName>
+  </EmbeddedResource>
+</ItemGroup>
+```
+
+For more information, see <xref:host-and-deploy/blazor/configure-linker>.
+
 ## Build, pack, and ship to NuGet
 
 Because component libraries are standard .NET libraries, packaging and shipping them to NuGet is no different from packaging and shipping any library to NuGet. Packaging is performed using the [dotnet pack](/dotnet/core/tools/dotnet-pack) command in a command shell:
@@ -115,10 +151,6 @@ dotnet pack
 ```
 
 Upload the package to NuGet using the [dotnet nuget push](/dotnet/core/tools/dotnet-nuget-push) command in a command shell.
-
-## Create a Razor components class library with static assets
-
-An RCL can include static assets. The static assets are available to any app that consumes the library. For more information, see <xref:razor-pages/ui-class#create-an-rcl-with-static-assets>.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/class-libraries.md
+++ b/aspnetcore/blazor/class-libraries.md
@@ -110,8 +110,6 @@ Include the `@using MyComponentLib1` directive in the top-level *_Import.razor* 
 
 An RCL can include static assets. The static assets are available to any app that consumes the library. For more information, see <xref:razor-pages/ui-class#create-an-rcl-with-static-assets>.
 
-
-
 ## Build, pack, and ship to NuGet
 
 Because component libraries are standard .NET libraries, packaging and shipping them to NuGet is no different from packaging and shipping any library to NuGet. Packaging is performed using the [dotnet pack](/dotnet/core/tools/dotnet-pack) command in a command shell:

--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -28,7 +28,7 @@ Linking for Blazor apps can be configured using these MSBuild features:
 
 ## Control linking with an MSBuild property
 
-Linking is enabled when an app is built in `Release` configuation. To change this, configure the `BlazorWebAssemblyEnableLinking` MSBuild property in the project file:
+Linking is enabled when an app is built in `Release` configuration. To change this, configure the `BlazorWebAssemblyEnableLinking` MSBuild property in the project file:
 
 ```xml
 <PropertyGroup>
@@ -42,11 +42,11 @@ Control linking on a per-assembly basis by providing an XML configuration file a
 
 ```xml
 <ItemGroup>
-  <BlazorLinkerDescriptor Include="Linker.xml" />
+  <BlazorLinkerDescriptor Include="LinkerConfig.xml" />
 </ItemGroup>
 ```
 
-*Linker.xml*:
+*LinkerConfig.xml*:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -78,7 +78,21 @@ Control linking on a per-assembly basis by providing an XML configuration file a
 </linker>
 ```
 
-For more information, see [IL Linker: Syntax of xml descriptor](https://github.com/mono/linker/blob/master/src/linker/README.md#syntax-of-xml-descriptor).
+For more information, see [Link xml file examples (mono/linker GitHub repository)](https://github.com/mono/linker#link-xml-file-examples).
+
+## Add an XML linker configuration file to a library
+
+Embed the XML file into the library as an embedded resource in the library's project file.
+
+In the following example, the *LinkerConfig.xml* file specified as an embedded resource that has the same name as the assembly:
+
+```xml
+<ItemGroup>
+  <EmbeddedResource Include="LinkerConfig.xml">
+    <LogicalName>$(MSBuildProjectName).xml</LogicalName>
+  </EmbeddedResource>
+</ItemGroup>
+```
 
 ### Configure the linker for internationalization
 
@@ -105,7 +119,3 @@ To control which I18N assemblies are retained, set the `<MonoLinkerI18NAssemblie
 Use a comma to separate multiple values (for example, `mideast,west`).
 
 For more information, see [I18N: Pnetlib Internationalization Framework Library (mono/mono GitHub repository)](https://github.com/mono/mono/tree/master/mcs/class/I18N).
-
-## Additional resources
-
-* [Add an XML linker configuration file to a library](xref:blazor/class-libraries#add-an-xml-linker-configuration-file-to-a-library)

--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -82,7 +82,7 @@ For more information, see [Link xml file examples (mono/linker GitHub repository
 
 ## Add an XML linker configuration file to a library
 
-Embed an XML linker configuration file into a library as an embedded resource in the library's project file.
+To configure the linker for a specific library, add an XML linker configuration file into the library as an embedded resource. The embedded resource must have the same name as the assembly.
 
 In the following example, the *LinkerConfig.xml* file is specified as an embedded resource that has the same name as the library's assembly:
 

--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -5,7 +5,7 @@ description: Learn how to control the Intermediate Language (IL) Linker when bui
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/10/2020
+ms.date: 03/23/2020
 no-loc: [Blazor, SignalR]
 uid: host-and-deploy/blazor/configure-linker
 ---
@@ -105,3 +105,7 @@ To control which I18N assemblies are retained, set the `<MonoLinkerI18NAssemblie
 Use a comma to separate multiple values (for example, `mideast,west`).
 
 For more information, see [I18N: Pnetlib Internationalization Framework Library (mono/mono GitHub repository)](https://github.com/mono/mono/tree/master/mcs/class/I18N).
+
+## Additional resources
+
+* [Add an XML linker configuration file to a library](xref:blazor/class-libraries#add-an-xml-linker-configuration-file-to-a-library)

--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -82,7 +82,7 @@ For more information, see [Link xml file examples (mono/linker GitHub repository
 
 ## Add an XML linker configuration file to a library
 
-Embed the XML file into the library as an embedded resource in the library's project file.
+Embed an XML linker configuration file into a library as an embedded resource in the library's project file.
 
 In the following example, the *LinkerConfig.xml* file specified as an embedded resource that has the same name as the assembly:
 

--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -84,7 +84,7 @@ For more information, see [Link xml file examples (mono/linker GitHub repository
 
 Embed an XML linker configuration file into a library as an embedded resource in the library's project file.
 
-In the following example, the *LinkerConfig.xml* file specified as an embedded resource that has the same name as the assembly:
+In the following example, the *LinkerConfig.xml* file is specified as an embedded resource that has the same name as the library's assembly:
 
 ```xml
 <ItemGroup>


### PR DESCRIPTION
Fixes #17369

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/class-libraries?view=aspnetcore-3.1&branch=pr-en-us-17425#add-an-xml-linker-configuration-file-to-a-library)

In passing, I'm moving the *Create a Razor components class library with static assets* section up because I want the *Build, pack, and ship to NuGet* section to appear last.