### PR TITLE
Blazor updates for 3.2 Preview 3

### DIFF
--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -19,15 +19,9 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 # [Visual Studio](#tab/visual-studio)
 
-1. Install [Visual Studio 2019 version 16.4 or later](https://visualstudio.microsoft.com/vs/preview/) with the **ASP.NET and web development** workload.
+1. To create Blazor Server apps, install [Visual Studio 2019 version 16.4 or later](https://visualstudio.microsoft.com/vs/preview/) with the **ASP.NET and web development** workload.
 
-   When installing Visual Studio 2019 16.6 Preview 2 or later, the .NET Core 3.1.300 SDK is automatically installed with Visual Studio. The 3.1.300 SDK automatically provides the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template to create Blazor WebAssembly apps.
-   
-   If installing a version of Visual Studio earlier than version 16.6 Preview 2, optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
-
-   ```dotnetcli
-   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
-   ```
+   To create Blazor Server and Blazor WebAssembly apps, install Visual Studio 2019 16.6 Preview 2 or later with the **ASP.NET and web development** workload.
 
    > [!NOTE]
    > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
@@ -38,7 +32,7 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Provide a project name in the **Project name** field or accept the default project name. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
 
-1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, return to the previous step and reinstall the template.
+1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
 
 1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
 
@@ -91,13 +85,20 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
 
+1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
+
+   ```dotnetcli
+   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
+   ```
+
+   > [!NOTE]
+   > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
+
 1. Select **File** > **New Solution** or create a **New Project**.
 
 1. In the sidebar, select **.NET Core** > **App**.
 
-1. Select the **Blazor Server App** template. Only the Blazor Server template is available in Visual Studio for Mac at this time. For a Blazor WebAssembly experience, follow the instructions on the **.NET Core CLI** tab. After selecting the Blazor Server template, select **Next**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
-
-<!-- For a Blazor WebAssembly experience, select the **Blazor WebAssembly App** template. Select **Next**. -->
+1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
 
 1. Set the **Target Framework** to **.NET Core 3.1** and select **Next**.
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -5,7 +5,7 @@ description: Get started with Blazor by building a Blazor app with the tooling o
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/10/2020
+ms.date: 03/26/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/get-started
 ---
@@ -15,91 +15,115 @@ By [Daniel Roth](https://github.com/danroth27) and [Luke Latham](https://github.
 
 [!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
 
-Get started with Blazor:
+To get started with Blazor, follow the guidance for your choice of tooling:
+
+# [Visual Studio](#tab/visual-studio)
+
+1. Install [Visual Studio 2019 version 16.4 or later](https://visualstudio.microsoft.com/vs/preview/) with the **ASP.NET and web development** workload.
+
+   When installing Visual Studio 2019 16.6 Preview 2 or later, the .NET Core 3.1.300 SDK is automatically installed with Visual Studio. The 3.1.300 SDK automatically provides the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template to create Blazor WebAssembly apps.
+   
+   If installing a version of Visual Studio earlier than version 16.6 Preview 2, optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
+
+   ```dotnetcli
+   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.XXXXX.X
+   ```
+
+   > [!NOTE]
+   > .NET Core SDK version 3.1.200 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
+
+1. Create a new project.
+
+1. Select **Blazor App**. Select **Next**.
+
+1. Provide a project name in the **Project name** field or accept the default project name. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
+
+1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, return to the previous step and reinstall the template.
+
+1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
+
+> [!NOTE]
+> If you installed the Blazor Visual Studio extension for a prior preview release of ASP.NET Core Blazor, you can uninstall the extension. Installing the Blazor templates in a command shell is now sufficient to surface the templates in Visual Studio when using a version prior to 16.6 Preview 2.
+
+# [Visual Studio Code](#tab/visual-studio-code)
 
 1. Install the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 
 1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template:
-   * Install the [.NET Core 3.1.102 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+
+   * Install the [.NET Core 3.1.200 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
    * Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
 
    ```dotnetcli
-   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview2.20160.5
+   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.XXXXX.X
    ```
 
    > [!NOTE]
-   > .NET Core SDK version 3.1.102 or later is **required** to use the 3.2 Preview 2 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
+   > .NET Core SDK version 3.1.200 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
-1. Follow the guidance for your choice of tooling:
+1. Install [Visual Studio Code](https://code.visualstudio.com/).
 
-   # [Visual Studio](#tab/visual-studio)
+1. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
-   1\. Install [Visual Studio 2019 version 16.4 or later](https://visualstudio.microsoft.com/vs/preview/) with the **ASP.NET and web development** workload.
+1. For a Blazor WebAssembly experience, execute the following command in a command shell:
 
-   2\. Create a new project.
+   ```dotnetcli
+   dotnet new blazorwasm -o WebApplication1
+   ```
 
-   3\. Select **Blazor App**. Select **Next**.
+   For a Blazor Server experience, execute the following command in a command shell:
 
-   4\. Provide a project name in the **Project name** field or accept the default project name. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
+   ```dotnetcli
+   dotnet new blazorserver -o WebApplication1
+   ```
 
-   5\. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, return to the previous step and reinstall the template.
+   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
-   6\. Press **Ctrl**+**F5** to run the app.
+1. Open the *WebApplication1* folder in Visual Studio Code.
+
+1. For a Blazor Server project, the IDE requests that you add assets to build and debug the project. Select **Yes**.
+
+1. If using a Blazor Server app, run the app using the Visual Studio Code debugger. If using a Blazor WebAssembly app, execute `dotnet run` from the app's project folder.
+
+1. In a browser, navigate to `https://localhost:5001`.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+1. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
+
+1. Select **File** > **New Solution** or create a **New Project**.
+
+1. In the sidebar, select **.NET Core** > **App**.
+
+1. Select the **Blazor Server App** template. Only the Blazor Server template is available in Visual Studio for Mac at this time. For a Blazor WebAssembly experience, follow the instructions on the **.NET Core CLI** tab. After selecting the Blazor Server template, select **Next**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
+
+<!-- For a Blazor WebAssembly experience, select the **Blazor WebAssembly App** template. Select **Next**. -->
+
+1. Set the **Target Framework** to **.NET Core 3.1** and select **Next**.
+
+1. In the **Project Name** field, name the app `WebApplication1`. Select **Create**.
+
+1. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Run the app with **Start Debugging** to run the app *with the debugger*.
+
+If a prompt appears to trust the development certificate, trust the certificate and continue.
+
+# [.NET Core CLI](#tab/netcore-cli/)
+
+1. Install the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+
+1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template:
+
+   * Install the [.NET Core 3.1.200 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+   * Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
+
+   ```dotnetcli
+   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.XXXXX.X
+   ```
 
    > [!NOTE]
-   > If you installed the Blazor Visual Studio extension for a prior preview release of ASP.NET Core Blazor (Preview 6 or earlier), you can uninstall the extension. Installing the Blazor templates in a command shell is now sufficient to surface the templates in Visual Studio.
+   > .NET Core SDK version 3.1.200 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
-   # [Visual Studio Code](#tab/visual-studio-code)
-
-   1\. Install [Visual Studio Code](https://code.visualstudio.com/).
-
-   2\. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
-
-   3\. For a Blazor WebAssembly experience, execute the following command in a command shell:
-
-      ```dotnetcli
-      dotnet new blazorwasm -o WebApplication1
-      ```
-
-      For a Blazor Server experience, execute the following command in a command shell:
-
-      ```dotnetcli
-      dotnet new blazorserver -o WebApplication1
-      ```
-
-      For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
-
-   4\. Open the *WebApplication1* folder in Visual Studio Code.
-
-   5\. For a Blazor Server project, the IDE requests that you add assets to build and debug the project. Select **Yes**.
-
-   6\. If using a Blazor Server app, run the app using the Visual Studio Code debugger. If using a Blazor WebAssembly app, execute `dotnet run` from the app's project folder.
-
-   7\. In a browser, navigate to `https://localhost:5001`.
-
-   # [Visual Studio for Mac](#tab/visual-studio-mac)
-
-   1\. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
-
-   2\. Select **File** > **New Solution** or create a **New Project**.
-
-   3\. In the sidebar, select **.NET Core** > **App**.
-
-   4\. Select the **Blazor Server App** template. Only the Blazor Server template is available in Visual Studio for Mac at this time. For a Blazor WebAssembly experience, follow the instructions on the **.NET Core CLI** tab. After selecting the Blazor Server template, select **Next**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
-
-   <!-- For a Blazor WebAssembly experience, select the **Blazor WebAssembly App** template. Select **Next**. -->
-
-   5\. Set the **Target Framework** to **.NET Core 3.1** and select **Next**.
-
-   6\. In the **Project Name** field, name the app `WebApplication1`. Select **Create**.
-
-   7\. Select **Run** > **Run Without Debugging** to run the app *without the debugger*. Run the app with **Start Debugging** to run the app *with the debugger*.
-
-   If a prompt appears to trust the development certificate, trust the certificate and continue.
-
-   # [.NET Core CLI](#tab/netcore-cli/)
-
-   For a Blazor WebAssembly experience, execute the following commands in a command shell:
+1. For a Blazor WebAssembly experience, execute the following commands in a command shell:
 
    ```dotnetcli
    dotnet new blazorwasm -o WebApplication1
@@ -117,9 +141,9 @@ Get started with Blazor:
 
    For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
-   In a browser, navigate to `https://localhost:5001`.
+1. In a browser, navigate to `https://localhost:5001`.
 
-   ---
+---
 
 Multiple pages are available from tabs in the sidebar:
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -72,7 +72,7 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. The IDE requests that you add assets to build and debug the project. Select **Yes**.
 
-1. If using a Blazor Server app, run the app using the Visual Studio Code debugger. If using a Blazor WebAssembly app, execute `dotnet run` from the app's project folder.
+1. Tun the app using the Visual Studio Code debugger.
 
 1. In a browser, navigate to `https://localhost:5001`.
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -39,7 +39,7 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Install the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 
-1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
+1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) preview template by running the following command:
 
    ```dotnetcli
    dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
@@ -100,7 +100,7 @@ If a prompt appears to trust the development certificate, trust the certificate 
 
 1. Install the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 
-1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
+1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) preview template by running the following command:
 
    ```dotnetcli
    dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -87,26 +87,17 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
+Blazor Server is supported in Visual Studio for Mac. Blazor WebAssembly isn't supported at this time. To build Blazor WebAssembly apps on macOS, follow the guidance on the **.NET Core CLI** tab.
+
 1. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
-
-1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
-
-   ```dotnetcli
-   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
-   ```
-
-   > [!NOTE]
-   > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
 1. Select **File** > **New Solution** or create a **New Project**.
 
 1. In the sidebar, select **.NET Core** > **App**.
 
-1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**.
+1. Select the **Blazor Server App** template. Select **Create**.
 
-   If the Blazor WebAssembly template isn't present, reinstall the template.
-
-   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
+   For information on the Blazor Server hosting model, see <xref:blazor/hosting-models>.
 
 1. Set the **Target Framework** to **.NET Core 3.1** and select **Next**.
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -26,11 +26,11 @@ To get started with Blazor, follow the guidance for your choice of tooling:
    If installing a version of Visual Studio earlier than version 16.6 Preview 2, optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
 
    ```dotnetcli
-   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.XXXXX.X
+   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
    ```
 
    > [!NOTE]
-   > .NET Core SDK version 3.1.200 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
+   > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
 1. Create a new project.
 
@@ -51,15 +51,15 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template:
 
-   * Install the [.NET Core 3.1.200 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+   * Install the [.NET Core 3.1.201 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
    * Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
 
    ```dotnetcli
-   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.XXXXX.X
+   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
    ```
 
    > [!NOTE]
-   > .NET Core SDK version 3.1.200 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
+   > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/).
 
@@ -113,15 +113,15 @@ If a prompt appears to trust the development certificate, trust the certificate 
 
 1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template:
 
-   * Install the [.NET Core 3.1.200 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
+   * Install the [.NET Core 3.1.201 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
    * Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
 
    ```dotnetcli
-   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.XXXXX.X
+   dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
    ```
 
    > [!NOTE]
-   > .NET Core SDK version 3.1.200 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
+   > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
 1. For a Blazor WebAssembly experience, execute the following commands in a command shell:
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -23,6 +23,8 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
    To create Blazor Server and Blazor WebAssembly apps, install Visual Studio 2019 16.6 Preview 2 or later with the **ASP.NET and web development** workload.
 
+   For information on the two Blazor hosting models, *Blazor WebAssembly* and *Blazor Server*, see <xref:blazor/hosting-models>.
+
 1. Create a new project.
 
 1. Select **Blazor App**. Select **Next**.
@@ -30,8 +32,6 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 1. Provide a project name in the **Project name** field or accept the default project name. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
 
 1. For a Blazor WebAssembly experience (Visual Studio 16.6 Preview 2 or later), choose the **Blazor WebAssembly App** template. For a Blazor Server experience (Visual Studio 16.4 or later), choose the **Blazor Server App** template. Select **Create**.
-
-   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
 1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -39,32 +39,31 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Install the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 
-1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template:
-
-   * Install the [.NET Core 3.1.201 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
-   * Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
+1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
 
    ```dotnetcli
    dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
    ```
 
    > [!NOTE]
-   > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
+   > The [.NET Core SDK version 3.1.201 or later](https://dotnet.microsoft.com/download/dotnet-core/3.1) is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
 1. Install [Visual Studio Code](https://code.visualstudio.com/).
 
-1. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
+1. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) and the [JavaScript Debugger (Nightly)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.js-debug-nightly) extension with `debug.javascript.usePreview` set to `true`.
 
-1. For a Blazor WebAssembly experience, execute the following command in a command shell:
 
-   ```dotnetcli
-   dotnet new blazorwasm -o WebApplication1
-   ```
 
-   For a Blazor Server experience, execute the following command in a command shell:
+1. For a Blazor Server experience, execute the following command in a command shell:
 
    ```dotnetcli
    dotnet new blazorserver -o WebApplication1
+   ```
+
+   For a Blazor WebAssembly experience, execute the following command in a command shell:
+
+   ```dotnetcli
+   dotnet new blazorwasm -o WebApplication1
    ```
 
    For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
@@ -103,17 +102,14 @@ If a prompt appears to trust the development certificate, trust the certificate 
 
 1. Install the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
 
-1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template:
-
-   * Install the [.NET Core 3.1.201 or later (Preview) SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).
-   * Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
+1. Optionally install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. Run the following command in a command shell. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview.
 
    ```dotnetcli
    dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
    ```
 
    > [!NOTE]
-   > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
+   > The [.NET Core SDK version 3.1.201 or later](https://dotnet.microsoft.com/download/dotnet-core/3.1) is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
 1. For a Blazor WebAssembly experience, execute the following commands in a command shell:
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -31,8 +31,6 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. For a Blazor WebAssembly experience (Visual Studio 16.6 Preview 2 or later), choose the **Blazor WebAssembly App** template. For a Blazor Server experience (Visual Studio 16.4 or later), choose the **Blazor Server App** template. Select **Create**.
 
-   If the Blazor WebAssembly template isn't present, reinstall the template.
-
    For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
 1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -23,9 +23,6 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
    To create Blazor Server and Blazor WebAssembly apps, install Visual Studio 2019 16.6 Preview 2 or later with the **ASP.NET and web development** workload.
 
-   > [!NOTE]
-   > .NET Core SDK version 3.1.201 or later is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
-
 1. Create a new project.
 
 1. Select **Blazor App**. Select **Next**.

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -52,8 +52,6 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) and the [JavaScript Debugger (Nightly)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.js-debug-nightly) extension with `debug.javascript.usePreview` set to `true`.
 
-
-
 1. For a Blazor Server experience, execute the following command in a command shell:
 
    ```dotnetcli

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -98,7 +98,7 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. In the sidebar, select **.NET Core** > **App**.
 
-1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
+1. For a Blazor WebAssembly experience (Visual Studio 16.6 Preview 2 or later), choose the **Blazor WebAssembly App** template. For a Blazor Server experience (Visual Studio 16.4 or later), choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
 
 1. Set the **Target Framework** to **.NET Core 3.1** and select **Next**.
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -32,7 +32,9 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Provide a project name in the **Project name** field or accept the default project name. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
 
-1. For a Blazor WebAssembly experience (Visual Studio 16.6 Preview 2 or later), choose the **Blazor WebAssembly App** template. For a Blazor Server experience (Visual Studio 16.4 or later), choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
+1. For a Blazor WebAssembly experience (Visual Studio 16.6 Preview 2 or later), choose the **Blazor WebAssembly App** template. For a Blazor Server experience (Visual Studio 16.4 or later), choose the **Blazor Server App** template. Select **Create**.
+
+   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
 
 1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
 
@@ -98,7 +100,9 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. In the sidebar, select **.NET Core** > **App**.
 
-1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
+1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**.
+
+   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
 
 1. Set the **Target Framework** to **.NET Core 3.1** and select **Next**.
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -34,7 +34,9 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. For a Blazor WebAssembly experience (Visual Studio 16.6 Preview 2 or later), choose the **Blazor WebAssembly App** template. For a Blazor Server experience (Visual Studio 16.4 or later), choose the **Blazor Server App** template. Select **Create**.
 
-   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
+   If the Blazor WebAssembly template isn't present, reinstall the template.
+
+   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
 1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
 
@@ -102,7 +104,9 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**.
 
-   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
+   If the Blazor WebAssembly template isn't present, reinstall the template.
+
+   For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>.
 
 1. Set the **Target Framework** to **.NET Core 3.1** and select **Next**.
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -111,18 +111,18 @@ If a prompt appears to trust the development certificate, trust the certificate 
    > [!NOTE]
    > The [.NET Core SDK version 3.1.201 or later](https://dotnet.microsoft.com/download/dotnet-core/3.1) is **required** to use the 3.2 Preview 3 Blazor WebAssembly template. Confirm the installed .NET Core SDK version by running `dotnet --version` in a command shell.
 
-1. For a Blazor WebAssembly experience, execute the following commands in a command shell:
+1. For a Blazor Server experience, execute the following commands in a command shell:
 
    ```dotnetcli
-   dotnet new blazorwasm -o WebApplication1
+   dotnet new blazorserver -o WebApplication1
    cd WebApplication1
    dotnet run
    ```
 
-   For a Blazor Server experience, execute the following commands in a command shell:
+   For a Blazor WebAssembly experience, execute the following commands in a command shell:
 
    ```dotnetcli
-   dotnet new blazorserver -o WebApplication1
+   dotnet new blazorwasm -o WebApplication1
    cd WebApplication1
    dotnet run
    ```

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -32,7 +32,7 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Provide a project name in the **Project name** field or accept the default project name. Confirm the **Location** entry is correct or provide a location for the project. Select **Create**.
 
-1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
+1. For a Blazor WebAssembly experience (Visual Studio 16.6 Preview 2 or later), choose the **Blazor WebAssembly App** template. For a Blazor Server experience (Visual Studio 16.4 or later), choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
 
 1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
 
@@ -98,7 +98,7 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. In the sidebar, select **.NET Core** > **App**.
 
-1. For a Blazor WebAssembly experience (Visual Studio 16.6 Preview 2 or later), choose the **Blazor WebAssembly App** template. For a Blazor Server experience (Visual Studio 16.4 or later), choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
+1. For a Blazor WebAssembly experience, choose the **Blazor WebAssembly App** template. For a Blazor Server experience, choose the **Blazor Server App** template. Select **Create**. For information on the two Blazor hosting models, *Blazor Server* and *Blazor WebAssembly*, see <xref:blazor/hosting-models>. If the Blazor WebAssembly template isn't present, reinstall the template.
 
 1. Set the **Target Framework** to **.NET Core 3.1** and select **Next**.
 

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -35,9 +35,6 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
 
-> [!NOTE]
-> If you installed the Blazor Visual Studio extension for a prior preview release of ASP.NET Core Blazor, you can uninstall the extension. Installing the Blazor templates in a command shell is now sufficient to surface the templates in Visual Studio when using a version prior to 16.6 Preview 2.
-
 # [Visual Studio Code](#tab/visual-studio-code)
 
 1. Install the [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1).

--- a/aspnetcore/blazor/get-started.md
+++ b/aspnetcore/blazor/get-started.md
@@ -70,7 +70,7 @@ To get started with Blazor, follow the guidance for your choice of tooling:
 
 1. Open the *WebApplication1* folder in Visual Studio Code.
 
-1. For a Blazor Server project, the IDE requests that you add assets to build and debug the project. Select **Yes**.
+1. The IDE requests that you add assets to build and debug the project. Select **Yes**.
 
 1. If using a Blazor Server app, run the app using the Visual Studio Code debugger. If using a Blazor WebAssembly app, execute `dotnet run` from the app's project folder.
 

--- a/aspnetcore/includes/blazorwasm-3.2-template-article-notice.md
+++ b/aspnetcore/includes/blazorwasm-3.2-template-article-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> The guidance in this article applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview2.20160.5`), see <xref:blazor/get-started>.
+> The guidance in this article applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview3.XXXXX.X`) when not using Visual Studio version 16.6 Preview 2 or later, see <xref:blazor/get-started>.

--- a/aspnetcore/includes/blazorwasm-3.2-template-article-notice.md
+++ b/aspnetcore/includes/blazorwasm-3.2-template-article-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> The guidance in this article applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview3.XXXXX.X`) when not using Visual Studio version 16.6 Preview 2 or later, see <xref:blazor/get-started>.
+> The guidance in this article applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview3.20168.3`) when not using Visual Studio version 16.6 Preview 2 or later, see <xref:blazor/get-started>.

--- a/aspnetcore/includes/blazorwasm-3.2-template-section-notice.md
+++ b/aspnetcore/includes/blazorwasm-3.2-template-section-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> The guidance in this section applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview2.20160.5`), see <xref:blazor/get-started>.
+> The guidance in this section applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview3.XXXXX.X`) when not using Visual Studio version 16.6 Preview 2 or later, see <xref:blazor/get-started>.

--- a/aspnetcore/includes/blazorwasm-3.2-template-section-notice.md
+++ b/aspnetcore/includes/blazorwasm-3.2-template-section-notice.md
@@ -1,2 +1,2 @@
 > [!NOTE]
-> The guidance in this section applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview3.XXXXX.X`) when not using Visual Studio version 16.6 Preview 2 or later, see <xref:blazor/get-started>.
+> The guidance in this section applies to the ASP.NET Core Blazor WebAssembly template version 3.2 or later. To obtain the latest Blazor WebAssembly template (version `3.2.0-preview3.20168.3`) when not using Visual Studio version 16.6 Preview 2 or later, see <xref:blazor/get-started>.

--- a/aspnetcore/tutorials/signalr-blazor-webassembly.md
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly.md
@@ -5,7 +5,7 @@ description: Create a chat app that uses ASP.NET Core SignalR with Blazor WebAss
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/31/2020
+ms.date: 03/26/2020
 no-loc: [Blazor, SignalR]
 uid: tutorials/signalr-blazor-webassembly
 ---
@@ -50,10 +50,10 @@ At the end of this tutorial, you'll have a working chat app.
 
 ## Create a hosted Blazor WebAssembly app project
 
-Install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview. In a command shell, execute the following command:
+When not using Visual Studio version 16.6 Preview 2 or later, install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview. In a command shell, execute the following command:
 
 ```dotnetcli
-dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview2.20160.5
+dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.XXXXX.X
 ```
 
 Follow the guidance for your choice of tooling:

--- a/aspnetcore/tutorials/signalr-blazor-webassembly.md
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly.md
@@ -53,7 +53,7 @@ At the end of this tutorial, you'll have a working chat app.
 When not using Visual Studio version 16.6 Preview 2 or later, install the [Blazor WebAssembly](xref:blazor/hosting-models#blazor-webassembly) template. The [Microsoft.AspNetCore.Components.WebAssembly.Templates](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Templates/) package has a preview version while Blazor WebAssembly is in preview. In a command shell, execute the following command:
 
 ```dotnetcli
-dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.XXXXX.X
+dotnet new -i Microsoft.AspNetCore.Components.WebAssembly.Templates::3.2.0-preview3.20168.3
 ```
 
 Follow the guidance for your choice of tooling:


### PR DESCRIPTION
Fixes #17427

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/get-started?view=aspnetcore-3.1&branch=pr-en-us-17441)

We can get the ball roll'in now and see how this is starting to compose.

Let's clarify the VSC scenario ... VSC users, like CLI users, won't be able to install 3.1.300, thus a separate Blazor WebAssembly template install step should remain, correct?