### PR TITLE
Surface Docker support for Blazor

### DIFF
--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -5,7 +5,7 @@ description: Understand Blazor WebAssembly and Blazor Server hosting models.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/18/2020
+ms.date: 03/25/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/hosting-models
 ---
@@ -50,6 +50,8 @@ There are downsides to Blazor WebAssembly hosting:
 * Download size is larger, and apps take longer to load.
 * .NET runtime and tooling support is less mature. For example, limitations exist in [.NET Standard](/dotnet/standard/net-standard) support and debugging.
 
+The Blazor Hosted app model supports [Docker containers](/dotnet/standard/microservices-architecture/container-docker-introduction/index). Right-click on the Server project in Visual Studio and select **Add** > **Docker Support**.
+
 ## Blazor Server
 
 With the Blazor Server hosting model, the app is executed on the server from within an ASP.NET Core app. UI updates, event handling, and JavaScript calls are handled over a [SignalR](xref:signalr/introduction) connection.
@@ -63,7 +65,7 @@ The ASP.NET Core app references the app's `Startup` class to add:
 * Server-side services.
 * The app to the request handling pipeline.
 
-The `blazor.server.js` script&dagger; establishes the client connection. It's the app's responsibility to persist and restore app state as required (for example, in the event of a lost network connection).
+The `blazor.server.js` script establishes the client connection. It's the app's responsibility to persist and restore app state as required (for example, in the event of a lost network connection). The `blazor.server.js` script is served from an embedded resource in the ASP.NET Core shared framework.
 
 The Blazor Server hosting model offers several benefits:
 
@@ -80,7 +82,7 @@ There are downsides to Blazor Server hosting:
 * Scalability is challenging for apps with many users. The server must manage multiple client connections and handle client state.
 * An ASP.NET Core server is required to serve the app. Serverless deployment scenarios aren't possible (for example, serving the app from a CDN).
 
-&dagger;The `blazor.server.js` script is served from an embedded resource in the ASP.NET Core shared framework.
+The Blazor Server app model supports [Docker containers](/dotnet/standard/microservices-architecture/container-docker-introduction/index). Right-click on the project in Visual Studio and select **Add** > **Docker Support**.
 
 ### Comparison to server-rendered UI
 

--- a/aspnetcore/blazor/index.md
+++ b/aspnetcore/blazor/index.md
@@ -5,7 +5,7 @@ description: Explore ASP.NET Core Blazor, a way to build interactive client-side
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: "mvc, seoapril2019"
-ms.date: 01/31/2020
+ms.date: 03/25/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/index
 ---
@@ -20,6 +20,7 @@ Blazor is a framework for building interactive client-side web UI with .NET:
 * Create rich interactive UIs using C# instead of JavaScript.
 * Share server-side and client-side app logic written in .NET.
 * Render the UI as HTML and CSS for wide browser support, including mobile browsers.
+* Integrate with modern hosting platforms, such as [Docker](/dotnet/standard/microservices-architecture/container-docker-introduction/index).
 
 Using .NET for client-side web development offers the following advantages:
 


### PR DESCRIPTION
Fixes #17191

Breaking the blog content down by paragraph ...

> Blazor WebAssembly apps now integrate seamlessly with how ASP.NET Core handles static web assets. Blazor WebAssembly apps can use the standard ASP.NET Core convention for consuming static web assets from referenced projects and packages: *_content/{LIBRARY NAME}/{path}*. This allows you to easily pick up static assets from referenced component libraries and JavaScript interop libraries just like you can in a Blazor Server app or any other ASP.NET Core web app.

We already document static asset references in the Blazor RCL topic (*Create a Razor components class library with static assets* section) via cross link to Razor Class Libs topic.

wrt this passage ...

> pick up static assets from referenced ... JavaScript interop libraries

I might need a little more detail to take action on that. If it merely means an RCL with JS interop bits for a library-consuming project, then we're covered ... no action required. If it means something else, then let me know what that means. :ear:

> Blazor WebAssembly apps are also now hosted in ASP.NET Core web apps using the same static web assets infrastructure. After all, a Blazor WebAssembly app is just a bunch of static files!

Framework implementation detail ... detail at this level usually isn't covered. *No action taken.*

> This integration simplifies the startup code for ASP.NET Core hosted Blazor WebAssembly apps and removes the need to have an assembly reference from the server project to the client project. Only the project reference is needed, so setting `ReferenceOutputAssembly` to `false` for the client project reference is now supported.

Ditto on this one ... looks like a framework implementation detail. *No action taken.*

> Building on the static web assets support in ASP.NET Core also enables new scenarios like hosting ASP.NET Core hosted Blazor WebAssembly apps in Docker containers. In Visual Studio you can add docker support to your Blazor WebAssembly app by right-clicking on the Server project and selecting **Add** > **Docker support**.

We don't surface Docker support, **_so that's what's on this PR_**.

btw ... VS UI uses "Docker Support" (capital "S"), so that's what's on the PR.