### PR TITLE
Surface workaround for referencing components in a loop

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/16/2020
+ms.date: 03/25/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/components
 ---
@@ -293,6 +293,8 @@ When the component is rendered, the `_loginDialog` field is populated with the `
 
 > [!IMPORTANT]
 > The `_loginDialog` variable is only populated after the component is rendered and its output includes the `MyLoginDialog` element. Until that point, there's nothing to reference. To manipulate components references after the component has finished rendering, use the [OnAfterRenderAsync or OnAfterRender methods](xref:blazor/lifecycle#after-component-render).
+
+To reference components in a loop, see [Capture references to multiple similar child-components (dotnet/aspnetcore #13358)](https://github.com/dotnet/aspnetcore/issues/13358).
 
 While capturing component references use a similar syntax to [capturing element references](xref:blazor/call-javascript-from-dotnet#capture-references-to-elements), it isn't a JavaScript interop feature. Component references aren't passed to JavaScript code&mdash;they're only used in .NET code.
 


### PR DESCRIPTION
Fixes #17291

For now, let's link the engineering issue given that this scenario might get some framework ❤️ and devs may want to :+1: that engineering issue. The approach/workaround at the end of the issue shows how to pull it off.

Thanks @rrsit! :rocket: ... btw - I can't comment on your `RadzenGrid` component scenario. They're doing some ✨ *magical things* ✨ inside their components to deal with this that I haven't seen.