### PR TITLE
Update grpc-start: Call insecure gRPC services

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -3,7 +3,7 @@ title: Create a .NET Core gRPC client and server in ASP.NET Core
 author: juntaoluo
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 ms.author: johluo
-ms.date: 12/05/2019
+ms.date: 04/08/2020
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core
@@ -292,10 +292,7 @@ info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
 ```
 
 > [!NOTE]
-> The code in this article requires the ASP.NET Core HTTPS development certificate to secure the gRPC service. If the client fails with the message `The remote certificate is invalid according to the validation procedure.`, the development certificate is not trusted. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
-
-> [!NOTE]
-> The .NET gRPC client requires the service to have a trusted certificate. If the client fails with the message `The SSL connection could not be established.` you can call the gRPC service with an untrusted/invalid certificate in **development mode**. For instructions to fix this issue, see [Call insecure gRPC services with .NET Core client](xref:grpc/troubleshoot#call-a-grpc-service-with-an-untrustedinvalid-certificate).
+> The code in this article requires the ASP.NET Core HTTPS development certificate to secure the gRPC service. If the .NET gRPC client fails with the message `The remote certificate is invalid according to the validation procedure.` or `The SSL connection could not be established.`, the development certificate isn't trusted. To fix this issue, see [Call a gRPC service with an untrusted/invalid certificate](xref:grpc/troubleshoot#call-a-grpc-service-with-an-untrustedinvalid-certificate).
 
 [!INCLUDE[](~/includes/gRPCazure.md)]
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -294,6 +294,9 @@ info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
 > [!NOTE]
 > The code in this article requires the ASP.NET Core HTTPS development certificate to secure the gRPC service. If the client fails with the message `The remote certificate is invalid according to the validation procedure.`, the development certificate is not trusted. For instructions to fix this issue, see [Trust the ASP.NET Core HTTPS development certificate on Windows and macOS](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos).
 
+> [!NOTE]
+> The .NET gRPC client requires the service to have a trusted certificate. If the client fails with the message `The SSL connection could not be established.` you can call the gRPC service with an untrusted/invalid certificate in **development mode**. For instructions to fix this issue, see [Call insecure gRPC services with .NET Core client](xref:grpc/troubleshoot#call-a-grpc-service-with-an-untrustedinvalid-certificate).
+
 [!INCLUDE[](~/includes/gRPCazure.md)]
 
 ### Next steps


### PR DESCRIPTION
Enable trust the HTTPS development certificate on some **Linux** distributions is not easy. 
Adding this instructions can make it easier to develop on Linux.