### PR TITLE
Fix ActionResult<T> for consistency

### DIFF
--- a/aspnetcore/tutorials/first-web-api/samples/3.0/TodoApiDTO/Controllers/TodoItemsController.cs
+++ b/aspnetcore/tutorials/first-web-api/samples/3.0/TodoApiDTO/Controllers/TodoItemsController.cs
@@ -71,7 +71,7 @@ namespace TodoApi.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult<TodoItem>> CreateTodoItem(TodoItemDTO todoItemDTO)
+        public async Task<ActionResult<TodoItemDTO>> CreateTodoItem(TodoItemDTO todoItemDTO)
         {
             var todoItem = new TodoItem
             {


### PR DESCRIPTION
Fixes #17528.

Really, this should just be `IActionResult`, because `TodoItemDTO` isn't returned from the method. I was gonna do that instead, but the scaffolded code sets things up like this. It really doesn't matter what type is used for the generic here, but using `TodoItemDTO` makes sense, at least.