### PR TITLE
Use a copy target for Blazor WASM custom web.config

### DIFF
--- a/aspnetcore/host-and-deploy/blazor/server.md
+++ b/aspnetcore/host-and-deploy/blazor/server.md
@@ -5,7 +5,7 @@ description: Learn how to host and deploy a Blazor Server app using ASP.NET Core
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/06/2020
+ms.date: 03/03/2020
 no-loc: [Blazor, SignalR]
 uid: host-and-deploy/blazor/server
 ---
@@ -83,22 +83,6 @@ When using IIS, enable:
 
 * [WebSockets on IIS](xref:fundamentals/websockets#enabling-websockets-on-iis).
 * [Sticky sessions with Application Request Routing](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing).
-
-#### Use a custom web.config file
-
-To use a custom *web.config* file:
-
-1. Place the custom *web.config* file at the root of the project folder.
-1. Add the following target to the project file (*.csproj*):
-
-   ```xml
-   <Target Name="CopyWebConfigOnPublish" AfterTargets="Publish">
-     <Copy SourceFiles="web.config" DestinationFolder="$(PublishDir)" />
-   </Target>
-   ```
-   
-> [!NOTE]
-> Use of the MSBuild property `<IsWebConfigTransformDisabled>` set to `true` isn't supported in Blazor [as it is for ASP.NET Core apps deployed to IIS](xref:host-and-deploy/iis/index#webconfig-file). For more information, see [Copy target required to provide custom web.config (dotnet/aspnetcore #20569)](https://github.com/dotnet/aspnetcore/issues/20569).
 
 #### Kubernetes
 

--- a/aspnetcore/host-and-deploy/blazor/server.md
+++ b/aspnetcore/host-and-deploy/blazor/server.md
@@ -5,7 +5,7 @@ description: Learn how to host and deploy a Blazor Server app using ASP.NET Core
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/03/2020
+ms.date: 04/06/2020
 no-loc: [Blazor, SignalR]
 uid: host-and-deploy/blazor/server
 ---
@@ -83,6 +83,22 @@ When using IIS, enable:
 
 * [WebSockets on IIS](xref:fundamentals/websockets#enabling-websockets-on-iis).
 * [Sticky sessions with Application Request Routing](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing).
+
+#### Use a custom web.config file
+
+To use a custom *web.config* file:
+
+1. Place the custom *web.config* file at the root of the project folder.
+1. Add the following target to the project file (*.csproj*):
+
+   ```xml
+   <Target Name="CopyWebConfigOnPublish" AfterTargets="Publish">
+     <Copy SourceFiles="web.config" DestinationFolder="$(PublishDir)" />
+   </Target>
+   ```
+   
+> [!NOTE]
+> Use of the MSBuild property `<IsWebConfigTransformDisabled>` set to `true` isn't supported in Blazor [as it is for ASP.NET Core apps deployed to IIS](xref:host-and-deploy/iis/index#webconfig-file). For more information, see [Copy target required to provide custom web.config (dotnet/aspnetcore #20569)](https://github.com/dotnet/aspnetcore/issues/20569).
 
 #### Kubernetes
 

--- a/aspnetcore/host-and-deploy/blazor/webassembly.md
+++ b/aspnetcore/host-and-deploy/blazor/webassembly.md
@@ -5,7 +5,7 @@ description: Learn how to host and deploy a Blazor app using ASP.NET Core, Conte
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/16/2020
+ms.date: 04/06/2020
 no-loc: [Blazor, SignalR]
 uid: host-and-deploy/blazor/webassembly
 ---
@@ -85,6 +85,22 @@ When a Blazor project is published, a *web.config* file is created with the foll
 * URL Rewrite Module rules are established:
   * Serve the sub-directory where the app's static assets reside (*wwwroot/{PATH REQUESTED}*).
   * Create SPA fallback routing so that requests for non-file assets are redirected to the app's default document in its static assets folder (*wwwroot/index.html*).
+  
+#### Use a custom web.config
+
+To use a custom *web.config* file:
+
+1. Place the custom *web.config* file at the root of the project folder.
+1. Add the following target to the project file (*.csproj*):
+
+   ```xml
+   <Target Name="CopyWebConfigOnPublish" AfterTargets="Publish">
+     <Copy SourceFiles="web.config" DestinationFolder="$(PublishDir)" />
+   </Target>
+   ```
+   
+> [!NOTE]
+> Use of the MSBuild property `<IsWebConfigTransformDisabled>` set to `true` isn't supported in Blazor [as it is for ASP.NET Core apps deployed to IIS](xref:host-and-deploy/iis/index#webconfig-file). For more information, see [Copy target required to provide custom web.config (dotnet/aspnetcore #20569)](https://github.com/dotnet/aspnetcore/issues/20569).
 
 #### Install the URL Rewrite Module
 

--- a/aspnetcore/host-and-deploy/blazor/webassembly.md
+++ b/aspnetcore/host-and-deploy/blazor/webassembly.md
@@ -100,7 +100,7 @@ To use a custom *web.config* file:
    ```
    
 > [!NOTE]
-> Use of the MSBuild property `<IsWebConfigTransformDisabled>` set to `true` isn't supported in Blazor [as it is for ASP.NET Core apps deployed to IIS](xref:host-and-deploy/iis/index#webconfig-file). For more information, see [Copy target required to provide custom Blazor WASM web.config (dotnet/aspnetcore #20569)](https://github.com/dotnet/aspnetcore/issues/20569).
+> Use of the MSBuild property `<IsWebConfigTransformDisabled>` set to `true` isn't supported in Blazor WebAssembly apps [as it is for ASP.NET Core apps deployed to IIS](xref:host-and-deploy/iis/index#webconfig-file). For more information, see [Copy target required to provide custom Blazor WASM web.config (dotnet/aspnetcore #20569)](https://github.com/dotnet/aspnetcore/issues/20569).
 
 #### Install the URL Rewrite Module
 

--- a/aspnetcore/host-and-deploy/blazor/webassembly.md
+++ b/aspnetcore/host-and-deploy/blazor/webassembly.md
@@ -100,7 +100,7 @@ To use a custom *web.config* file:
    ```
    
 > [!NOTE]
-> Use of the MSBuild property `<IsWebConfigTransformDisabled>` set to `true` isn't supported in Blazor [as it is for ASP.NET Core apps deployed to IIS](xref:host-and-deploy/iis/index#webconfig-file). For more information, see [Copy target required to provide custom web.config (dotnet/aspnetcore #20569)](https://github.com/dotnet/aspnetcore/issues/20569).
+> Use of the MSBuild property `<IsWebConfigTransformDisabled>` set to `true` isn't supported in Blazor [as it is for ASP.NET Core apps deployed to IIS](xref:host-and-deploy/iis/index#webconfig-file). For more information, see [Copy target required to provide custom Blazor WASM web.config (dotnet/aspnetcore #20569)](https://github.com/dotnet/aspnetcore/issues/20569).
 
 #### Install the URL Rewrite Module
 


### PR DESCRIPTION
Fixes #17617

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/blazor/webassembly?view=aspnetcore-3.1&branch=pr-en-us-17619#use-a-custom-webconfig)

Opened doc issue to react to engineering issue at https://github.com/dotnet/AspNetCore.Docs/issues/17620.

cc: @cornem
