### PR TITLE
Straighten apostrophe character for consistency

### DIFF
--- a/aspnetcore/includes/MTcomments.md
+++ b/aspnetcore/includes/MTcomments.md
@@ -1,1 +1,1 @@
-If you are reading this in a language other than English, let us know in this [GitHub discussion issue](https://github.com/aspnet/AspNetCore.Docs/issues/16455) if you’d like to see the code comments in your native language.
+If you are reading this in a language other than English, let us know in this [GitHub discussion issue](https://github.com/aspnet/AspNetCore.Docs/issues/16455) if you'd like to see the code comments in your native language.

--- a/aspnetcore/performance/performance-best-practices.md
+++ b/aspnetcore/performance/performance-best-practices.md
@@ -205,7 +205,7 @@ In .NET, every object allocation greater than 85 KB ends up in the large object 
 
 This [blog post](https://adamsitnik.com/Array-Pool/#the-problem) describes the problem succinctly:
 
-> When a large object is allocated, it’s marked as Gen 2 object. Not Gen 0 as for small objects. The consequences are that if you run out of memory in LOH, GC cleans up the whole managed heap, not only LOH. So it cleans up Gen 0, Gen 1 and Gen 2 including LOH. This is called full garbage collection and is the most time-consuming garbage collection. For many applications, it can be acceptable. But definitely not for high-performance web servers, where few big memory buffers are needed to handle an average web request (read from a socket, decompress, decode JSON & more).
+> When a large object is allocated, it's marked as Gen 2 object. Not Gen 0 as for small objects. The consequences are that if you run out of memory in LOH, GC cleans up the whole managed heap, not only LOH. So it cleans up Gen 0, Gen 1 and Gen 2 including LOH. This is called full garbage collection and is the most time-consuming garbage collection. For many applications, it can be acceptable. But definitely not for high-performance web servers, where few big memory buffers are needed to handle an average web request (read from a socket, decompress, decode JSON & more).
 
 Naively storing a large request or response body into a single `byte[]` or `string`:
 

--- a/aspnetcore/release-notes/aspnetcore-2.2.md
+++ b/aspnetcore/release-notes/aspnetcore-2.2.md
@@ -100,7 +100,7 @@ ASP.NET Core web project templates were updated to [Bootstrap 4](https://getboot
 
 ## Validation performance
 
-MVC’s validation system is designed to be extensible and flexible, allowing you to determine on a per request basis which validators apply to a given model. This is great for authoring complex validation providers. However, in the most common case an application only uses the built-in validators and don’t require this extra flexibility. Built-in validators include DataAnnotations such as [Required] and [StringLength], and `IValidatableObject`.
+MVC's validation system is designed to be extensible and flexible, allowing you to determine on a per request basis which validators apply to a given model. This is great for authoring complex validation providers. However, in the most common case an application only uses the built-in validators and don't require this extra flexibility. Built-in validators include DataAnnotations such as [Required] and [StringLength], and `IValidatableObject`.
 
 In ASP.NET Core 2.2, MVC can short-circuit validation if it determines that a given model graph doesn't require validation. Skipping validation results in significant improvements when validating models that can't or don't have any validators. This includes objects such as collections of primitives (such as `byte[]`, `string[]`, `Dictionary<string, string>`), or complex object graphs without many validators.
 


### PR DESCRIPTION
This is a simple correction. There is no associated issue. Three markdown documents within the repository use the curly apostrophe character ( ’ ) instead of the straight apostrophe ( ' ). This was changed for the sake of consistency.