### PR TITLE
Update certauth.md

### DIFF
--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -266,16 +266,9 @@ public void ConfigureServices(IServiceCollection services)
     });
 }
 
-private static byte[] StringToByteArray(string hex)
+private static byte[] StringToByteArray(string base64)
 {
-    int NumberChars = hex.Length;
-    byte[] bytes = new byte[NumberChars / 2];
-
-    for (int i = 0; i < NumberChars; i += 2)
-    {
-        bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
-    }
-
+    var bytes = Convert.FromBase64String(base64);
     return bytes;
 }
 ```

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -233,7 +233,7 @@ See the [host and deploy documentation](xref:host-and-deploy/proxy-load-balancer
 
 No forwarding configuration for `HeaderConverter` is required for Azure. This is already setup in the certificate forwarding middleware by setting `HeaderConverter` to  `Convert.FromBase64String(headerValue)`.
 
-Azure Application Service sends certificates in header `X-ARR-ClientCert`, so you need to set this header in certificate forwarding configuration if your application will be deployed to Azure.
+Azure Application Service sends certificates in the `X-ARR-ClientCert` header. For apps deployed to Azure Application service, set  `X-ARR-ClientCert` as shown in the following code:
 
 ```csharp
  services.AddCertificateForwarding(options =>

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -231,19 +231,19 @@ See the [host and deploy documentation](xref:host-and-deploy/proxy-load-balancer
 
 ### Use certificate authentication in Azure Web Apps
 
-No forwarding configuration for `HeaderConverter` is required for Azure. This is already setup in the certificate forwarding middleware by setting `HeaderConverter` to  `Convert.FromBase64String(headerValue)`.
+No forwarding configuration is required for Azure. This is already setup in the certificate forwarding middleware.
 
-Azure Application Service sends certificates in the `X-ARR-ClientCert` header. For apps deployed to Azure Application service, set  `X-ARR-ClientCert` as shown in the following code:
-
-```csharp
- services.AddCertificateForwarding(options =>
- 	{
-		options.CertificateHeader = "X-ARR-ClientCert";
-	}
-```
+Azure Application Service sends certificates in the `X-ARR-ClientCert` header. To configure the middleware for Azure Application Services, use the following code:
+ 
+ ```csharp
+  services.AddCertificateForwarding(options =>
+  	{
+ 		options.CertificateHeader = "X-ARR-ClientCert";
+ 	}
+ ```
 
 > [!NOTE]
-> This requires that the CertificateForwardingMiddleware is present.
+> Certificate authentication in Azure Web Apps requires that the CertificateForwardingMiddleware is present.
 
 ### Use certificate authentication in custom web proxies
 


### PR DESCRIPTION
Azure sends header in Base64 string, not base16.
 Mentioned this in sample


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->