### PR TITLE
AccessDeniedPath

### DIFF
--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -82,34 +82,48 @@ services.AddAuthentication().AddFacebook(facebookOptions =>
 
 [!INCLUDE [default settings configuration](includes/default-settings.md)]
 
+## Sign in with Facebook
+
+* Run the app and select **Log in**. 
+* Under **Use another service to log in.**, select Facebook.
+* You are redirected to **Facebook** for authentication.
+* Enter your Facebook credentials.
+* You are redirected back to your site where you can set your email.
+
+You are now logged in using your Facebook credentials:
+
+<a name="react"></a>
+
+## React to cancel authorize external sign-in
+
+<xref:Microsoft.AspNetCore.Authentication.RemoteAuthenticationOptions.AccessDeniedPath> can provide a path the user agent is redirected to if the user doesn't approve the authorization demand requested by the remote server.
+
+The following code sets the `AccessDeniedPath` to `"/AccessDeniedPathInfo"`:
+
+[!code-csharp[](~/security/authentication/social/social-code/StartupAccessDeniedPath.cs?name=snippetFB)]
+
+We recommend the `AccessDeniedPath` page contain the following information:
+
+*  Remote authentication was canceled.
+* This app requires authentication.
+* To try sign-in again, select the Login link.
+
+### Test AccessDeniedPath
+
+* Navigate to [facebook.com](https://www.facebook.com/)
+* If you are signed in, you must sign out.
+* Run the app and select facebook sign-in.
+* Select **Not now**. You are redirected to the specified `AccessDeniedPath` page.
+
+<!-- End of React  -->
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
+
 [!INCLUDE[](includes/chain-auth-providers.md)]
 
 See the [FacebookOptions](/dotnet/api/microsoft.aspnetcore.builder.facebookoptions) API reference for more information on configuration options supported by Facebook authentication. Configuration options can be used to:
 
 * Request different information about the user.
 * Add query string arguments to customize the login experience.
-
-## Sign in with Facebook
-
-Run your application and click **Log in**. You see an option to sign in with Facebook.
-
-![Web application: User not authenticated](index/_static/DoneFacebook.png)
-
-When you click on **Facebook**, you are redirected to Facebook for authentication:
-
-![Facebook authentication page](index/_static/FBLogin.png)
-
-Facebook authentication requests public profile and email address by default:
-
-![Facebook authentication page consent screen](index/_static/FBLoginDone.png)
-
-Once you enter your Facebook credentials you are redirected back to your site where you can set your email.
-
-You are now logged in using your Facebook credentials:
-
-![Web application: User authenticated](index/_static/Done.png)
-
-[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
 
 ## Troubleshooting
 

--- a/aspnetcore/security/authentication/social/facebook-logins.md
+++ b/aspnetcore/security/authentication/social/facebook-logins.md
@@ -13,6 +13,9 @@ uid: security/authentication/facebook-logins
 
 By [Valeriy Novytskyy](https://github.com/01binary) and [Rick Anderson](https://twitter.com/RickAndMSFT)
 
+<!-- per @rick-anderson and scott addie, don't update images. Remove images and point the customer to the FB set up page. FB needs to maintain  instructions to get key and secret.
+-->
+
 This tutorial with code examples shows how to enable your users to sign in with their Facebook account using a sample ASP.NET Core 3.0 project created on the [previous page](xref:security/authentication/social/index). We start by creating a Facebook App ID by following the [official steps](https://developers.facebook.com).
 
 ## Create the app in Facebook
@@ -96,7 +99,7 @@ You are now logged in using your Facebook credentials:
 
 ## React to cancel authorize external sign-in
 
-<xref:Microsoft.AspNetCore.Authentication.RemoteAuthenticationOptions.AccessDeniedPath> can provide a path the user agent is redirected to if the user doesn't approve the authorization demand requested by the remote server.
+<xref:Microsoft.AspNetCore.Authentication.RemoteAuthenticationOptions.AccessDeniedPath> can provide a redirect path to the user agent when the user doesn't approve the requested authorization demand.
 
 The following code sets the `AccessDeniedPath` to `"/AccessDeniedPathInfo"`:
 
@@ -112,7 +115,7 @@ We recommend the `AccessDeniedPath` page contain the following information:
 
 * Navigate to [facebook.com](https://www.facebook.com/)
 * If you are signed in, you must sign out.
-* Run the app and select facebook sign-in.
+* Run the app and select Facebook sign-in.
 * Select **Not now**. You are redirected to the specified `AccessDeniedPath` page.
 
 <!-- End of React  -->

--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -70,9 +70,7 @@ Run the app and click **Log in**. An option to sign in with Microsoft appears. W
 Tap **Yes** and you will be redirected back to the web site where you can set your email.
 
 You are now logged in using your Microsoft credentials:
-
-[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
-
+<!--  This doesn't work with MSFT external sign-in
 <a name="react"></a>
 
 ## React to cancel authorize external sign-in
@@ -94,9 +92,12 @@ We recommend the `AccessDeniedPath` page contain the following information:
 * Navigate to [office.com](https://www.office.com/)
 * If you are signed in, you must sign out.
 * Run the app and select Microsoft sign-in.
-* Select **No** when prompted to accept access and permissions. You are redirected to the specified `AccessDeniedPath` page.
+* Select **Cancel** when prompted to accept access and permissions. You are redirected to the specified `AccessDeniedPath` page.
+-->
 
 [!INCLUDE[](includes/chain-auth-providers.md)]
+
+[!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
 
 ## Troubleshooting
 

--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -23,7 +23,7 @@ If you don't have a Microsoft account, select **Create one**. After signing in, 
 
 * Select **New registration**
 * Enter a **Name**.
-* Select an option for **Supported account types**.  <!-- Accounts for any org work with MS domain accounts. Most folks probably want the last option, personal MS accounts -->
+* Select an option for **Supported account types**.  <!-- Accounts for any org work with MS domain accounts. Most folks probably want the last option, personal MS accounts. It took 24 hours after setting this up for the keys to work -->
 * Under **Redirect URI**, enter your development URL with `/signin-microsoft` appended. For example, `https://localhost:5001/signin-microsoft`. The Microsoft authentication scheme configured later in this sample will automatically handle requests at `/signin-microsoft` route to implement the OAuth flow.
 * Select **Register**
 
@@ -37,8 +37,7 @@ If you don't have a Microsoft account, select **Create one**. After signing in, 
 
 * Under **Client secrets**, copy the value of the client secret.
 
-> [!NOTE]
-> The URI segment `/signin-microsoft` is set as the default callback of the Microsoft authentication provider. You can change the default callback URI while configuring the Microsoft authentication middleware via the inherited [RemoteAuthenticationOptions.CallbackPath](/dotnet/api/microsoft.aspnetcore.authentication.remoteauthenticationoptions.callbackpath) property of the [MicrosoftAccountOptions](/dotnet/api/microsoft.aspnetcore.authentication.microsoftaccount.microsoftaccountoptions) class.
+The URI segment `/signin-microsoft` is set as the default callback of the Microsoft authentication provider. You can change the default callback URI while configuring the Microsoft authentication middleware via the inherited [RemoteAuthenticationOptions.CallbackPath](/dotnet/api/microsoft.aspnetcore.authentication.remoteauthenticationoptions.callbackpath) property of the [MicrosoftAccountOptions](/dotnet/api/microsoft.aspnetcore.authentication.microsoftaccount.microsoftaccountoptions) class.
 
 ## Store the Microsoft client ID and secret
 
@@ -62,8 +61,6 @@ Add the Microsoft Account service to the `Startup.ConfigureServices`:
 
 [!INCLUDE [default settings configuration](includes/default-settings.md)]
 
-[!INCLUDE[](includes/chain-auth-providers.md)]
-
 For more information about configuration options supported by Microsoft Account authentication, see the [MicrosoftAccountOptions](/dotnet/api/microsoft.aspnetcore.builder.microsoftaccountoptions) API reference. This can be used to request different information about the user.
 
 ## Sign in with Microsoft Account
@@ -75,6 +72,31 @@ Tap **Yes** and you will be redirected back to the web site where you can set yo
 You are now logged in using your Microsoft credentials:
 
 [!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
+
+<a name="react"></a>
+
+## React to cancel authorize external sign-in
+
+<xref:Microsoft.AspNetCore.Authentication.RemoteAuthenticationOptions.AccessDeniedPath> can provide a redirect path to the user agent when the user doesn't approve the requested authorization demand.
+
+The following code sets the `AccessDeniedPath` to `"/AccessDeniedPathInfo"`:
+
+[!code-csharp[](~/security/authentication/social/social-code/StartupAccessDeniedPath.cs?name=snippetMS)]
+
+We recommend the `AccessDeniedPath` page contain the following information:
+
+*  Remote authentication was canceled.
+* This app requires authentication.
+* To try sign-in again, select the Login link.
+
+### Test AccessDeniedPath
+
+* Navigate to [office.com](https://www.office.com/)
+* If you are signed in, you must sign out.
+* Run the app and select Microsoft sign-in.
+* Select **No** when prompted to accept access and permissions. You are redirected to the specified `AccessDeniedPath` page.
+
+[!INCLUDE[](includes/chain-auth-providers.md)]
 
 ## Troubleshooting
 

--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -70,30 +70,6 @@ Run the app and click **Log in**. An option to sign in with Microsoft appears. W
 Tap **Yes** and you will be redirected back to the web site where you can set your email.
 
 You are now logged in using your Microsoft credentials:
-<!--  This doesn't work with MSFT external sign-in
-<a name="react"></a>
-
-## React to cancel authorize external sign-in
-
-<xref:Microsoft.AspNetCore.Authentication.RemoteAuthenticationOptions.AccessDeniedPath> can provide a redirect path to the user agent when the user doesn't approve the requested authorization demand.
-
-The following code sets the `AccessDeniedPath` to `"/AccessDeniedPathInfo"`:
-
-[!code-csharp[](~/security/authentication/social/social-code/StartupAccessDeniedPath.cs?name=snippetMS)]
-
-We recommend the `AccessDeniedPath` page contain the following information:
-
-*  Remote authentication was canceled.
-* This app requires authentication.
-* To try sign-in again, select the Login link.
-
-### Test AccessDeniedPath
-
-* Navigate to [office.com](https://www.office.com/)
-* If you are signed in, you must sign out.
-* Run the app and select Microsoft sign-in.
-* Select **Cancel** when prompted to accept access and permissions. You are redirected to the specified `AccessDeniedPath` page.
--->
 
 [!INCLUDE[](includes/chain-auth-providers.md)]
 

--- a/aspnetcore/security/authentication/social/social-code/AccessDeniedPathInfo.cshtml
+++ b/aspnetcore/security/authentication/social/social-code/AccessDeniedPathInfo.cshtml
@@ -1,0 +1,11 @@
+﻿@page
+@model RPgoog2.Pages.AccessDeniedPathInfoModel
+@{
+    ViewData["Title"] = "AccessDeniedPathInfo";
+}
+
+<h1>AccessDeniedPathInfo</h1>
+
+<p>
+    Remote authentication was canceled. This app requires authentication. To try again, select the Login link.
+</p>

--- a/aspnetcore/security/authentication/social/social-code/StartupAccessDeniedPath.cs
+++ b/aspnetcore/security/authentication/social/social-code/StartupAccessDeniedPath.cs
@@ -48,14 +48,12 @@ namespace RPgoog2
             });
             #endregion
 
-            #region snippetMS
             services.AddAuthentication().AddMicrosoftAccount(options =>
             {
                 options.ClientId = Configuration["Authentication:Microsoft:ClientId"];
                 options.ClientSecret = Configuration["Authentication:Microsoft:ClientSecret"];
-                options.AccessDeniedPath = "/AccessDeniedPathInfo";
+                // options.AccessDeniedPath = "/AccessDeniedPathInfo";
             });
-            #endregion
 
             services.AddAuthentication().AddTwitter(options =>
             {

--- a/aspnetcore/security/authentication/social/social-code/StartupAccessDeniedPath.cs
+++ b/aspnetcore/security/authentication/social/social-code/StartupAccessDeniedPath.cs
@@ -1,0 +1,96 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using RPgoog2.Data;
+
+namespace RPgoog2
+{
+    public class StartupAccessDeniedPath
+    {
+        public StartupAccessDeniedPath(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddDbContext<ApplicationDbContext>(options =>
+                options.UseSqlServer(
+                    Configuration.GetConnectionString("DefaultConnection")));
+            services.AddDefaultIdentity<IdentityUser>(
+                             options => options.SignIn.RequireConfirmedAccount = true)
+                .AddEntityFrameworkStores<ApplicationDbContext>();
+            services.AddRazorPages();
+
+            services.AddAuthentication().AddGoogle(options =>
+                    {
+                        IConfigurationSection googleAuthNSection =
+                            Configuration.GetSection("Authentication:Google");
+
+                        options.ClientId = googleAuthNSection["ClientId"];
+                        options.ClientSecret = googleAuthNSection["ClientSecret"];
+                        // AccessDeniedPath not supported
+                        // options.AccessDeniedPath = "/AccessDeniedPathInfo";
+                    });
+
+            #region snippetFB
+            services.AddAuthentication().AddFacebook(options =>
+            {
+                options.AppId = Configuration["Authentication:Facebook:AppId"];
+                options.AppSecret = Configuration["Authentication:Facebook:AppSecret"];
+                options.AccessDeniedPath = "/AccessDeniedPathInfo";
+            });
+            #endregion
+
+            #region snippetMS
+            services.AddAuthentication().AddMicrosoftAccount(options =>
+            {
+                options.ClientId = Configuration["Authentication:Microsoft:ClientId"];
+                options.ClientSecret = Configuration["Authentication:Microsoft:ClientSecret"];
+                options.AccessDeniedPath = "/AccessDeniedPathInfo";
+            });
+            #endregion
+
+            services.AddAuthentication().AddTwitter(options =>
+            {
+                options.ConsumerKey = Configuration["Authentication:Twitter:ConsumerAPIKey"];
+                options.ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"];
+                options.RetrieveUserDetails = true;
+                // options.AccessDeniedPath = "/AccessDeniedPathInfo"; // Not supported
+            });
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+                app.UseDatabaseErrorPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+
+            app.UseRouting();
+
+            app.UseAuthentication();
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapRazorPages();
+            });
+        }
+    }
+}

--- a/aspnetcore/security/authentication/social/twitter-logins.md
+++ b/aspnetcore/security/authentication/social/twitter-logins.md
@@ -73,6 +73,12 @@ You are now logged in using your Twitter credentials:
 
 [!INCLUDE[Forward request information when behind a proxy or load balancer section](includes/forwarded-headers-middleware.md)]
 
+<!-- 
+### React to cancel Authorize External sign-in
+Twitter doesn't support AccessDeniedPath
+Rather in the twitter setup, you can provide an External sign-in homepage. The external sign-in homepage doesn't support localhost. Tested with https://cors3.azurewebsites.net/ and that works.
+-->
+
 ## Troubleshooting
 
 * **ASP.NET Core 2.x only:** If Identity isn't configured by calling `services.AddIdentity` in `ConfigureServices`, attempting to authenticate will result in *ArgumentException: The 'SignInScheme' option must be provided*. The project template used in this sample ensures that this is done.


### PR DESCRIPTION
Fixes #9603
Only FB seems to support this.
Internal review URLs
* [FB](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/social/facebook-logins?view=aspnetcore-3.1&branch=pr-en-us-17679#react-to-cancel-authorize-external-sign-in)
