### PR TITLE
Fix missing @ before typeof(Startup)

### DIFF
--- a/aspnetcore/blazor/layouts/sample_snapshot/3.x/App2.razor
+++ b/aspnetcore/blazor/layouts/sample_snapshot/3.x/App2.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="typeof(Startup).Assembly">
+<Router AppAssembly="@typeof(Startup).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>


### PR DESCRIPTION
Fixes an error in the second layout code example of the docs under: https://docs.microsoft.com/en-us/aspnet/core/blazor/layouts?view=aspnetcore-5.0#default-layout