### PR TITLE
Razor file compilation

### DIFF
--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -23,19 +23,12 @@ Build- and publish-time compilation of Razor files is enabled by default by the 
 
 To enable runtime compilation for all environments and configuration modes:
 
-1. Install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
+* Install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
 
-1. Update the project's `Startup.ConfigureServices` method to include a call to `AddRazorRuntimeCompilation`. For example:
+* Update the project's `Startup.ConfigureServices` method to include a call to <xref:Microsoft.Extensions.DependencyInjection.RazorRuntimeCompilationMvcBuilderExtensions.AddRazorRuntimeCompilation*>. For example:
 
-    ```csharp
-    public void ConfigureServices(IServiceCollection services)
-    {
-        services.AddRazorPages()
-            .AddRazorRuntimeCompilation();
-
-        // code omitted for brevity
-    }
-    ```
+[!code-csharp[](~/mvc/views/view-compilation/sample/Startup.cs
+?name=snippet]
 
 ### Conditionally enable runtime compilation
 
@@ -75,9 +68,11 @@ To enable runtime compilation based on the environment and configuration mode:
 
 ## Additional resources
 
+* [RazorCompileOnBuild and RazorCompileOnPublish](xref:razor-pages/sdk#properties) properties.
 * <xref:razor-pages/index>
 * <xref:mvc/views/overview>
 * <xref:razor-pages/sdk>
+* See the [runtimecompilation sample on GitHub](https://github.com/aspnet/samples/tree/master/samples/aspnetcore/mvc/runtimecompilation) for a sample that shows making `RuntimeCompilation` work across projects.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -27,8 +27,15 @@ To enable runtime compilation for all environments and configuration modes:
 
 * Update the project's `Startup.ConfigureServices` method to include a call to <xref:Microsoft.Extensions.DependencyInjection.RazorRuntimeCompilationMvcBuilderExtensions.AddRazorRuntimeCompilation*>. For example:
 
-[!code-csharp[](~/mvc/views/view-compilation/sample/Startup.cs
-?name=snippet]
+    ```csharp
+    public void ConfigureServices(IServiceCollection services)
+    {
+        services.AddRazorPages()
+            .AddRazorRuntimeCompilation();
+
+        // code omitted for brevity
+    }
+    ```
 
 ### Conditionally enable runtime compilation
 
@@ -40,31 +47,15 @@ Runtime compilation can be enabled such that it's only available for local devel
 
 To enable runtime compilation based on the environment and configuration mode:
 
-1. Conditionally reference the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) package based on the active `Configuration` value:
+* Conditionally reference the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) package based on the active `Configuration` value:
 
     ```xml
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" Condition="'$(Configuration)' == 'Debug'" />
     ```
 
-1. Update the project's `Startup.ConfigureServices` method to include a call to `AddRazorRuntimeCompilation`. Conditionally execute `AddRazorRuntimeCompilation` such that it only runs in Debug mode when the `ASPNETCORE_ENVIRONMENT` variable is set to `Development`:
+* Update the project's `Startup.ConfigureServices` method to include a call to `AddRazorRuntimeCompilation`. Conditionally execute `AddRazorRuntimeCompilation` such that it only runs in Debug mode when the `ASPNETCORE_ENVIRONMENT` variable is set to `Development`:
 
-    ```csharp
-    public IWebHostEnvironment Env { get; set; }
-
-    public void ConfigureServices(IServiceCollection services)
-    {
-        IMvcBuilder builder = services.AddRazorPages();
-
-    #if DEBUG
-        if (Env.IsDevelopment())
-        {
-            builder.AddRazorRuntimeCompilation();
-        }
-    #endif
-
-        // code omitted for brevity
-    }
-    ```
+[!code-csharp[](~/mvc/views/view-compilation/sample/Startup.cs?name=snippet]
 
 ## Additional resources
 

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -63,7 +63,7 @@ To enable runtime compilation based on the environment and configuration mode:
 * <xref:razor-pages/index>
 * <xref:mvc/views/overview>
 * <xref:razor-pages/sdk>
-* See the [runtimecompilation sample on GitHub](https://github.com/aspnet/samples/tree/master/samples/aspnetcore/mvc/runtimecompilation) for a sample that shows making `RuntimeCompilation` work across projects.
+* See the [runtimecompilation sample on GitHub](https://github.com/aspnet/samples/tree/master/samples/aspnetcore/mvc/runtimecompilation) for a sample that shows making runtime compilation work across projects.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -25,7 +25,7 @@ To enable runtime compilation for all environments and configuration modes:
 
 1. Install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
 
-2. Update the project's `Startup.ConfigureServices` method to include a call to <xref:Microsoft.Extensions.DependencyInjection.RazorRuntimeCompilationMvcBuilderExtensions.AddRazorRuntimeCompilation*>. For example:
+1. Update the project's `Startup.ConfigureServices` method to include a call to <xref:Microsoft.Extensions.DependencyInjection.RazorRuntimeCompilationMvcBuilderExtensions.AddRazorRuntimeCompilation*>. For example:
 
     ```csharp
     public void ConfigureServices(IServiceCollection services)
@@ -47,15 +47,15 @@ Runtime compilation can be enabled such that it's only available for local devel
 
 To enable runtime compilation based on the environment and configuration mode:
 
-* Conditionally reference the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) package based on the active `Configuration` value:
+1. Conditionally reference the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) package based on the active `Configuration` value:
 
     ```xml
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" Condition="'$(Configuration)' == 'Debug'" />
     ```
 
-* Update the project's `Startup.ConfigureServices` method to include a call to `AddRazorRuntimeCompilation`. Conditionally execute `AddRazorRuntimeCompilation` such that it only runs in Debug mode when the `ASPNETCORE_ENVIRONMENT` variable is set to `Development`:
+1. Update the project's `Startup.ConfigureServices` method to include a call to `AddRazorRuntimeCompilation`. Conditionally execute `AddRazorRuntimeCompilation` such that it only runs in Debug mode when the `ASPNETCORE_ENVIRONMENT` variable is set to `Development`:
 
-[!code-csharp[](~/mvc/views/view-compilation/sample/Startup.cs?name=snippet)]
+  [!code-csharp[](~/mvc/views/view-compilation/sample/Startup.cs?name=snippet)]
 
 ## Additional resources
 

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -23,9 +23,9 @@ Build- and publish-time compilation of Razor files is enabled by default by the 
 
 To enable runtime compilation for all environments and configuration modes:
 
-* Install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
+1. Install the [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation/) NuGet package.
 
-* Update the project's `Startup.ConfigureServices` method to include a call to <xref:Microsoft.Extensions.DependencyInjection.RazorRuntimeCompilationMvcBuilderExtensions.AddRazorRuntimeCompilation*>. For example:
+2. Update the project's `Startup.ConfigureServices` method to include a call to <xref:Microsoft.Extensions.DependencyInjection.RazorRuntimeCompilationMvcBuilderExtensions.AddRazorRuntimeCompilation*>. For example:
 
     ```csharp
     public void ConfigureServices(IServiceCollection services)

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -55,7 +55,7 @@ To enable runtime compilation based on the environment and configuration mode:
 
 * Update the project's `Startup.ConfigureServices` method to include a call to `AddRazorRuntimeCompilation`. Conditionally execute `AddRazorRuntimeCompilation` such that it only runs in Debug mode when the `ASPNETCORE_ENVIRONMENT` variable is set to `Development`:
 
-[!code-csharp[](~/mvc/views/view-compilation/sample/Startup.cs?name=snippet]
+[!code-csharp[](~/mvc/views/view-compilation/sample/Startup.cs?name=snippet)]
 
 ## Additional resources
 

--- a/aspnetcore/mvc/views/view-compilation/sample/Startup.cs
+++ b/aspnetcore/mvc/views/view-compilation/sample/Startup.cs
@@ -1,0 +1,59 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace RazorRuntimeComp
+{
+    #region snippet
+    public class Startup
+    {
+        public Startup(IConfiguration configuration, IWebHostEnvironment env)
+        {
+            Configuration = configuration;
+            Env = env;
+        }
+
+        public IWebHostEnvironment Env { get; set; }
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            IMvcBuilder builder = services.AddRazorPages();
+
+#if DEBUG
+            if (Env.IsDevelopment())
+            {
+                builder.AddRazorRuntimeCompilation();
+            }
+#endif
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            if (Env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapRazorPages();
+            });
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/mvc/views/view-compilation/sample/Startup.cs
+++ b/aspnetcore/mvc/views/view-compilation/sample/Startup.cs
@@ -4,23 +4,21 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
-namespace RazorRuntimeComp
+#region snippet
+public class Startup
 {
-    #region snippet
-    public class Startup
+    public Startup(IConfiguration configuration, IWebHostEnvironment env)
     {
-        public Startup(IConfiguration configuration, IWebHostEnvironment env)
-        {
-            Configuration = configuration;
-            Env = env;
-        }
+        Configuration = configuration;
+        Env = env;
+    }
 
-        public IWebHostEnvironment Env { get; set; }
-        public IConfiguration Configuration { get; }
+    public IWebHostEnvironment Env { get; set; }
+    public IConfiguration Configuration { get; }
 
-        public void ConfigureServices(IServiceCollection services)
-        {
-            IMvcBuilder builder = services.AddRazorPages();
+    public void ConfigureServices(IServiceCollection services)
+    {
+        IMvcBuilder builder = services.AddRazorPages();
 
 #if DEBUG
             if (Env.IsDevelopment())
@@ -28,32 +26,31 @@ namespace RazorRuntimeComp
                 builder.AddRazorRuntimeCompilation();
             }
 #endif
-        }
-
-        public void Configure(IApplicationBuilder app)
-        {
-            if (Env.IsDevelopment())
-            {
-                app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                app.UseExceptionHandler("/Error");
-                app.UseHsts();
-            }
-
-            app.UseHttpsRedirection();
-            app.UseStaticFiles();
-
-            app.UseRouting();
-
-            app.UseAuthorization();
-
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapRazorPages();
-            });
-        }
     }
-    #endregion
+
+    public void Configure(IApplicationBuilder app)
+    {
+        if (Env.IsDevelopment())
+        {
+            app.UseDeveloperExceptionPage();
+        }
+        else
+        {
+            app.UseExceptionHandler("/Error");
+            app.UseHsts();
+        }
+
+        app.UseHttpsRedirection();
+        app.UseStaticFiles();
+
+        app.UseRouting();
+
+        app.UseAuthorization();
+
+        app.UseEndpoints(endpoints =>
+        {
+            endpoints.MapRazorPages();
+        });
+    }
 }
+#endregion


### PR DESCRIPTION
Fixes #16420
Fixes #15505 

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/views/view-compilation?view=aspnetcore-3.1&branch=pr-en-us-17709)

Prefer bullets to numbers unless customer is likely to do the steps out of order, and order is critical. That's a rare case. When order doesn't matter, as in this case, use bullets. For multi-step instructions that do need order, bullets are better anyway. Customer will naturally follow the bullets in order. Easier to write/maintain and it looks better.