### PR TITLE
Update MessagePack docs for 5.0

### DIFF
--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -5,7 +5,7 @@ description: Add MessagePack Hub Protocol to ASP.NET Core SignalR.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 11/12/2019
+ms.date: 04/13/2020
 no-loc: [SignalR]
 uid: signalr/messagepackhubprotocol
 ---
@@ -18,11 +18,11 @@ This article assumes the reader is familiar with the topics covered in [Get Star
 
 ## What is MessagePack?
 
-[MessagePack](https://msgpack.org/index.html) is a binary serialization format that is fast and compact. It's useful when performance and bandwidth are a concern because it creates smaller messages compared to [JSON](https://www.json.org/). Because it's a binary format, messages are unreadable when looking at network traces and logs unless the bytes are passed through a MessagePack parser. SignalR has built-in support for the MessagePack format, and provides APIs for the client and server to use.
+[MessagePack](https://msgpack.org/index.html) is a fast and compact binary serialization format. It's useful when performance and bandwidth are a concern because it creates smaller messages compared to [JSON](https://www.json.org/). The binary messages are unreadable when looking at network traces and logs unless the bytes are passed through a MessagePack parser. SignalR has built-in support for the MessagePack format and provides APIs for the client and server to use.
 
 ## Configure MessagePack on the server
 
-To enable the MessagePack Hub Protocol on the server, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package in your app. In the Startup.cs file add `AddMessagePackProtocol` to the `AddSignalR` call to enable MessagePack support on the server.
+To enable the MessagePack Hub Protocol on the server, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package in your app. In the `Startup.ConfigureServices` method, add `AddMessagePackProtocol` to the `AddSignalR` call to enable MessagePack support on the server.
 
 > [!NOTE]
 > JSON is enabled by default. Adding MessagePack enables support for both JSON and MessagePack clients.
@@ -68,14 +68,13 @@ var hubConnection = new HubConnectionBuilder()
 
 ### JavaScript client
 
-MessagePack support for the JavaScript client is provided by the `@microsoft/signalr-protocol-msgpack` npm package. Install the package by executing the following command in a command shell:
+MessagePack support for the JavaScript client is provided by the [@microsoft/signalr-protocol-msgpack](https://www.npmjs.com/package/@microsoft/signalr-protocol-msgpack) npm package. Install the package by executing the following command in a command shell:
 
-```console
+```bash
 npm install @microsoft/signalr-protocol-msgpack
 ```
 
 After installing the npm package, the module can be used directly via a JavaScript module loader or imported into the browser by referencing the following file:
-
 
 *node_modules\\@microsoft\signalr-protocol-msgpack\dist\browser\signalr-protocol-msgpack.js* 
 
@@ -132,7 +131,7 @@ The MessagePack protocol doesn't provide a way to encode the `Kind` value of a `
 
 ### DateTime.MinValue is not supported by MessagePack in JavaScript
 
-The [msgpack5](https://github.com/mcollina/msgpack5) library used by the SignalR JavaScript client doesn't support the `timestamp96` type in MessagePack. This type is used to encode very large date values (either very early in the past or very far in the future). The value of `DateTime.MinValue` is `January 1, 0001` which must be encoded in a `timestamp96` value. Because of this, sending `DateTime.MinValue` to a JavaScript client isn't supported. When `DateTime.MinValue` is received by the JavaScript client, the following error is thrown:
+The [msgpack5](https://github.com/mcollina/msgpack5) library used by the SignalR JavaScript client doesn't support the `timestamp96` type in MessagePack. This type is used to encode very large date values (either very early in the past or very far in the future). The value of `DateTime.MinValue` is `January 1, 0001`, which must be encoded in a `timestamp96` value. Because of this, sending `DateTime.MinValue` to a JavaScript client isn't supported. When `DateTime.MinValue` is received by the JavaScript client, the following error is thrown:
 
 ```
 Uncaught Error: unable to find ext type 255 at decoder.js:427
@@ -177,17 +176,18 @@ For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](
 * [JavaScript client](xref:signalr/javascript-client)
 
 ::: moniker-end
+
 ::: moniker range=">= aspnetcore-3.0 < aspnetcore-5.0"
 
 This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
 
 ## What is MessagePack?
 
-[MessagePack](https://msgpack.org/index.html) is a binary serialization format that is fast and compact. It's useful when performance and bandwidth are a concern because it creates smaller messages compared to [JSON](https://www.json.org/). Because it's a binary format, messages are unreadable when looking at network traces and logs unless the bytes are passed through a MessagePack parser. SignalR has built-in support for the MessagePack format, and provides APIs for the client and server to use.
+[MessagePack](https://msgpack.org/index.html) is a fast and compact binary serialization format. It's useful when performance and bandwidth are a concern because it creates smaller messages compared to [JSON](https://www.json.org/). The binary messages are unreadable when looking at network traces and logs unless the bytes are passed through a MessagePack parser. SignalR has built-in support for the MessagePack format, and provides APIs for the client and server to use.
 
 ## Configure MessagePack on the server
 
-To enable the MessagePack Hub Protocol on the server, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package in your app. In the Startup.cs file add `AddMessagePackProtocol` to the `AddSignalR` call to enable MessagePack support on the server.
+To enable the MessagePack Hub Protocol on the server, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package in your app. In the `Startup.ConfigureServices` method, add `AddMessagePackProtocol` to the `AddSignalR` call to enable MessagePack support on the server.
 
 > [!NOTE]
 > JSON is enabled by default. Adding MessagePack enables support for both JSON and MessagePack clients.
@@ -243,14 +243,13 @@ var hubConnection = new HubConnectionBuilder()
 
 ### JavaScript client
 
-MessagePack support for the JavaScript client is provided by the `@microsoft/signalr-protocol-msgpack` npm package. Install the package by executing the following command in a command shell:
+MessagePack support for the JavaScript client is provided by the [@microsoft/signalr-protocol-msgpack](https://www.npmjs.com/package/@microsoft/signalr-protocol-msgpack) npm package. Install the package by executing the following command in a command shell:
 
-```console
+```bash
 npm install @microsoft/signalr-protocol-msgpack
 ```
 
 After installing the npm package, the module can be used directly via a JavaScript module loader or imported into the browser by referencing the following file:
-
 
 *node_modules\\@microsoft\signalr-protocol-msgpack\dist\browser\signalr-protocol-msgpack.js* 
 
@@ -309,7 +308,7 @@ For more information on this limitation, see GitHub issue [aspnet/SignalR#2632](
 
 ### DateTime.MinValue is not supported by MessagePack in JavaScript
 
-The [msgpack5](https://github.com/mcollina/msgpack5) library used by the SignalR JavaScript client doesn't support the `timestamp96` type in MessagePack. This type is used to encode very large date values (either very early in the past or very far in the future). The value of `DateTime.MinValue` is `January 1, 0001` which must be encoded in a `timestamp96` value. Because of this, sending `DateTime.MinValue` to a JavaScript client isn't supported. When `DateTime.MinValue` is received by the JavaScript client, the following error is thrown:
+The [msgpack5](https://github.com/mcollina/msgpack5) library used by the SignalR JavaScript client doesn't support the `timestamp96` type in MessagePack. This type is used to encode very large date values (either very early in the past or very far in the future). The value of `DateTime.MinValue` is `January 1, 0001`, which must be encoded in a `timestamp96` value. Because of this, sending `DateTime.MinValue` to a JavaScript client isn't supported. When `DateTime.MinValue` is received by the JavaScript client, the following error is thrown:
 
 ```
 Uncaught Error: unable to find ext type 255 at decoder.js:427
@@ -352,17 +351,18 @@ For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](
 * [JavaScript client](xref:signalr/javascript-client)
 
 ::: moniker-end
+
 ::: moniker range="< aspnetcore-3.0"
 
 This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
 
 ## What is MessagePack?
 
-[MessagePack](https://msgpack.org/index.html) is a binary serialization format that is fast and compact. It's useful when performance and bandwidth are a concern because it creates smaller messages compared to [JSON](https://www.json.org/). Because it's a binary format, messages are unreadable when looking at network traces and logs unless the bytes are passed through a MessagePack parser. SignalR has built-in support for the MessagePack format, and provides APIs for the client and server to use.
+[MessagePack](https://msgpack.org/index.html) is a fast and compact binary serialization format. It's useful when performance and bandwidth are a concern because it creates smaller messages compared to [JSON](https://www.json.org/). The binary messages are unreadable when looking at network traces and logs unless the bytes are passed through a MessagePack parser. SignalR has built-in support for the MessagePack format, and provides APIs for the client and server to use.
 
 ## Configure MessagePack on the server
 
-To enable the MessagePack Hub Protocol on the server, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package in your app. In the Startup.cs file add `AddMessagePackProtocol` to the `AddSignalR` call to enable MessagePack support on the server.
+To enable the MessagePack Hub Protocol on the server, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package in your app. In the `Startup.ConfigureServices` method, add `AddMessagePackProtocol` to the `AddSignalR` call to enable MessagePack support on the server.
 
 > [!NOTE]
 > JSON is enabled by default. Adding MessagePack enables support for both JSON and MessagePack clients.
@@ -418,9 +418,9 @@ var hubConnection = new HubConnectionBuilder()
 
 ### JavaScript client
 
-MessagePack support for the JavaScript client is provided by the `@aspnet/signalr-protocol-msgpack` npm package. Install the package by executing the following command in a command shell:
+MessagePack support for the JavaScript client is provided by the [@aspnet/signalr-protocol-msgpack](https://www.npmjs.com/package/@aspnet/signalr-protocol-msgpack) npm package. Install the package by executing the following command in a command shell:
 
-```console
+```bash
 npm install @aspnet/signalr-protocol-msgpack
 ```
 

--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -9,9 +9,171 @@ ms.date: 11/12/2019
 no-loc: [SignalR]
 uid: signalr/messagepackhubprotocol
 ---
+
 # Use MessagePack Hub Protocol in SignalR for ASP.NET Core
 
-By [Brennan Conroy](https://github.com/BrennanConroy)
+::: moniker range=">= aspnetcore-5.0"
+
+This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
+
+## What is MessagePack?
+
+[MessagePack](https://msgpack.org/index.html) is a binary serialization format that is fast and compact. It's useful when performance and bandwidth are a concern because it creates smaller messages compared to [JSON](https://www.json.org/). Because it's a binary format, messages are unreadable when looking at network traces and logs unless the bytes are passed through a MessagePack parser. SignalR has built-in support for the MessagePack format, and provides APIs for the client and server to use.
+
+## Configure MessagePack on the server
+
+To enable the MessagePack Hub Protocol on the server, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package in your app. In the Startup.cs file add `AddMessagePackProtocol` to the `AddSignalR` call to enable MessagePack support on the server.
+
+> [!NOTE]
+> JSON is enabled by default. Adding MessagePack enables support for both JSON and MessagePack clients.
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol();
+```
+
+To customize how MessagePack will format your data, `AddMessagePackProtocol` takes a delegate for configuring options. In that delegate, the `SerializerOptions` property can be used to configure MessagePack serialization options. For more information on how the resolvers work, visit the MessagePack library at [MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp). Attributes can be used on the objects you want to serialize to define how they should be handled.
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol(options =>
+    {
+        options.SerializerOptions = MessagePackSerializerOptions.Standard.WithResolver(new CustomResolver()).WithSecurity(MessagePackSecurity.UntrustedData);
+    });
+```
+
+> [!WARNING]
+> We strongly recommend reviewing [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf) and applying the recommended patches. For example, calling `.WithSecurity(MessagePackSecurity.UntrustedData)` when overriding the `SerializerOptions`.
+
+## Configure MessagePack on the client
+
+> [!NOTE]
+> JSON is enabled by default for the supported clients. Clients can only support a single protocol. Adding MessagePack support will replace any previously configured protocols.
+
+### .NET client
+
+To enable MessagePack in the .NET Client, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package and call `AddMessagePackProtocol` on `HubConnectionBuilder`.
+
+```csharp
+var hubConnection = new HubConnectionBuilder()
+                        .WithUrl("/chatHub")
+                        .AddMessagePackProtocol()
+                        .Build();
+```
+
+> [!NOTE]
+> This `AddMessagePackProtocol` call takes a delegate for configuring options just like the server.
+
+### JavaScript client
+
+MessagePack support for the JavaScript client is provided by the `@microsoft/signalr-protocol-msgpack` npm package. Install the package by executing the following command in a command shell:
+
+```console
+npm install @microsoft/signalr-protocol-msgpack
+```
+
+After installing the npm package, the module can be used directly via a JavaScript module loader or imported into the browser by referencing the following file:
+
+
+*node_modules\\@microsoft\signalr-protocol-msgpack\dist\browser\signalr-protocol-msgpack.js* 
+
+In a browser, the `msgpack5` library must also be referenced. Use a `<script>` tag to create a reference. The library can be found at *node_modules\msgpack5\dist\msgpack5.js*.
+
+> [!NOTE]
+> When using the `<script>` element, the order is important. If *signalr-protocol-msgpack.js* is referenced before *msgpack5.js*, an error occurs when trying to connect with MessagePack. *signalr.js* is also required before *signalr-protocol-msgpack.js*.
+
+```html
+<script src="~/lib/signalr/signalr.js"></script>
+<script src="~/lib/msgpack5/msgpack5.js"></script>
+<script src="~/lib/signalr/signalr-protocol-msgpack.js"></script>
+```
+
+Adding `.withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())` to the `HubConnectionBuilder` will configure the client to use the MessagePack protocol when connecting to a server.
+
+```javascript
+const connection = new signalR.HubConnectionBuilder()
+    .withUrl("/chatHub")
+    .withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
+    .build();
+```
+
+> [!NOTE]
+> At this time, there are no configuration options for the MessagePack protocol on the JavaScript client.
+
+## MessagePack quirks
+
+There are a few issues to be aware of when using the MessagePack Hub Protocol.
+
+### MessagePack is case-sensitive
+
+The MessagePack protocol is case-sensitive. For example, consider the following C# class:
+
+```csharp
+public class ChatMessage
+{
+    public string Sender { get; }
+    public string Message { get; }
+}
+```
+
+When sending from the JavaScript client, you must use `PascalCased` property names, since the casing must match the C# class exactly. For example:
+
+```javascript
+connection.invoke("SomeMethod", { Sender: "Sally", Message: "Hello!" });
+```
+
+Using `camelCased` names won't properly bind to the C# class. You can work around this by using the `Key` attribute to specify a different name for the MessagePack property. For more information, see [the MessagePack-CSharp documentation](https://github.com/neuecc/MessagePack-CSharp#object-serialization).
+
+### DateTime.Kind is not preserved when serializing/deserializing
+
+The MessagePack protocol doesn't provide a way to encode the `Kind` value of a `DateTime`. As a result, when deserializing a date, the MessagePack Hub Protocol will convert to the UTC format if the `DateTime.Kind` is `DateTimeKind.Local` otherwise it will not touch the time and pass it as is. If you're working with `DateTime` values, we recommend converting to UTC before sending them. Convert them from UTC to local time when you receive them.
+
+### DateTime.MinValue is not supported by MessagePack in JavaScript
+
+The [msgpack5](https://github.com/mcollina/msgpack5) library used by the SignalR JavaScript client doesn't support the `timestamp96` type in MessagePack. This type is used to encode very large date values (either very early in the past or very far in the future). The value of `DateTime.MinValue` is `January 1, 0001` which must be encoded in a `timestamp96` value. Because of this, sending `DateTime.MinValue` to a JavaScript client isn't supported. When `DateTime.MinValue` is received by the JavaScript client, the following error is thrown:
+
+```
+Uncaught Error: unable to find ext type 255 at decoder.js:427
+```
+
+Usually, `DateTime.MinValue` is used to encode a "missing" or `null` value. If you need to encode that value in MessagePack, use a nullable `DateTime` value (`DateTime?`) or encode a separate `bool` value indicating if the date is present.
+
+For more information on this limitation, see GitHub issue [aspnet/SignalR#2228](https://github.com/aspnet/SignalR/issues/2228).
+
+### MessagePack support in "ahead-of-time" compilation environment
+
+The [MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp/tree/v2.1.90) library used by the .NET client and server uses code generation to optimize serialization. As a result, it isn't supported by default on environments that use "ahead-of-time" compilation (such as Xamarin iOS or Unity). It's possible to use MessagePack in these environments by "pre-generating" the serializer/deserializer code. For more information, see [the MessagePack-CSharp documentation](https://github.com/neuecc/MessagePack-CSharp/tree/v2.1.90#aot-code-generation-to-support-unityxamarin). Once you have pre-generated the serializers, you can register them using the configuration delegate passed to `AddMessagePackProtocol`:
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol(options =>
+    {
+        StaticCompositeResolver.Instance.Register(
+            MessagePack.Resolvers.GeneratedResolver.Instance,
+            MessagePack.Resolvers.StandardResolver.Instance
+        );
+        options.SerializerOptions = MessagePackSerializerOptions.Standard.WithResolver(StaticCompositeResolver.Instance).WithSecurity(MessagePackSecurity.UntrustedData);
+    });
+```
+
+### Type checks are more strict in MessagePack
+
+The JSON Hub Protocol will perform type conversions during deserialization. For example, if the incoming object has a property value that is a number (`{ foo: 42 }`) but the property on the .NET class is of type `string`, the value will be converted. However, MessagePack doesn't perform this conversion and will throw an exception that can be seen in server-side logs (and in the console):
+
+```
+InvalidDataException: Error binding arguments. Make sure that the types of the provided values match the types of the hub method being invoked.
+```
+
+For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](https://github.com/aspnet/SignalR/issues/2937).
+
+## Related resources
+
+* [Get Started](xref:tutorials/signalr)
+* [.NET client](xref:signalr/dotnet-client)
+* [JavaScript client](xref:signalr/javascript-client)
+
+::: moniker-end
+::: moniker range=">= aspnetcore-3.0 < aspnetcore-5.0"
 
 This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
 
@@ -77,39 +239,16 @@ var hubConnection = new HubConnectionBuilder()
 
 ### JavaScript client
 
-::: moniker range=">= aspnetcore-3.0"
-
 MessagePack support for the JavaScript client is provided by the `@microsoft/signalr-protocol-msgpack` npm package. Install the package by executing the following command in a command shell:
 
 ```console
 npm install @microsoft/signalr-protocol-msgpack
 ```
 
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-MessagePack support for the JavaScript client is provided by the `@aspnet/signalr-protocol-msgpack` npm package. Install the package by executing the following command in a command shell:
-
-```console
-npm install @aspnet/signalr-protocol-msgpack
-```
-
-::: moniker-end
-
 After installing the npm package, the module can be used directly via a JavaScript module loader or imported into the browser by referencing the following file:
 
-::: moniker range=">= aspnetcore-3.0"
 
 *node_modules\\@microsoft\signalr-protocol-msgpack\dist\browser\signalr-protocol-msgpack.js* 
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-3.0"
-
-*node_modules\\@aspnet\signalr-protocol-msgpack\dist\browser\signalr-protocol-msgpack.js* 
-
-::: moniker-end
 
 In a browser, the `msgpack5` library must also be referenced. Use a `<script>` tag to create a reference. The library can be found at *node_modules\msgpack5\dist\msgpack5.js*.
 
@@ -178,7 +317,7 @@ For more information on this limitation, see GitHub issue [aspnet/SignalR#2228](
 
 ### MessagePack support in "ahead-of-time" compilation environment
 
-The [MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp/tree/v1.8) library used by the .NET client and server uses code generation to optimize serialization. As a result, it isn't supported by default on environments that use "ahead-of-time" compilation (such as Xamarin iOS or Unity). It's possible to use MessagePack in these environments by "pre-generating" the serializer/deserializer code. For more information, see [the MessagePack-CSharp documentation](https://github.com/neuecc/MessagePack-CSharp/tree/v1.8#pre-code-generationunityxamarin-supports). Once you have pre-generated the serializers, you can register them using the configuration delegate passed to `AddMessagePackProtocol`:
+The [MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp/tree/v1.8.80) library used by the .NET client and server uses code generation to optimize serialization. As a result, it isn't supported by default on environments that use "ahead-of-time" compilation (such as Xamarin iOS or Unity). It's possible to use MessagePack in these environments by "pre-generating" the serializer/deserializer code. For more information, see [the MessagePack-CSharp documentation](https://github.com/neuecc/MessagePack-CSharp/tree/v1.8.80#pre-code-generationunityxamarin-supports). Once you have pre-generated the serializers, you can register them using the configuration delegate passed to `AddMessagePackProtocol`:
 
 ```csharp
 services.AddSignalR()
@@ -207,3 +346,179 @@ For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](
 * [Get Started](xref:tutorials/signalr)
 * [.NET client](xref:signalr/dotnet-client)
 * [JavaScript client](xref:signalr/javascript-client)
+
+::: moniker-end
+::: moniker range="< aspnetcore-3.0"
+
+This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
+
+## What is MessagePack?
+
+[MessagePack](https://msgpack.org/index.html) is a binary serialization format that is fast and compact. It's useful when performance and bandwidth are a concern because it creates smaller messages compared to [JSON](https://www.json.org/). Because it's a binary format, messages are unreadable when looking at network traces and logs unless the bytes are passed through a MessagePack parser. SignalR has built-in support for the MessagePack format, and provides APIs for the client and server to use.
+
+## Configure MessagePack on the server
+
+To enable the MessagePack Hub Protocol on the server, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package in your app. In the Startup.cs file add `AddMessagePackProtocol` to the `AddSignalR` call to enable MessagePack support on the server.
+
+> [!NOTE]
+> JSON is enabled by default. Adding MessagePack enables support for both JSON and MessagePack clients.
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol();
+```
+
+To customize how MessagePack will format your data, `AddMessagePackProtocol` takes a delegate for configuring options. In that delegate, the `FormatterResolvers` property can be used to configure MessagePack serialization options. For more information on how the resolvers work, visit the MessagePack library at [MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp). Attributes can be used on the objects you want to serialize to define how they should be handled.
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol(options =>
+    {
+        options.FormatterResolvers = new List<MessagePack.IFormatterResolver>()
+        {
+            MessagePack.Resolvers.StandardResolver.Instance
+        };
+    });
+```
+
+> [!WARNING]
+> We strongly recommend reviewing [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf) and applying the recommended patches. For example, setting the `MessagePackSecurity.Active` static property to `MessagePackSecurity.UntrustedData`. Setting the `MessagePackSecurity.Active` requires manually installing a [1.9.x version of MessagePack](https://www.nuget.org/packages/MessagePack/1.9.3). Installing `MessagePack` 1.9.x upgrades the version SignalR uses. When `MessagePackSecurity.Active` is not set to `MessagePackSecurity.UntrustedData`, a malicious client could cause a denial of service. Set `MessagePackSecurity.Active` in `Program.Main`, as shown in the following code:
+
+```csharp
+public static void Main(string[] args)
+{
+  MessagePackSecurity.Active = MessagePackSecurity.UntrustedData;
+
+  CreateHostBuilder(args).Build().Run();
+}
+```
+
+## Configure MessagePack on the client
+
+> [!NOTE]
+> JSON is enabled by default for the supported clients. Clients can only support a single protocol. Adding MessagePack support will replace any previously configured protocols.
+
+### .NET client
+
+To enable MessagePack in the .NET Client, install the `Microsoft.AspNetCore.SignalR.Protocols.MessagePack` package and call `AddMessagePackProtocol` on `HubConnectionBuilder`.
+
+```csharp
+var hubConnection = new HubConnectionBuilder()
+                        .WithUrl("/chatHub")
+                        .AddMessagePackProtocol()
+                        .Build();
+```
+
+> [!NOTE]
+> This `AddMessagePackProtocol` call takes a delegate for configuring options just like the server.
+
+### JavaScript client
+
+MessagePack support for the JavaScript client is provided by the `@aspnet/signalr-protocol-msgpack` npm package. Install the package by executing the following command in a command shell:
+
+```console
+npm install @aspnet/signalr-protocol-msgpack
+```
+
+After installing the npm package, the module can be used directly via a JavaScript module loader or imported into the browser by referencing the following file:
+
+*node_modules\\@aspnet\signalr-protocol-msgpack\dist\browser\signalr-protocol-msgpack.js*
+
+In a browser, the `msgpack5` library must also be referenced. Use a `<script>` tag to create a reference. The library can be found at *node_modules\msgpack5\dist\msgpack5.js*.
+
+> [!NOTE]
+> When using the `<script>` element, the order is important. If *signalr-protocol-msgpack.js* is referenced before *msgpack5.js*, an error occurs when trying to connect with MessagePack. *signalr.js* is also required before *signalr-protocol-msgpack.js*.
+
+```html
+<script src="~/lib/signalr/signalr.js"></script>
+<script src="~/lib/msgpack5/msgpack5.js"></script>
+<script src="~/lib/signalr/signalr-protocol-msgpack.js"></script>
+```
+
+Adding `.withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())` to the `HubConnectionBuilder` will configure the client to use the MessagePack protocol when connecting to a server.
+
+```javascript
+const connection = new signalR.HubConnectionBuilder()
+    .withUrl("/chatHub")
+    .withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
+    .build();
+```
+
+> [!NOTE]
+> At this time, there are no configuration options for the MessagePack protocol on the JavaScript client.
+
+## MessagePack quirks
+
+There are a few issues to be aware of when using the MessagePack Hub Protocol.
+
+### MessagePack is case-sensitive
+
+The MessagePack protocol is case-sensitive. For example, consider the following C# class:
+
+```csharp
+public class ChatMessage
+{
+    public string Sender { get; }
+    public string Message { get; }
+}
+```
+
+When sending from the JavaScript client, you must use `PascalCased` property names, since the casing must match the C# class exactly. For example:
+
+```javascript
+connection.invoke("SomeMethod", { Sender: "Sally", Message: "Hello!" });
+```
+
+Using `camelCased` names won't properly bind to the C# class. You can work around this by using the `Key` attribute to specify a different name for the MessagePack property. For more information, see [the MessagePack-CSharp documentation](https://github.com/neuecc/MessagePack-CSharp#object-serialization).
+
+### DateTime.Kind is not preserved when serializing/deserializing
+
+The MessagePack protocol doesn't provide a way to encode the `Kind` value of a `DateTime`. As a result, when deserializing a date, the MessagePack Hub Protocol assumes the incoming date is in UTC format. If you're working with `DateTime` values in local time, we recommend converting to UTC before sending them. Convert them from UTC to local time when you receive them.
+
+For more information on this limitation, see GitHub issue [aspnet/SignalR#2632](https://github.com/aspnet/SignalR/issues/2632).
+
+### DateTime.MinValue is not supported by MessagePack in JavaScript
+
+The [msgpack5](https://github.com/mcollina/msgpack5) library used by the SignalR JavaScript client doesn't support the `timestamp96` type in MessagePack. This type is used to encode very large date values (either very early in the past or very far in the future). The value of `DateTime.MinValue` is `January 1, 0001` which must be encoded in a `timestamp96` value. Because of this, sending `DateTime.MinValue` to a JavaScript client isn't supported. When `DateTime.MinValue` is received by the JavaScript client, the following error is thrown:
+
+```
+Uncaught Error: unable to find ext type 255 at decoder.js:427
+```
+
+Usually, `DateTime.MinValue` is used to encode a "missing" or `null` value. If you need to encode that value in MessagePack, use a nullable `DateTime` value (`DateTime?`) or encode a separate `bool` value indicating if the date is present.
+
+For more information on this limitation, see GitHub issue [aspnet/SignalR#2228](https://github.com/aspnet/SignalR/issues/2228).
+
+### MessagePack support in "ahead-of-time" compilation environment
+
+The [MessagePack-CSharp](https://github.com/neuecc/MessagePack-CSharp/tree/v1.8.80) library used by the .NET client and server uses code generation to optimize serialization. As a result, it isn't supported by default on environments that use "ahead-of-time" compilation (such as Xamarin iOS or Unity). It's possible to use MessagePack in these environments by "pre-generating" the serializer/deserializer code. For more information, see [the MessagePack-CSharp documentation](https://github.com/neuecc/MessagePack-CSharp/tree/v1.8.80#pre-code-generationunityxamarin-supports). Once you have pre-generated the serializers, you can register them using the configuration delegate passed to `AddMessagePackProtocol`:
+
+```csharp
+services.AddSignalR()
+    .AddMessagePackProtocol(options =>
+    {
+        options.FormatterResolvers = new List<MessagePack.IFormatterResolver>()
+        {
+            MessagePack.Resolvers.GeneratedResolver.Instance,
+            MessagePack.Resolvers.StandardResolver.Instance
+        };
+    });
+```
+
+### Type checks are more strict in MessagePack
+
+The JSON Hub Protocol will perform type conversions during deserialization. For example, if the incoming object has a property value that is a number (`{ foo: 42 }`) but the property on the .NET class is of type `string`, the value will be converted. However, MessagePack doesn't perform this conversion and will throw an exception that can be seen in server-side logs (and in the console):
+
+```
+InvalidDataException: Error binding arguments. Make sure that the types of the provided values match the types of the hub method being invoked.
+```
+
+For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](https://github.com/aspnet/SignalR/issues/2937).
+
+## Related resources
+
+* [Get Started](xref:tutorials/signalr)
+* [.NET client](xref:signalr/dotnet-client)
+* [JavaScript client](xref:signalr/javascript-client)
+
+::: moniker-end

--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -38,12 +38,14 @@ To customize how MessagePack will format your data, `AddMessagePackProtocol` tak
 services.AddSignalR()
     .AddMessagePackProtocol(options =>
     {
-        options.SerializerOptions = MessagePackSerializerOptions.Standard.WithResolver(new CustomResolver()).WithSecurity(MessagePackSecurity.UntrustedData);
+        options.SerializerOptions = MessagePackSerializerOptions.Standard
+            .WithResolver(new CustomResolver())
+            .WithSecurity(MessagePackSecurity.UntrustedData);
     });
 ```
 
 > [!WARNING]
-> We strongly recommend reviewing [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf) and applying the recommended patches. For example, calling `.WithSecurity(MessagePackSecurity.UntrustedData)` when overriding the `SerializerOptions`.
+> We strongly recommend reviewing [CVE-2020-5234](https://github.com/neuecc/MessagePack-CSharp/security/advisories/GHSA-7q36-4xx7-xcxf) and applying the recommended patches. For example, calling `.WithSecurity(MessagePackSecurity.UntrustedData)` when replacing the `SerializerOptions`.
 
 ## Configure MessagePack on the client
 
@@ -152,7 +154,9 @@ services.AddSignalR()
             MessagePack.Resolvers.GeneratedResolver.Instance,
             MessagePack.Resolvers.StandardResolver.Instance
         );
-        options.SerializerOptions = MessagePackSerializerOptions.Standard.WithResolver(StaticCompositeResolver.Instance).WithSecurity(MessagePackSecurity.UntrustedData);
+        options.SerializerOptions = MessagePackSerializerOptions.Standard
+            .WithResolver(StaticCompositeResolver.Instance)
+            .WithSecurity(MessagePackSecurity.UntrustedData);
     });
 ```
 


### PR DESCRIPTION
In 5.0 we updated the library to 2.x and we also changed how the options are set.

Main changes: fixed some links, changed options in 5.0, changed DateTime section in 5.0, changed warning in 5.0

Extra: this was using the old format of monikers for sub-sections. Updated it to copy paste the whole doc for each moniker.

[Internal review page](https://review.docs.microsoft.com/aspnet/core/signalr/messagepackhubprotocol?view=aspnetcore-5.0&branch=pr-en-us-17736)