### PR TITLE
Update read-related-data.md

### DIFF
--- a/aspnetcore/data/ef-rp/read-related-data.md
+++ b/aspnetcore/data/ef-rp/read-related-data.md
@@ -132,6 +132,9 @@ The following code loads related data with the `Select` method:
 
 [!code-csharp[](intro/samples/cu30snapshots/6-related/Pages/Courses/IndexSelect.cshtml.cs?name=snippet_RevisedIndexMethod&highlight=6)]
 
+Notice that the result set doesn't contain any entity types, then no tracking is done. we return a `CourseViewModel` object with some of the values from the entity (but no instances of the actual entity type). There are no tracked entities coming out of the query.
+For more information about the Tracking behavior, see [Tracking vs. No-Tracking Queries](/ef/core/querying/tracking)
+
 The `CourseViewModel`:
 
 [!code-csharp[](intro/samples/cu30snapshots/6-related/Models/SchoolViewModels/CourseViewModel.cs?name=snippet)]

--- a/aspnetcore/data/ef-rp/read-related-data.md
+++ b/aspnetcore/data/ef-rp/read-related-data.md
@@ -132,8 +132,7 @@ The following code loads related data with the `Select` method:
 
 [!code-csharp[](intro/samples/cu30snapshots/6-related/Pages/Courses/IndexSelect.cshtml.cs?name=snippet_RevisedIndexMethod&highlight=6)]
 
-Notice that the result set doesn't contain any entity types, then no tracking is done. we return a `CourseViewModel` object with some of the values from the entity (but no instances of the actual entity type). There are no tracked entities coming out of the query.
-For more information about the Tracking behavior, see [Tracking vs. No-Tracking Queries](/ef/core/querying/tracking)
+The preceding code doesn't return any entity types, therefore no tracking is done. For more information about the EF tracking, see [Tracking vs. No-Tracking Queries](/ef/core/querying/tracking)
 
 The `CourseViewModel`:
 

--- a/aspnetcore/data/ef-rp/read-related-data.md
+++ b/aspnetcore/data/ef-rp/read-related-data.md
@@ -132,7 +132,7 @@ The following code loads related data with the `Select` method:
 
 [!code-csharp[](intro/samples/cu30snapshots/6-related/Pages/Courses/IndexSelect.cshtml.cs?name=snippet_RevisedIndexMethod&highlight=6)]
 
-The preceding code doesn't return any entity types, therefore no tracking is done. For more information about the EF tracking, see [Tracking vs. No-Tracking Queries](/ef/core/querying/tracking)
+The preceding code doesn't return any entity types, therefore no tracking is done. For more information about the EF tracking, see [Tracking vs. No-Tracking Queries](/ef/core/querying/tracking).
 
 The `CourseViewModel`:
 


### PR DESCRIPTION
Add an explanation of why `AsNoTracking` method was not used in [Loading related data with Select](https://docs.microsoft.com/en-us/aspnet/core/data/ef-rp/read-related-data?view=aspnetcore-3.1&tabs=visual-studio-code#loading-related-data-with-select).
Fixes #17764 