### PR TITLE
Fix broken links

### DIFF
--- a/aspnetcore/security/authentication/samples.md
+++ b/aspnetcore/security/authentication/samples.md
@@ -14,17 +14,17 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 The [ASP.NET Core repository](https://github.com/dotnet/AspNetCore) contains the following authentication samples in the *AspNetCore/src/Security/samples* folder:
 
-* [Claims transformation](https://github.com/dotnet/AspNetCore/tree/release/3.0/src/Security/samples/ClaimsTransformation)
-* [Cookie authentication](https://github.com/dotnet/AspNetCore/tree/release/3.0/src/Security/samples/Cookies)
-* [Custom policy provider - IAuthorizationPolicyProvider](https://github.com/dotnet/AspNetCore/tree/release/3.0/src/Security/samples/CustomPolicyProvider)
-* [Dynamic authentication schemes and options](https://github.com/dotnet/AspNetCore/tree/release/3.0/src/Security/samples/DynamicSchemes)
-* [External claims](https://github.com/dotnet/AspNetCore/tree/release/3.0/src/Security/samples/Identity.ExternalClaims)
-* [Selecting between cookie and another authentication scheme based on the request](https://github.com/dotnet/AspNetCore/tree/release/3.0/src/Security/samples/PathSchemeSelection)
-* [Restricts access to static files](https://github.com/dotnet/AspNetCore/tree/release/3.0/src/Security/samples/StaticFilesAuth)
+* [Claims transformation](https://github.com/dotnet/AspNetCore/tree/release/3.1/src/Security/samples/ClaimsTransformation)
+* [Cookie authentication](https://github.com/dotnet/AspNetCore/tree/release/3.1/src/Security/samples/Cookies)
+* [Custom policy provider - IAuthorizationPolicyProvider](https://github.com/dotnet/AspNetCore/tree/release/3.1/src/Security/samples/CustomPolicyProvider)
+* [Dynamic authentication schemes and options](https://github.com/dotnet/AspNetCore/tree/release/3.1/src/Security/samples/DynamicSchemes)
+* [External claims](https://github.com/dotnet/AspNetCore/tree/release/3.1/src/Security/samples/Identity.ExternalClaims)
+* [Selecting between cookie and another authentication scheme based on the request](https://github.com/dotnet/AspNetCore/tree/release/3.1/src/Security/samples/PathSchemeSelection)
+* [Restricts access to static files](https://github.com/dotnet/AspNetCore/tree/release/3.1/src/Security/samples/StaticFilesAuth)
 
 ## Run the samples
 
-* Select a [branch](https://github.com/dotnet/AspNetCore). For example, `Tag:v3.0.0`
+* Select a [branch](https://github.com/dotnet/AspNetCore). For example, `release/3.1`
 * Clone or download the [ASP.NET Core repository](https://github.com/dotnet/AspNetCore).
 * Verify you have installed the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core) version matching the clone of the ASP.NET Core repository.
 * Navigate to a sample in *AspNetCore/src/Security/samples* and run the sample with `dotnet run`.


### PR DESCRIPTION
Fixes #17757

Samples links for the range >= aspnetcore3-0 are not working anymore.
I updated it with links of ASP.NET Core 3.1 because it is the latest LTS release available.
(Hint: the ASP.NET Core 3.0 samples are available [here](https://github.com/dotnet/AspNetCore/tree/3.0/src/Security/samples). You can remove  "release/" from the paths and it will work. )



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->