### PR TITLE
Explain how to enable Razor Class Library runtime compilation in ASP.NET Core 3.1+

### DIFF
--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -79,7 +79,7 @@ No code changes are needed in the project's `Startup` class. At runtime, ASP.NET
 
 ## Enable runtime compilation for a Razor Class Library
 
-Imagine a scenario in which a Razor Pages project references a [Razor Class Library (RCL)](xref:razor-pages/ui-class) named *MyClassLib*. The RCL contains a *_Layout.cshtml* file that all of your team's MVC and Razor Pages projects consume. You want to enable runtime compilation for the *_Layout.cshtml* file in that RCL. Make the following changes in the Razor Pages project:
+Consider a scenario in which a Razor Pages project references a [Razor Class Library (RCL)](xref:razor-pages/ui-class) named *MyClassLib*. The RCL contains a *_Layout.cshtml* file that all of your team's MVC and Razor Pages projects consume. You want to enable runtime compilation for the *_Layout.cshtml* file in that RCL. Make the following changes in the Razor Pages project:
 
 1. Enable runtime compilation with the instructions at [Conditionally enable runtime compilation in an existing project](#conditionally-enable-runtime-compilation-in-an-existing-project).
 1. Configure the runtime compilation options in `Startup.ConfigureServices`:

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how compilation of Razor files occurs in an ASP.NET Core app.
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/13/2020
+ms.date: 04/14/2020
 uid: mvc/views/view-compilation
 ---
 # Razor file compilation in ASP.NET Core
@@ -77,13 +77,23 @@ In the following example, runtime compilation is enabled in the Development envi
 
 No code changes are needed in the project's `Startup` class. At runtime, ASP.NET Core searches for an [assembly-level HostingStartup attribute](xref:fundamentals/configuration/platform-specific-configuration#hostingstartup-attribute) in `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation`. The `HostingStartup` attribute specifies the app startup code to execute. That startup code enables runtime compilation.
 
+## Enable runtime compilation for a Razor Class Library
+
+Imagine a scenario in which a Razor Pages project references a [Razor Class Library (RCL)](xref:razor-pages/ui-class) named *MyClassLib*. The RCL contains a *_Layout.cshtml* file that all of your team's MVC and Razor Pages projects consume. You want to enable runtime compilation for the *_Layout.cshtml* file in that RCL. Use the following steps:
+
+1. Enable runtime compilation in the ASP.NET Core project with the instructions at [Conditionally enable runtime compilation in an existing project](#conditionally-enable-runtime-compilation-in-an-existing-project).
+1. Configure the Razor runtime compilation options in `Startup.ConfigureServices`:
+
+    [!code-csharp[](~/mvc/views/view-compilation/samples/3.1/Startup.cs?name=snippet_ConfigureServices&highlight=5-10)]
+
+    In the preceding code, an absolute path to the *MyClassLib* RCL is constructed. The [PhysicalFileProvider API](xref:fundamentals/file-providers#physicalfileprovider) is used to locate directories and files at that absolute path. Finally, the `PhysicalFileProvider` instance is added to a file providers collection, which allows access to the RCL's *.cshtml* files.
+
 ## Additional resources
 
 * [RazorCompileOnBuild and RazorCompileOnPublish](xref:razor-pages/sdk#properties) properties.
 * <xref:razor-pages/index>
 * <xref:mvc/views/overview>
 * <xref:razor-pages/sdk>
-* See the [runtime compilation sample on GitHub](https://github.com/aspnet/samples/tree/master/samples/aspnetcore/mvc/runtimecompilation) for a sample that shows making runtime compilation work across projects.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -79,10 +79,10 @@ No code changes are needed in the project's `Startup` class. At runtime, ASP.NET
 
 ## Enable runtime compilation for a Razor Class Library
 
-Imagine a scenario in which a Razor Pages project references a [Razor Class Library (RCL)](xref:razor-pages/ui-class) named *MyClassLib*. The RCL contains a *_Layout.cshtml* file that all of your team's MVC and Razor Pages projects consume. You want to enable runtime compilation for the *_Layout.cshtml* file in that RCL. Use the following steps:
+Imagine a scenario in which a Razor Pages project references a [Razor Class Library (RCL)](xref:razor-pages/ui-class) named *MyClassLib*. The RCL contains a *_Layout.cshtml* file that all of your team's MVC and Razor Pages projects consume. You want to enable runtime compilation for the *_Layout.cshtml* file in that RCL. Make the following changes in the Razor Pages project:
 
-1. Enable runtime compilation in the Razor Pages project with the instructions at [Conditionally enable runtime compilation in an existing project](#conditionally-enable-runtime-compilation-in-an-existing-project).
-1. Configure the runtime compilation options in the Razor Pages project's `Startup.ConfigureServices` method:
+1. Enable runtime compilation with the instructions at [Conditionally enable runtime compilation in an existing project](#conditionally-enable-runtime-compilation-in-an-existing-project).
+1. Configure the runtime compilation options in `Startup.ConfigureServices`:
 
     [!code-csharp[](~/mvc/views/view-compilation/samples/3.1/Startup.cs?name=snippet_ConfigureServices&highlight=5-10)]
 

--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -81,8 +81,8 @@ No code changes are needed in the project's `Startup` class. At runtime, ASP.NET
 
 Imagine a scenario in which a Razor Pages project references a [Razor Class Library (RCL)](xref:razor-pages/ui-class) named *MyClassLib*. The RCL contains a *_Layout.cshtml* file that all of your team's MVC and Razor Pages projects consume. You want to enable runtime compilation for the *_Layout.cshtml* file in that RCL. Use the following steps:
 
-1. Enable runtime compilation in the ASP.NET Core project with the instructions at [Conditionally enable runtime compilation in an existing project](#conditionally-enable-runtime-compilation-in-an-existing-project).
-1. Configure the Razor runtime compilation options in `Startup.ConfigureServices`:
+1. Enable runtime compilation in the Razor Pages project with the instructions at [Conditionally enable runtime compilation in an existing project](#conditionally-enable-runtime-compilation-in-an-existing-project).
+1. Configure the runtime compilation options in the Razor Pages project's `Startup.ConfigureServices` method:
 
     [!code-csharp[](~/mvc/views/view-compilation/samples/3.1/Startup.cs?name=snippet_ConfigureServices&highlight=5-10)]
 

--- a/aspnetcore/mvc/views/view-compilation/samples/3.1/Startup.cs
+++ b/aspnetcore/mvc/views/view-compilation/samples/3.1/Startup.cs
@@ -1,0 +1,65 @@
+using System.IO;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace MyApp
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration, IWebHostEnvironment env)
+        {
+            Configuration = configuration;
+            HostEnvironment = env;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public IWebHostEnvironment HostEnvironment { get; }
+
+        #region snippet_ConfigureServices
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddRazorPages();
+
+            services.Configure<MvcRazorRuntimeCompilationOptions>(options =>
+            {
+                var libraryPath = Path.GetFullPath(
+                    Path.Combine(HostEnvironment.ContentRootPath, "..", "MyClassLib"));
+                options.FileProviders.Add(new PhysicalFileProvider(libraryPath));
+            });
+        }
+        #endregion
+
+        public void Configure(IApplicationBuilder app)
+        {
+            if (HostEnvironment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Home/Error");
+                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+                app.UseHsts();
+            }
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
+            });
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/17791

[Internal review page (ASP.NET Core 3.1+)](https://review.docs.microsoft.com/aspnet/core/mvc/views/view-compilation?view=aspnetcore-3.1&branch=pr-en-us-17792#enable-runtime-compilation-for-a-razor-class-library)