### PR TITLE
Fix doubled-up UseAuthorization (part 2)

### DIFF
--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -103,7 +103,7 @@ Enabling CORS on a per-endpoint basis using `RequireCors` currently does ***not*
 
 With endpoint routing, CORS can be enabled on a per-endpoint basis using the <xref:Microsoft.AspNetCore.Builder.CorsEndpointConventionBuilderExtensions.RequireCors*> set of extension methods:
 
-[!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupEndPt.cs?name=snippet2&highlight=3,7-15,32,41,44)]
+[!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupEndPt.cs?name=snippet2&highlight=3,7-15,32,40,43)]
 
 In the preceding code:
 


### PR DESCRIPTION
Fixes #17803, again.

cc @Rick-Anderson 

It looks like it's just the one snippet where the highlighting went wrong. If you'd rather I put `UseAuthentication` in, just say the word.