### PR TITLE
Hub link update

### DIFF
--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -11,7 +11,7 @@ metadata:
   ms.topic: hub-page
   author: WadePickett
   ms.author: wpickett
-  ms.date: 03/27/2020
+  ms.date: 04/15/2020
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -49,7 +49,7 @@ highlightedContent:
     # Card
     - title: "Create your first data-driven MVC web app"
       itemType: get-started
-      url: tutorials/first-mvc-app/index.md
+      url: tutorials/first-mvc-app//start-mvc.md
 
 # conceptualContent section (optional)
 conceptualContent:


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/?view=aspnetcore-3.1&branch=pr-en-us-17845)

Fixes #17554 

Updated link for Create your first data-driven MVC web app to point to first tutorial in the series rather than the "overview" page which just contains links.