### PR TITLE
Add vscode anchor to Blazor debugging page

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -96,6 +96,8 @@ While debugging your Blazor WebAssembly app, you can also debug your server code
 
 1. Press <kbd>F5</kbd> again to let execution continue and see the weather forecast table rendered.
 
+<a id="vscode"></a>
+
 ## Visual Studio Code
 
 To debug a Blazor WebAssembly app in Visual Studio Code:


### PR DESCRIPTION
We need this anchor for the VSCode debugging experience for Blazor WebAssembly.