### PR TITLE
Add note about ANCM 500.38 error

### DIFF
--- a/aspnetcore/test/troubleshoot-azure-iis.md
+++ b/aspnetcore/test/troubleshoot-azure-iis.md
@@ -154,6 +154,15 @@ ANCM failed to start within the provied startup time limit. By default, the time
 
 This error can occur when starting a large number of apps on the same machine. Check for CPU/Memory usage spikes on the server during startup. You may need to stagger the startup process of multiple apps.
 
+### 500.38 ANCM Application DLL Not Found
+
+ANCM failed to locate the application DLL, which should be next to the executable.
+
+This error occurs when hosting an app packaged as a [single-file executable](https://docs.microsoft.com/dotnet/core/whats-new/dotnet-core-3-0#single-file-executables) using the in-process hosting model. The in-process model requires that ANCM load the .NET Core app into the existing IIS process. This scenario is not supported by the single-file deployment model. To fix this error:
+
+1. Disable single-file publishing for your app by setting the `PublishSingleFile` MSBuild property to `false` in your project file.
+1. Or, switch to the out-of-process hosting model by setting the `AspNetCoreHostingModel` MSBuild property to `OutOfProcess` in your project file.
+
 ### 502.5 Process Failure
 
 The worker process fails. The app doesn't start.

--- a/aspnetcore/test/troubleshoot-azure-iis.md
+++ b/aspnetcore/test/troubleshoot-azure-iis.md
@@ -158,10 +158,10 @@ This error can occur when starting a large number of apps on the same machine. C
 
 ANCM failed to locate the application DLL, which should be next to the executable.
 
-This error occurs when hosting an app packaged as a [single-file executable](https://docs.microsoft.com/dotnet/core/whats-new/dotnet-core-3-0#single-file-executables) using the in-process hosting model. The in-process model requires that ANCM load the .NET Core app into the existing IIS process. This scenario is not supported by the single-file deployment model. To fix this error:
+This error occurs when hosting an app packaged as a [single-file executable](/dotnet/core/whats-new/dotnet-core-3-0#single-file-executables) using the in-process hosting model. The in-process model requires that the ANCM load the .NET Core app into the existing IIS process. This scenario isn't supported by the single-file deployment model. Use **one** of the following approaches in the app's project file to fix this error:
 
-1. Disable single-file publishing for your app by setting the `PublishSingleFile` MSBuild property to `false` in your project file.
-1. Or, switch to the out-of-process hosting model by setting the `AspNetCoreHostingModel` MSBuild property to `OutOfProcess` in your project file.
+1. Disable single-file publishing by setting the `PublishSingleFile` MSBuild property to `false`.
+1. Switch to the out-of-process hosting model by setting the `AspNetCoreHostingModel` MSBuild property to `OutOfProcess`.
 
 ### 502.5 Process Failure
 


### PR DESCRIPTION
Specifically, with details about the incompatibility between in-process hosting and single-file executables.

[Internal Review Link](https://review.docs.microsoft.com/en-us/aspnet/core/test/troubleshoot-azure-iis?view=aspnetcore-3.1&branch=pr-en-us-17930#50038-ancm-application-dll-not-found)