### PR TITLE
Enhance Blazor WASM Brotli content

### DIFF
--- a/aspnetcore/host-and-deploy/blazor/webassembly.md
+++ b/aspnetcore/host-and-deploy/blazor/webassembly.md
@@ -5,13 +5,13 @@ description: Learn how to host and deploy a Blazor app using ASP.NET Core, Conte
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/16/2020
+ms.date: 04/22/2020
 no-loc: [Blazor, SignalR]
 uid: host-and-deploy/blazor/webassembly
 ---
 # Host and deploy ASP.NET Core Blazor WebAssembly
 
-By [Luke Latham](https://github.com/guardrex), [Rainer Stropek](https://www.timecockpit.com), and [Daniel Roth](https://github.com/danroth27)
+By [Luke Latham](https://github.com/guardrex), [Rainer Stropek](https://www.timecockpit.com), [Daniel Roth](https://github.com/danroth27), and [Ben Adams](https://twitter.com/ben_a_adams).
 
 [!INCLUDE[](~/includes/blazorwasm-preview-notice.md)]
 
@@ -28,6 +28,8 @@ The following deployment strategies are supported:
 ## Brotli precompression
 
 When a Blazor WebAssembly app is published, the output is precompressed using the [Brotli compression algorithm](https://tools.ietf.org/html/rfc7932) at the highest level to reduce the app size and remove the need for runtime compression.
+
+For IIS *web.config* compression configuration, see the [IIS: Brotli and Gzip compression](#brotli-and-gzip-compression) section.
 
 ## Rewrite URLs for correct routing
 
@@ -151,6 +153,10 @@ If a standalone app is hosted as an IIS sub-app, perform either of the following
   ```
 
 Removing the handler or disabling inheritance is performed in addition to [configuring the app's base path](xref:host-and-deploy/blazor/index#app-base-path). Set the app base path in the app's *index.html* file to the IIS alias used when configuring the sub-app in IIS.
+
+#### Brotli and Gzip compression
+
+IIS can be configured via *web.config* to serve Brotli or Gzip compressed Blazor assets. For an example configuration, see [web.config](webassembly/_samples/web.config?raw=true).
 
 #### Troubleshooting
 

--- a/aspnetcore/host-and-deploy/blazor/webassembly/_samples/web.config
+++ b/aspnetcore/host-and-deploy/blazor/webassembly/_samples/web.config
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <remove fileExtension=".dll" />
+      <remove fileExtension=".json" />
+      <remove fileExtension=".wasm" />
+      <remove fileExtension=".woff" />
+      <remove fileExtension=".woff2" />
+      <remove fileExtension=".js.gz" />
+      <remove fileExtension=".dll.gz" />
+      <remove fileExtension=".json.gz" />
+      <remove fileExtension=".wasm.gz" />
+      <remove fileExtension=".js.br" />
+      <remove fileExtension=".dll.br" />
+      <remove fileExtension=".json.br" />
+      <remove fileExtension=".wasm.br" />
+      <mimeMap fileExtension=".dll" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".json" mimeType="application/json" />
+      <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
+      <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
+      <mimeMap fileExtension=".woff2" mimeType="application/font-woff" />
+      <mimeMap fileExtension=".js.gz" mimeType="application/javascript" />
+      <mimeMap fileExtension=".dll.gz" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".json.gz" mimeType="application/json" />
+      <mimeMap fileExtension=".wasm.gz" mimeType="application/wasm" />
+      <mimeMap fileExtension=".js.br" mimeType="application/javascript" />
+      <mimeMap fileExtension=".dll.br" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".json.br" mimeType="application/json" />
+      <mimeMap fileExtension=".wasm.br" mimeType="application/wasm" />
+    </staticContent>
+    <httpCompression>
+      <dynamicTypes>
+        <remove mimeType="application/javascript" />
+        <remove mimeType="application/json" />
+        <remove mimeType="application/octet-stream" />
+        <remove mimeType="application/wasm" />
+      </dynamicTypes>
+      <staticTypes>
+        <remove mimeType="application/javascript" />
+        <remove mimeType="application/json" />
+        <remove mimeType="application/octet-stream" />
+        <remove mimeType="application/wasm" />
+      </staticTypes>
+    </httpCompression>
+    <rewrite>
+      <outboundRules rewriteBeforeCache="true">
+        <rule name="Add Vary Accept-Encoding" preCondition="PreCompressedFile" enabled="true">
+            <match serverVariable="RESPONSE_Vary" pattern=".*" />
+            <action type="Rewrite" value="Accept-Encoding" />
+        </rule>
+        <rule name="Add Encoding Brotli" preCondition="PreCompressedBrotli" enabled="true" stopProcessing="true">
+            <match serverVariable="RESPONSE_Content_Encoding" pattern=".*" />
+            <action type="Rewrite" value="br" />
+        </rule>
+        <rule name="Add Encoding Gzip" preCondition="PreCompressedGzip" enabled="true" stopProcessing="true">
+            <match serverVariable="RESPONSE_Content_Encoding" pattern=".*" />
+            <action type="Rewrite" value="gzip" />
+        </rule>
+        <preConditions>
+            <preCondition name="PreCompressedFile">
+                <add input="{HTTP_URL}" pattern="\.(gz|br)$" />
+            </preCondition>
+            <preCondition name="PreCompressedGzip">
+                <add input="{HTTP_URL}" pattern="\.gz$" />
+            </preCondition>
+            <preCondition name="PreCompressedBrotli">
+                <add input="{HTTP_URL}" pattern="\.br$" />
+            </preCondition>
+        </preConditions>
+      </outboundRules>
+      <rules>
+        <rule name="Serve subdir">
+          <match url=".*" />
+          <action type="Rewrite" url="wwwroot\{R:0}" />
+        </rule>
+        <rule name="Rewrite brotli file" stopProcessing="true">
+          <match url="(.*)"/>
+          <conditions>
+            <add input="{HTTP_ACCEPT_ENCODING}" pattern="br" />
+            <add input="{REQUEST_FILENAME}.br" matchType="IsFile" />
+          </conditions>
+          <action type="Rewrite" url="{R:1}.br" />
+        </rule>
+        <rule name="Rewrite gzip file" stopProcessing="true">
+          <match url="(.*)"/>
+          <conditions>
+            <add input="{HTTP_ACCEPT_ENCODING}" pattern="gzip" />
+            <add input="{REQUEST_FILENAME}.gz" matchType="IsFile" />
+          </conditions>
+          <action type="Rewrite" url="{R:1}.gz" />
+        </rule>
+        <rule name="SPA fallback routing" stopProcessing="true">
+          <match url=".*" />
+          <conditions logicalGrouping="MatchAll">
+            <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
+          </conditions>
+          <action type="Rewrite" url="wwwroot\" />
+        </rule>
+      </rules>
+    </rewrite>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
Fixes #17857

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/blazor/webassembly?view=aspnetcore-3.1&branch=pr-en-us-17958#brotli-and-gzip-compression)

Looks good. Tested one file (*dotnet-wasm*) for all three and whole site for Gzip.

`http://localhost:8022/_framework/wasm/dotnet.wasm`

* No compression (`Accept-Encoding: identity`)
  * Content-Type: application/wasm
  * Content-Length: 1931045
  * File size on disk: 1933312
* Gzip compression (`Accept-Encoding: gzip`)
  * Content-Type: gzip
  * Content-Length: 776068
  * File size on disk: 778240
* Brotli compression (`Accept-Encoding: br`)
  * Content-Type: br
  * Content-Length: 619583
  * File size on disk: 622592

Whole app came in at 2.04 MB without compression and 1.92 MB Gzipped.

@benaadams ... Thanks for supplying the *web.config* file. I gave u byline props pointed to your Twitter. Do you want that pointed elsewhere?