### PR TITLE
Move Blazor Lifecycle topic UP in TOC

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -299,14 +299,14 @@
           uid: blazor/data-binding
         - name: Event handling
           uid: blazor/event-handling
+        - name: Lifecycle
+          uid: blazor/lifecycle
         - name: Templated components
           uid: blazor/templated-components
         - name: Integrate components
           uid: blazor/integrate-components
         - name: Globalization and localization
           uid: blazor/globalization-localization
-        - name: Lifecycle
-          uid: blazor/lifecycle
         - name: Layouts
           uid: blazor/layouts
         - name: Forms and validation


### PR DESCRIPTION
Fixes #18009

@scottaddie ... This will place "Lifecycle" closer to the *Components* topic to make it a bit more noticeable. We're not going to have a node for *Components* ... at least not right now. I decided to keep going with just *Lifecycle* (short) over *Component lifecycle*, which would imply that we also change to *Component data-binding* and *Component event handling*. It's all a bit much, so I think let's just stick with *Lifecycle* here and keep an :ear: open for more feedback.

Thanks @behroozbc! :rocket: