### PR TITLE
Update to Hub and What's new for L2 removal

### DIFF
--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -11,7 +11,7 @@ metadata:
   ms.topic: hub-page
   author: WadePickett
   ms.author: wpickett
-  ms.date: 04/15/2020
+  ms.date: 04/26/2020
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -27,9 +27,9 @@ highlightedContent:
       itemType: overview
       url: introduction-to-aspnet-core.md
     # Card
-    - title: "ASP.NET Core video tutorials"
-      itemType: video
-      url: https://www.youtube.com/playlist?list=PLdo4fOcmZ0oW8nviYduHq7bmKode-p8Wy
+    - title: "Download .NET"
+      itemType: download
+      url: https://dotnet.microsoft.com/download
     # Card
     - title: "What's new in ASP.NET Core docs"
       itemType: whats-new
@@ -233,6 +233,24 @@ conceptualContent:
         - url: https://docs.microsoft.com/aspnet/overview
           itemType: concept
           text: "ASP.NET 4.x"
+      # Card
+    - title: ASP.NET Core video tutorials
+      links:
+        - url: https://www.youtube.com/playlist?list=PLdo4fOcmZ0oW8nviYduHq7bmKode-p8Wy
+          itemType: video
+          text: "ASP.NET Core 101 video series"
+        - url: https://www.youtube.com/playlist?list=PLdo4fOcmZ0oX7uTkjYwvCJDG2qhcSzwZ6
+          itemType: video
+          text: "Entity Framework Core 101 video series with .NET Core and ASP.NET Core"
+        - url: https://www.youtube.com/watch?v=RyHDWlIq6vI
+          itemType: video
+          text: "Microservice architecture with ASP.NET Core"
+        - url: https://www.youtube.com/watch?v=KlngrOF6RPw&list=PLdo4fOcmZ0oWlP1Qpzg7Dwzxr298ewdUQ
+          itemType: video
+          text: "Focus on Blazor video series"
+        - url: https://www.youtube.com/channel/UCvtT19MZW8dq5Wwfu6B0oxw/
+          itemType: video
+          text: ".NET Channel"
 
 # Card with summary style
 additionalContent:

--- a/aspnetcore/whats-new/index.yml
+++ b/aspnetcore/whats-new/index.yml
@@ -7,7 +7,7 @@ metadata:
   title: ASP.NET Core documentation - What's new?
   description: "Learn about new and updated content in ASP.NET Core docs."
   ms.topic: landing-page
-  ms.date: 04/01/2020
+  ms.date: 04/26/2020
 
 landingContent:
   - title: "Find ASP.NET Core docs updates"
@@ -45,6 +45,13 @@ landingContent:
             url: https://github.com/dotnet/AspNetApiDocs/blob/master/CONTRIBUTING.md
           # - text: "ASP.NET Core samples contributor guide"
           #   url: https://github.com/aspnet/samples/blob/master/CONTRIBUTING.md
+
+  - title: "Community"
+    linkLists:
+      - linkListType: whats-new
+        links:
+          - text: Community
+            url: https://dotnet.microsoft.com/platform/community
 
   - title: "Related what's new pages"
     linkLists:


### PR DESCRIPTION
[Internal Review - Hub page](https://review.docs.microsoft.com/en-us/aspnet/core/index?view=aspnetcore-3.1&branch=pr-en-us-18024)
[Internal Review - What's New page](https://review.docs.microsoft.com/en-us/aspnet/core/whats-new/index?view=aspnetcore-3.1&branch=pr-en-us-18024)

Fixes #17962 

Goal: Make sure ASP.NET developers can find the Download .NET and Community links in a somewhat prominent place since the L2 navigation that contains those links currently are being removed.

Updated the following to prep for L2 navigation bar removal:

- Hub page: Added a Download .NET card to the top highlights section at the top. Since the number of highlights cards were at the max, moved the video tutorial card to a more expanded card in the next section.  This also allowed for pointing to more than just the 101 video series.
- What's New page: Added a Community card to match the .NET What's New page design and pointed to the .NET Community page.

I also verified that all tutorials we highlight in the Hub also have the a link to the .NET Download page or to a more specific SDK version if that is needed.  They all already did, so no updates needed there.