### PR TITLE
Create Blazor Server security node

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -919,6 +919,11 @@
             "source_path": "aspnetcore/blazor/javascript-interop.md",
             "redirect_url": "/aspnet/core/blazor/call-javascript-from-dotnet",
             "redirect_document_id": false
+        },
+        {
+            "source_path": "aspnetcore/security/blazor/server.md",
+            "redirect_url": "/aspnet/core/security/blazor/server",
+            "redirect_document_id": false
         }
     ]
 }

--- a/aspnetcore/blazor/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/call-javascript-from-dotnet.md
@@ -450,7 +450,7 @@ JS interop may fail due to networking errors and should be treated as unreliable
       TimeSpan.FromSeconds({SECONDS}), new[] { "Arg1" });
   ```
 
-For more information on resource exhaustion, see <xref:security/blazor/server>.
+For more information on resource exhaustion, see <xref:security/blazor/server/threat-mitigation>.
 
 [!INCLUDE[Share interop code in a class library](~/includes/blazor-share-interop-code.md)]
 

--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -958,4 +958,4 @@ However, inline SVG markup isn't supported in all scenarios. If you place an `<s
 
 ## Additional resources
 
-* <xref:security/blazor/server> &ndash; Includes guidance on building Blazor Server apps that must contend with resource exhaustion.
+* <xref:security/blazor/server/threat-mitigation> &ndash; Includes guidance on building Blazor Server apps that must contend with resource exhaustion.

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -107,7 +107,7 @@ A UI update in Blazor is triggered by:
 
 The graph is rerendered, and a UI *diff* (difference) is calculated. This diff is the smallest set of DOM edits required to update the UI on the client. The diff is sent to the client in a binary format and applied by the browser.
 
-A component is disposed after the user navigates away from it on the client. While a user is interacting with a component, the component's state (services, resources) must be held in the server's memory. Because the state of many components might be maintained by the server concurrently, memory exhaustion is a concern that must be addressed. For guidance on how to author a Blazor Server app to ensure the best use of server memory, see <xref:security/blazor/server>.
+A component is disposed after the user navigates away from it on the client. While a user is interacting with a component, the component's state (services, resources) must be held in the server's memory. Because the state of many components might be maintained by the server concurrently, memory exhaustion is a concern that must be addressed. For guidance on how to author a Blazor Server app to ensure the best use of server memory, see <xref:security/blazor/server/threat-mitigation>.
 
 ### Circuits
 
@@ -125,12 +125,12 @@ UI latency is the time it takes from an initiated action to the time the UI is u
 
 For a line of business app that's limited to a private corporate network, the effect on user perceptions of latency due to network latency are usually imperceptible. For an app deployed over the Internet, latency may become noticeable to users, particularly if users are widely distributed geographically.
 
-Memory usage can also contribute to app latency. Increased memory usage results in frequent garbage collection or paging memory to disk, both of which degrade app performance and consequently increase UI latency. For more information, see <xref:security/blazor/server>.
+Memory usage can also contribute to app latency. Increased memory usage results in frequent garbage collection or paging memory to disk, both of which degrade app performance and consequently increase UI latency.
 
 Blazor Server apps should be optimized to minimize UI latency by reducing network latency and memory usage. For an approach to measuring network latency, see <xref:host-and-deploy/blazor/server#measure-network-latency>. For more information on SignalR and Blazor, see:
 
 * <xref:host-and-deploy/blazor/server>
-* <xref:security/blazor/server>
+* <xref:security/blazor/server/threat-mitigation>
 
 ### Connection to the server
 

--- a/aspnetcore/host-and-deploy/blazor/server.md
+++ b/aspnetcore/host-and-deploy/blazor/server.md
@@ -28,7 +28,7 @@ A web server capable of hosting an ASP.NET Core app is required. Visual Studio i
 Plan a deployment to make the best use of the available infrastructure for a Blazor Server app. See the following resources to address Blazor Server app scalability:
 
 * [Fundamentals of Blazor Server apps](xref:blazor/hosting-models#blazor-server)
-* <xref:security/blazor/server>
+* <xref:security/blazor/server/threat-mitigation>
 
 ### Deployment server
 
@@ -37,7 +37,7 @@ When considering the scalability of a single server (scale up), the memory avail
 * Number of active circuits that a server can support.
 * UI latency on the client.
 
-For guidance on building secure and scalable Blazor server apps, see <xref:security/blazor/server>.
+For guidance on building secure and scalable Blazor server apps, see <xref:security/blazor/server/threat-mitigation>.
 
 Each circuit uses approximately 250 KB of memory for a minimal *Hello World*-style app. The size of a circuit depends on the app's code and the state maintenance requirements associated with each component. We recommend that you measure resource demands during development for your app and infrastructure, but the following baseline can be a starting point in planning your deployment target: If you expect your app to support 5,000 concurrent users, consider budgeting at least 1.3 GB of server memory to the app (or ~273 KB per user).
 

--- a/aspnetcore/security/blazor/index.md
+++ b/aspnetcore/security/blazor/index.md
@@ -53,7 +53,7 @@ For more information on creating apps and configuration, see <xref:security/blaz
 
 Blazor Server apps operate over a real-time connection that's created using SignalR. [Authentication in SignalR-based apps](xref:signalr/authn-and-authz) is handled when the connection is established. Authentication can be based on a cookie or some other bearer token.
 
-For more information on creating apps and configuration, see <xref:security/blazor/server>.
+For more information on creating apps and configuration, see <xref:security/blazor/server/index>.
 
 ## AuthenticationStateProvider service
 
@@ -491,6 +491,5 @@ The `CascadingAuthenticationState` supplies the `Task<AuthenticationState>` casc
 ## Additional resources
 
 * <xref:security/index>
-* <xref:security/blazor/server>
 * <xref:security/authentication/windowsauth>
 * [Awesome Blazor: Authentication](https://github.com/AdrienTorris/awesome-blazor#authentication) community sample links

--- a/aspnetcore/security/blazor/server/additional-scenarios.md
+++ b/aspnetcore/security/blazor/server/additional-scenarios.md
@@ -1,0 +1,138 @@
+---
+title: ASP.NET Core Blazor Server additional security scenarios
+author: guardrex
+description: Learn how to configure Blazor Server for additional security scenarios.
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 04/27/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/server/additional-scenarios
+---
+# ASP.NET Core Blazor Server additional security scenarios
+
+By [Javier Calvarro Nelson](https://github.com/javiercn)
+
+## Pass tokens to a Blazor Server app
+
+Tokens available outside of the Razor components in a Blazor Server app can be passed to components with the approach described in this section. For sample code, including a complete `Startup.ConfigureServices` example, see the [Passing tokens to a server-side Blazor application](https://github.com/javiercn/blazor-server-aad-sample).
+
+Authenticate the Blazor Server app as you would with a regular Razor Pages or MVC app. Provision and save the tokens to the authentication cookie. For example:
+
+```csharp
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+
+...
+
+services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
+{
+    options.ResponseType = "code";
+    options.SaveTokens = true;
+
+    options.Scope.Add("offline_access");
+    options.Scope.Add("{SCOPE}");
+    options.Resource = "{RESOURCE}";
+});
+```
+
+Define a class to pass in the initial app state with the access and refresh tokens:
+
+```csharp
+public class InitialApplicationState
+{
+    public string AccessToken { get; set; }
+    public string RefreshToken { get; set; }
+}
+```
+
+Define a **scoped** token provider service that can be used within the Blazor app to resolve the tokens from DI:
+
+```csharp
+public class TokenProvider
+{
+    public string AccessToken { get; set; }
+    public string RefreshToken { get; set; }
+}
+```
+
+In `Startup.ConfigureServices`, add services for:
+
+* `IHttpClientFactory`
+* `TokenProvider`
+
+```csharp
+services.AddHttpClient();
+services.AddScoped<TokenProvider>();
+```
+
+In the *_Host.cshtml* file, create and instance of `InitialApplicationState` and pass it as a parameter to the app:
+
+```cshtml
+@using Microsoft.AspNetCore.Authentication
+
+...
+
+@{
+    var tokens = new InitialApplicationState
+    {
+        AccessToken = await HttpContext.GetTokenAsync("access_token"),
+        RefreshToken = await HttpContext.GetTokenAsync("refresh_token")
+    };
+}
+
+<app>
+    <component type="typeof(App)" param-InitialState="tokens" 
+        render-mode="ServerPrerendered" />
+</app>
+```
+
+In the `App` component (*App.razor*), resolve the service and initialize it with the data from the parameter:
+
+```razor
+@inject TokenProvider TokenProvider
+
+...
+
+@code {
+    [Parameter]
+    public InitialApplicationState InitialState { get; set; }
+
+    protected override Task OnInitializedAsync()
+    {
+        TokenProvider.AccessToken = InitialState.AccessToken;
+        TokenProvider.RefreshToken = InitialState.RefreshToken;
+
+        return base.OnInitializedAsync();
+    }
+}
+```
+
+In the service that makes a secure API request, inject the token provider and retrieve the token to call the API:
+
+```csharp
+public class WeatherForecastService
+{
+    private readonly TokenProvider _store;
+
+    public WeatherForecastService(IHttpClientFactory clientFactory, 
+        TokenProvider tokenProvider)
+    {
+        Client = clientFactory.CreateClient();
+        _store = tokenProvider;
+    }
+
+    public HttpClient Client { get; }
+
+    public async Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
+    {
+        var token = _store.AccessToken;
+        var request = new HttpRequestMessage(HttpMethod.Get, 
+            "https://localhost:5003/WeatherForecast");
+        request.Headers.Add("Authorization", $"Bearer {token}");
+        var response = await Client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadAsAsync<WeatherForecast[]>();
+    }
+}
+```

--- a/aspnetcore/security/blazor/server/additional-scenarios.md
+++ b/aspnetcore/security/blazor/server/additional-scenarios.md
@@ -45,7 +45,7 @@ public class InitialApplicationState
 }
 ```
 
-Define a **scoped** token provider service that can be used within the Blazor app to resolve the tokens from DI:
+Define a **scoped** token provider service that can be used within the Blazor app to resolve the tokens from [dependency injection (DI)](xref:blazor/dependency-injection):
 
 ```csharp
 public class TokenProvider

--- a/aspnetcore/security/blazor/server/index.md
+++ b/aspnetcore/security/blazor/server/index.md
@@ -42,14 +42,14 @@ dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
 
 Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
 
-| Authentication mechanism                                                                 | `{AUTHENTICATION}` value |
-| ---------------------------------------------------------------------------------------- | :----------------------: |
-| No Authentication                                                                        | `None`                   |
-| Individual<br>Users stored in the app with ASP.NET Core Identity.                        | `Individual`             |
-| Individual<br>Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c). | `IndividualB2C`          |
-| Work or School Accounts<br>Organizational authentication for a single tenant.            | `SingleOrg`              |
-| Work or School Accounts<br>Organizational authentication for multiple tenants.           | `MultiOrg`               |
-| Windows Authentication                                                                   | `Windows`                |
+| Authentication mechanism | Description |
+| ------------------------ | ----------- |
+| `None` (default)         | No authentication |
+| `Individual`             | Users stored in the app with ASP.NET Core Identity |
+| `IndividualB2C`          | Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c) |
+| `SingleOrg`              | Organizational authentication for a single tenant |
+| `MultiOrg`               | Organizational authentication for multiple tenants |
+| `Windows`                | Windows Authentication |
 
 Using the `-o|--output` option, the command uses the value provided for the `{APP NAME}` placeholder to:
 
@@ -76,14 +76,14 @@ dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
 
 Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
 
-| Authentication mechanism                                                                 | `{AUTHENTICATION}` value |
-| ---------------------------------------------------------------------------------------- | :----------------------: |
-| No Authentication                                                                        | `None`                   |
-| Individual<br>Users stored in the app with ASP.NET Core Identity.                        | `Individual`             |
-| Individual<br>Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c). | `IndividualB2C`          |
-| Work or School Accounts<br>Organizational authentication for a single tenant.            | `SingleOrg`              |
-| Work or School Accounts<br>Organizational authentication for multiple tenants.           | `MultiOrg`               |
-| Windows Authentication                                                                   | `Windows`                |
+| Authentication mechanism | Description |
+| ------------------------ | ----------- |
+| `None` (default)         | No authentication |
+| `Individual`             | Users stored in the app with ASP.NET Core Identity |
+| `IndividualB2C`          | Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c) |
+| `SingleOrg`              | Organizational authentication for a single tenant |
+| `MultiOrg`               | Organizational authentication for multiple tenants |
+| `Windows`                | Windows Authentication |
 
 Using the `-o|--output` option, the command uses the value provided for the `{APP NAME}` placeholder to:
 

--- a/aspnetcore/security/blazor/server/index.md
+++ b/aspnetcore/security/blazor/server/index.md
@@ -1,0 +1,95 @@
+---
+title: Secure ASP.NET Core Blazor Server apps
+author: guardrex
+description: Learn how to secure Blazor Server apps as ASP.NET Core applications.
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 04/27/2020
+no-loc: [Blazor, SignalR]
+uid: security/blazor/server/index
+---
+# Secure ASP.NET Core Blazor Server apps
+
+By [Luke Latham](https://github.com/guardrex)
+
+## Blazor Server project template
+
+The Blazor Server project template can be configured for authentication when the project is created.
+
+# [Visual Studio](#tab/visual-studio)
+
+Follow the Visual Studio guidance in the <xref:blazor/get-started> article to create a new Blazor Server project with an authentication mechanism.
+
+After choosing the **Blazor Server App** template in the **Create a new ASP.NET Core Web Application** dialog, select **Change** under **Authentication**.
+
+A dialog opens to offer the same set of authentication mechanisms available for other ASP.NET Core projects:
+
+* **No Authentication**
+* **Individual User Accounts** &ndash; User accounts can be stored:
+  * Within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
+  * With [Azure AD B2C](xref:security/authentication/azure-ad-b2c).
+* **Work or School Accounts**
+* **Windows Authentication**
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+Follow the Visual Studio Code guidance in the <xref:blazor/get-started> article to create a new Blazor Server project with an authentication mechanism:
+
+```dotnetcli
+dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
+```
+
+Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
+
+| Authentication mechanism                                                                 | `{AUTHENTICATION}` value |
+| ---------------------------------------------------------------------------------------- | :----------------------: |
+| No Authentication                                                                        | `None`                   |
+| Individual<br>Users stored in the app with ASP.NET Core Identity.                        | `Individual`             |
+| Individual<br>Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c). | `IndividualB2C`          |
+| Work or School Accounts<br>Organizational authentication for a single tenant.            | `SingleOrg`              |
+| Work or School Accounts<br>Organizational authentication for multiple tenants.           | `MultiOrg`               |
+| Windows Authentication                                                                   | `Windows`                |
+
+Using the `-o|--output` option, the command uses the value provided for the `{APP NAME}` placeholder to:
+
+* Create a folder for the project.
+* Name the project.
+
+For more information, see the [dotnet new](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+1. Follow the Visual Studio for Mac guidance in the <xref:blazor/get-started> article.
+
+1. On the **Configure your new Blazor Server App** step, select **Individual Authentication (in-app)** from the **Authentication** drop down.
+
+1. The app is created for individual users stored in the app with ASP.NET Core Identity.
+
+# [.NET Core CLI](#tab/netcore-cli/)
+
+Follow the .NET Core CLI guidance in the <xref:blazor/get-started> article to create a new Blazor Server project with an authentication mechanism:
+
+```dotnetcli
+dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
+```
+
+Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
+
+| Authentication mechanism                                                                 | `{AUTHENTICATION}` value |
+| ---------------------------------------------------------------------------------------- | :----------------------: |
+| No Authentication                                                                        | `None`                   |
+| Individual<br>Users stored in the app with ASP.NET Core Identity.                        | `Individual`             |
+| Individual<br>Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c). | `IndividualB2C`          |
+| Work or School Accounts<br>Organizational authentication for a single tenant.            | `SingleOrg`              |
+| Work or School Accounts<br>Organizational authentication for multiple tenants.           | `MultiOrg`               |
+| Windows Authentication                                                                   | `Windows`                |
+
+Using the `-o|--output` option, the command uses the value provided for the `{APP NAME}` placeholder to:
+
+* Create a folder for the project.
+* Name the project.
+
+For more information, see the [dotnet new](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+
+---

--- a/aspnetcore/security/blazor/server/threat-mitigation.md
+++ b/aspnetcore/security/blazor/server/threat-mitigation.md
@@ -1,15 +1,15 @@
 ---
-title: Secure ASP.NET Core Blazor Server apps
+title: Threat mitigation guidance for ASP.NET Core Blazor Server
 author: guardrex
 description: Learn how to mitigate security threats to Blazor Server apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/02/2020
+ms.date: 04/27/2020
 no-loc: [Blazor, SignalR]
-uid: security/blazor/server
+uid: security/blazor/server/threat-mitigation
 ---
-# Secure ASP.NET Core Blazor Server apps
+# Threat mitigation guidance for ASP.NET Core Blazor Server
 
 By [Javier Calvarro Nelson](https://github.com/javiercn)
 
@@ -23,205 +23,6 @@ In constrained environments, such as inside corporate networks or intranets, som
 
 * Doesn't apply in the constrained environment.
 * Isn't worth the cost to implement because the security risk is low in a constrained environment.
-
-## Blazor Server project template
-
-The Blazor Server project template can be configured for authentication when the project is created.
-
-# [Visual Studio](#tab/visual-studio)
-
-Follow the Visual Studio guidance in the <xref:blazor/get-started> article to create a new Blazor Server project with an authentication mechanism.
-
-After choosing the **Blazor Server App** template in the **Create a new ASP.NET Core Web Application** dialog, select **Change** under **Authentication**.
-
-A dialog opens to offer the same set of authentication mechanisms available for other ASP.NET Core projects:
-
-* **No Authentication**
-* **Individual User Accounts** &ndash; User accounts can be stored:
-  * Within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
-  * With [Azure AD B2C](xref:security/authentication/azure-ad-b2c).
-* **Work or School Accounts**
-* **Windows Authentication**
-
-# [Visual Studio Code](#tab/visual-studio-code)
-
-Follow the Visual Studio Code guidance in the <xref:blazor/get-started> article to create a new Blazor Server project with an authentication mechanism:
-
-```dotnetcli
-dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
-```
-
-Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
-
-| Authentication mechanism                                                                 | `{AUTHENTICATION}` value |
-| ---------------------------------------------------------------------------------------- | :----------------------: |
-| No Authentication                                                                        | `None`                   |
-| Individual<br>Users stored in the app with ASP.NET Core Identity.                        | `Individual`             |
-| Individual<br>Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c). | `IndividualB2C`          |
-| Work or School Accounts<br>Organizational authentication for a single tenant.            | `SingleOrg`              |
-| Work or School Accounts<br>Organizational authentication for multiple tenants.           | `MultiOrg`               |
-| Windows Authentication                                                                   | `Windows`                |
-
-The command creates a folder named with the value provided for the `{APP NAME}` placeholder and uses the folder name as the app's name. For more information, see the [dotnet new](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-1. Follow the Visual Studio for Mac guidance in the <xref:blazor/get-started> article.
-
-1. On the **Configure your new Blazor Server App** step, select **Individual Authentication (in-app)** from the **Authentication** drop down.
-
-1. The app is created for individual users stored in the app with ASP.NET Core Identity.
-
-# [.NET Core CLI](#tab/netcore-cli/)
-
-Follow the .NET Core CLI guidance in the <xref:blazor/get-started> article to create a new Blazor Server project with an authentication mechanism:
-
-```dotnetcli
-dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
-```
-
-Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
-
-| Authentication mechanism                                                                 | `{AUTHENTICATION}` value |
-| ---------------------------------------------------------------------------------------- | :----------------------: |
-| No Authentication                                                                        | `None`                   |
-| Individual<br>Users stored in the app with ASP.NET Core Identity.                        | `Individual`             |
-| Individual<br>Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c). | `IndividualB2C`          |
-| Work or School Accounts<br>Organizational authentication for a single tenant.            | `SingleOrg`              |
-| Work or School Accounts<br>Organizational authentication for multiple tenants.           | `MultiOrg`               |
-| Windows Authentication                                                                   | `Windows`                |
-
-The command creates a folder named with the value provided for the `{APP NAME}` placeholder and uses the folder name as the app's name. For more information, see the [dotnet new](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
-
----
-
-## Pass tokens to a Blazor Server app
-
-Authenticate the Blazor Server app as you would with a regular Razor Pages or MVC app. Provision and save the tokens to the authentication cookie. For example:
-
-```csharp
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
-
-...
-
-services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
-{
-    options.ResponseType = "code";
-    options.SaveTokens = true;
-
-    options.Scope.Add("offline_access");
-    options.Scope.Add("{SCOPE}");
-    options.Resource = "{RESOURCE}";
-});
-```
-
-For sample code, including a complete `Startup.ConfigureServices` example, see the [Passing tokens to a server-side Blazor application](https://github.com/javiercn/blazor-server-aad-sample).
-
-Define a class to pass in the initial app state with the access and refresh tokens:
-
-```csharp
-public class InitialApplicationState
-{
-    public string AccessToken { get; set; }
-    public string RefreshToken { get; set; }
-}
-```
-
-Define a **scoped** token provider service that can be used within the Blazor app to resolve the tokens from DI:
-
-```csharp
-using System;
-using System.Security.Claims;
-using System.Threading.Tasks;
-
-public class TokenProvider
-{
-    public string AccessToken { get; set; }
-    public string RefreshToken { get; set; }
-}
-```
-
-In `Startup.ConfigureServices`, add services for:
-
-* `IHttpClientFactory`
-* `TokenProvider`
-
-```csharp
-services.AddHttpClient();
-services.AddScoped<TokenProvider>();
-```
-
-In the *_Host.cshtml* file, create and instance of `InitialApplicationState` and pass it as a parameter to the app:
-
-```cshtml
-@using Microsoft.AspNetCore.Authentication
-
-...
-
-@{
-    var tokens = new InitialApplicationState
-    {
-        AccessToken = await HttpContext.GetTokenAsync("access_token"),
-        RefreshToken = await HttpContext.GetTokenAsync("refresh_token")
-    };
-}
-
-<app>
-    <component type="typeof(App)" param-InitialState="tokens" 
-        render-mode="ServerPrerendered" />
-</app>
-```
-
-In the `App` component (*App.razor*), resolve the service and initialize it with the data from the parameter:
-
-```razor
-@inject TokenProvider TokensProvider
-
-...
-
-@code {
-    [Parameter]
-    public InitialApplicationState InitialState { get; set; }
-
-    protected override Task OnInitializedAsync()
-    {
-        TokensProvider.AccessToken = InitialState.AccessToken;
-        TokensProvider.RefreshToken = InitialState.RefreshToken;
-
-        return base.OnInitializedAsync();
-    }
-}
-```
-
-In the service that makes a secure API request, inject the token provider and retrieve the token to call the API:
-
-```csharp
-public class WeatherForecastService
-{
-    private readonly TokenProvider _store;
-
-    public WeatherForecastService(IHttpClientFactory clientFactory, 
-        TokenProvider tokenProvider)
-    {
-        Client = clientFactory.CreateClient();
-        _store = tokenProvider;
-    }
-
-    public HttpClient Client { get; }
-
-    public async Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
-    {
-        var token = _store.AccessToken;
-        var request = new HttpRequestMessage(HttpMethod.Get, 
-            "https://localhost:5003/WeatherForecast");
-        request.Headers.Add("Authorization", $"Bearer {token}");
-        var response = await Client.SendAsync(request);
-        response.EnsureSuccessStatusCode();
-
-        return await response.Content.ReadAsAsync<WeatherForecast[]>();
-    }
-}
-```
 
 ## Resource exhaustion
 
@@ -577,10 +378,6 @@ This advice also applies when rendering links as part of the app:
 * Validate that absolute link destinations are valid before including them in a page.
 
 For more information, see <xref:security/preventing-open-redirects>.
-
-## Authentication and authorization
-
-For guidance on authentication and authorization, see <xref:security/blazor/index>.
 
 ## Security checklist
 

--- a/aspnetcore/security/blazor/webassembly/additional-scenarios.md
+++ b/aspnetcore/security/blazor/webassembly/additional-scenarios.md
@@ -1,11 +1,11 @@
 ---
 title: ASP.NET Core Blazor WebAssembly additional security scenarios
 author: guardrex
-description: 
+description: Learn how to configure Blazor WebAssembly for additional security scenarios.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/22/2020
+ms.date: 04/27/2020
 no-loc: [Blazor, SignalR]
 uid: security/blazor/webassembly/additional-scenarios
 ---

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -348,7 +348,13 @@
                 - name: Additional scenarios
                   uid: security/blazor/webassembly/additional-scenarios
             - name: Blazor Server
-              uid: security/blazor/server
+              items:
+                - name: Overview
+                  uid: security/blazor/server/index
+                - name: Threat mitigation
+                  uid: security/blazor/server/threat-mitigation
+                - name: Additional scenarios
+                  uid: security/blazor/server/additional-scenarios
             - name: Content Security Policy
               uid: security/blazor/content-security-policy
         - name: State management
@@ -1135,7 +1141,13 @@
             - name: Additional scenarios
               uid: security/blazor/webassembly/additional-scenarios
         - name: Blazor Server
-          uid: security/blazor/server
+          items:
+            - name: Overview
+              uid: security/blazor/server/index
+            - name: Threat mitigation
+              uid: security/blazor/server/threat-mitigation
+            - name: Additional scenarios
+              uid: security/blazor/server/additional-scenarios
         - name: Content Security Policy
           uid: security/blazor/content-security-policy
 - name: Performance


### PR DESCRIPTION
Fixes #18027

We're splitting the Blazor Server security topic into a node that mirrors the TOC approach taken for WASM security topics.

We're still planning on hitting all of the topics with UE work later. It should happen after 3.2 is released. I'll ping you for review on those PRs when the time comes. Right now, the focus here is on the topic split, TOC changes, and the redirect file addition.

Also note a strange thing that's cropped up on my last few PRs here. I'm getting build warnings for an XREF in aspnetcore/blazor/integrate-components.md ...

> Cross reference not found: 'xref:mvc/views/tag-helpers/builtin-th/component-tag-helper'

... but that reference is correct, and it seems to generate the correct link in the live topic. See the 2nd bullet of the opening section at ...

https://docs.microsoft.com/en-us/aspnet/core/blazor/integrate-components?view=aspnetcore-3.1

cc: @mkArtakMSFT This is the new node PR that we discussed offline. I decided to hold off on the tiny bit of AAD and AAD B2C guidance and cross-links until this goes in. That's probably next, so that PR will arrive shortly.