### PR TITLE
Update Hub - First web UI link point to Razor Pages instead of Blazor

### DIFF
--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -11,7 +11,7 @@ metadata:
   ms.topic: hub-page
   author: WadePickett
   ms.author: wpickett
-  ms.date: 04/26/2020
+  ms.date: 05/01/2020
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -37,7 +37,7 @@ highlightedContent:
     # Card
     - title: "Create your first web UI"
       itemType: get-started
-      url: tutorials/build-your-first-blazor-app.md
+      url: tutorials/razor-pages/razor-pages-start.md
     # Card
     - title: "Create your first web API"
       itemType: get-started


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/?view=aspnetcore-3.1&branch=pr-en-us-18099)

Fixes #17555 

Update the _Create your first web UI_ card to point to [Tutorial: Get started with Razor Pages in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/razor-pages-start?view=aspnetcore-3.1&tabs=visual-studio) instead of the Blazor get started.