### PR TITLE
3.1 update for gRPC-start tutorial and its two sample apps

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -3,7 +3,7 @@ title: Create a .NET Core gRPC client and server in ASP.NET Core
 author: juntaoluo
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 ms.author: johluo
-ms.date: 04/08/2020
+ms.date: 05/01/2020
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core
@@ -27,15 +27,15 @@ In this tutorial, you:
 
 # [Visual Studio](#tab/visual-studio)
 
-[!INCLUDE[](~/includes/net-core-prereqs-vs-3.0.md)]
+[!INCLUDE[](~/includes/net-core-prereqs-vs-3.1.md)]
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-[!INCLUDE[](~/includes/net-core-prereqs-vsc-3.0.md)]
+[!INCLUDE[](~/includes/net-core-prereqs-vsc-3.1.md)]
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
-[!INCLUDE[](~/includes/net-core-prereqs-mac-3.0.md)]
+[!INCLUDE[](~/includes/net-core-prereqs-mac-3.1.md)]
 
 ---
 
@@ -124,7 +124,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 * Open a second instance of Visual Studio and select **Create a new project**.
 * In the **Create a new project** dialog, select **Console App (.NET Core)** and select **Next**.
-* In the **Name** text box, enter **GrpcGreeterClient** and select **Create**.
+* In the **Project name** text box, enter **GrpcGreeterClient** and select **Create**.
 
 # [Visual Studio Code](#tab/visual-studio-code)
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -4,6 +4,7 @@ author: juntaoluo
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 ms.author: johluo
 ms.date: 05/01/2020
+no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -3,7 +3,7 @@ title: Create a .NET Core gRPC client and server in ASP.NET Core
 author: juntaoluo
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 ms.author: johluo
-ms.date: 05/01/2020
+ms.date: 04/08/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: tutorials/grpc/grpc-start
 ---

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.28.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.23.2" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.28.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/Program.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/Program.cs
@@ -15,6 +15,8 @@ namespace GrpcGreeter
             CreateHostBuilder(args).Build().Run();
         }
 
+        // Additional configuration is required to successfully run gRPC on macOS.
+        // For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/Services/GreeterService.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/Services/GreeterService.cs
@@ -3,14 +3,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
+using Microsoft.Extensions.Logging;
 
 namespace GrpcGreeter
 {
     #region snippet
     public class GreeterService : Greeter.GreeterBase
     {
-        public override Task<HelloReply> SayHello(
-            HelloRequest request, ServerCallContext context)
+        private readonly ILogger<GreeterService> _logger;
+        public GreeterService(ILogger<GreeterService> logger)
+        {
+            _logger = logger;
+        }
+
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
         {
             return Task.FromResult(new HelloReply
             {

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/appsettings.json
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeter/appsettings.json
@@ -1,7 +1,8 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning",
+      "Default": "Information",
+      "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/GrpcGreeterClient/GrpcGreeterClient.csproj
@@ -1,14 +1,17 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Protobuf" Version="3.9.2" />
-    <PackageReference Include="Grpc.Net.Client" Version="2.23.2" />
-    <PackageReference Include="Grpc.Tools" Version="2.23.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.11.4" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.28.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.28.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
[Internal Review - Tutorial: Create a gRPC client and server in ASP.NET Core](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/grpc/grpc-start?view=aspnetcore-3.1&branch=pr-en-us-18103&tabs=visual-studio)

Fixes #18104

Updated for ASP.NET Core 3.1:
- grpc-start.md tutorial
- GrpcGreeter sample app
- GrpcGreeterClient sample app

Completing this issue is a prerequisite to related issue #16467 which includes creating a new 3.1 version samples .zip for download and redirecting to this updated tutorial.