### PR TITLE
Directly link Blazor WASM linker data formats

### DIFF
--- a/aspnetcore/host-and-deploy/blazor/configure-linker.md
+++ b/aspnetcore/host-and-deploy/blazor/configure-linker.md
@@ -5,7 +5,7 @@ description: Learn how to control the Intermediate Language (IL) Linker when bui
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/29/2020
+ms.date: 05/04/2020
 no-loc: [Blazor, SignalR]
 uid: host-and-deploy/blazor/configure-linker
 ---
@@ -78,7 +78,7 @@ Control linking on a per-assembly basis by providing an XML configuration file a
 </linker>
 ```
 
-For more information, see [Link xml file examples (mono/linker GitHub repository)](https://github.com/mono/linker#link-xml-file-examples).
+For more information and examples, see [Data Formats (mono/linker GitHub repository)](https://github.com/mono/linker/blob/master/docs/data-formats.md).
 
 ## Add an XML linker configuration file to a library
 


### PR DESCRIPTION
Fixes #18096

Links directly to example XML files (data formats), not the landing for the entire `mono/linker` repo.

cc: @mkArtakMSFT 