### PR TITLE
Blazor WASM HttpClient is Transient now

### DIFF
--- a/aspnetcore/blazor/dependency-injection.md
+++ b/aspnetcore/blazor/dependency-injection.md
@@ -5,7 +5,7 @@ description: See how Blazor apps can inject services into components.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/20/2020
+ms.date: 05/04/2020
 no-loc: [Blazor, SignalR]
 uid: blazor/dependency-injection
 ---
@@ -28,7 +28,7 @@ Default services are automatically added to the app's service collection.
 
 | Service | Lifetime | Description |
 | ------- | -------- | ----------- |
-| <xref:System.Net.Http.HttpClient> | Singleton | Provides methods for sending HTTP requests and receiving HTTP responses from a resource identified by a URI.<br><br>The instance of `HttpClient` in a Blazor WebAssembly app uses the browser for handling the HTTP traffic in the background.<br><br>Blazor Server apps don't include an `HttpClient` configured as a service by default. Provide an `HttpClient` to a Blazor Server app.<br><br>For more information, see <xref:blazor/call-web-api>. |
+| <xref:System.Net.Http.HttpClient> | Transient | Provides methods for sending HTTP requests and receiving HTTP responses from a resource identified by a URI.<br><br>The instance of `HttpClient` in a Blazor WebAssembly app uses the browser for handling the HTTP traffic in the background.<br><br>Blazor Server apps don't include an `HttpClient` configured as a service by default. Provide an `HttpClient` to a Blazor Server app.<br><br>For more information, see <xref:blazor/call-web-api>. |
 | `IJSRuntime` | Singleton (Blazor WebAssembly)<br>Scoped (Blazor Server) | Represents an instance of a JavaScript runtime where JavaScript calls are dispatched. For more information, see <xref:blazor/call-javascript-from-dotnet>. |
 | `NavigationManager` | Singleton (Blazor WebAssembly)<br>Scoped (Blazor Server) | Contains helpers for working with URIs and navigation state. For more information, see [URI and navigation state helpers](xref:blazor/routing#uri-and-navigation-state-helpers). |
 


### PR DESCRIPTION
Fixes #18130

cc: @mkArtakMSFT ... This isn't for the ask on https://github.com/dotnet/aspnetcore/issues/18077 because I don't see the problem described ...

> This page says that IJSInterop etc are scoped as singletons, which is incorrect in server-side apps.

It only says that `IJSRuntime` is ...

> Singleton (Blazor WebAssembly)
> Scoped (Blazor Server)

... and doesn't refer to `IJSInterop` or JS interop otherwise.

I did notice this change tho for `HttpClient` for WASM ... Transient now.