### PR TITLE
Blazor WASM with AAD groups and roles

### DIFF
--- a/aspnetcore/includes/blazor-security/azuread-roles-groups.md
+++ b/aspnetcore/includes/blazor-security/azuread-roles-groups.md
@@ -1,0 +1,313 @@
+AAD provides several authorization approaches that can be combined with ASP.NET Core Identity:
+
+* User-defined groups
+  * Security
+  * O365
+  * Distribution
+* Roles
+  * Built-in Administrative Roles
+  * User-defined roles
+
+### User-defined groups and AAD built-in Administrative Roles
+
+To enable an AAD-registered app for user-defined AAD groups and built-in Administrative Roles, perform the following actions in the Azure portal:
+
+1. Edit the app's manifest (standalone app or Client app of a Hosted solution).
+1. Set `groupMembershipClaims` to `All` to have AAD send a `groups` claim for:
+
+   * AAD Security Groups
+   * Distribution Groups
+   * Administrative Roles
+
+   Set `groupMembershipClaims` to `SecurityGroup` to have AAD send a `roles` claim for:
+
+   * AAD Security Groups
+   * Administrative Roles
+
+1. Assign users to user-defined AAD groups and built-in Administrative Roles. The following examples assume that a user is assigned to the AAD built-in Billing Administrator Role.
+
+The `groups` claim sent by AAD presents the user's groups and roles as Object IDs (GUIDs) in a JSON array. The app must convert the JSON array of groups and roles into individual `groups` claims that the app can build [policies](xref:security/authorization/policies) against. Create a custom user factory in the standalone app or Client app of a Hosted solution:
+
+```csharp
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal;
+
+public class CustomUserFactory
+    : AccountClaimsPrincipalFactory<RemoteUserAccount>
+{
+    public CustomUserFactory(NavigationManager navigationManager,
+        IAccessTokenProviderAccessor accessor)
+        : base(accessor)
+    {
+    }
+
+    public async override ValueTask<ClaimsPrincipal> CreateUserAsync(
+        RemoteUserAccount account,
+        RemoteAuthenticationUserOptions options)
+    {
+        var initialUser = await base.CreateUserAsync(account, options);
+
+        if (initialUser.Identity.IsAuthenticated)
+        {
+            SetClaimsFromJsonArray(account, initialUser, "roles", true);
+            SetClaimsFromJsonArray(account, initialUser, "groups", true);
+        }
+
+        return initialUser;
+    }
+
+    private void SetClaimsFromJsonArray(RemoteUserAccount account, 
+        ClaimsPrincipal user, string claimName, bool removeOriginalClaim)
+    {
+        if (account.AdditionalProperties.TryGetValue(claimName, out var rolesObj))
+        {
+            var identity = (ClaimsIdentity)user.Identity;
+            var rolesElement = (JsonElement)rolesObj;
+
+            if (rolesElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var element in rolesElement.EnumerateArray())
+                {
+                    identity.AddClaim(new Claim(claimName, element.GetString()));
+                }
+
+                if (removeOriginalClaim)
+                {
+                    identity.TryRemoveClaim(
+                        identity.FindFirst(c => c.Type == claimName));
+                }
+            }
+        }
+    }
+}
+```
+
+Register the factory in `Program.Main` (*Program.cs*) of the standalone app or Client app of a Hosted solution:
+
+```csharp
+builder.Services.AddApiAuthorization<RemoteAuthenticationState, RemoteUserAccount>()
+    .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, RemoteUserAccount, 
+        CustomUserFactory>();
+```
+
+Create a [policy](xref:security/authorization/policies) for each group or role in `Program.Main`. The following example creates a policy for the AAD built-in Billing Administrator Role:
+
+```csharp
+builder.Services.AddAuthorizationCore(options =>
+{
+    options.AddPolicy("BillingAdministrator", policy => 
+        policy.RequireClaim("groups", "69ff516a-b57d-4697-a429-9de4af7b5609"));
+});
+```
+
+For the complete list of AAD role Object IDs, see the [AAD Adminstrative Role Group IDs](#aad-adminstrative-role-group-ids) section.
+
+In the following examples, the app uses the preceding policy to authorize the user.
+
+The `AuthorizeView` component works with the policy:
+
+```razor
+<AuthorizeView Policy="BillingAdministrator">
+    <Authorized>
+        <p>The user is in the 'Billing Adminstrator' AAD Administrative Role.</p>
+    </Authorized>
+    <NotAuthorized>
+        <p>You aren't authorized to see this content.</p>
+    </NotAuthorized>
+</AuthorizeView>
+```
+
+Access to a component can be based on the policy:
+
+```razor
+@page "/"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Policy = "BillingAdministrator")]
+```
+
+If the user isn't logged in, they're redirected to the AAD sign-in page and then back to the component after they sign in.
+
+A policy check can also be performed in code:
+
+```razor
+@page "/checkpolicy"
+@using Microsoft.AspNetCore.Authorization
+@inject IAuthorizationService AuthorizationService
+
+<h1>Check Policy</h1>
+
+<p>This component checks a policy in code.</p>
+
+<button @onclick="CheckPolicy">Check 'BillingAdministrator' policy</button>
+
+<p>Policy Message: @_policyMessage</p>
+
+@code {
+    private string _policyMessage = "Check hasn't been made yet.";
+
+    [CascadingParameter]
+    private Task<AuthenticationState> authenticationStateTask { get; set; }
+
+    private async void CheckPolicy()
+    {
+        var user = (await authenticationStateTask).User;
+
+        if ((await AuthorizationService.AuthorizeAsync(user, "BillingAdministrator"))
+            .Succeeded)
+        {
+            _policyMessage = "Yes! The 'BillingAdministrator' policy is met.";
+        }
+        else
+        {
+            _policyMessage = "No! 'BillingAdministrator' policy is NOT met.";
+        }
+    }
+}
+```
+
+### User-defined roles
+
+An AAD-registered app can also be configured to use user-defined roles:
+
+1. Edit the app's manifest (standalone app or Client app of a Hosted solution) and provide user-defined roles. The following example creates two roles:
+
+   * `admin`
+   * `developer`
+
+   Generate unique custom `id` entires for each role added to the manifest.
+
+   ```json
+   "appRoles": [
+       {
+           "allowedMemberTypes": [
+               "User"
+           ],
+           "description": "Administrators can access administrator-only areas",
+           "displayName": "Administrators",
+           "id": "d1613ef0-097a-44a0-b1d2-c13c02231a97",
+           "isEnabled": true,
+           "lang": null,
+           "origin": "Application",
+           "value": "admin"
+       },
+       {
+           "allowedMemberTypes": [
+               "User"
+           ],
+           "description": "Developers can access developer-only areas",
+           "displayName": "Developers",
+           "id": "87731ab9-df42-418a-b3bb-37b759eb4111",
+           "isEnabled": true,
+           "lang": null,
+           "origin": "Application",
+           "value": "developer"
+       }
+   ],
+   ```
+
+1. Navigate to **Enterprise Applications** and select the app's registration.
+1. In **Users and groups**, add a user and give them one of the configured roles. Multiple roles are allowed by **_re-adding a user_** for each additional role assignment.
+
+The `roles` claim sent by AAD presents the user-defined roles as the `appRoles`'s `value`s set in the manifest file in a JSON array. The app must convert the JSON array of roles into individual `roles` claims. Use the `CustomUserFactory` shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section in the standalone app or Client app of a Hosted solution. The example `CustomUserFactory` is already configured to act on a `roles` claim with a JSON array value:
+
+```csharp
+SetClaimsFromJsonArray(account, initialUser, "roles", true);
+```
+
+Register the `CustomUserFactory` as shown in the *User-defined groups and AAD built-in Administrative Roles* section.
+
+In `Program.Main` of the standalone app or Client app of a Hosted solution, specify the claim named "`roles`" as the role claim:
+
+```csharp
+builder.Services.AddMsalAuthentication(options =>
+{
+    ...
+
+    options.UserOptions.RoleClaim = "roles";
+});
+```
+
+Component authorization approaches are functional at this point. The following examples use the `admin` role to authorize the user:
+
+* `<AuthorizeView Roles="admin">`
+* `@attribute [Authorize(Roles = "admin")]`
+* `if (user.IsInRole("admin")) { ... }`
+
+Multiple role tests are supported:
+
+```csharp
+if (user.IsInRole("admin") && user.IsInRole("developer"))
+{
+    ...
+}
+```
+
+## AAD Adminstrative Role Group IDs
+
+The Object IDs presented in the following table are used to create [policies](xref:security/authorization/policies) for `groups` claims. The policies permit an app to authorize users for various activities in an app.
+
+AAD Administrative Role | Object ID
+-- | --
+Application administrator | fa11557b-4f15-4ddd-85d5-313c7cd74047
+Application developer | 68adcbb8-9504-44f6-89f2-5cd48dc74a2c
+Authentication administrator | 02d110a1-96b1-419e-af87-746461b60ed7
+Azure DevOps administrator | a5311ace-ca41-44cd-b833-8d22caa0b34f
+Azure Information Protection   administrator | 18632dce-f9b5-4f01-abb5-37051f06860e
+B2C IEF Keyset administrator | 0c2e87e5-94f9-4adb-ae8c-bcafe11bd368
+B2C IEF Policy administrator | bfcab36c-10c6-4b13-b63c-4d8b62c0c44e
+B2C user flow administrator | baa531b7-8cf0-44ad-8f98-eded88dae827
+B2C user flow attribute   administrator | dd0baca0-a535-48c1-b871-8431abe16452
+Billing administrator | 69ff516a-b57d-4697-a429-9de4af7b5609
+Cloud application administrator | 250b5fe3-b553-458d-9a53-b782c13c34bf
+Cloud device administrator | 26cd4b44-2636-4ddb-bdfa-27feae66f86d
+Compliance administrator | 9d6e1dd0-c9f8-45f8-b558-b134f700116c
+Compliance data administrator | 4c0ca3a2-231e-416c-9411-4abe57d5cb9d
+Conditional Access administrator | 8f71a611-137d-49af-87ad-e97f1fd5da76
+Customer LockBox access approver | c18d54a8-b13e-4954-a1a4-7deaf2e4f184
+Desktop Analytics administrator | c62c4ac5-e4c6-4096-8a2f-1ee3cbaaae15
+Directory readers | e1fc84a6-7762-4b9b-8e29-518b4adbc23b
+Dynamics 365 administrator | f20a9cfa-9fdf-49a8-a977-1afe446a1d6e
+Exchange administrator | b2ec2cc0-d5c9-4864-ad9b-38dd9dba2652
+External Identity Provider   administrator | febfaeb4-e478-407a-b4b3-f4d9716618a2
+Global administrator | a45ba61b-44db-462c-924b-3b2719152588
+Global reader | f6903b21-6aba-4124-b44c-76671796b9d5
+Groups administrator | 158b3e5a-d89d-460b-92b5-3b34985f0197
+Guest inviter | 4c730a1d-cc22-44af-8f9f-4eec635c7502
+Helpdesk administrator | 108678c8-6628-44e1-8d01-caf598a6a5f5
+Intune administrator | 79950741-23fa-4189-b2cb-46640601c497
+Kaizala administrator | d6322af2-48e7-42e0-8c68-0bbe31af3412
+License administrator | 3355458a-e423-44bf-8b98-4ac5e572cea5
+Message center privacy reader | 6395db95-9fb8-42b9-b1ed-30a2405eee6f
+Message center reader | fd5d37b8-4e24-434b-9e63-70ed3b759a16
+Office apps administrator | 5f3870cd-b042-4f93-86d7-c9d77c664dc7
+Password administrator | 466e48b7-5d66-4ae5-8911-1a118de74941
+Power BI administrator | 984e83b8-8337-4255-91a1-acb663175ab4
+Power platform administrator | 76d6f95e-9a15-4d7d-8d21-00de00faf9fd
+Privileged authentication   administrator | 0829f731-b46d-419f-9742-aeb122367d11
+Privileged role administrator | f20a725a-d1c8-4107-83ea-1171c97d00c7
+Reports reader | 54635450-e8ed-4f2d-9632-07db2517b4de
+Search administrator | c770a2f1-c9ba-4e60-9176-9f52b1eb1a31
+Search editor | 6a6858c6-5f0d-44ac-87c7-0190fbedd271
+Security administrator | 20fa50e3-6531-44d8-bd39-b251420568ad
+Security operator | 43aae017-8e51-4188-91ab-e6debd572800
+Security reader | 45035cd3-fd97-4250-8197-3a53d3562d9b
+Service support administrator | 2c92cf45-c914-48f8-9bf9-fc14b28818ab
+SharePoint administrator | e1c32229-875e-461d-ae24-3cb99116e86c
+Skype for Business administrator | 0a8cee12-e21d-43ef-abd9-f1ea85710e30
+Teams Communications Administrator | 2393e455-6e13-4743-9f52-63fcec2b6a9c
+Teams Communications Support   Engineer | 802dd94e-d717-46f6-af98-b9167071e9fc
+Teams Communications Support   Specialist | ef547281-cf46-4cc6-bcaa-f5eac3f030c9
+Teams Service Administrator | 8846a0be-197b-443a-b13c-11192691fa24
+User administrator | 1f6eed58-7dd3-460b-a298-666f975427a1
+
+## Additional resources for AAD groups and roles
+
+* [Roles using Azure AD security groups (Azure documentation)](/azure/architecture/multitenant-identity/app-roles#roles-using-azure-ad-security-groups)
+* [groupMembershipClaims attribute (Azure documentation)](/azure/active-directory/develop/reference-app-manifest#groupmembershipclaims-attribute)
+* <xref:security/authorization/claims>
+* <xref:security/blazor/index>
+* [How to: Add app roles in your application and receive them in the token (Azure documentation)](/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps)

--- a/aspnetcore/includes/blazor-security/azuread-roles-groups.md
+++ b/aspnetcore/includes/blazor-security/azuread-roles-groups.md
@@ -251,16 +251,16 @@ if (user.IsInRole("admin") && user.IsInRole("developer"))
 The Object IDs presented in the following table are used to create [policies](xref:security/authorization/policies) for `groups` claims. The policies permit an app to authorize users for various activities in an app.
 
 AAD Administrative Role | Object ID
--- | --
+--- | ---
 Application administrator | fa11557b-4f15-4ddd-85d5-313c7cd74047
 Application developer | 68adcbb8-9504-44f6-89f2-5cd48dc74a2c
 Authentication administrator | 02d110a1-96b1-419e-af87-746461b60ed7
 Azure DevOps administrator | a5311ace-ca41-44cd-b833-8d22caa0b34f
-Azure Information Protection   administrator | 18632dce-f9b5-4f01-abb5-37051f06860e
+Azure Information Protection administrator | 18632dce-f9b5-4f01-abb5-37051f06860e
 B2C IEF Keyset administrator | 0c2e87e5-94f9-4adb-ae8c-bcafe11bd368
 B2C IEF Policy administrator | bfcab36c-10c6-4b13-b63c-4d8b62c0c44e
 B2C user flow administrator | baa531b7-8cf0-44ad-8f98-eded88dae827
-B2C user flow attribute   administrator | dd0baca0-a535-48c1-b871-8431abe16452
+B2C user flow attribute administrator | dd0baca0-a535-48c1-b871-8431abe16452
 Billing administrator | 69ff516a-b57d-4697-a429-9de4af7b5609
 Cloud application administrator | 250b5fe3-b553-458d-9a53-b782c13c34bf
 Cloud device administrator | 26cd4b44-2636-4ddb-bdfa-27feae66f86d
@@ -272,7 +272,7 @@ Desktop Analytics administrator | c62c4ac5-e4c6-4096-8a2f-1ee3cbaaae15
 Directory readers | e1fc84a6-7762-4b9b-8e29-518b4adbc23b
 Dynamics 365 administrator | f20a9cfa-9fdf-49a8-a977-1afe446a1d6e
 Exchange administrator | b2ec2cc0-d5c9-4864-ad9b-38dd9dba2652
-External Identity Provider   administrator | febfaeb4-e478-407a-b4b3-f4d9716618a2
+External Identity Provider administrator | febfaeb4-e478-407a-b4b3-f4d9716618a2
 Global administrator | a45ba61b-44db-462c-924b-3b2719152588
 Global reader | f6903b21-6aba-4124-b44c-76671796b9d5
 Groups administrator | 158b3e5a-d89d-460b-92b5-3b34985f0197
@@ -287,7 +287,7 @@ Office apps administrator | 5f3870cd-b042-4f93-86d7-c9d77c664dc7
 Password administrator | 466e48b7-5d66-4ae5-8911-1a118de74941
 Power BI administrator | 984e83b8-8337-4255-91a1-acb663175ab4
 Power platform administrator | 76d6f95e-9a15-4d7d-8d21-00de00faf9fd
-Privileged authentication   administrator | 0829f731-b46d-419f-9742-aeb122367d11
+Privileged authentication administrator | 0829f731-b46d-419f-9742-aeb122367d11
 Privileged role administrator | f20a725a-d1c8-4107-83ea-1171c97d00c7
 Reports reader | 54635450-e8ed-4f2d-9632-07db2517b4de
 Search administrator | c770a2f1-c9ba-4e60-9176-9f52b1eb1a31
@@ -299,8 +299,8 @@ Service support administrator | 2c92cf45-c914-48f8-9bf9-fc14b28818ab
 SharePoint administrator | e1c32229-875e-461d-ae24-3cb99116e86c
 Skype for Business administrator | 0a8cee12-e21d-43ef-abd9-f1ea85710e30
 Teams Communications Administrator | 2393e455-6e13-4743-9f52-63fcec2b6a9c
-Teams Communications Support   Engineer | 802dd94e-d717-46f6-af98-b9167071e9fc
-Teams Communications Support   Specialist | ef547281-cf46-4cc6-bcaa-f5eac3f030c9
+Teams Communications Support Engineer | 802dd94e-d717-46f6-af98-b9167071e9fc
+Teams Communications Specialist | ef547281-cf46-4cc6-bcaa-f5eac3f030c9
 Teams Service Administrator | 8846a0be-197b-443a-b13c-11192691fa24
 User administrator | 1f6eed58-7dd3-460b-a298-666f975427a1
 

--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -1467,7 +1467,7 @@ The examples in this topic rely upon <xref:System.IO.MemoryStream> to hold the u
 
 ## Additional resources
 
-* [HTTP connection request draining](xref:fundamentals/servers/kestrel#http-connection-request-draining)
+* [HTTP connection request draining](xref:fundamentals/servers/kestrel#http11-request-draining)
 * [Unrestricted File Upload](https://owasp.org/www-community/vulnerabilities/Unrestricted_File_Upload)
 * [Azure Security: Security Frame: Input Validation | Mitigations](/azure/security/azure-security-threat-modeling-tool-input-validation)
 * [Azure Cloud Design Patterns: Valet Key pattern](/azure/architecture/patterns/valet-key)

--- a/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
@@ -93,8 +93,18 @@ public class CustomUserFactory
 
         if (initialUser.Identity.IsAuthenticated)
         {
-            SetClaimsFromJsonArray(account, initialUser, "roles", true);
-            SetClaimsFromJsonArray(account, initialUser, "groups", true);
+            
+            var userIdentity = (ClaimsIdentity)initialUser.Identity;
+
+            foreach (var role in account.Roles)
+            {
+                userIdentity.AddClaim(new Claim("role", role));
+            }
+
+            foreach (var group in account.Groups)
+            {
+                userIdentity.AddClaim(new Claim("group", group));
+            }
         }
 
         return initialUser;
@@ -116,7 +126,7 @@ Create a [policy](xref:security/authorization/policies) for each group or role i
 builder.Services.AddAuthorizationCore(options =>
 {
     options.AddPolicy("BillingAdministrator", policy => 
-        policy.RequireClaim("groups", "69ff516a-b57d-4697-a429-9de4af7b5609"));
+        policy.RequireClaim("group", "69ff516a-b57d-4697-a429-9de4af7b5609"));
 });
 ```
 
@@ -228,13 +238,9 @@ An AAD-registered app can also be configured to use user-defined roles:
 1. Navigate to **Enterprise Applications** and select the app's registration.
 1. In **Users and groups**, add a user and give them one of the configured roles. Multiple roles are allowed by **_re-adding a user_** for each additional role assignment.
 
-The `roles` claim sent by AAD presents the user-defined roles as the `appRoles`'s `value`s set in the manifest file in a JSON array. The app must convert the JSON array of roles into individual `roles` claims. Use the `CustomUserFactory` shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section in the standalone app or Client app of a Hosted solution. The example `CustomUserFactory` is already configured to act on a `roles` claim with a JSON array value:
+The `roles` claim sent by AAD presents the user-defined roles as the `appRoles`'s `value`s set in the manifest file in a JSON array. The app must convert the JSON array of roles into individual `role` claims.
 
-```csharp
-SetClaimsFromJsonArray(account, initialUser, "roles", true);
-```
-
-Register the `CustomUserFactory` as shown in the *User-defined groups and AAD built-in Administrative Roles* section.
+The `CustomUserFactory` shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section is set up to act on a `roles` claim with a JSON array value. Add and register the `CustomUserFactory` in the standalone app or Client app of a Hosted solution as shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section.
 
 In `Program.Main` of the standalone app or Client app of a Hosted solution, specify the claim named "`roles`" as the role claim:
 
@@ -243,7 +249,7 @@ builder.Services.AddMsalAuthentication(options =>
 {
     ...
 
-    options.UserOptions.RoleClaim = "roles";
+    options.UserOptions.RoleClaim = "role";
 });
 ```
 

--- a/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
@@ -62,7 +62,10 @@ using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
 public class CustomUserAccount : RemoteUserAccount
 {
+    [JsonPropertyName("groups")]
     public string[] Groups { get; set; }
+
+    [JsonPropertyName("roles")]
     public string[] Roles { get; set; }
 }
 ```
@@ -111,12 +114,19 @@ public class CustomUserFactory
 }
 ```
 
+There's no need to provide code to remove the original `groups` claim, as it is automatically removed by the framework.
+
 Register the factory in `Program.Main` (*Program.cs*) of the standalone app or Client app of a Hosted solution:
 
 ```csharp
-builder.Services.AddApiAuthorization<RemoteAuthenticationState, CustomUserAccount>()
-    .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, CustomUserAccount, 
-        CustomUserFactory>();
+builder.Services.AddMsalAuthentication<RemoteAuthenticationState, CustomUserAccount>(options =>
+{
+    builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
+    options.ProviderOptions.DefaultAccessTokenScopes.Add("...");
+
+    ...
+})
+.AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, CustomUserAccount, CustomUserFactory>();
 ```
 
 Create a [policy](xref:security/authorization/policies) for each group or role in `Program.Main`. The following example creates a policy for the AAD built-in Billing Administrator Role:
@@ -239,7 +249,7 @@ An AAD-registered app can also be configured to use user-defined roles:
 
 The `roles` claim sent by AAD presents the user-defined roles as the `appRoles`'s `value`s set in the manifest file in a JSON array. The app must convert the JSON array of roles into individual `role` claims.
 
-The `CustomUserFactory` shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section is set up to act on a `roles` claim with a JSON array value. Add and register the `CustomUserFactory` in the standalone app or Client app of a Hosted solution as shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section.
+The `CustomUserFactory` shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section is set up to act on a `roles` claim with a JSON array value. Add and register the `CustomUserFactory` in the standalone app or Client app of a Hosted solution as shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section. There's no need to provide code to remove the original `roles` claim, as it is automatically removed by the framework.
 
 In `Program.Main` of the standalone app or Client app of a Hosted solution, specify the claim named "`roles`" as the role claim:
 

--- a/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
@@ -173,10 +173,10 @@ A policy check can also be performed in code:
 
 <button @onclick="CheckPolicy">Check 'BillingAdministrator' policy</button>
 
-<p>Policy Message: @_policyMessage</p>
+<p>Policy Message: @policyMessage</p>
 
 @code {
-    private string _policyMessage = "Check hasn't been made yet.";
+    private string policyMessage = "Check hasn't been made yet.";
 
     [CascadingParameter]
     private Task<AuthenticationState> authenticationStateTask { get; set; }
@@ -188,11 +188,11 @@ A policy check can also be performed in code:
         if ((await AuthorizationService.AuthorizeAsync(user, "BillingAdministrator"))
             .Succeeded)
         {
-            _policyMessage = "Yes! The 'BillingAdministrator' policy is met.";
+            policyMessage = "Yes! The 'BillingAdministrator' policy is met.";
         }
         else
         {
-            _policyMessage = "No! 'BillingAdministrator' policy is NOT met.";
+            policyMessage = "No! 'BillingAdministrator' policy is NOT met.";
         }
     }
 }

--- a/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
@@ -35,23 +35,14 @@ The guidance in this article applies to the AAD deployment scenarios described i
 
 ### User-defined groups and AAD built-in Administrative Roles
 
-To enable an AAD-registered app for user-defined AAD groups and built-in Administrative Roles, perform the following actions in the Azure portal:
+To configure the app in the Azure portal to provide a `groups` membership claim, see the following Azure articles. Assign users to user-defined AAD groups and built-in Administrative Roles.
 
-1. Edit the app's manifest (standalone app or Client app of a Hosted solution).
-1. Set `groupMembershipClaims` to `All` to have AAD send a `groups` claim for:
+* [Roles using Azure AD security groups](/azure/architecture/multitenant-identity/app-roles#roles-using-azure-ad-security-groups)
+* [groupMembershipClaims attribute](/azure/active-directory/develop/reference-app-manifest#groupmembershipclaims-attribute)
 
-   * AAD Security Groups
-   * Distribution Groups
-   * Administrative Roles
+The following examples assume that a user is assigned to the AAD built-in **Billing Administrator** Role.
 
-   Set `groupMembershipClaims` to `SecurityGroup` to have AAD send a `roles` claim for:
-
-   * AAD Security Groups
-   * Administrative Roles
-
-1. Assign users to user-defined AAD groups and built-in Administrative Roles. The following examples assume that a user is assigned to the AAD built-in Billing Administrator Role.
-
-The `groups` claim sent by AAD presents the user's groups and roles as Object IDs (GUIDs) in a JSON array. The app must convert the JSON array of groups and roles into individual `groups` claims that the app can build [policies](xref:security/authorization/policies) against.
+The `groups` claim sent by AAD presents the user's groups and roles as Object IDs (GUIDs) in a JSON array. The app must convert the JSON array of groups and roles into individual `group` claims that the app can build [policies](xref:security/authorization/policies) against.
 
 Extend `RemoteUserAccount` to include array properties for groups and roles.
 
@@ -208,50 +199,23 @@ A policy check can also be performed in code:
 
 An AAD-registered app can also be configured to use user-defined roles:
 
-1. Edit the app's manifest (standalone app or Client app of a Hosted solution) and provide user-defined roles. The following example creates two roles:
+To configure the app in the Azure portal to provide a `roles` membership claim, see [How to: Add app roles in your application and receive them in the token (Azure documentation)](/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps).
 
-   * `admin`
-   * `developer`
+The following example assumes that an app is configured with two roles:
 
-   Generate unique custom `id` entires for each role added to the manifest.
+* `admin`
+* `developer`
 
-   ```json
-   "appRoles": [
-       {
-           "allowedMemberTypes": [
-               "User"
-           ],
-           "description": "Administrators can access administrator-only areas",
-           "displayName": "Administrators",
-           "id": "d1613ef0-097a-44a0-b1d2-c13c02231a97",
-           "isEnabled": true,
-           "lang": null,
-           "origin": "Application",
-           "value": "admin"
-       },
-       {
-           "allowedMemberTypes": [
-               "User"
-           ],
-           "description": "Developers can access developer-only areas",
-           "displayName": "Developers",
-           "id": "87731ab9-df42-418a-b3bb-37b759eb4111",
-           "isEnabled": true,
-           "lang": null,
-           "origin": "Application",
-           "value": "developer"
-       }
-   ],
-   ```
+> [!NOTE]
+> Although you can't assign roles to security groups without an Azure AD Premium account, you can assign users to roles and receive a `roles` claim for users with a standard Azure account. The guidance in this section doesn't require an Azure AD Premium account.
+>
+> Multiple roles are assigned in the Azure portal by **_re-adding a user_** for each additional role assignment.
 
-1. Navigate to **Enterprise Applications** and select the app's registration.
-1. In **Users and groups**, add a user and give them one of the configured roles. Multiple roles are allowed by **_re-adding a user_** for each additional role assignment.
-
-The `roles` claim sent by AAD presents the user-defined roles as the `appRoles`'s `value`s set in the manifest file in a JSON array. The app must convert the JSON array of roles into individual `role` claims.
+The `roles` claim sent by AAD presents the user-defined roles as the `appRoles`'s `value`s in a JSON array. The app must convert the JSON array of roles into individual `role` claims.
 
 The `CustomUserFactory` shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section is set up to act on a `roles` claim with a JSON array value. Add and register the `CustomUserFactory` in the standalone app or Client app of a Hosted solution as shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-aad-built-in-administrative-roles) section. There's no need to provide code to remove the original `roles` claim, as it is automatically removed by the framework.
 
-In `Program.Main` of the standalone app or Client app of a Hosted solution, specify the claim named "`roles`" as the role claim:
+In `Program.Main` of the standalone app or Client app of a Hosted solution, specify the claim named "`role`" as the role claim:
 
 ```csharp
 builder.Services.AddMsalAuthentication(options =>
@@ -279,7 +243,7 @@ if (user.IsInRole("admin") && user.IsInRole("developer"))
 
 ## AAD Adminstrative Role Group IDs
 
-The Object IDs presented in the following table are used to create [policies](xref:security/authorization/policies) for `groups` claims. The policies permit an app to authorize users for various activities in an app.
+The Object IDs presented in the following table are used to create [policies](xref:security/authorization/policies) for `group` claims. The policies permit an app to authorize users for various activities in an app.
 
 AAD Administrative Role | Object ID
 --- | ---
@@ -335,11 +299,7 @@ Teams Communications Specialist | ef547281-cf46-4cc6-bcaa-f5eac3f030c9
 Teams Service Administrator | 8846a0be-197b-443a-b13c-11192691fa24
 User administrator | 1f6eed58-7dd3-460b-a298-666f975427a1
 
-## Additional resources for AAD groups and roles
+## Additional resources
 
-* [Roles using Azure AD security groups (Azure documentation)](/azure/architecture/multitenant-identity/app-roles#roles-using-azure-ad-security-groups)
-* [groupMembershipClaims attribute (Azure documentation)](/azure/active-directory/develop/reference-app-manifest#groupmembershipclaims-attribute)
 * <xref:security/authorization/claims>
 * <xref:security/blazor/index>
-* [How to: Add app roles in your application and receive them in the token (Azure documentation)](/azure/active-directory/develop/howto-add-app-roles-in-azure-ad-apps)
-

--- a/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
@@ -93,7 +93,6 @@ public class CustomUserFactory
 
         if (initialUser.Identity.IsAuthenticated)
         {
-            
             var userIdentity = (ClaimsIdentity)initialUser.Identity;
 
             foreach (var role in account.Roles)

--- a/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
@@ -110,14 +110,17 @@ There's no need to provide code to remove the original `groups` claim, as it is 
 Register the factory in `Program.Main` (*Program.cs*) of the standalone app or Client app of a Hosted solution:
 
 ```csharp
-builder.Services.AddMsalAuthentication<RemoteAuthenticationState, CustomUserAccount>(options =>
-{
-    builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
-    options.ProviderOptions.DefaultAccessTokenScopes.Add("...");
-
-    ...
-})
-.AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, CustomUserAccount, CustomUserFactory>();
+builder.Services.AddMsalAuthentication<RemoteAuthenticationState, 
+    CustomUserAccount>(options =>
+    {
+        builder.Configuration.Bind("AzureAd", 
+            options.ProviderOptions.Authentication);
+        options.ProviderOptions.DefaultAccessTokenScopes.Add("...");
+    
+        ...
+    })
+.AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, CustomUserAccount, 
+    CustomUserFactory>();
 ```
 
 Create a [policy](xref:security/authorization/policies) for each group or role in `Program.Main`. The following example creates a policy for the AAD built-in Billing Administrator Role:

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2020
+ms.date: 05/06/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/hosted-with-azure-active-directory
 ---
@@ -340,12 +340,9 @@ Run the app from the Server project. When using Visual Studio, select the Server
 
 [!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
 
-## Azure AD Groups, Administrative Roles, and user-defined roles
-
-[!INCLUDE[](~/includes/blazor-security/azuread-roles-groups.md)]
-
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* <xref:security/blazor/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
@@ -340,6 +340,10 @@ Run the app from the Server project. When using Visual Studio, select the Server
 
 [!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
 
+## Azure AD Groups, Administrative Roles, and user-defined roles
+
+[!INCLUDE[](~/includes/blazor-security/azuread-roles-groups.md)]
+
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2020
+ms.date: 05/06/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/standalone-with-azure-active-directory
 ---
@@ -157,12 +157,9 @@ For more information, see the following sections of the *Additional scenarios* a
 
 [!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
 
-## Azure AD Groups, Administrative Roles, and user-defined roles
-
-[!INCLUDE[](~/includes/blazor-security/azuread-roles-groups.md)]
-
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* <xref:security/blazor/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
@@ -157,6 +157,10 @@ For more information, see the following sections of the *Additional scenarios* a
 
 [!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
 
+## Azure AD Groups, Administrative Roles, and user-defined roles
+
+[!INCLUDE[](~/includes/blazor-security/azuread-roles-groups.md)]
+
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>

--- a/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
@@ -159,6 +159,10 @@ For more information, see the following sections of the *Additional scenarios* a
 
 [!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
 
+## Azure AD Groups, Administrative Roles, and user-defined roles
+
+[!INCLUDE[](~/includes/blazor-security/azuread-roles-groups.md)]
+
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>

--- a/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2020
+ms.date: 05/06/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/standalone-with-microsoft-accounts
 ---
@@ -159,12 +159,9 @@ For more information, see the following sections of the *Additional scenarios* a
 
 [!INCLUDE[](~/includes/blazor-security/troubleshoot.md)]
 
-## Azure AD Groups, Administrative Roles, and user-defined roles
-
-[!INCLUDE[](~/includes/blazor-security/azuread-roles-groups.md)]
-
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* <xref:security/blazor/webassembly/aad-groups-roles>
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal)
 * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -347,6 +347,8 @@
                   uid: security/blazor/webassembly/hosted-with-identity-server
                 - name: Additional scenarios
                   uid: security/blazor/webassembly/additional-scenarios
+                - name: AAD groups and roles
+                  uid: security/blazor/webassembly/aad-groups-roles
             - name: Blazor Server
               items:
                 - name: Overview
@@ -1140,6 +1142,8 @@
               uid: security/blazor/webassembly/hosted-with-identity-server
             - name: Additional scenarios
               uid: security/blazor/webassembly/additional-scenarios
+            - name: AAD groups and roles
+              uid: security/blazor/webassembly/aad-groups-roles
         - name: Blazor Server
           items:
             - name: Overview

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -339,12 +339,12 @@
                   uid: security/blazor/webassembly/standalone-with-azure-active-directory
                 - name: Standalone with AAD B2C
                   uid: security/blazor/webassembly/standalone-with-azure-active-directory-b2c
-                - name: Hosted with Identity Server
-                  uid: security/blazor/webassembly/hosted-with-identity-server
                 - name: Hosted with AAD
                   uid: security/blazor/webassembly/hosted-with-azure-active-directory
                 - name: Hosted with AAD B2C
                   uid: security/blazor/webassembly/hosted-with-azure-active-directory-b2c
+                - name: Hosted with Identity Server
+                  uid: security/blazor/webassembly/hosted-with-identity-server
                 - name: Additional scenarios
                   uid: security/blazor/webassembly/additional-scenarios
             - name: Blazor Server
@@ -1132,12 +1132,12 @@
               uid: security/blazor/webassembly/standalone-with-azure-active-directory
             - name: Standalone with AAD B2C
               uid: security/blazor/webassembly/standalone-with-azure-active-directory-b2c
-            - name: Hosted with Identity Server
-              uid: security/blazor/webassembly/hosted-with-identity-server
             - name: Hosted with AAD
               uid: security/blazor/webassembly/hosted-with-azure-active-directory
             - name: Hosted with AAD B2C
               uid: security/blazor/webassembly/hosted-with-azure-active-directory-b2c
+            - name: Hosted with Identity Server
+              uid: security/blazor/webassembly/hosted-with-identity-server
             - name: Additional scenarios
               uid: security/blazor/webassembly/additional-scenarios
         - name: Blazor Server

--- a/aspnetcore/whats-new/2020-04.md
+++ b/aspnetcore/whats-new/2020-04.md
@@ -33,7 +33,7 @@ This article lists some of the significant changes to docs during this period.
 
 - [Add, download, and delete custom user data to Identity in an ASP.NET Core project](../security/authentication/add-user-data.md) - Adding additional claims to Identity
 - [ASP.NET Core Blazor authentication and authorization](../security/blazor/index.md) - Improvements to Blazor auth coverage
-- [Secure ASP.NET Core Blazor Server apps](../security/blazor/server.md) - Improvements to Blazor auth coverage
+- [Secure ASP.NET Core Blazor Server apps](../security/blazor/server/index.md) - Improvements to Blazor auth coverage
 - [ASP.NET Core Blazor WebAssembly additional security scenarios](../security/blazor/webassembly/additional-scenarios.md)
   - Apply Blazor Preview 5 updates
   - Move two Blazor WASM Overview sections


### PR DESCRIPTION
Fixes #17660
Fixes #17927
Fixes #17928

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/standalone-with-azure-active-directory?view=aspnetcore-3.1&branch=pr-en-us-18145)

:tada::beers: I'm *very happy* to present how to use AAD groups, built-in Administrative Roles, and user-defined roles with Blazor WASM apps.

B2C for these approaches is going to require a bit more elbow grease given that it has to be done via Graph API. That's on [another issue](https://github.com/dotnet/AspNetCore.Docs/issues/17683) for another day.

This PR focuses on creating an INCLUDE that's used in the following WASM security topics:

* Standalone with Microsoft Accounts
* Standalone with AAD
* Hosted with AAD

You won't find the Object ID table **_anywhere on 🌍!_** I had to generate it. The 🙏 *server gods* 🙏 will be pleased. The Object IDs in the table are what AAD sends down in the `groups` claim, and the app needs to create policies from them to make AAD groups and built-in Administrative Roles work. If there's a better alternative, I'm :ear:, but this is what works thus far.