### PR TITLE
Surface handling errors in Blazor web API topic

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -5,7 +5,7 @@ description: Learn how to call a web API from a Blazor WebAssembly app using JSO
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/04/2020
+ms.date: 05/07/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/call-web-api
 ---
@@ -169,6 +169,33 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
         await Http.DeleteAsync($"api/TodoItems/{id}");
 }
 ```
+
+## Handle errors
+
+When errors occur, they can be handled by developer code. For example, `GetFromJsonAsync` is expected to return JSON, a `Content-Type` of `application/json`. If the response isn't JSON, content validation throws a <xref:System.NotSupportedException>.
+
+In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e"). The call expects JSON to be returned, but HTML for a *404 - Not Found* response is returned with a `Content-Type` of `text/html`. The call throws a <xref:System.NotSupportedException> when the response content is validated as JSON. The exception is caught in the `catch` block, where it could be logged or result in a friendly error message to the user.
+
+```csharp
+protected override async Task OnInitializedAsync()
+{
+    try
+    {
+        forecasts = await Http.GetFromJsonAsync<WeatherForecast[]>(
+            "WeatherForcast");
+    }
+    catch (AccessTokenNotAvailableException exception)
+    {
+        exception.Redirect();
+    }
+    catch (NotSupportedException exception)
+    {
+        ...
+    }
+}
+```
+
+For more information, see <xref:blazor/handle-errors>.
 
 ## Cross-origin resource sharing (CORS)
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -178,7 +178,7 @@ In the following example, the URI endpoint for the weather forecast data request
 
 The `GetFromJsonAsync` call expects JSON to be returned, but the server returns HTML for an unhandled exception on the server with a `Content-Type` of `text/html`. The unhandled exception occurs on the server because the path isn't found and middleware can't serve a page or view for the request.
 
-The call throws a <xref:System.NotSupportedException> when the response content is validated as non-JSON. The exception is caught in the `catch` block, where custom logic could log the error or present a friendly error message to the user.
+In `OnInitializedAsync` on the client, <xref:System.NotSupportedException> is thrown when the response content is validated as non-JSON. The exception is caught in the `catch` block, where custom logic could log the error or present a friendly error message to the user:
 
 ```csharp
 protected override async Task OnInitializedAsync()

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -172,7 +172,7 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
 
 ## Handle errors
 
-When errors occur when interacting with a web API, they can be handled by developer code. For example, `GetFromJsonAsync` expects JSON from the server API, a `Content-Type` of `application/json`. If the response isn't JSON, content validation throws a <xref:System.NotSupportedException>.
+When errors occur while interacting with a web API, they can be handled by developer code. For example, `GetFromJsonAsync` expects JSON from the server API, a `Content-Type` of `application/json`. If the response isn't JSON, content validation throws a <xref:System.NotSupportedException>.
 
 In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e"). The call expects JSON to be returned, but the server returns HTML for an unhandled exception on the server with a `Content-Type` of `text/html`. The call throws a <xref:System.NotSupportedException> when the response content is validated as non-JSON. The exception is caught in the `catch` block, where it could be logged or result in a friendly error message to the user.
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -176,7 +176,7 @@ When errors occur while interacting with a web API, they can be handled by devel
 
 In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e").
 
-The call expects JSON to be returned, but the server returns HTML for an unhandled exception on the server with a `Content-Type` of `text/html`. The unhandled exception occurs on the server because the path isn't found and middleware can't serve a page or view for the request.
+The `GetFromJsonAsync` call expects JSON to be returned, but the server returns HTML for an unhandled exception on the server with a `Content-Type` of `text/html`. The unhandled exception occurs on the server because the path isn't found and middleware can't serve a page or view for the request.
 
 The call throws a <xref:System.NotSupportedException> when the response content is validated as non-JSON. The exception is caught in the `catch` block, where custom logic could log the error or present a friendly error message to the user.
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -172,9 +172,9 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
 
 ## Handle errors
 
-When errors occur, they can be handled by developer code. For example, `GetFromJsonAsync` expects JSON from the server API, a `Content-Type` of `application/json`. If the response isn't JSON, content validation throws a <xref:System.NotSupportedException>.
+When errors occur when interacting with a web API, they can be handled by developer code. For example, `GetFromJsonAsync` expects JSON from the server API, a `Content-Type` of `application/json`. If the response isn't JSON, content validation throws a <xref:System.NotSupportedException>.
 
-In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e"). The call expects JSON to be returned, but HTML for a *404 - Not Found* response is returned with a `Content-Type` of `text/html`. The call throws a <xref:System.NotSupportedException> when the response content is validated as JSON. The exception is caught in the `catch` block, where it could be logged or result in a friendly error message to the user.
+In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e"). The call expects JSON to be returned, but the server returns HTML for an unhandled exception on the server with a `Content-Type` of `text/html`. The call throws a <xref:System.NotSupportedException> when the response content is validated as non-JSON. The exception is caught in the `catch` block, where it could be logged or result in a friendly error message to the user.
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -196,7 +196,7 @@ protected override async Task OnInitializedAsync()
 ```
 
 > [!NOTE]
-> A web API server app can be configured to return JSON even when an endpoint doesn't exist. The preceding example assumes that the server API merely returns a standard *404 - Not Found* HTML response.
+> The preceding example is for demonstration purposes. A web API server app can be configured to return JSON even when an endpoint doesn't exist or an unhandled excpetion on the server occurs.
 
 For more information, see <xref:blazor/handle-errors>.
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -172,7 +172,7 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
 
 ## Handle errors
 
-When errors occur, they can be handled by developer code. For example, `GetFromJsonAsync` is expected to return JSON, a `Content-Type` of `application/json`. If the response isn't JSON, content validation throws a <xref:System.NotSupportedException>.
+When errors occur, they can be handled by developer code. For example, `GetFromJsonAsync` expects JSON from the server API, a `Content-Type` of `application/json`. If the response isn't JSON, content validation throws a <xref:System.NotSupportedException>.
 
 In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e"). The call expects JSON to be returned, but HTML for a *404 - Not Found* response is returned with a `Content-Type` of `text/html`. The call throws a <xref:System.NotSupportedException> when the response content is validated as JSON. The exception is caught in the `catch` block, where it could be logged or result in a friendly error message to the user.
 
@@ -194,6 +194,9 @@ protected override async Task OnInitializedAsync()
     }
 }
 ```
+
+> [!NOTE]
+> A web API server app can be configured to return JSON even when an endpoint doesn't exist. The preceding example assumes that the server API merely returns a standard *404 - Not Found* HTML response.
 
 For more information, see <xref:blazor/handle-errors>.
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -174,7 +174,11 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
 
 When errors occur while interacting with a web API, they can be handled by developer code. For example, `GetFromJsonAsync` expects a JSON response from the server API with a `Content-Type` of `application/json`. If the response isn't in JSON format, content validation throws a <xref:System.NotSupportedException>.
 
-In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e"). The call expects JSON to be returned, but the server returns HTML for an unhandled exception on the server with a `Content-Type` of `text/html`. The call throws a <xref:System.NotSupportedException> when the response content is validated as non-JSON. The exception is caught in the `catch` block, where it could be logged or result in a friendly error message to the user.
+In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e").
+
+The call expects JSON to be returned, but the server returns HTML for an unhandled exception on the server with a `Content-Type` of `text/html`. The unhandled exception occurs on the server because the path isn't found and middleware can't serve a page or view for the request.
+
+The call throws a <xref:System.NotSupportedException> when the response content is validated as non-JSON. The exception is caught in the `catch` block, where custom logic could log the error or present a friendly error message to the user.
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -183,10 +187,6 @@ protected override async Task OnInitializedAsync()
     {
         forecasts = await Http.GetFromJsonAsync<WeatherForecast[]>(
             "WeatherForcast");
-    }
-    catch (AccessTokenNotAvailableException exception)
-    {
-        exception.Redirect();
     }
     catch (NotSupportedException exception)
     {

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -172,7 +172,7 @@ In the following code, the Delete `<button>` element calls the `DeleteItem` meth
 
 ## Handle errors
 
-When errors occur while interacting with a web API, they can be handled by developer code. For example, `GetFromJsonAsync` expects JSON from the server API, a `Content-Type` of `application/json`. If the response isn't JSON, content validation throws a <xref:System.NotSupportedException>.
+When errors occur while interacting with a web API, they can be handled by developer code. For example, `GetFromJsonAsync` expects a JSON response from the server API with a `Content-Type` of `application/json`. If the response isn't in JSON format, content validation throws a <xref:System.NotSupportedException>.
 
 In the following example, the URI endpoint for the weather forecast data request is misspelled. The URI should be to `WeatherForecast` but appears in the call as `WeatherForcast` (missing "e"). The call expects JSON to be returned, but the server returns HTML for an unhandled exception on the server with a `Content-Type` of `text/html`. The call throws a <xref:System.NotSupportedException> when the response content is validated as non-JSON. The exception is caught in the `catch` block, where it could be logged or result in a friendly error message to the user.
 


### PR DESCRIPTION
Fixes #17634

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/call-web-api?view=aspnetcore-3.1&branch=pr-en-us-18187#handle-errors)

At this point, the draft language is for discussion. I used a vanilla example ... the exact scenario from a Hosted app with defaults and a bad URI. Would you like to do something else?