### PR TITLE
Temporary no-loc Razor term fix for high vis issue

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -1,5 +1,5 @@
 ---
-title: Create and use ASP.NET Core Razor components
+title: Create and use ASP.NET Core razor components
 author: guardrex
 description: Learn how to create and use Razor components, including how to bind to data, handle events, and manage component life cycles.
 monikerRange: '>= aspnetcore-3.1'


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components?view=aspnetcore-3.1&branch=pr-en-us-18192)
Review note: This is a meta data change work around to trigger the localization system to not localize the term "Razor".  There is no link to review until the localization has kicked off per this merged change in two days. This is a tiny change not warranting a review perhaps but since it is a temp work around which we normally avoid I'm asking for one.

Related to #18076 

Changing the title meta data so that "Razor" is lower case as "razor" as recommended by the localization team to test out as a near term solution.  There is currently an issue where no-loc: topic meta data terms are ignored if the same word in the same case exists in the title meta data.   

For this particular topic's case, it ends up with the translation of Razor into "Shaving" and similar translations.  The support team and product unit would like it fixed quickly and the community has complained about it. 

Localization is working on a longer term fix for this issue but are blocked at the moment.
