### PR TITLE
Update Blazor custom user account section

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -919,11 +919,6 @@
             "source_path": "aspnetcore/blazor/javascript-interop.md",
             "redirect_url": "/aspnet/core/blazor/call-javascript-from-dotnet",
             "redirect_document_id": false
-        },
-        {
-            "source_path": "aspnetcore/security/blazor/server.md",
-            "redirect_url": "/aspnet/core/security/blazor/server",
-            "redirect_document_id": false
         }
     ]
 }

--- a/aspnetcore/security/blazor/webassembly/additional-scenarios.md
+++ b/aspnetcore/security/blazor/webassembly/additional-scenarios.md
@@ -586,18 +586,55 @@ public class CustomAccountFactory
 }
 ```
 
-Register services to use the `CustomAccountFactory`:
+Register the `CustomAccountFactory` factory for the authentication provider in use. Any of the following registrations are valid: 
 
-```csharp
-using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+* `AddOidcAuthentication`:
 
-...
+  ```csharp
+  using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
-builder.Services.AddMsalAuthentication<RemoteAuthenticationState, 
-    CustomUserAccount>()
-    .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, 
-        CustomUserAccount, CustomAccountFactory>();
-```
+  ...
+
+  builder.Services.AddOidcAuthentication<RemoteAuthenticationState, 
+      CustomUserAccount>(options =>
+  {
+      ...
+  })
+  .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, 
+      CustomUserAccount, CustomAccountFactory>();
+  ```
+
+* `AddMsalAthentication`:
+
+  ```csharp
+  using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+
+  ...
+
+  builder.Services.AddMsalAuthentication<RemoteAuthenticationState, 
+      CustomUserAccount>(options =>
+  {
+      ...
+  })
+  .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, 
+      CustomUserAccount, CustomAccountFactory>();
+  ```
+  
+* `AddApiAuthorization`:
+
+  ```csharp
+  using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+
+  ...
+
+  builder.Services.AddApiAuthorization<RemoteAuthenticationState, 
+      CustomUserAccount>(options =>
+  {
+      ...
+  })
+  .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, 
+      CustomUserAccount, CustomAccountFactory>();
+  ```
 
 ## Support prerendering with authentication
 

--- a/aspnetcore/security/blazor/webassembly/additional-scenarios.md
+++ b/aspnetcore/security/blazor/webassembly/additional-scenarios.md
@@ -5,7 +5,7 @@ description: Learn how to configure Blazor WebAssembly for additional security s
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/04/2020
+ms.date: 05/08/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/additional-scenarios
 ---
@@ -543,7 +543,7 @@ Create a class that extends the `RemoteUserAccount` class:
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
-public class OidcAccount : RemoteUserAccount
+public class CustomUserAccount : RemoteUserAccount
 {
     [JsonPropertyName("amr")]
     public string[] AuthenticationMethod { get; set; }
@@ -560,7 +560,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication.Internal;
 
 public class CustomAccountFactory 
-    : AccountClaimsPrincipalFactory<OidcAccount>
+    : AccountClaimsPrincipalFactory<CustomUserAccount>
 {
     public CustomAccountFactory(NavigationManager navigationManager, 
         IAccessTokenProviderAccessor accessor) : base(accessor)
@@ -568,7 +568,7 @@ public class CustomAccountFactory
     }
   
     public async override ValueTask<ClaimsPrincipal> CreateUserAsync(
-        OidcAccount account, RemoteAuthenticationUserOptions options)
+        CustomUserAccount account, RemoteAuthenticationUserOptions options)
     {
         var initialUser = await base.CreateUserAsync(account, options);
         
@@ -593,9 +593,10 @@ using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
 ...
 
-builder.Services.AddApiAuthorization<RemoteAuthenticationState, OidcAccount>()
-    .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, OidcAccount, 
-        CustomAccountFactory>();
+builder.Services.AddMsalAuthentication<RemoteAuthenticationState, 
+    CustomUserAccount>()
+    .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, 
+        CustomUserAccount, CustomAccountFactory>();
 ```
 
 ## Support prerendering with authentication

--- a/aspnetcore/security/blazor/webassembly/additional-scenarios.md
+++ b/aspnetcore/security/blazor/webassembly/additional-scenarios.md
@@ -604,7 +604,7 @@ Register the `CustomAccountFactory` for the authentication provider in use. Any 
       CustomUserAccount, CustomAccountFactory>();
   ```
 
-* `AddMsalAthentication`:
+* `AddMsalAuthentication`:
 
   ```csharp
   using Microsoft.AspNetCore.Components.WebAssembly.Authentication;

--- a/aspnetcore/security/blazor/webassembly/additional-scenarios.md
+++ b/aspnetcore/security/blazor/webassembly/additional-scenarios.md
@@ -586,7 +586,7 @@ public class CustomAccountFactory
 }
 ```
 
-Register the `CustomAccountFactory` factory for the authentication provider in use. Any of the following registrations are valid: 
+Register the `CustomAccountFactory` for the authentication provider in use. Any of the following registrations are valid: 
 
 * `AddOidcAuthentication`:
 


### PR DESCRIPTION
Fixes #18199

From the original issue ...

https://github.com/dotnet/AspNetCore.Docs/issues/17650#issue-595775463

The registration is shown as ...

```csharp
builder.Services.AddApiAuthorization<RemoteAuthenticationState, OidcAccount>()
    .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, OidcAccount, 
        CustomAccountFactory>();
```

... but should that be on `AddMsalAuthentication`? ...

```csharp
builder.Services.AddMsalAuthentication<RemoteAuthenticationState, OidcAccount>()
    .AddAccountClaimsPrincipalFactory<RemoteAuthenticationState, OidcAccount, 
        CustomAccountFactory>();
```

That's what actually worked in the AAD groups and roles scenario on the https://github.com/dotnet/AspNetCore.Docs/pull/18145 PR (i.e., adding it to `AddApiAuthorization` was a no-op for the scenario). Also, `AddApiAuthorization` wouldn't make sense in an app that doesn't call an API because `AddApiAuthorization` wouldn't exist.

... **_AND/OR_** ... are we missing guidance on when the factory would be registered on one versus the other or even both?

I'd also like to change `OidcAccount` to `CustomUserAccount` to match the naming format of `RemoteUserAccount` (this change is on the PR).