### PR TITLE
Change GDPR URL

### DIFF
--- a/aspnetcore/security/gdpr.md
+++ b/aspnetcore/security/gdpr.md
@@ -12,7 +12,7 @@ uid: security/gdpr
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
-ASP.NET Core provides APIs and templates to help meet some of the [EU General Data Protection Regulation (GDPR)](https://www.eugdpr.org/) requirements:
+ASP.NET Core provides APIs and templates to help meet some of the [EU General Data Protection Regulation (GDPR)](https://ec.europa.eu/info/law/law-topic/data-protection/reform/what-does-general-data-protection-regulation-gdpr-govern_en) requirements:
 
 ::: moniker range=">= aspnetcore-3.0"
 


### PR DESCRIPTION
The GDPR URL points to https://www.eugdpr.org/ which reports to be under construction.

I propose using this: https://ec.europa.eu/info/law/law-topic/data-protection/reform/what-does-general-data-protection-regulation-gdpr-govern_en

P.S.: I'm not a lawyer.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->