### PR TITLE
Fix Azure AD B2C markdown link

### DIFF
--- a/aspnetcore/includes/IdentityServer4.md
+++ b/aspnetcore/includes/IdentityServer4.md
@@ -1,7 +1,7 @@
 ASP.NET Core Identity adds user interface (UI) login functionality to ASP.NET Core web apps. To secure web APIs and SPAs, use one of the following:
 
 * [Azure Active Directory](/azure/api-management/api-management-howto-protect-backend-with-aad)
-* [Azure Active Directory B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw) (Azure AD B2C)]
+* [Azure Active Directory B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw) (Azure AD B2C)
 * [IdentityServer4](https://identityserver.io)
 
 IdentityServer4 is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core 3.0. IdentityServer4 enables the following security features:


### PR DESCRIPTION
Removes excessive `]` that shows up in the rendered markdown in the docs.

Docs: https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?view=aspnetcore-3.1&tabs=visual-studio