### PR TITLE
Blazor call web API enhancements

### DIFF
--- a/aspnetcore/security/blazor/webassembly/additional-scenarios.md
+++ b/aspnetcore/security/blazor/webassembly/additional-scenarios.md
@@ -163,9 +163,9 @@ builder.Services.AddHttpClient<WeatherForecastClient>(client => client.BaseAddre
         scopes: new[] { "example.read", "example.write" }));
 ```
 
-## Insecure web API requests in an app with a secure default client
+## Unauthenticated or unauthorized web API requests in an app with a secure default client
 
-If the Blazor WebAssembly app ordinarily uses a secure default <xref:System.Net.Http.HttpClient>, the app can also make insecure web API requests by configuring a named <xref:System.Net.Http.HttpClient>:
+If the Blazor WebAssembly app ordinarily uses a secure default <xref:System.Net.Http.HttpClient>, the app can also make unauthenticated or unauthorized web API requests by configuring a named <xref:System.Net.Http.HttpClient>:
 
 `Program.Main` (*Program.cs*):
 
@@ -176,7 +176,7 @@ builder.Services.AddHttpClient("ServerAPI.NoAuthenticationClient",
 
 The preceding registration is in addition to the existing secure default <xref:System.Net.Http.HttpClient> registration.
 
-A component creates the <xref:System.Net.Http.HttpClient> from the <xref:System.Net.Http.IHttpClientFactory> to make insecure requests:
+A component creates the <xref:System.Net.Http.HttpClient> from the <xref:System.Net.Http.IHttpClientFactory> to make unauthenticated or unauthorized requests:
 
 ```razor
 @inject IHttpClientFactory ClientFactory

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -355,7 +355,7 @@ Run the app from the Server project. When using Visual Studio, select the Server
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
-* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
+* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/authentication/azure-ad-b2c>
 * [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2020
+ms.date: 05/11/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/hosted-with-azure-active-directory-b2c
 ---
@@ -355,6 +355,7 @@ Run the app from the Server project. When using Visual Studio, select the Server
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/authentication/azure-ad-b2c>
 * [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
@@ -343,7 +343,7 @@ Run the app from the Server project. When using Visual Studio, select the Server
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
-* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
+* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/blazor/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/06/2020
+ms.date: 05/11/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/hosted-with-azure-active-directory
 ---
@@ -343,6 +343,7 @@ Run the app from the Server project. When using Visual Studio, select the Server
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/blazor/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -230,4 +230,4 @@ Run the app from the Server project. When using Visual Studio, select the Server
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
-* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
+* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -5,7 +5,7 @@ description: To create a new Blazor hosted app with authentication from within V
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2020
+ms.date: 05/11/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/hosted-with-identity-server
 ---
@@ -230,3 +230,4 @@ Run the app from the Server project. When using Visual Studio, select the Server
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2020
+ms.date: 05/11/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/standalone-with-authentication-library
 ---
@@ -128,3 +128,4 @@ For more information, see the following sections of the *Additional scenarios* a
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
@@ -128,4 +128,4 @@ For more information, see the following sections of the *Additional scenarios* a
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
-* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
+* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -161,7 +161,7 @@ For more information, see the following sections of the *Additional scenarios* a
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
-* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
+* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/authentication/azure-ad-b2c>
 * [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/24/2020
+ms.date: 05/11/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/standalone-with-azure-active-directory-b2c
 ---
@@ -161,6 +161,7 @@ For more information, see the following sections of the *Additional scenarios* a
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/authentication/azure-ad-b2c>
 * [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
@@ -160,7 +160,7 @@ For more information, see the following sections of the *Additional scenarios* a
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
-* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
+* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/blazor/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/06/2020
+ms.date: 05/11/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/standalone-with-azure-active-directory
 ---
@@ -160,6 +160,7 @@ For more information, see the following sections of the *Additional scenarios* a
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/blazor/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/06/2020
+ms.date: 05/11/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/standalone-with-microsoft-accounts
 ---
@@ -162,6 +162,7 @@ For more information, see the following sections of the *Additional scenarios* a
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
+* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/blazor/webassembly/aad-groups-roles>
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal)
 * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)

--- a/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
@@ -162,7 +162,7 @@ For more information, see the following sections of the *Additional scenarios* a
 ## Additional resources
 
 * <xref:security/blazor/webassembly/additional-scenarios>
-* [Insecure web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#insecure-web-api-requests-in-an-app-with-a-secure-default-client)
+* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:security/blazor/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)
 * <xref:security/blazor/webassembly/aad-groups-roles>
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal)
 * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)


### PR DESCRIPTION
Fixes #18230

* Important improvements to our Blazor WASM call web API coverage.
  * Client coverage added and improved, including for named and typed clients.
  * Naming consistency in code examples.
  * The insecure approaches are in the *Call web API* topic with the rest of the insecure approaches.
  * The secure approaches are in the Blazor WASM security node with the rest of the secure approaches.
* How to add an insecure client to an app with a default secure client is in an *Additional Scenarios* topic section and cross-linked from the rest of the Blazor WASM security topics.  
  Thanks 🛸 **_@Alienroid_** 👽 for the suggestion and discussion on the issue.

There will be more improvements on the upcoming UE pass for all Blazor topics post 3.2 GA. For now, these changes surface and improve basic scenario coverage.

Internal Review Topics ...

* [Call web API topic (Named HttpClient with IHttpClientFactory section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/call-web-api?view=aspnetcore-3.1&branch=pr-en-us-18240#named-httpclient-with-ihttpclientfactory) ... and see the following section named *Typed HttpClient*.
* [Blazor WASM Additional Scenarios topic (Configure the HttpClient handler section)](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/additional-scenarios?view=aspnetcore-3.1&branch=pr-en-us-18240#configure-the-httpclient-handler) ... and see the following section named *Insecure web API requests in an app with a secure default client*, which is cross-linked in the *Additional Resources* sections of the individual Blazor WASM auth topics in this node.
