### PR TITLE
Name and role for Blazor with Identity Server

### DIFF
--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -5,7 +5,7 @@ description: To create a new Blazor hosted app with authentication from within V
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/12/2020
+ms.date: 05/26/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/hosted-with-identity-server
 ---

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -227,7 +227,7 @@ Run the app from the Server project. When using Visual Studio, select the Server
 
 Identity Server can be configured to send `name` and `role` claims for authenticated users.
 
-In the Client app, create a custom user factory. Identity Server sends multiple roles as a string array in a single `role` claim. The factory creates an individual `role` claim for each role in the array. A single role is sent as a string value in the claim. Multiple roles are sent as a JSON array in the claim's value.
+In the Client app, create a custom user factory. Identity Server sends multiple roles as a JSON array in a single `role` claim. A single role is sent as a string value in the claim. The factory creates an individual `role` claim for each of the user's roles.
 
 *CustomUserFactory.cs*:
 
@@ -289,9 +289,7 @@ public class CustomUserFactory
 }
 ```
 
-In the Client app, register the factory.
-
-`Program.Main` (*Program.cs*):
+In the Client app, register the factory in `Program.Main` (*Program.cs*):
 
 ```csharp
 builder.Services.AddApiAuthorization()

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -350,7 +350,7 @@ Component authorization approaches are functional at this point. Any of the auth
 
 ## Profile Service
 
-In the Server app, create a `ProfileService` implementation. The Profile Service example in this section creates `name` and `role` claims for users similar to the scenario shown in the [Name and role claim with API authorization](#name-and-role-claim-with-api-authorization) section. The value of the `role` claim represents the user's assigned role.
+In the Server app, create a `ProfileService` implementation. The Profile Service example in this section creates `name` and `role` claims for users similar to the scenario shown in the [Name and role claim with API authorization](#name-and-role-claim-with-api-authorization) section. The value of the `role` claim represents the user's assigned roles.
 
 *ProfileService.cs*:
 

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -317,7 +317,10 @@ builder.Services.AddApiAuthorization<RemoteAuthenticationState, CustomUserAccoun
       .AddEntityFrameworkStores<ApplicationDbContext>();
   ```
 
-* In the Server app, configure Identity Server to put the `name` and `roles` claims into the ID token and the access token and prevent the default mapping for roles in the `JwtSecurityTokenHandler`:
+* In the Server app:
+
+  * Configure Identity Server to put the `name` and `role` claims into the ID token and access token.
+  * Prevent the default mapping for roles in the JWT token handler.
 
   ```csharp
   using System.IdentityModel.Tokens.Jwt;
@@ -353,7 +356,7 @@ Component authorization approaches are functional at this point. Any of the auth
   ```
 -->
 
-`User.Identity.Name` is populated in the Client app with the user's user name, which is usually their sign-in email address.
+`User.Identity.Name` is populated in the Client app with the user's username, which is usually their sign-in email address.
 
 ## Profile Service
 

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -5,7 +5,7 @@ description: To create a new Blazor hosted app with authentication from within V
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/26/2020
+ms.date: 05/19/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/blazor/webassembly/hosted-with-identity-server
 ---

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -352,9 +352,6 @@ Component authorization approaches are functional at this point. Any of the auth
 
 In the Server app, create a `ProfileService` implementation. The Profile Service example in this section creates `name` and `role` claims for users similar to the scenario shown in the [Name and role claim with API authorization](#name-and-role-claim-with-api-authorization) section. The value of the `role` claim represents the user's assigned role.
 
-> [!NOTE]
-> Currently, only one assigned role per user is supported.
-
 *ProfileService.cs*:
 
 ```csharp
@@ -403,7 +400,6 @@ Component authorization approaches are functional at this point. Any of the auth
 * [`[Authorize]` attribute directive](xref:security/blazor/index#authorize-attribute) (Example: `@attribute [Authorize(Roles = "admin")]`)
 * [Procedural logic](xref:security/blazor/index#procedural-logic) (Example: `if (user.IsInRole("admin")) { ... }`)
 
-<!-- HOLD until the factory pattern issue is resolved.
   Multiple role tests are supported:
 
   ```csharp
@@ -412,7 +408,6 @@ Component authorization approaches are functional at this point. Any of the auth
       ...
   }
   ```
--->
 
 `User.Identity.Name` is populated in the Client app with the user's user name, which is usually their sign-in email address.
 


### PR DESCRIPTION
Fixes #17317
Fixes #17649

Thanks @caleblloyd, @AlbertoPa, @hakenr, and @denmitchell.

[Internal Review Topic (links to *Name and role claim with API authorization* section)](https://review.docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/hosted-with-identity-server?view=aspnetcore-3.1&branch=pr-en-us-18278#name-and-role-claim-with-api-authorization) ... and see the following new section here on *Profile Service*.

Some of the ask on #17317 was worked on prior PRs. The parts that pertain to Identity Server are on this PR.

The guidance on the PR **_only supports ONE role per authenticated user_**. I ran into a problem trying to use the factory pattern for multiple roles. If all you want to do is support one role per user right now, then the PR is fine for now, and we can ignore what follows here :point_down:.

If you want to know what's failing ........

### No factory

:+1: **RESOLVED** ... Single role without a factory works. The app receives a role claim with a string role value. The PR covers this scenario.

### Factory pattern

For multiple roles in a role claim ...

```json
"role": [ "role1", "role2" ]
```

... a factory that parses the JSON works, but this isn't what we want to show. See: https://github.com/dotnet/AspNetCore.Docs/issues/17649#issuecomment-616253008 for @hakenr's approach.

When a factory is implemented without directly parsing JSON (the code for the factory is commented out on the PR to hold it for now) ...

:+1: **RESOLVED** ... When the user has no assigned role (no `role` claim), `account.Roles` in the factory is `null` and so the factory throws. To resolve it, the `Roles` property in `CustomUserAccount` is set to an empty string array:

```csharp
public class CustomUserAccount : RemoteUserAccount
{
    [JsonPropertyName("role")]
    public string[] Roles { get; set; } = new string[0];
}
```

... let me know if you prefer an alternate approach.

:+1: **RESOLVED** ... When the user has two or more roles ...

```json
"role": [ "role1", "role2" ]
```

... the factory works and creates a separate role claim for each role. :guitar:

:boom: **_BROKEN_** :boom: ... When the user only has one assigned role in a string (not an array) ...

```json
"role": "role1"
```

... the factory approach breaks with ...

> Unhandled exception rendering component: An exception occurred executing JS interop: The JSON value could not be converted to System.String. Path: $.role[0] | LineNumber: 0 | BytePositionInLine: 181.. See InnerException for more details.
> Microsoft.JSInterop.JSException: An exception occurred executing JS interop: The JSON value could not be converted to System.String. Path: $.role[0] | LineNumber: 0 | BytePositionInLine: 181.. See InnerException for more details. --- System.Text.Json.JsonException: The JSON value could not be converted to System.String. Path: $.role[0] | LineNumber: 0 | BytePositionInLine: 181.
  at System.Text.Json.ThrowHelper.ThrowJsonException_DeserializeUnableToConvertValue (System.Type propertyType) <0x2fb6d70 + 0x0002c> in <filename unknown>:0 
  at System.Text.Json.JsonPropertyInfo.Read (System.Text.Json.JsonTokenType tokenType, System.Text.Json.ReadStack& state, System.Text.Json.Utf8JsonReader& reader) <0x2fa1238 + 0x00044> in <filename unknown>:0 
  at System.Text.Json.JsonSerializer.HandleValue (System.Text.Json.JsonTokenType tokenType, System.Text.Json.JsonSerializerOptions options, System.Text.Json.Utf8JsonReader& reader, System.Text.Json.ReadStack& state) <0x2fa0fc8 + 0x000a0> in <filename unknown>:0 
  at System.Text.Json.JsonSerializer.ReadCore (System.Text.Json.JsonSerializerOptions options, System.Text.Json.Utf8JsonReader& reader, System.Text.Json.ReadStack& readStack) <0x2e69f08 + 0x0034c> in <filename unknown>:0 
  at System.Text.Json.JsonSerializer.ReadValueCore (System.Text.Json.JsonSerializerOptions options, System.Text.Json.Utf8JsonReader& reader, System.Text.Json.ReadStack& readStack) <0x2e68d38 + 0x00548> in <filename unknown>:0 
  at System.Text.Json.JsonSerializer.ReadValueCore (System.Text.Json.Utf8JsonReader& reader, System.Type returnType, System.Text.Json.JsonSerializerOptions options) <0x2e61360 + 0x0003e> in <filename unknown>:0 
  at System.Text.Json.JsonSerializer.Deserialize (System.Text.Json.Utf8JsonReader& reader, System.Type returnType, System.Text.Json.JsonSerializerOptions options) <0x2e611c0 + 0x00024> in <filename unknown>:0 
  at Microsoft.JSInterop.JSRuntime.EndInvokeJS (System.Int64 taskId, System.Boolean succeeded, System.Text.Json.Utf8JsonReader& jsonReader) <0x2e50d40 + 0x00050> in <filename unknown>:0