### PR TITLE
Move MS Learn ToC links to Tutorials

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -27,6 +27,7 @@
     - name: What's new in 1.1
       uid: aspnetcore-1.1
 - name: Tutorials
+  displayName: tutorial
   items:
     - name: Web apps
       items:
@@ -154,20 +155,19 @@
               uid: data/ef-mvc/inheritance
             - name: Advanced topics
               uid: data/ef-mvc/advanced
-- name: Tutorials (Microsoft Learn)
-  displayName: tutorial
-  items:
-    - name: Web apps
-      displayName: tutorial, razor, razor pages, ui
-      href: /learn/modules/create-razor-pages-aspnet-core/
-    - name: Web API apps
-      href: /learn/modules/build-web-api-net-core/
-    - name: Data access
-      displayName: tutorial, ef, entity framework
-      href: /learn/modules/persist-data-ef-core/
-    - name: Web app security
-      displayName: tutorial, identity
-      href: /learn/modules/secure-aspnet-core-identity/
+    - name: Microsoft Learn modules
+      items:
+        - name: Web apps >>
+          displayName: tutorial, razor, razor pages, ui
+          href: /learn/modules/create-razor-pages-aspnet-core/
+        - name: Web API apps >>
+          href: /learn/modules/build-web-api-net-core/
+        - name: Data access >>
+          displayName: tutorial, ef, entity framework
+          href: /learn/modules/persist-data-ef-core/
+        - name: Web app security >>
+          displayName: tutorial, identity
+          href: /learn/modules/secure-aspnet-core-identity/
 - name: Fundamentals
   items:
     - name: Overview


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/18171

[Internal review page](https://review.docs.microsoft.com/en-us/aspnet/core/introduction-to-aspnet-core?view=aspnetcore-1.0&branch=pr-en-us-18279)

I also added ">>" to denote that the MS Learn links navigate away from our Table of Contents (ToC).