### PR TITLE
fix markdown url

### DIFF
--- a/aspnetcore/performance/caching/middleware.md
+++ b/aspnetcore/performance/caching/middleware.md
@@ -184,7 +184,7 @@ The sample app adds headers to control caching on subsequent requests:
 
 The preceding headers are not written to the response and are overridden when a controller, action, or Razor Page:
 
-* Has a [[ResponseCache]](xref:Microsoft.AspNetCore.Mvc.ResponseCacheAttribute) attribute. This applies even if a property isn't set. For example, omitting the [VaryByHeader] property (/aspnet/core/performance/caching/response#vary) will cause the corresponding header to be removed from the response.
+* Has a [[ResponseCache]](xref:Microsoft.AspNetCore.Mvc.ResponseCacheAttribute) attribute. This applies even if a property isn't set. For example, omitting the [VaryByHeader](/aspnet/core/performance/caching/response#vary) property will cause the corresponding header to be removed from the response.
 
 Response Caching Middleware only caches server responses that result in a 200 (OK) status code. Any other responses, including [error pages](xref:fundamentals/error-handling), are ignored by the middleware.
 


### PR DESCRIPTION
Related to #18298 
Some markdown was fixed in one version, but not the other.
This updates the other one.
(`[VaryByHeader](/aspnet/core/performance/caching/response#vary) property`)