### PR TITLE
Add info for setting environment on IWebHostBuilder

### DIFF
--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -315,7 +315,7 @@ protected override IHostBuilder CreateHostBuilder() =>
             config => config.AddEnvironmentVariables("ASPNETCORE"));
 ```
 
-If the SUT uses the Web Host (`IWebHostBuilder`), override `CreateWebHostBuilder` instead:
+If the SUT uses the Web Host (`IWebHostBuilder`), override `CreateWebHostBuilder`:
 
 ```csharp
 protected override IWebHostBuilder CreateWebHostBuilder() =>

--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -303,16 +303,23 @@ For more information on `WebApplicationFactoryClientOptions`, see the [Client op
 
 ## Set the environment
 
-By default, the SUT's host and app environment is configured to use the Development environment. To override the SUT's environment:
+By default, the SUT's host and app environment is configured to use the Development environment. To override the SUT's environment when using `IHostBuilder`:
 
 * Set the `ASPNETCORE_ENVIRONMENT` environment variable (for example, `Staging`, `Production`, or other custom value, such as `Testing`).
 * Override `CreateHostBuilder` in the test app to read environment variables prefixed with `ASPNETCORE`.
 
 ```csharp
-protected override IHostBuilder CreateHostBuilder() => 
+protected override IHostBuilder CreateHostBuilder() =>
     base.CreateHostBuilder()
         .ConfigureHostConfiguration(
             config => config.AddEnvironmentVariables("ASPNETCORE"));
+```
+
+If using `IWebHostBuilder`, override `CreateWebHostBuilder` instead:
+
+```csharp
+protected override IWebHostBuilder CreateWebHostBuilder() =>
+    base.CreateWebHostBuilder().UseEnvironment("Testing");
 ```
 
 ## How the test infrastructure infers the app content root path

--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -315,7 +315,7 @@ protected override IHostBuilder CreateHostBuilder() =>
             config => config.AddEnvironmentVariables("ASPNETCORE"));
 ```
 
-If using `IWebHostBuilder`, override `CreateWebHostBuilder` instead:
+If the SUT uses the Web Host (`IWebHostBuilder`), override `CreateWebHostBuilder` instead:
 
 ```csharp
 protected override IWebHostBuilder CreateWebHostBuilder() =>


### PR DESCRIPTION
The proposed override of `CreateHostBuilder` throws `NullReferenceException`s when the SUT provides an `IWebHostBuilder` rather than `IHostBuilder`.

Further, following the same environment variable approach does not work for `IWebHostBuilder`; however, `UseEnvironment()`  does work and is a single line.

@Rick-Anderson  edit:
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-3.1&branch=pr-en-us-18313#set-the-environment)