### PR TITLE
Blazor WASM security topic updates

### DIFF
--- a/aspnetcore/includes/blazor-security/logindisplay-component.md
+++ b/aspnetcore/includes/blazor-security/logindisplay-component.md
@@ -14,7 +14,7 @@ The `LoginDisplay` component (*Shared/LoginDisplay.razor*) is rendered in the `M
 <AuthorizeView>
     <Authorized>
         Hello, @context.User.Identity.Name!
-        <button class="nav-link btn btn-link" @onclick="BeginSignOut">
+        <button class="nav-link btn btn-link" @onclick="BeginLogout">
             Log out
         </button>
     </Authorized>
@@ -24,7 +24,7 @@ The `LoginDisplay` component (*Shared/LoginDisplay.razor*) is rendered in the `M
 </AuthorizeView>
 
 @code {
-    private async Task BeginSignOut(MouseEventArgs args)
+    private async Task BeginLogout(MouseEventArgs args)
     {
         await SignOutManager.SetSignOutState();
         Navigation.NavigateTo("authentication/logout");

--- a/aspnetcore/includes/blazor-security/usermanager-signinmanager.md
+++ b/aspnetcore/includes/blazor-security/usermanager-signinmanager.md
@@ -8,6 +8,10 @@ Set the user identifier claim type when a Server app requires:
 In `Startup.ConfigureServices`:
 
 ```csharp
+using System.Security.Claims;
+
+...
+
 services.Configure<IdentityOptions>(options => 
     options.ClaimsIdentity.UserIdClaimType = ClaimTypes.NameIdentifier);
 ```
@@ -33,7 +37,7 @@ namespace {APP NAMESPACE}.Server.Controllers
     [Route("[controller]")]
     public class WeatherForecastController : ControllerBase
     {
-        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly UserManager<ApplicationUser> userManager;
 
         private static readonly string[] Summaries = new[]
         {
@@ -47,7 +51,7 @@ namespace {APP NAMESPACE}.Server.Controllers
             UserManager<ApplicationUser> userManager)
         {
             this.logger = logger;
-            _userManager = userManager;
+            this.userManager = userManager;
         }
 
         [HttpGet]
@@ -55,7 +59,7 @@ namespace {APP NAMESPACE}.Server.Controllers
         {
             var rng = new Random();
 
-            var user = await _userManager.GetUserAsync(User);
+            var user = await userManager.GetUserAsync(User);
 
             if (user != null)
             {

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -23,21 +23,29 @@ This article describes how to create a Blazor WebAssembly standalone app that us
 
 ### Create a tenant
 
-Follow the guidance in [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant) to create an AAD B2C tenant and record the following information:
+Follow the guidance in [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant) to create an AAD B2C tenant.
+
+Record the following information:
 
 * AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash)
 * AAD B2C Tenant domain (for example, `contoso.onmicrosoft.com`)
 
 ### Register a server API app
 
-Follow the guidance in [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications) to register an AAD app for the *Server API app* in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+Follow the guidance in [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications) to register an AAD app for the *Server API app*:
 
-1. Select **New registration**.
+1. In **Azure Active Directory** > **App registrations**, select **New registration**.
 1. Provide a **Name** for the app (for example, **Blazor Server AAD B2C**).
-1. For **Supported account types**, select **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.** (multi-tenant) for this experience.
+1. For **Supported account types**, select the multi-tenant option: **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.**
 1. The *Server API app* doesn't require a **Redirect URI** in this scenario, so leave the drop down set to **Web** and don't enter a redirect URI.
 1. Confirm that **Permissions** > **Grant admin concent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
+
+Record the following information:
+
+* *Server API app* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
+* Directory ID (Tenant ID) (for example, `222222222-2222-2222-2222-222222222222`)
+* AAD Tenant domain (for example, `contoso.onmicrosoft.com`) &ndash; The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
 
 In **Expose an API**:
 
@@ -51,22 +59,21 @@ In **Expose an API**:
 
 Record the following information:
 
-* *Server API app* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
 * App ID URI (for example, `https://contoso.onmicrosoft.com/11111111-1111-1111-1111-111111111111`, `api://11111111-1111-1111-1111-111111111111`, or the custom value that you provided)
-* Directory ID (Tenant ID) (for example, `222222222-2222-2222-2222-222222222222`)
-* *Server API app* App ID URI (for example, `https://contoso.onmicrosoft.com/11111111-1111-1111-1111-111111111111`, the Azure portal might default the value to the Client ID)
 * Default scope (for example, `API.Access`)
 
 ### Register a client app
 
-Follow the guidance in [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications) again to register an AAD app for the *Client app* in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+Follow the guidance in [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications) again to register an AAD app for the *Client app*:
 
-1. Select **New registration**.
+1. In **Azure Active Directory** > **App registrations**, select **New registration**.
 1. Provide a **Name** for the app (for example, **Blazor Client AAD B2C**).
-1. For **Supported account types**, select **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.** (multi-tenant) for this experience.
-1. Leave the **Redirect URI** drop down set to **Web**, and provide a redirect URI of `https://localhost:5001/authentication/login-callback`.
+1. For **Supported account types**, select the multi-tenant option: **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.**
+1. Leave the **Redirect URI** drop down set to **Web**, and provide the following redirect URI: `https://localhost:5001/authentication/login-callback`
 1. Confirm that **Permissions** > **Grant admin concent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
+
+Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
 
 In **Authentication** > **Platform configurations** > **Web**:
 
@@ -77,7 +84,6 @@ In **Authentication** > **Platform configurations** > **Web**:
 
 In **API permissions**:
 
-1. Confirm that the app has **Microsoft Graph** > **User.Read** permission.
 1. Select **Add a permission** followed by **My APIs**.
 1. Select the *Server API app* from the **Name** column (for example, **Blazor Server AAD B2C**).
 1. Open the **API** list.
@@ -85,29 +91,30 @@ In **API permissions**:
 1. Select **Add permissions**.
 1. Select the **Grant admin content for {TENANT NAME}** button. Select **Yes** to confirm.
 
+Record the App ID URI (for example, `https://{ORGANIZATION}.onmicrosoft.com/{SERVER API APP CLIENT ID OR CUSTOM VALUE}`).
+
 In **Home** > **Azure AD B2C** > **User flows**:
 
 [Create a sign-up and sign-in user flow](/azure/active-directory-b2c/tutorial-create-user-flows)
 
 At a minimum, select the **Application claims** > **Display Name** user attribute to populate the `context.User.Identity.Name` in the `LoginDisplay` component (*Shared/LoginDisplay.razor*).
 
-Record the following information:
-
-* Record the *Client app* Application ID (Client ID) (for example, `33333333-3333-3333-3333-333333333333`).
-* Record the sign-up and sign-in user flow name created for the app (for example, `B2C_1_signupsignin`).
+Record the sign-up and sign-in user flow name created for the app (for example, `B2C_1_signupsignin`).
 
 ### Create the app
 
 Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
 
 ```dotnetcli
-dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{DOMAIN}" -ho -ssp "{SIGN UP OR SIGN IN POLICY}" --tenant-id "{TENANT ID}"
+dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{TENANT DOMAIN}" -ho -ssp "{SIGN UP OR SIGN IN POLICY}" --tenant-id "{TENANT ID}"
 ```
 
 To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
 
 > [!NOTE]
 > Pass the App ID URI to the `app-id-uri` option, but note a configuration change might be required in the client app, which is described in the [Access token scopes](#access-token-scopes) section.
+>
+> Additionally, the scope set up by the Hosted Blazor template might have the App ID URI host repeated. Confirm that the scope configured for the `DefaultAccessTokenScopes` collection is correct in `Program.Main` (*Program.cs*) of the *Client app*.
 
 ## Server app configuration
 
@@ -148,6 +155,10 @@ By default, the `User.Identity.Name` isn't populated.
 To configure the app to receive the value from the `name` claim type, configure the [TokenValidationParameters.NameClaimType](xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType) of the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions> in `Startup.ConfigureServices`:
 
 ```csharp
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+...
+
 services.Configure<JwtBearerOptions>(
     AzureADB2CDefaults.JwtBearerAuthenticationScheme, options =>
     {
@@ -162,9 +173,9 @@ The *appsettings.json* file contains the options to configure the JWT bearer han
 ```json
 {
   "AzureAdB2C": {
-    "Instance": "https://{ORGANIZATION}.b2clogin.com/",
+    "Instance": "https://{TENANT}.b2clogin.com/",
     "ClientId": "{SERVER API APP CLIENT ID}",
-    "Domain": "{DOMAIN}",
+    "Domain": "{TENANT DOMAIN}",
     "SignUpSignInPolicyId": "{SIGN UP OR SIGN IN POLICY}"
   }
 }
@@ -231,14 +242,14 @@ Support for `HttpClient` instances is added that include access tokens when maki
 
 ```csharp
 builder.Services.AddHttpClient("{APP ASSEMBLY}.ServerAPI", client => 
-        client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress))
+    client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress))
     .AddHttpMessageHandler<BaseAddressAuthorizationMessageHandler>();
 
 builder.Services.AddTransient(sp => sp.GetRequiredService<IHttpClientFactory>()
     .CreateClient("{APP ASSEMBLY}.ServerAPI"));
 ```
 
-Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up the services required for the app to interact with the Identity Provider (IP).
 
 *Program.cs*:
 
@@ -257,7 +268,7 @@ Configuration is supplied by the *wwwroot/appsettings.json* file:
 ```json
 {
   "AzureAdB2C": {
-    "Authority": "{AAD B2C INSTANCE}{DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
+    "Authority": "{AAD B2C INSTANCE}{TENANT DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
     "ClientId": "{CLIENT APP CLIENT ID}",
     "ValidateAuthority": false
   }
@@ -342,7 +353,10 @@ For more information, see the following sections of the *Additional scenarios* a
 
 ## Run the app
 
-Run the app from the Server project. When using Visual Studio, select the Server project in **Solution Explorer** and select the **Run** button in the toolbar or start the app from the **Debug** menu.
+Run the app from the Server project. When using Visual Studio, either:
+
+* Set the **Startup Projects** drop down list in the toolbar to the *Server API app* and select the **Run** button.
+* Select the Server project in **Solution Explorer** and select the **Run** button in the toolbar or start the app from the **Debug** menu.
 
 <!-- HOLD
 [!INCLUDE[](~/includes/blazor-security/usermanager-signinmanager.md)]

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
@@ -27,16 +27,22 @@ Follow the guidance in [Quickstart: Set up a tenant](/azure/active-directory/dev
 
 ### Register a server API app
 
-Follow the guidance in [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app) and subsequent Azure AAD topics to register an AAD app for the *Server API app* in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+Follow the guidance in [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app) and subsequent Azure AAD topics to register an AAD app for the *Server API app*:
 
-1. Select **New registration**.
+1. In **Azure Active Directory** > **App registrations**, select **New registration**.
 1. Provide a **Name** for the app (for example, **Blazor Server AAD**).
 1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** (single tenant) for this experience.
 1. The *Server API app* doesn't require a **Redirect URI** in this scenario, so leave the drop down set to **Web** and don't enter a redirect URI.
 1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
-In **API permissions**, remove the **Microsoft Graph** > **User.Read** permission, as the app doesn't require sign in or uer profile access.
+Record the following information:
+
+* *Server API app* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
+* Directory ID (Tenant ID) (for example, `222222222-2222-2222-2222-222222222222`)
+* AAD Tenant domain (for example, `contoso.onmicrosoft.com`) &ndash; The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
+
+In **API permissions**, remove the **Microsoft Graph** > **User.Read** permission, as the app doesn't require sign in or user profile access.
 
 In **Expose an API**:
 
@@ -50,22 +56,21 @@ In **Expose an API**:
 
 Record the following information:
 
-* *Server API app* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
 * App ID URI (for example, `https://contoso.onmicrosoft.com/11111111-1111-1111-1111-111111111111`, `api://11111111-1111-1111-1111-111111111111`, or the custom value that you provided)
-* Directory ID (Tenant ID) (for example, `222222222-2222-2222-2222-222222222222`)
-* AAD Tenant domain (for example, `contoso.onmicrosoft.com`)
 * Default scope (for example, `API.Access`)
 
 ### Register a client app
 
-Follow the guidance in [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app) and subsequent Azure AAD topics to register a AAD app for the *Client app* in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+Follow the guidance in [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app) and subsequent Azure AAD topics to register a AAD app for the *Client app*:
 
-1. Select **New registration**.
+1. In **Azure Active Directory** > **App registrations**, select **New registration**.
 1. Provide a **Name** for the app (for example, **Blazor Client AAD**).
 1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** (single tenant) for this experience.
-1. Leave the **Redirect URI** drop down set to **Web**, and provide a redirect URI of `https://localhost:5001/authentication/login-callback`.
+1. Leave the **Redirect URI** drop down set to **Web**, and provide the following redirect URI: `https://localhost:5001/authentication/login-callback`
 1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
 1. Select **Register**.
+
+Record the *Client app* Application ID (Client ID) (for example, `33333333-3333-3333-3333-333333333333`).
 
 In **Authentication** > **Platform configurations** > **Web**:
 
@@ -84,14 +89,14 @@ In **API permissions**:
 1. Select **Add permissions**.
 1. Select the **Grant admin content for {TENANT NAME}** button. Select **Yes** to confirm.
 
-Record the *Client app* Application ID (Client ID) (for example, `33333333-3333-3333-3333-333333333333`).
+Record the App ID URI (for example, `https://{ORGANIZATION}.onmicrosoft.com/{SERVER API APP CLIENT ID OR CUSTOM VALUE}`).
 
 ### Create the app
 
 Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
 
 ```dotnetcli
-dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{DOMAIN}" -ho --tenant-id "{TENANT ID}"
+dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{TENANT DOMAIN}" -ho --tenant-id "{TENANT ID}"
 ```
 
 To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
@@ -138,6 +143,10 @@ By default, the Server app API populates `User.Identity.Name` with the value fro
 To configure the app to receive the value from the `name` claim type, configure the [TokenValidationParameters.NameClaimType](xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType) of the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions> in `Startup.ConfigureServices`:
 
 ```csharp
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
+...
+
 services.Configure<JwtBearerOptions>(
     AzureADDefaults.JwtBearerAuthenticationScheme, options =>
     {
@@ -147,7 +156,7 @@ services.Configure<JwtBearerOptions>(
 
 ### App settings
 
-The *appsettings.json* file contains the options to configure the JWT bearer handler used to validate access tokens.
+The *appsettings.json* file contains the options to configure the JWT bearer handler used to validate access tokens:
 
 ```json
 {
@@ -228,7 +237,7 @@ builder.Services.AddTransient(sp => sp.GetRequiredService<IHttpClientFactory>()
     .CreateClient("{APP ASSEMBLY}.ServerAPI"));
 ```
 
-Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up the services required for the app to interact with the Identity Provider (IP).
 
 *Program.cs*:
 
@@ -332,7 +341,10 @@ For more information, see the following sections of the *Additional scenarios* a
 
 ## Run the app
 
-Run the app from the Server project. When using Visual Studio, select the Server project in **Solution Explorer** and select the **Run** button in the toolbar or start the app from the **Debug** menu.
+Run the app from the Server project. When using Visual Studio, either:
+
+* Set the **Startup Projects** drop down list in the toolbar to the *Server API app* and select the **Run** button.
+* Select the Server project in **Solution Explorer** and select the **Run** button in the toolbar or start the app from the **Debug** menu.
 
 <!-- HOLD
 [!INCLUDE[](~/includes/blazor-security/usermanager-signinmanager.md)]

--- a/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-identity-server.md
@@ -17,13 +17,19 @@ By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https
 
 [!INCLUDE[](~/includes/blazorwasm-3.2-template-article-notice.md)]
 
-To create a new Blazor hosted app in Visual Studio that uses [IdentityServer](https://identityserver.io/) to authenticate users and API calls:
+This article explains how to create a new Blazor hosted app that uses [IdentityServer](https://identityserver.io/) to authenticate users and API calls.
 
-1. Use Visual Studio to create a new **Blazor WebAssembly** app. For more information, see <xref:blazor/get-started>.
+# [Visual Studio](#tab/visual-studio)
+
+In Visual Studio:
+
+1. Create a new **Blazor WebAssembly** app. For more information, see <xref:blazor/get-started>.
 1. In the **Create a new Blazor app** dialog, select **Change** in the **Authentication** section.
 1. Select **Individual User Accounts** followed by **OK**.
 1. Select the **ASP.NET Core hosted** checkbox in the **Advanced** section.
 1. Select the **Create** button.
+
+# [.NET Core CLI](#tab/netcore-cli/)
 
 To create the app in a command shell, execute the following command:
 
@@ -33,17 +39,19 @@ dotnet new blazorwasm -au Individual -ho
 
 To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
 
+---
+
 ## Server app configuration
 
 The following sections describe additions to the project when authentication support is included.
 
 ### Startup class
 
-The `Startup` class has the following additions:
+The `Startup` class has the following additions.
 
 * In `Startup.ConfigureServices`:
 
-  * Identity:
+  * ASP.NET Core Identity:
 
     ```csharp
     services.AddDbContext<ApplicationDbContext>(options =>
@@ -55,7 +63,7 @@ The `Startup` class has the following additions:
         .AddEntityFrameworkStores<ApplicationDbContext>();
     ```
 
-  * IdentityServer with an additional <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method that sets up some default ASP.NET Core conventions on top of IdentityServer:
+  * IdentityServer with an additional <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method that sets up default ASP.NET Core conventions on top of IdentityServer:
 
     ```csharp
     services.AddIdentityServer()
@@ -71,19 +79,19 @@ The `Startup` class has the following additions:
 
 * In `Startup.Configure`:
 
-  * The authentication middleware that is responsible for validating the request credentials and setting the user on the request context:
-
-    ```csharp
-    app.UseAuthentication();
-    ```
-
-  * The IdentityServer middleware that exposes the Open ID Connect (OIDC) endpoints:
+  * The IdentityServer middleware exposes the Open ID Connect (OIDC) endpoints:
 
     ```csharp
     app.UseIdentityServer();
     ```
 
-  * Authentication and Authorization Middleware:
+  * The Authentication middleware is responsible for validating request credentials and setting the user on the request context:
+
+    ```csharp
+    app.UseAuthentication();
+    ```
+
+  * Authorization Middleware enables authorization capabilities:
 
     ```csharp
     app.UseAuthentication();
@@ -92,7 +100,7 @@ The `Startup` class has the following additions:
 
 ### AddApiAuthorization
 
-The <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method configures [IdentityServer](https://identityserver.io/) for ASP.NET Core scenarios. IdentityServer is a powerful and extensible framework for handling app security concerns. IdentityServer exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided that we consider a good starting point. Once your authentication needs change, the full power of IdentityServer is still available to customize authentication to suit an app's requirements.
+The <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method configures [IdentityServer](https://identityserver.io/) for ASP.NET Core scenarios. IdentityServer is a powerful and extensible framework for handling app security concerns. IdentityServer exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided that we consider a good starting point. Once your authentication needs change, the full power of IdentityServer is available to customize authentication to suit an app's requirements.
 
 ### AddIdentityServerJwt
 
@@ -103,11 +111,11 @@ The <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.Ad
 
 ### WeatherForecastController
 
-In the `WeatherForecastController` (*Controllers/WeatherForecastController.cs*), the [`[Authorize]`](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) attribute is applied to the class. The attribute indicates that the user must be authorized based on the default policy to access the resource. The default authorization policy is configured to use the default authentication scheme, which is set up by <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.AddIdentityServerJwt%2A> to the policy scheme that was mentioned earlier. The helper method configures <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerHandler> as the default handler for requests to the app.
+In the `WeatherForecastController` (*Controllers/WeatherForecastController.cs*), the [`[Authorize]`](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) attribute is applied to the class. The attribute indicates that the user must be authorized based on the default policy to access the resource. The default authorization policy is configured to use the default authentication scheme, which is set up by <xref:Microsoft.AspNetCore.Authentication.AuthenticationBuilderExtensions.AddIdentityServerJwt%2A>. The helper method configures <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerHandler> as the default handler for requests to the app.
 
 ### ApplicationDbContext
 
-In the `ApplicationDbContext` (*Data/ApplicationDbContext.cs*), the same <xref:Microsoft.EntityFrameworkCore.DbContext> is used in Identity with the exception that it extends <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> to include the schema for IdentityServer. <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> is derived from <xref:Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext>.
+In the `ApplicationDbContext` (*Data/ApplicationDbContext.cs*), <xref:Microsoft.EntityFrameworkCore.DbContext> extends <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> to include the schema for IdentityServer. <xref:Microsoft.AspNetCore.ApiAuthorization.IdentityServer.ApiAuthorizationDbContext%601> is derived from <xref:Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext>.
 
 To gain full control of the database schema, inherit from one of the available Identity <xref:Microsoft.EntityFrameworkCore.DbContext> classes and configure the context to include the Identity schema by calling `builder.ConfigurePersistedGrantContext(_operationalStoreOptions.Value)` in the `OnModelCreating` method.
 
@@ -147,13 +155,13 @@ Replace `{VERSION}` in the preceding package reference with the version of the `
 
 ### API authorization support
 
-The support for authenticating users is plugged into the service container by the extension method provided inside the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package. This method sets up all the services needed for the app to interact with the existing authorization system.
+The support for authenticating users is plugged into the service container by the extension method provided inside the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package. This method sets up the services required by the app to interact with the existing authorization system.
 
 ```csharp
 builder.Services.AddApiAuthorization();
 ```
 
-By default, it loads the configuration for the app by convention from `_configuration/{client-id}`. By convention, the client ID is set to the app's assembly name. This URL can be changed to point to a separate endpoint by calling the overload with options.
+By default, configuration for the app is loaded by convention from `_configuration/{client-id}`. By convention, the client ID is set to the app's assembly name. This URL can be changed to point to a separate endpoint by calling the overload with options.
 
 ### Imports file
 
@@ -221,7 +229,10 @@ The `LoginDisplay` component (*Shared/LoginDisplay.razor*) is rendered in the `M
 
 ## Run the app
 
-Run the app from the Server project. When using Visual Studio, select the Server project in **Solution Explorer** and select the **Run** button in the toolbar or start the app from the **Debug** menu.
+Run the app from the Server project. When using Visual Studio, either:
+
+* Set the **Startup Projects** drop down list in the toolbar to the *Server API app* and select the **Run** button.
+* Select the Server project in **Solution Explorer** and select the **Run** button in the toolbar or start the app from the **Debug** menu.
 
 [!INCLUDE[](~/includes/blazor-security/usermanager-signinmanager.md)]
 

--- a/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
@@ -117,7 +117,39 @@ For more information, see the following sections of the *Additional scenarios* a
 
 ## LoginDisplay component
 
-[!INCLUDE[](~/includes/blazor-security/logindisplay-component.md)]
+The `LoginDisplay` component (*Shared/LoginDisplay.razor*) is rendered in the `MainLayout` component (*Shared/MainLayout.razor*) and manages the following behaviors:
+
+* For authenticated users:
+  * Displays the current username.
+  * Offers a button to log out of the app.
+* For anonymous users, offers the option to log in.
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+@inject NavigationManager Navigation
+@inject SignOutSessionStateManager SignOutManager
+
+<AuthorizeView>
+    <Authorized>
+        Hello, @context.User.Identity.Name!
+        <button class="nav-link btn btn-link" @onclick="BeginSignOut">
+            Log out
+        </button>
+    </Authorized>
+    <NotAuthorized>
+        <a href="authentication/login">Log in</a>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private async Task BeginSignOut(MouseEventArgs args)
+    {
+        await SignOutManager.SetSignOutState();
+        Navigation.NavigateTo("authentication/logout");
+    }
+}
+```
 
 ## Authentication component
 

--- a/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
@@ -45,7 +45,7 @@ Replace `{VERSION}` in the preceding package reference with the version of the `
 
 ## Authentication service support
 
-Support for authenticating users is registered in the service container with the `AddOidcAuthentication` extension method provided by the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+Support for authenticating users is registered in the service container with the `AddOidcAuthentication` extension method provided by the `Microsoft.AspNetCore.Components.WebAssembly.Authentication` package. This method sets up the services required for the app to interact with the Identity Provider (IP).
 
 *Program.cs*:
 

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -19,34 +19,47 @@ By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https
 
 To create a Blazor WebAssembly standalone app that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication:
 
-1. Follow the guidance in the following topics to create a tenant and register a web app in the Azure Portal:
+Follow the guidance in the following topics to create a tenant and register a web app in the Azure Portal:
 
-   * [Create an AAD B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant) &ndash; Record the following information:
+* [Create an AAD B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant)
 
-     1\. AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash)<br>
-     2\. AAD B2C Tenant domain (for example, `contoso.onmicrosoft.com`)
+  Record the following information:
 
-   * [Register a web application](/azure/active-directory-b2c/tutorial-register-applications) &ndash; Make the following selections during app registration:
+  * AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash).
+  * AAD B2C Tenant domain (for example, `contoso.onmicrosoft.com`).
 
-     1\. Set **Web App / Web API** to **Yes**.<br>
-     2\. Set **Allow implicit flow** to **Yes**.<br>
-     3\. Add a **Reply URL** of `https://localhost:5001/authentication/login-callback`.
+* [Register a web application](/azure/active-directory-b2c/tutorial-register-applications) &ndash; Make the following selections during app registration:
 
-     Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
+  1. Provide a **Name** for the app (for example, **Blazor Client AAD B2C**).
+  1. Set **Web App / Web API** to **Yes**.
+  1. Set **Allow implicit flow** to **Yes**.
+  1. Add a **Reply URL** of `https://localhost:5001/authentication/login-callback`.
+  1. Leave **App ID URI** blank.
+  1. Leave **Include native client** set to **No**.
+  1. Select the **Create** button.
 
-   * [Create user flows](/azure/active-directory-b2c/tutorial-create-user-flows) &ndash; Create a sign-up and sign-in user flow.
+  Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
 
-     At a minimum, select the **Application claims** > **Display Name** user attribute to populate the `context.User.Identity.Name` in the `LoginDisplay` component (*Shared/LoginDisplay.razor*).
+* [Create user flows](/azure/active-directory-b2c/tutorial-create-user-flows) &ndash; Create a sign-up and sign-in user flow.
 
-     Record the sign-up and sign-in user flow name created for the app (for example, `B2C_1_signupsignin`).
+  At a minimum, select the **Application claims** > **Display Name** user attribute. This attribute populates the `context.User.Identity.Name` in the `LoginDisplay` component (*Shared/LoginDisplay.razor*) of the app.
 
-1. Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+  Record the sign-up and sign-in user flow name created for the app (for example, `B2C_1_signupsignin`).
 
-   ```dotnetcli
-   dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --client-id "{CLIENT ID}" --domain "{DOMAIN}" -ssp "{SIGN UP OR SIGN IN POLICY}"
-   ```
+Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
 
-   To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+```dotnetcli
+dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --client-id "{CLIENT ID}" --domain "{TENANT DOMAIN}" -ssp "{SIGN UP OR SIGN IN POLICY}"
+```
+
+To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+After creating the app, you should be able to:
+
+* Log into the app using an AAD user account.
+* Request access tokens for Microsoft APIs. For more information, see:
+  * [Access token scopes](#access-token-scopes)
+  * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis).
 
 ## Authentication package
 
@@ -76,7 +89,7 @@ builder.Services.AddMsalAuthentication(options =>
 });
 ```
 
-The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Microsoft Accounts configuration when you register the app.
+The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the AAD configuration when you register the app.
 
 Configuration is supplied by the *wwwroot/appsettings.json* file:
 
@@ -84,7 +97,8 @@ Configuration is supplied by the *wwwroot/appsettings.json* file:
 {
   "AzureAdB2C": {
     "Authority": "{AAD B2C INSTANCE}{DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
-    "ClientId": "{CLIENT ID}"
+    "ClientId": "{CLIENT ID}",
+    "ValidateAuthority": false
   }
 }
 ```
@@ -95,7 +109,8 @@ Example:
 {
   "AzureAdB2C": {
     "Authority": "https://contoso.b2clogin.com/contoso.onmicrosoft.com/B2C_1_signupsignin1",
-    "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd"
+    "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd",
+    "ValidateAuthority": false
   }
 }
 ```

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
@@ -25,9 +25,14 @@ Register a AAD app in the **Azure Active Directory** > **App registrations** are
 
 1. Provide a **Name** for the app (for example, **Blazor Client AAD**).
 1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** for this experience.
-1. Leave the **Redirect URI** drop down set to **Web**, and provide a redirect URI of `https://localhost:5001/authentication/login-callback`.
+1. Leave the **Redirect URI** drop down set to **Web**, and provide the following redirect URI: `https://localhost:5001/authentication/login-callback`
 1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
 1. Select **Register**.
+
+Record the following information:
+
+* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
+* Directory ID (Tenant ID) (for example, `22222222-2222-2222-2222-222222222222`)
 
 In **Authentication** > **Platform configurations** > **Web**:
 
@@ -36,18 +41,20 @@ In **Authentication** > **Platform configurations** > **Web**:
 1. The remaining defaults for the app are acceptable for this experience.
 1. Select the **Save** button.
 
-Record the following information:
-
-* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
-* Directory ID (Tenant ID) (for example, `22222222-2222-2222-2222-222222222222`)
-
-Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+Create the app. Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
 
 ```dotnetcli
 dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" --tenant-id "{TENANT ID}"
 ```
 
 To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+
+After creating the app, you should be able to:
+
+* Log into the app using an AAD user account.
+* Request access tokens for Microsoft APIs. For more information, see:
+  * [Access token scopes](#access-token-scopes)
+  * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis).
 
 ## Authentication package
 
@@ -66,7 +73,7 @@ The `Microsoft.Authentication.WebAssembly.Msal` package transitively adds the `M
 
 ## Authentication service support
 
-Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up all of the services required for the app to interact with the Identity Provider (IP).
+Support for authenticating users is registered in the service container with the `AddMsalAuthentication` extension method provided by the `Microsoft.Authentication.WebAssembly.Msal` package. This method sets up the services required for the app to interact with the Identity Provider (IP).
 
 *Program.cs*:
 
@@ -77,7 +84,7 @@ builder.Services.AddMsalAuthentication(options =>
 });
 ```
 
-The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Microsoft Accounts configuration when you register the app.
+The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the AAD configuration when you register the app.
 
 Configuration is supplied by the *wwwroot/appsettings.json* file:
 
@@ -85,7 +92,8 @@ Configuration is supplied by the *wwwroot/appsettings.json* file:
 {
   "AzureAd": {
     "Authority": "https://login.microsoftonline.com/{TENANT ID}",
-    "ClientId": "{CLIENT ID}"
+    "ClientId": "{CLIENT ID}",
+    "ValidateAuthority": true
   }
 }
 ```
@@ -96,7 +104,8 @@ Example:
 {
   "AzureAd": {
     "Authority": "https://login.microsoftonline.com/e86c78e2-...-918e0565a45e",
-    "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd"
+    "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd",
+    "ValidateAuthority": true
   }
 }
 ```

--- a/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
@@ -19,37 +19,39 @@ By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https
 
 To create a Blazor WebAssembly standalone app that uses [Microsoft Accounts with Azure Active Directory (AAD)](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal) for authentication:
 
-1. [Create an AAD tenant and web application](/azure/active-directory/develop/v2-overview)
+[Create an AAD tenant and web application](/azure/active-directory/develop/v2-overview)
 
-   Register a AAD app in the **Azure Active Directory** > **App registrations** area of the Azure portal:
+Register a AAD app in the **Azure Active Directory** > **App registrations** area of the Azure portal:
 
-   1\. Provide a **Name** for the app (for example, **Blazor Client AAD**).<br>
-   2\. In **Supported account types**, select **Accounts in any organizational directory**.<br>
-   3\. Leave the **Redirect URI** drop down set to **Web**, and provide a redirect URI of `https://localhost:5001/authentication/login-callback`.<br>
-   4\. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.<br>
-   5\. Select **Register**.
+1. Provide a **Name** for the app (for example, **Blazor Client AAD**).
+1. In **Supported account types**, select **Accounts in any organizational directory**.
+1. Leave the **Redirect URI** drop down set to **Web**, and provide the following redirect URI: `https://localhost:5001/authentication/login-callback`.
+1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
+1. Select **Register**.
 
-   In **Authentication** > **Platform configurations** > **Web**:
+Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
 
-   1\. Confirm the **Redirect URI** of `https://localhost:5001/authentication/login-callback` is present.<br>
-   2\. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.<br>
-   3\. The remaining defaults for the app are acceptable for this experience.<br>
-   4\. Select the **Save** button.
+In **Authentication** > **Platform configurations** > **Web**:
 
-   Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
+1. Confirm the **Redirect URI** of `https://localhost:5001/authentication/login-callback` is present.
+1. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.
+1. The remaining defaults for the app are acceptable for this experience.
+1. Select the **Save** button.
 
-1. Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+Create the app. Replace the placeholders in the following command with the information recorded earlier and execute the following command in a command shell:
 
-   ```dotnetcli
-   dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" --tenant-id "common"
-   ```
+```dotnetcli
+dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" --tenant-id "common"
+```
 
-   To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
 
 After creating the app, you should be able to:
 
-* Log into the app using a Microsoft Account.
-* Request access tokens for Microsoft APIs using the same approach as for standalone Blazor apps provided that you have configured the app correctly. For more information, see [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis).
+* Log into the app using a Microsoft account.
+* Request access tokens for Microsoft APIs. For more information, see:
+  * [Access token scopes](#access-token-scopes)
+  * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis).
 
 ## Authentication package
 
@@ -79,7 +81,7 @@ builder.Services.AddMsalAuthentication(options =>
 });
 ```
 
-The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Microsoft Accounts configuration when you register the app.
+The `AddMsalAuthentication` method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the AAD configuration when you register the app.
 
 Configuration is supplied by the *wwwroot/appsettings.json* file:
 
@@ -87,7 +89,8 @@ Configuration is supplied by the *wwwroot/appsettings.json* file:
 {
   "AzureAd": {
     "Authority": "https://login.microsoftonline.com/common",
-    "ClientId": "{CLIENT ID}"
+    "ClientId": "{CLIENT ID}",
+    "ValidateAuthority": true
   }
 }
 ```
@@ -98,7 +101,8 @@ Example:
 {
   "AzureAd": {
     "Authority": "https://login.microsoftonline.com/common",
-    "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd"
+    "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd",
+    "ValidateAuthority": true
   }
 }
 ```


### PR DESCRIPTION
Addresses #18078

* Mostly nits ... small improvements in language and layout.
  * Fixed the `LoginDisplay` component markup for the MSAL-based scenarios ... it must have shifted at Pre5 or RC.
  * Let's stick with CLI commands for now, but I add a tab control for IS (VS and CLI). After 3.2 lands, I'll do that for all of these topics. We might end up pointing VS readers to Azure guidance and just point out any gotchas or edge cases.
* Generally, the guidance seems to be ok at this stage. I walked the topics and created test apps from scratch. I'm still challenged on what to say about scopes. The NOTE that I've included covers alternate scenarios. I just not happy having to say, *if X doesn't work and the app :boom: on you, then try this Y approach*. **_Yuck!_**
* I'll read the published topics again on Monday.

cc: @mkArtakMSFT 