### PR TITLE
Fix indent in MVC routing code sample

### DIFF
--- a/aspnetcore/mvc/controllers/routing/samples/3.x/main/Controllers/MyDemo2Controller.cs
+++ b/aspnetcore/mvc/controllers/routing/samples/3.x/main/Controllers/MyDemo2Controller.cs
@@ -7,7 +7,7 @@ namespace RoutingSample.Controllers
 #if First
     #region snippet
     public class MyDemo2Controller : Controller
-        {
+    {
         [Route("/articles/{page}")]
         public IActionResult ListArticles(int page)
         {


### PR DESCRIPTION
A very minor indent fix for the code sample that can be found here: https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/routing?view=aspnetcore-3.1#reserved-routing-names
