### PR TITLE
Remove double xref reference to ParameterAttribute

### DIFF
--- a/aspnetcore/blazor/components.md
+++ b/aspnetcore/blazor/components.md
@@ -137,7 +137,7 @@ Optional parameters aren't supported, so two [`@page`][9] directives are applied
 
 ### Component parameters
 
-Components can have *component parameters*, which are defined using public properties on the component class with the [`[Parameter]`](xref:Microsoft.AspNetCore.Components.ParameterAttribute)](xref:Microsoft.AspNetCore.Components.ParameterAttribute) attribute. Use attributes to specify arguments for a component in markup.
+Components can have *component parameters*, which are defined using public properties on the component class with the [`[Parameter]`](xref:Microsoft.AspNetCore.Components.ParameterAttribute) attribute. Use attributes to specify arguments for a component in markup.
 
 *Components/ChildComponent.razor*:
 


### PR DESCRIPTION
The **Component parameters** section contains a superfluous `xref` which gets rendered as text:

> with the [`[Parameter]`](xref:Microsoft.AspNetCore.Components.ParameterAttribute)](xref:Microsoft.AspNetCore.Components.ParameterAttribute) attribute.

The redundant second `xref` shall be removed:

> with the [`[Parameter]`](xref:Microsoft.AspNetCore.Components.ParameterAttribute) attribute.