### PR TITLE
Blazor WASM auth config binding

### DIFF
--- a/aspnetcore/blazor/hosting-model-configuration.md
+++ b/aspnetcore/blazor/hosting-model-configuration.md
@@ -213,9 +213,9 @@ builder.Configuration.AddJsonStream(stream);
 
 ```json
 {
-  "AzureAD": {
-    "Authority": "https://login.microsoftonline.com/",
-    "ClientId": "aeaebf0f-d416-4d92-a08f-e1d5b51fc494"
+  "Local": {
+    "Authority": "{AUTHORITY}",
+    "ClientId": "{CLIENT ID}"
   }
 }
 ```
@@ -224,7 +224,7 @@ builder.Configuration.AddJsonStream(stream);
 
 ```csharp
 builder.Services.AddOidcAuthentication(options =>
-    builder.Configuration.Bind("AzureAD", options);
+    builder.Configuration.Bind("Local", options);
 ```
 
 #### Logging configuration

--- a/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/security/blazor/webassembly/azure-active-directory-groups-and-roles.md
@@ -110,8 +110,7 @@ Register the factory in `Program.Main` (*Program.cs*) of the standalone app or C
 builder.Services.AddMsalAuthentication<RemoteAuthenticationState, 
     CustomUserAccount>(options =>
 {
-    builder.Configuration.Bind("AzureAd", 
-        options.ProviderOptions.Authentication);
+    builder.Configuration.Bind("AzureAd", options);
     options.ProviderOptions.DefaultAccessTokenScopes.Add("...");
     
     ...

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -255,7 +255,7 @@ Support for authenticating users is registered in the service container with the
 ```csharp
 builder.Services.AddMsalAuthentication(options =>
 {
-    builder.Configuration.Bind("AzureAdB2C", options.ProviderOptions.Authentication);
+    builder.Configuration.Bind("AzureAdB2C", options);
     options.ProviderOptions.DefaultAccessTokenScopes.Add("{SCOPE URI}");
 });
 ```

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
@@ -243,7 +243,7 @@ Support for authenticating users is registered in the service container with the
 ```csharp
 builder.Services.AddMsalAuthentication(options =>
 {
-    builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
+    builder.Configuration.Bind("AzureAd", options);
     options.ProviderOptions.DefaultAccessTokenScopes.Add("{SCOPE URI}");
 });
 ```

--- a/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-authentication-library.md
@@ -46,7 +46,7 @@ Support for authenticating users is registered in the service container with the
 ```csharp
 builder.Services.AddOidcAuthentication(options =>
 {
-    builder.Configuration.Bind("Local", options.ProviderOptions);
+    builder.Configuration.Bind("Local", options);
 });
 ```
 

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -94,7 +94,7 @@ Support for authenticating users is registered in the service container with the
 ```csharp
 builder.Services.AddMsalAuthentication(options =>
 {
-    builder.Configuration.Bind("AzureAdB2C", options.ProviderOptions.Authentication);
+    builder.Configuration.Bind("AzureAdB2C", options);
 });
 ```
 

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
@@ -81,7 +81,7 @@ Support for authenticating users is registered in the service container with the
 ```csharp
 builder.Services.AddMsalAuthentication(options =>
 {
-    builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
+    builder.Configuration.Bind("AzureAd", options);
 });
 ```
 

--- a/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
@@ -78,7 +78,7 @@ Support for authenticating users is registered in the service container with the
 ```csharp
 builder.Services.AddMsalAuthentication(options =>
 {
-    builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
+    builder.Configuration.Bind("AzureAd", options);
 });
 ```
 


### PR DESCRIPTION
Fixes #18516

Per the update at https://docs.microsoft.com/en-us/aspnet/core/blazor/hosting-model-configuration?view=aspnetcore-3.1#authentication-configuration.

btw @captainsafia, let's change the OIDC example in the configuration content. Javier told a dev recently not to take that route following the *Standalone with Auth Lib* topic but instead to go with the dedicated Azure AD topic and MSAL.

Thanks @RedBlue1776! :rocket: