### PR TITLE
Patch Blazor config example

### DIFF
--- a/aspnetcore/blazor/hosting-model-configuration.md
+++ b/aspnetcore/blazor/hosting-model-configuration.md
@@ -5,7 +5,7 @@ description: Learn about Blazor hosting model configuration, including how to in
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 05/27/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/hosting-model-configuration
 ---
@@ -213,9 +213,9 @@ builder.Configuration.AddJsonStream(stream);
 
 ```json
 {
-  "AzureAD": {
-    "Authority": "https://login.microsoftonline.com/",
-    "ClientId": "aeaebf0f-d416-4d92-a08f-e1d5b51fc494"
+  "Local": {
+    "Authority": "{AUTHORITY}",
+    "ClientId": "{CLIENT ID}"
   }
 }
 ```
@@ -224,7 +224,7 @@ builder.Configuration.AddJsonStream(stream);
 
 ```csharp
 builder.Services.AddOidcAuthentication(options =>
-    builder.Configuration.Bind("AzureAD", options);
+    builder.Configuration.Bind("Local", options.ProviderOptions);
 ```
 
 #### Logging configuration


### PR DESCRIPTION
Addresses #18516

Let's make this example based on "Local" and a placeholder for authority and client id. We don't want to suggest Azure AD with `AddOidcAuthentication` here.

Also, check me on the statement ... `options.ProviderOptions`, not just `options`. That matches the *Standalone with Auth Lib* topic at ...

https://docs.microsoft.com/en-us/aspnet/core/security/blazor/webassembly/standalone-with-authentication-library?view=aspnetcore-3.1#authentication-service-support

... where we show ...

```csharp
builder.Services.AddOidcAuthentication(options =>
{
    builder.Configuration.Bind("Local", options.ProviderOptions);
});
```

I never tested this scenario because I don't have a non-Azure, non-Identity Server OIDC provider readily available.

This seems correct [a test app loaded config correctly (`@Config["Local:ClientId"]`)], so I'm going to go ahead and merge it. Hit me up :ear: if I need to patch it.
