### PR TITLE
Add .dat to sample web.config

### DIFF
--- a/aspnetcore/host-and-deploy/blazor/webassembly/_samples/web.config
+++ b/aspnetcore/host-and-deploy/blazor/webassembly/_samples/web.config
@@ -2,29 +2,35 @@
 <configuration>
   <system.webServer>
     <staticContent>
+      <remove fileExtension=".dat" />
       <remove fileExtension=".dll" />
       <remove fileExtension=".json" />
       <remove fileExtension=".wasm" />
       <remove fileExtension=".woff" />
       <remove fileExtension=".woff2" />
       <remove fileExtension=".js.gz" />
+      <remove fileExtension=".dat.gz" />
       <remove fileExtension=".dll.gz" />
       <remove fileExtension=".json.gz" />
       <remove fileExtension=".wasm.gz" />
       <remove fileExtension=".js.br" />
+      <remove fileExtension=".dat.br" />
       <remove fileExtension=".dll.br" />
       <remove fileExtension=".json.br" />
       <remove fileExtension=".wasm.br" />
+      <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".dll" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".json" mimeType="application/json" />
       <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
       <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
       <mimeMap fileExtension=".woff2" mimeType="application/font-woff" />
       <mimeMap fileExtension=".js.gz" mimeType="application/javascript" />
+      <mimeMap fileExtension=".dat.gz" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".dll.gz" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".json.gz" mimeType="application/json" />
       <mimeMap fileExtension=".wasm.gz" mimeType="application/wasm" />
       <mimeMap fileExtension=".js.br" mimeType="application/javascript" />
+      <mimeMap fileExtension=".dat.br" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".dll.br" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".json.br" mimeType="application/json" />
       <mimeMap fileExtension=".wasm.br" mimeType="application/wasm" />


### PR DESCRIPTION
Blazor WebAssembly apps have a .dat file for the timezone data, but it's missing from the sample web.config.