### PR TITLE
Certificates are managed by your server, not host

### DIFF
--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -12,7 +12,7 @@ uid: security/authentication/certauth
 
 `Microsoft.AspNetCore.Authentication.Certificate` contains an implementation similar to [Certificate Authentication](https://tools.ietf.org/html/rfc5246#section-7.4.4) for ASP.NET Core. Certificate authentication happens at the TLS level, long before it ever gets to ASP.NET Core. More accurately, this is an authentication handler that validates the certificate and then gives you an event where you can resolve that certificate to a `ClaimsPrincipal`. 
 
-[Configure your host](#configure-your-host-to-require-certificates) for certificate authentication, be it IIS, Kestrel, Azure Web Apps, or whatever else you're using.
+[Configure your server](#configure-your-server-to-require-certificates) for certificate authentication, be it IIS, Kestrel, Azure Web Apps, or whatever else you're using.
 
 ## Proxy and load balancer scenarios
 
@@ -25,7 +25,7 @@ An alternative to certificate authentication in environments where proxies and l
 
 ## Get started
 
-Acquire an HTTPS certificate, apply it, and [configure your host](#configure-your-host-to-require-certificates) to require certificates.
+Acquire an HTTPS certificate, apply it, and [configure your server](#configure-your-server-to-require-certificates) to require certificates.
 
 In your web app, add a reference to the `Microsoft.AspNetCore.Authentication.Certificate` package. Then in the `Startup.ConfigureServices` method, call
 `services.AddAuthentication(CertificateAuthenticationDefaults.AuthenticationScheme).AddCertificate(...);` with your options, providing a delegate for `OnCertificateValidated` to do any supplementary validation on the client certificate sent with requests. Turn that information into a `ClaimsPrincipal` and set it on the `context.Principal` property.
@@ -185,7 +185,7 @@ services.AddAuthentication(
 
 Conceptually, the validation of the certificate is an authorization concern. Adding a check on, for example, an issuer or thumbprint in an authorization policy, rather than inside `OnCertificateValidated`, is perfectly acceptable.
 
-## Configure your host to require certificates
+## Configure your server to require certificates
 
 ### Kestrel
 


### PR DESCRIPTION
Clarification: client certificate settings are configured on servers like IIS and Kestrel, not hosts like WebHost. Admittedly the two blur when you get to places like Azure.

Preview: https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/certauth?view=aspnetcore-3.0&branch=tratcher%2Fhostserver