### PR TITLE
Genre regular expression

### DIFF
--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie30/Models/MovieDateRatingDA.cs
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie30/Models/MovieDateRatingDA.cs
@@ -28,7 +28,7 @@ namespace RazorPagesMovie.Models
         public decimal Price { get; set; }
         #endregion
 
-        [RegularExpression(@"^[A-Z]+[a-zA-Z""'\s-]*$")]
+        [RegularExpression(@"^[A-Z]+[a-zA-Z]*$")]
         [Required]
         [StringLength(30)]
         public string Genre { get; set; }


### PR DESCRIPTION
Update Genre regular expression to match the intention as described in the tutorial text.

[This page](https://github.com/dotnet/AspNetCore.Docs/blob/master/aspnetcore/tutorials/razor-pages/validation.md) says that Genre:

* Must only use letters
* The first letter is required to be uppercase. White space, numbers, and special characters are not allowed.

The original regular expression used:

`@"^[A-Z]+[a-zA-Z""'\s-]*$"`

says to allow double quotes, whitespace, and dashes after the first letter. This contradicts "must only use letters".

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->