### PR TITLE
Fix link to point to correct sample

### DIFF
--- a/aspnetcore/security/authentication/identity-custom-storage-providers.md
+++ b/aspnetcore/security/authentication/identity-custom-storage-providers.md
@@ -14,7 +14,7 @@ By [Steve Smith](https://ardalis.com/)
 
 ASP.NET Core Identity is an extensible system which enables you to create a custom storage provider and connect it to your app. This topic describes how to create a customized storage provider for ASP.NET Core Identity. It covers the important concepts for creating your own storage provider, but isn't a step-by-step walkthrough.
 
-[View or download sample from GitHub](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/security/authentication/identity/sample).
+[View or download sample from GitHub](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/security/authentication/identity-custom-storage-providers/sample/CustomIdentityProviderSample).
 
 ## Introduction
 


### PR DESCRIPTION
The View or download sample from GitHub link on this page currently points to a generic identity sample instead of the custom storage providers sample that actual contains the code shown in the article. This change fixes the link to point to the expected sample.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->