### PR TITLE
Misspelled word in Blazor WASM security topics

### DIFF
--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -34,7 +34,7 @@ Follow the guidance in [Tutorial: Register an application in Azure Active Direct
 1. Provide a **Name** for the app (for example, **Blazor Server AAD B2C**).
 1. For **Supported account types**, select the multi-tenant option: **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.**
 1. The *Server API app* doesn't require a **Redirect URI** in this scenario, so leave the drop down set to **Web** and don't enter a redirect URI.
-1. Confirm that **Permissions** > **Grant admin concent to openid and offline_access permissions** is enabled.
+1. Confirm that **Permissions** > **Grant admin consent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
 
 Record the following information:
@@ -66,7 +66,7 @@ Follow the guidance in [Tutorial: Register an application in Azure Active Direct
 1. Provide a **Name** for the app (for example, **Blazor Client AAD B2C**).
 1. For **Supported account types**, select the multi-tenant option: **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.**
 1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the Server app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears in the [Create the app](#create-the-app) section to remind IIS Express users to update the redirect URI.
-1. Confirm that **Permissions** > **Grant admin concent to openid and offline_access permissions** is enabled.
+1. Confirm that **Permissions** > **Grant admin consent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
 
 Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).

--- a/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/hosted-with-azure-active-directory.md
@@ -29,7 +29,7 @@ Follow the guidance in [Quickstart: Register an application with the Microsoft i
 1. Provide a **Name** for the app (for example, **Blazor Server AAD**).
 1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** (single tenant) for this experience.
 1. The *Server API app* doesn't require a **Redirect URI** in this scenario, so leave the drop down set to **Web** and don't enter a redirect URI.
-1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
+1. Disable the **Permissions** > **Grant admin consent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
 Record the following information:
@@ -63,7 +63,7 @@ Follow the guidance in [Quickstart: Register an application with the Microsoft i
 1. Provide a **Name** for the app (for example, **Blazor Client AAD**).
 1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** (single tenant) for this experience.
 1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the Server app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears in the [Create the app](#create-the-app) section to remind IIS Express users to update the redirect URI.
-1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
+1. Disable the **Permissions** > **Grant admin consent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
 Record the *Client app* Application ID (Client ID) (for example, `33333333-3333-3333-3333-333333333333`).

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -30,7 +30,7 @@ Follow the guidance in [Tutorial: Register an application in Azure Active Direct
 1. Provide a **Name** for the app (for example, **Blazor Standalone AAD B2C**).
 1. For **Supported account types**, select the multi-tenant option: **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.**
 1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears later in this topic to remind IIS Express users to update the redirect URI.
-1. Confirm that **Permissions** > **Grant admin concent to openid and offline_access permissions** is enabled.
+1. Confirm that **Permissions** > **Grant admin consent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
 
 Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).

--- a/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-azure-active-directory.md
@@ -22,7 +22,7 @@ Register a AAD app in the **Azure Active Directory** > **App registrations** are
 1. Provide a **Name** for the app (for example, **Blazor Standalone AAD**).
 1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** for this experience.
 1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears later in this topic to remind IIS Express users to update the redirect URI.
-1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
+1. Disable the **Permissions** > **Grant admin consent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
 Record the following information:

--- a/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/security/blazor/webassembly/standalone-with-microsoft-accounts.md
@@ -22,7 +22,7 @@ Register a AAD app in the **Azure Active Directory** > **App registrations** are
 1. Provide a **Name** for the app (for example, **Blazor Standalone AAD Microsoft Accounts**).
 1. In **Supported account types**, select **Accounts in any organizational directory**.
 1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears later in this topic to remind IIS Express users to update the redirect URI.
-1. Disable the **Permissions** > **Grant admin concent to openid and offline_access permissions** check box.
+1. Disable the **Permissions** > **Grant admin consent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
 Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).


### PR DESCRIPTION
Fixes #18752

I was curious to see if the word "consent" would work better with an alternate spelling. I just think it's good if we change the spelling of words occasionally to see if they look better on the screen or sound better when spoken. *Nah!* ... let's stick with "consent." I think that's best. 😁 

Seriously tho ... Azure portal UI screens threw me off for a sec on the other checks that I was making for potential updates this morning. I changed tenant directories from my default directory to the one that I've been using lately for Blazor apps, and the Azure portal matches the topics as written, so I think we're still good on the current instructions.

Will get back into this node on soon for [VS guidance in Blazor WASM security topics](https://github.com/dotnet/AspNetCore.Docs/issues/18379).