### PR TITLE
SignalR naming consistency

### DIFF
--- a/aspnetcore/blazor/hosting-model-configuration.md
+++ b/aspnetcore/blazor/hosting-model-configuration.md
@@ -302,7 +302,7 @@ To configure SignalR's underlying client to send credentials, such as cookies or
 * Assign the <xref:System.Net.Http.HttpMessageHandler> to the <xref:Microsoft.AspNetCore.Http.Connections.Client.HttpConnectionOptions.HttpMessageHandlerFactory> option:
 
   ```csharp
-  var client = new HubConnectionBuilder()
+  var connection = new HubConnectionBuilder()
       .WithUrl(new Uri("http://signalr.example.com"), options =>
       {
           options.HttpMessageHandlerFactory = innerHandler => 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -452,7 +452,7 @@ The default JSON serializer for ASP.NET Core is now <xref:System.Text.Json>, whi
 
   ```csharp
   new HubConnectionBuilder()
-      .WithUrl("/chatHub")
+      .WithUrl("/chathub")
       .AddNewtonsoftJsonProtocol(...)
       .Build();
   ```
@@ -1091,7 +1091,7 @@ services.AddSignalR(...)
 
 ```csharp
 new HubConnectionBuilder()
-    .WithUrl("/chatHub")
+    .WithUrl("/chathub")
     .AddJsonProtocol(options =>
     {
         options.PayloadSerializerOptions.WriteIndented = false;

--- a/aspnetcore/release-notes/aspnetcore-3.0.md
+++ b/aspnetcore/release-notes/aspnetcore-3.0.md
@@ -79,7 +79,7 @@ In the JavaScript and .NET Clients for SignalR, support was added for automatic 
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .withAutomaticReconnect()
     .build();
 ```

--- a/aspnetcore/signalr/authn-and-authz.md
+++ b/aspnetcore/signalr/authn-and-authz.md
@@ -94,7 +94,7 @@ In the .NET client, there's a similar [AccessTokenProvider](xref:signalr/configu
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options =>
+    .WithUrl("https://example.com/chathub", options =>
     { 
         options.AccessTokenProvider = () => Task.FromResult(_myAccessToken);
     })
@@ -146,7 +146,7 @@ In the .NET Client, Windows Authentication must be enabled by setting the [UseDe
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options =>
+    .WithUrl("https://example.com/chathub", options =>
     {
         options.UseDefaultCredentials = true;
     })

--- a/aspnetcore/signalr/configuration.md
+++ b/aspnetcore/signalr/configuration.md
@@ -87,7 +87,7 @@ public void ConfigureServices(IServiceCollection services)
 Options for a single hub override the global options provided in `AddSignalR` and can be configured using <xref:Microsoft.Extensions.DependencyInjection.SignalRDependencyInjectionExtensions.AddHubOptions*>:
 
 ```csharp
-services.AddSignalR().AddHubOptions<MyHub>(options =>
+services.AddSignalR().AddHubOptions<ChatHub>(options =>
 {
     options.EnableDetailedErrors = true;
 });
@@ -104,7 +104,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 
     app.UseEndpoints(endpoints =>
     {
-        endpoints.MapHub<MyHub>("/myhub", options =>
+        endpoints.MapHub<ChatHub>("/chathub", options =>
         {
             options.Transports =
                 HttpTransportType.WebSockets |
@@ -154,7 +154,7 @@ For example, to enable Console logging, install the `Microsoft.Extensions.Loggin
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub")
+    .WithUrl("https://example.com/chathub")
     .ConfigureLogging(logging => {
         logging.SetMinimumLevel(LogLevel.Information);
         logging.AddConsole();
@@ -166,7 +166,7 @@ In the JavaScript client, a similar `configureLogging` method exists. Provide a 
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub")
+    .withUrl("/chathub")
     .configureLogging(signalR.LogLevel.Information)
     .build();
 ```
@@ -175,7 +175,7 @@ Instead of a `LogLevel` value, you can also provide a `string` value representin
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub")
+    .withUrl("/chathub")
     .configureLogging("warn")
     .build();
 ```
@@ -221,7 +221,7 @@ For example, to disable the Server-Sent Events transport, but allow WebSockets a
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
+    .WithUrl("https://example.com/chathub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
     .Build();
 ```
 
@@ -229,7 +229,7 @@ In the JavaScript client, transports are configured by setting the `transport` f
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
+    .withUrl("/chathub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
     .build();
 ```
 
@@ -238,7 +238,7 @@ In this version of the Java client websockets is the only available transport.
 In the Java client, the transport is selected with the `withTransport` method on the `HttpHubConnectionBuilder`. The Java client defaults to using the WebSockets transport.
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
     .withTransport(TransportEnum.WEBSOCKETS)
     .build();
 ```
@@ -254,7 +254,7 @@ In the .NET client, the `AccessTokenProvider` option can be specified using the 
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.AccessTokenProvider = async () => {
             // Get and return the access token.
         };
@@ -266,7 +266,7 @@ In the JavaScript client, the access token is configured by setting the `accessT
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         accessTokenFactory: () => {
             // Get and return the access token.
             // This function can return a JavaScript Promise if asynchronous
@@ -279,7 +279,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the SignalR Java client, you can configure a bearer token to use for authentication by providing an access token factory to the [HttpHubConnectionBuilder](/java/api/com.microsoft.signalr._http_hub_connection_builder?view=aspnet-signalr-java). Use [withAccessTokenFactory](/java/api/com.microsoft.signalr._http_hub_connection_builder.withaccesstokenprovider?view=aspnet-signalr-java#com_microsoft_signalr__http_hub_connection_builder_withAccessTokenProvider_Single_String__) to provide an [RxJava](https://github.com/ReactiveX/RxJava) [Single\<String>](https://reactivex.io/documentation/single.html). With a call to [Single.defer](https://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#defer-java.util.concurrent.Callable-), you can write logic to produce access tokens for your client.
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
     .withAccessTokenProvider(Single.defer(() -> {
         // Your logic here.
         return Single.just("An Access Token");
@@ -359,7 +359,7 @@ In the .NET Client, these options can be modified by the options delegate provid
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.Headers["Foo"] = "Bar";
         options.Cookies.Add(new Cookie(/* ... */);
         options.ClientCertificates.Add(/* ... */);
@@ -371,7 +371,7 @@ In the JavaScript Client, these options can be provided in a JavaScript object p
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         skipNegotiation: true,
         transport: signalR.HttpTransportType.WebSockets
     })
@@ -381,7 +381,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the Java client, these options can be configured with the methods on the `HttpHubConnectionBuilder` returned from the `HubConnectionBuilder.create("HUB URL")`
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
         .withHeader("Foo", "Bar")
         .shouldSkipNegotiate(true)
         .withHandshakeResponseTimeout(30*1000)
@@ -473,7 +473,7 @@ public void ConfigureServices(IServiceCollection services)
 Options for a single hub override the global options provided in `AddSignalR` and can be configured using <xref:Microsoft.Extensions.DependencyInjection.SignalRDependencyInjectionExtensions.AddHubOptions*>:
 
 ```csharp
-services.AddSignalR().AddHubOptions<MyHub>(options =>
+services.AddSignalR().AddHubOptions<ChatHub>(options =>
 {
     options.EnableDetailedErrors = true;
 });
@@ -490,7 +490,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 
     app.UseEndpoints(endpoints =>
     {
-        endpoints.MapHub<MyHub>("/myhub", options =>
+        endpoints.MapHub<ChatHub>("/chathub", options =>
         {
             options.Transports =
                 HttpTransportType.WebSockets |
@@ -540,7 +540,7 @@ For example, to enable Console logging, install the `Microsoft.Extensions.Loggin
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub")
+    .WithUrl("https://example.com/chathub")
     .ConfigureLogging(logging => {
         logging.SetMinimumLevel(LogLevel.Information);
         logging.AddConsole();
@@ -552,7 +552,7 @@ In the JavaScript client, a similar `configureLogging` method exists. Provide a 
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub")
+    .withUrl("/chathub")
     .configureLogging(signalR.LogLevel.Information)
     .build();
 ```
@@ -561,7 +561,7 @@ Instead of a `LogLevel` value, you can also provide a `string` value representin
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub")
+    .withUrl("/chathub")
     .configureLogging("warn")
     .build();
 ```
@@ -607,7 +607,7 @@ For example, to disable the Server-Sent Events transport, but allow WebSockets a
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
+    .WithUrl("https://example.com/chathub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
     .Build();
 ```
 
@@ -615,7 +615,7 @@ In the JavaScript client, transports are configured by setting the `transport` f
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
+    .withUrl("/chathub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
     .build();
 ```
 
@@ -624,7 +624,7 @@ In this version of the Java client websockets is the only available transport.
 In the Java client, the transport is selected with the `withTransport` method on the `HttpHubConnectionBuilder`. The Java client defaults to using the WebSockets transport.
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
     .withTransport(TransportEnum.WEBSOCKETS)
     .build();
 ```
@@ -640,7 +640,7 @@ In the .NET client, the `AccessTokenProvider` option can be specified using the 
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.AccessTokenProvider = async () => {
             // Get and return the access token.
         };
@@ -652,7 +652,7 @@ In the JavaScript client, the access token is configured by setting the `accessT
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         accessTokenFactory: () => {
             // Get and return the access token.
             // This function can return a JavaScript Promise if asynchronous
@@ -665,7 +665,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the SignalR Java client, you can configure a bearer token to use for authentication by providing an access token factory to the [HttpHubConnectionBuilder](/java/api/com.microsoft.signalr._http_hub_connection_builder?view=aspnet-signalr-java). Use [withAccessTokenFactory](/java/api/com.microsoft.signalr._http_hub_connection_builder.withaccesstokenprovider?view=aspnet-signalr-java#com_microsoft_signalr__http_hub_connection_builder_withAccessTokenProvider_Single_String__) to provide an [RxJava](https://github.com/ReactiveX/RxJava) [Single\<String>](https://reactivex.io/documentation/single.html). With a call to [Single.defer](https://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#defer-java.util.concurrent.Callable-), you can write logic to produce access tokens for your client.
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
     .withAccessTokenProvider(Single.defer(() -> {
         // Your logic here.
         return Single.just("An Access Token");
@@ -744,7 +744,7 @@ In the .NET Client, these options can be modified by the options delegate provid
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.Headers["Foo"] = "Bar";
         options.Cookies.Add(new Cookie(/* ... */);
         options.ClientCertificates.Add(/* ... */);
@@ -756,7 +756,7 @@ In the JavaScript Client, these options can be provided in a JavaScript object p
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         skipNegotiation: true,
         transport: signalR.HttpTransportType.WebSockets
     })
@@ -766,7 +766,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the Java client, these options can be configured with the methods on the `HttpHubConnectionBuilder` returned from the `HubConnectionBuilder.create("HUB URL")`
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
         .withHeader("Foo", "Bar")
         .shouldSkipNegotiate(true)
         .withHandshakeResponseTimeout(30*1000)
@@ -858,7 +858,7 @@ public void ConfigureServices(IServiceCollection services)
 Options for a single hub override the global options provided in `AddSignalR` and can be configured using <xref:Microsoft.Extensions.DependencyInjection.SignalRDependencyInjectionExtensions.AddHubOptions*>:
 
 ```csharp
-services.AddSignalR().AddHubOptions<MyHub>(options =>
+services.AddSignalR().AddHubOptions<ChatHub>(options =>
 {
     options.EnableDetailedErrors = true;
 });
@@ -875,7 +875,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 
     app.UseEndpoints(endpoints =>
     {
-        endpoints.MapHub<MyHub>("/myhub", options =>
+        endpoints.MapHub<ChatHub>("/chathub", options =>
         {
             options.Transports =
                 HttpTransportType.WebSockets |
@@ -924,7 +924,7 @@ For example, to enable Console logging, install the `Microsoft.Extensions.Loggin
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub")
+    .WithUrl("https://example.com/chathub")
     .ConfigureLogging(logging => {
         logging.SetMinimumLevel(LogLevel.Information);
         logging.AddConsole();
@@ -936,7 +936,7 @@ In the JavaScript client, a similar `configureLogging` method exists. Provide a 
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub")
+    .withUrl("/chathub")
     .configureLogging(signalR.LogLevel.Information)
     .build();
 ```
@@ -945,7 +945,7 @@ Instead of a `LogLevel` value, you can also provide a `string` value representin
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub")
+    .withUrl("/chathub")
     .configureLogging("warn")
     .build();
 ```
@@ -991,7 +991,7 @@ For example, to disable the Server-Sent Events transport, but allow WebSockets a
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
+    .WithUrl("https://example.com/chathub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
     .Build();
 ```
 
@@ -999,7 +999,7 @@ In the JavaScript client, transports are configured by setting the `transport` f
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
+    .withUrl("/chathub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
     .build();
 ```
 
@@ -1008,7 +1008,7 @@ In this version of the Java client websockets is the only available transport.
 In the Java client, the transport is selected with the `withTransport` method on the `HttpHubConnectionBuilder`. The Java client defaults to using the WebSockets transport.
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
     .withTransport(TransportEnum.WEBSOCKETS)
     .build();
 ```
@@ -1024,7 +1024,7 @@ In the .NET client, the `AccessTokenProvider` option can be specified using the 
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.AccessTokenProvider = async () => {
             // Get and return the access token.
         };
@@ -1036,7 +1036,7 @@ In the JavaScript client, the access token is configured by setting the `accessT
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         accessTokenFactory: () => {
             // Get and return the access token.
             // This function can return a JavaScript Promise if asynchronous
@@ -1049,7 +1049,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the SignalR Java client, you can configure a bearer token to use for authentication by providing an access token factory to the [HttpHubConnectionBuilder](/java/api/com.microsoft.signalr._http_hub_connection_builder?view=aspnet-signalr-java). Use [withAccessTokenFactory](/java/api/com.microsoft.signalr._http_hub_connection_builder.withaccesstokenprovider?view=aspnet-signalr-java#com_microsoft_signalr__http_hub_connection_builder_withAccessTokenProvider_Single_String__) to provide an [RxJava](https://github.com/ReactiveX/RxJava) [Single\<String>](https://reactivex.io/documentation/single.html). With a call to [Single.defer](https://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#defer-java.util.concurrent.Callable-), you can write logic to produce access tokens for your client.
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
     .withAccessTokenProvider(Single.defer(() -> {
         // Your logic here.
         return Single.just("An Access Token");
@@ -1128,7 +1128,7 @@ In the .NET Client, these options can be modified by the options delegate provid
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.Headers["Foo"] = "Bar";
         options.Cookies.Add(new Cookie(/* ... */);
         options.ClientCertificates.Add(/* ... */);
@@ -1140,7 +1140,7 @@ In the JavaScript Client, these options can be provided in a JavaScript object p
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         skipNegotiation: true,
         transport: signalR.HttpTransportType.WebSockets
     })
@@ -1150,7 +1150,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the Java client, these options can be configured with the methods on the `HttpHubConnectionBuilder` returned from the `HubConnectionBuilder.create("HUB URL")`
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
         .withHeader("Foo", "Bar")
         .shouldSkipNegotiate(true)
         .withHandshakeResponseTimeout(30*1000)
@@ -1238,7 +1238,7 @@ public void ConfigureServices(IServiceCollection services)
 Options for a single hub override the global options provided in `AddSignalR` and can be configured using <xref:Microsoft.Extensions.DependencyInjection.SignalRDependencyInjectionExtensions.AddHubOptions*>:
 
 ```csharp
-services.AddSignalR().AddHubOptions<MyHub>(options =>
+services.AddSignalR().AddHubOptions<ChatHub>(options =>
 {
     options.EnableDetailedErrors = true;
 });
@@ -1257,7 +1257,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
             HttpTransportType.WebSockets |
             HttpTransportType.LongPolling;
 
-        configure.MapHub<MyHub>("/myhub", (options) =>
+        configure.MapHub<ChatHub>("/chathub", (options) =>
         {
             options.Transports = desiredTransports;
         });
@@ -1304,7 +1304,7 @@ For example, to enable Console logging, install the `Microsoft.Extensions.Loggin
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub")
+    .WithUrl("https://example.com/chathub")
     .ConfigureLogging(logging => {
         logging.SetMinimumLevel(LogLevel.Information);
         logging.AddConsole();
@@ -1316,7 +1316,7 @@ In the JavaScript client, a similar `configureLogging` method exists. Provide a 
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub")
+    .withUrl("/chathub")
     .configureLogging(signalR.LogLevel.Information)
     .build();
 ```
@@ -1350,7 +1350,7 @@ For example, to disable the Server-Sent Events transport, but allow WebSockets a
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
+    .WithUrl("https://example.com/chathub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
     .Build();
 ```
 
@@ -1358,7 +1358,7 @@ In the JavaScript client, transports are configured by setting the `transport` f
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
+    .withUrl("/chathub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
     .build();
 ```
 
@@ -1372,7 +1372,7 @@ In the .NET client, the `AccessTokenProvider` option can be specified using the 
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.AccessTokenProvider = async () => {
             // Get and return the access token.
         };
@@ -1384,7 +1384,7 @@ In the JavaScript client, the access token is configured by setting the `accessT
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         accessTokenFactory: () => {
             // Get and return the access token.
             // This function can return a JavaScript Promise if asynchronous
@@ -1397,7 +1397,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the SignalR Java client, you can configure a bearer token to use for authentication by providing an access token factory to the [HttpHubConnectionBuilder](/java/api/com.microsoft.signalr._http_hub_connection_builder?view=aspnet-signalr-java). Use [withAccessTokenFactory](/java/api/com.microsoft.signalr._http_hub_connection_builder.withaccesstokenprovider?view=aspnet-signalr-java#com_microsoft_signalr__http_hub_connection_builder_withAccessTokenProvider_Single_String__) to provide an [RxJava](https://github.com/ReactiveX/RxJava) [Single\<String>](https://reactivex.io/documentation/single.html). With a call to [Single.defer](https://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#defer-java.util.concurrent.Callable-), you can write logic to produce access tokens for your client.
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
     .withAccessTokenProvider(Single.defer(() -> {
         // Your logic here.
         return Single.just("An Access Token");
@@ -1476,7 +1476,7 @@ In the .NET Client, these options can be modified by the options delegate provid
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.Headers["Foo"] = "Bar";
         options.Cookies.Add(new Cookie(/* ... */);
         options.ClientCertificates.Add(/* ... */);
@@ -1488,7 +1488,7 @@ In the JavaScript Client, these options can be provided in a JavaScript object p
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         skipNegotiation: true,
         transport: signalR.HttpTransportType.WebSockets
     })
@@ -1498,7 +1498,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the Java client, these options can be configured with the methods on the `HttpHubConnectionBuilder` returned from the `HubConnectionBuilder.create("HUB URL")`
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
         .withHeader("Foo", "Bar")
         .shouldSkipNegotiate(true)
         .withHandshakeResponseTimeout(30*1000)
@@ -1585,7 +1585,7 @@ public void ConfigureServices(IServiceCollection services)
 Options for a single hub override the global options provided in `AddSignalR` and can be configured using <xref:Microsoft.Extensions.DependencyInjection.SignalRDependencyInjectionExtensions.AddHubOptions*>:
 
 ```csharp
-services.AddSignalR().AddHubOptions<MyHub>(options =>
+services.AddSignalR().AddHubOptions<ChatHub>(options =>
 {
     options.EnableDetailedErrors = true;
 });
@@ -1604,7 +1604,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
             HttpTransportType.WebSockets |
             HttpTransportType.LongPolling;
 
-        configure.MapHub<MyHub>("/myhub", (options) =>
+        configure.MapHub<ChatHub>("/chathub", (options) =>
         {
             options.Transports = desiredTransports;
         });
@@ -1651,7 +1651,7 @@ For example, to enable Console logging, install the `Microsoft.Extensions.Loggin
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub")
+    .WithUrl("https://example.com/chathub")
     .ConfigureLogging(logging => {
         logging.SetMinimumLevel(LogLevel.Information);
         logging.AddConsole();
@@ -1663,7 +1663,7 @@ In the JavaScript client, a similar `configureLogging` method exists. Provide a 
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub")
+    .withUrl("/chathub")
     .configureLogging(signalR.LogLevel.Information)
     .build();
 ```
@@ -1697,7 +1697,7 @@ For example, to disable the Server-Sent Events transport, but allow WebSockets a
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
+    .WithUrl("https://example.com/chathub", HttpTransportType.WebSockets | HttpTransportType.LongPolling)
     .Build();
 ```
 
@@ -1705,7 +1705,7 @@ In the JavaScript client, transports are configured by setting the `transport` f
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
+    .withUrl("/chathub", { transport: signalR.HttpTransportType.WebSockets | signalR.HttpTransportType.LongPolling })
     .build();
 ```
 
@@ -1717,7 +1717,7 @@ In the .NET client, the `AccessTokenProvider` option can be specified using the 
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.AccessTokenProvider = async () => {
             // Get and return the access token.
         };
@@ -1729,7 +1729,7 @@ In the JavaScript client, the access token is configured by setting the `accessT
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         accessTokenFactory: () => {
             // Get and return the access token.
             // This function can return a JavaScript Promise if asynchronous
@@ -1742,7 +1742,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the SignalR Java client, you can configure a bearer token to use for authentication by providing an access token factory to the [HttpHubConnectionBuilder](/java/api/com.microsoft.signalr._http_hub_connection_builder?view=aspnet-signalr-java). Use [withAccessTokenFactory](/java/api/com.microsoft.signalr._http_hub_connection_builder.withaccesstokenprovider?view=aspnet-signalr-java#com_microsoft_signalr__http_hub_connection_builder_withAccessTokenProvider_Single_String__) to provide an [RxJava](https://github.com/ReactiveX/RxJava) [Single\<String>](https://reactivex.io/documentation/single.html). With a call to [Single.defer](https://reactivex.io/RxJava/javadoc/io/reactivex/Single.html#defer-java.util.concurrent.Callable-), you can write logic to produce access tokens for your client.
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
     .withAccessTokenProvider(Single.defer(() -> {
         // Your logic here.
         return Single.just("An Access Token");
@@ -1818,7 +1818,7 @@ In the .NET Client, these options can be modified by the options delegate provid
 
 ```csharp
 var connection = new HubConnectionBuilder()
-    .WithUrl("https://example.com/myhub", options => {
+    .WithUrl("https://example.com/chathub", options => {
         options.Headers["Foo"] = "Bar";
         options.Cookies.Add(new Cookie(/* ... */);
         options.ClientCertificates.Add(/* ... */);
@@ -1830,7 +1830,7 @@ In the JavaScript Client, these options can be provided in a JavaScript object p
 
 ```javascript
 let connection = new signalR.HubConnectionBuilder()
-    .withUrl("/myhub", {
+    .withUrl("/chathub", {
         skipNegotiation: true,
         transport: signalR.HttpTransportType.WebSockets
     })
@@ -1840,7 +1840,7 @@ let connection = new signalR.HubConnectionBuilder()
 In the Java client, these options can be configured with the methods on the `HttpHubConnectionBuilder` returned from the `HubConnectionBuilder.create("HUB URL")`
 
 ```java
-HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/myhub")
+HubConnection hubConnection = HubConnectionBuilder.create("https://example.com/chathub")
         .withHeader("Foo", "Bar")
         .shouldSkipNegotiate(true)
         .withHandshakeResponseTimeout(30*1000)

--- a/aspnetcore/signalr/dotnet-client.md
+++ b/aspnetcore/signalr/dotnet-client.md
@@ -56,7 +56,7 @@ The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection> can be configured t
 
 ```csharp
 HubConnection connection= new HubConnectionBuilder()
-    .WithUrl(new Uri("http://127.0.0.1:5000/chatHub"))
+    .WithUrl(new Uri("http://127.0.0.1:5000/chathub"))
     .WithAutomaticReconnect()
     .Build();
 ```
@@ -141,7 +141,7 @@ In order to configure a custom number of reconnect attempts before disconnecting
 
 ```csharp
 HubConnection connection= new HubConnectionBuilder()
-    .WithUrl(new Uri("http://127.0.0.1:5000/chatHub"))
+    .WithUrl(new Uri("http://127.0.0.1:5000/chathub"))
     .WithAutomaticReconnect(new[] { TimeSpan.Zero, TimeSpan.Zero, TimeSpan.FromSeconds(10) })
     .Build();
 
@@ -186,7 +186,7 @@ public class RandomRetryPolicy : IRetryPolicy
 
 ```csharp
 HubConnection connection = new HubConnectionBuilder()
-    .WithUrl(new Uri("http://127.0.0.1:5000/chatHub"))
+    .WithUrl(new Uri("http://127.0.0.1:5000/chathub"))
     .WithAutomaticReconnect(new RandomRetryPolicy())
     .Build();
 ```

--- a/aspnetcore/signalr/groups/sample/wwwroot/ts/chat.ts
+++ b/aspnetcore/signalr/groups/sample/wwwroot/ts/chat.ts
@@ -2,7 +2,7 @@
 // before a browser can execute it.
 
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .build();
 
 connection.on("Send", function (message) {

--- a/aspnetcore/signalr/hub-filters.md
+++ b/aspnetcore/signalr/hub-filters.md
@@ -30,7 +30,7 @@ public void ConfigureServices(IServiceCollection services)
     {
         // Global filters will run first
         options.AddFilter<CustomFilter>();
-    }).AddHubOptions<MyHub>(options =>
+    }).AddHubOptions<ChatHub>(options =>
     {
         // Local filters will run second
         options.AddFilter<CustomFilter2>();

--- a/aspnetcore/signalr/hubcontext.md
+++ b/aspnetcore/signalr/hubcontext.md
@@ -42,7 +42,7 @@ Access the `IHubContext` within the middleware pipeline like so:
 app.Use(async (context, next) =>
 {
     var hubContext = context.RequestServices
-                            .GetRequiredService<IHubContext<MyHub>>();
+                            .GetRequiredService<IHubContext<ChatHub>>();
     //...
     
     if (next != null)
@@ -66,7 +66,7 @@ integrating with areas outside of ASP.NET Core, for example, using 3rd party dep
         public static void Main(string[] args)
         {
             var host = CreateHostBuilder(args).Build();
-            var hubContext = host.Services.GetService(typeof(IHubContext<MyHub>));
+            var hubContext = host.Services.GetService(typeof(IHubContext<ChatHub>));
             host.Run();
         }
 

--- a/aspnetcore/signalr/hubs/sample/wwwroot/ts/chat.ts
+++ b/aspnetcore/signalr/hubs/sample/wwwroot/ts/chat.ts
@@ -2,7 +2,7 @@
 // before a browser can execute it.
 
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .build();
 
 connection.on("ReceiveMessage", function (user, message) {

--- a/aspnetcore/signalr/javascript-client.md
+++ b/aspnetcore/signalr/javascript-client.md
@@ -161,7 +161,7 @@ The JavaScript client for SignalR can be configured to automatically reconnect u
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .withAutomaticReconnect()
     .build();
 ```
@@ -235,7 +235,7 @@ In order to configure a custom number of reconnect attempts before disconnecting
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .withAutomaticReconnect([0, 0, 10000])
     .build();
 
@@ -258,7 +258,7 @@ If you want even more control over the timing and number of automatic reconnect 
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .withAutomaticReconnect({
         nextRetryDelayInMilliseconds: retryContext => {
             if (retryContext.elapsedMilliseconds < 60000) {

--- a/aspnetcore/signalr/javascript-client/sample/wwwroot/ts/chat.ts
+++ b/aspnetcore/signalr/javascript-client/sample/wwwroot/ts/chat.ts
@@ -2,7 +2,7 @@
 // before a browser can execute it.
 
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .configureLogging(signalR.LogLevel.Information)
     .build();
 

--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -58,7 +58,7 @@ To enable MessagePack in the .NET Client, install the `Microsoft.AspNetCore.Sign
 
 ```csharp
 var hubConnection = new HubConnectionBuilder()
-                        .WithUrl("/chatHub")
+                        .WithUrl("/chathub")
                         .AddMessagePackProtocol()
                         .Build();
 ```
@@ -93,7 +93,7 @@ Adding `.withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
     .build();
 ```
@@ -233,7 +233,7 @@ To enable MessagePack in the .NET Client, install the `Microsoft.AspNetCore.Sign
 
 ```csharp
 var hubConnection = new HubConnectionBuilder()
-                        .WithUrl("/chatHub")
+                        .WithUrl("/chathub")
                         .AddMessagePackProtocol()
                         .Build();
 ```
@@ -268,7 +268,7 @@ Adding `.withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
     .build();
 ```
@@ -408,7 +408,7 @@ To enable MessagePack in the .NET Client, install the `Microsoft.AspNetCore.Sign
 
 ```csharp
 var hubConnection = new HubConnectionBuilder()
-                        .WithUrl("/chatHub")
+                        .WithUrl("/chathub")
                         .AddMessagePackProtocol()
                         .Build();
 ```
@@ -443,7 +443,7 @@ Adding `.withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .withHubProtocol(new signalR.protocols.msgpack.MessagePackHubProtocol())
     .build();
 ```

--- a/aspnetcore/signalr/security.md
+++ b/aspnetcore/signalr/security.md
@@ -60,7 +60,7 @@ public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 
     app.UseEndpoints(endpoints =>
     {
-        endpoints.MapHub<ChatHub>("/chatHub");
+        endpoints.MapHub<ChatHub>("/chathub");
     });
 
     // ... other middleware ...
@@ -111,7 +111,7 @@ When using WebSockets or Server-Sent Events, the browser client sends the access
 
 ```
 info: Microsoft.AspNetCore.Hosting.Internal.WebHost[1]
-      Request starting HTTP/1.1 GET http://localhost:5000/myhub?access_token=1234
+      Request starting HTTP/1.1 GET http://localhost:5000/chathub?access_token=1234
 ```
 
 If you have concerns about logging this data with your server logs, you can disable this logging entirely by configuring the `Microsoft.AspNetCore.Hosting` logger to the `Warning` level or above (these messages are written at `Info` level). For more information, see [Log Filtering](xref:fundamentals/logging/index#log-filtering) for more information. If you still want to log certain request information, you can [write a middleware](xref:fundamentals/middleware/write) to log the data you require and filter out the `access_token` query string value (if present).

--- a/aspnetcore/signalr/security/sample/Startup.cs
+++ b/aspnetcore/signalr/security/sample/Startup.cs
@@ -36,7 +36,7 @@ namespace SignalR_CORS
 
             app.UseSignalR(routes =>
             {
-                routes.MapHub<ChatHub>("/chatHub");
+                routes.MapHub<ChatHub>("/chathub");
             });
 
             // ... other middleware ...
@@ -86,7 +86,7 @@ namespace SignalR_CORS
 
             app.UseSignalR(routes =>
             {
-                routes.MapHub<ChatHub>("/chatHub");
+                routes.MapHub<ChatHub>("/chathub");
             });
 
             // ... other middleware ...

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -57,14 +57,14 @@ In ASP.NET Core SignalR:
 
 ```csharp
 HubConnection connection = new HubConnectionBuilder()
-    .WithUrl(new Uri("http://127.0.0.1:5000/chatHub"))
+    .WithUrl(new Uri("http://127.0.0.1:5000/chathub"))
     .WithAutomaticReconnect()
     .Build();
 ```
 
 ```javascript
 const connection = new signalR.HubConnectionBuilder()
-    .withUrl("/chatHub")
+    .withUrl("/chathub")
     .withAutomaticReconnect()
     .build();
 ```

--- a/aspnetcore/tutorials/signalr-blazor-webassembly/samples/3.x/BlazorSignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly/samples/3.x/BlazorSignalRApp/Client/Pages/Index.razor
@@ -35,7 +35,7 @@
     protected override async Task OnInitializedAsync()
     {
         hubConnection = new HubConnectionBuilder()
-            .WithUrl(NavigationManager.ToAbsoluteUri("/chatHub"))
+            .WithUrl(NavigationManager.ToAbsoluteUri("/chathub"))
             .Build();
 
         hubConnection.On<string, string>("ReceiveMessage", (user, message) =>

--- a/aspnetcore/tutorials/signalr-blazor-webassembly/samples/3.x/BlazorSignalRApp/Server/Startup.cs
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly/samples/3.x/BlazorSignalRApp/Server/Startup.cs
@@ -50,7 +50,7 @@ namespace BlazorSignalRApp.Server
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllers();
-                endpoints.MapHub<ChatHub>("/chatHub");
+                endpoints.MapHub<ChatHub>("/chathub");
                 endpoints.MapFallbackToFile("index.html");
             });
         }

--- a/aspnetcore/tutorials/signalr/sample-snapshot/2.x/Startup.cs
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/2.x/Startup.cs
@@ -51,7 +51,7 @@ namespace SignalRChat
             app.UseCookiePolicy();
             app.UseSignalR(routes =>
             {
-                routes.MapHub<ChatHub>("/chatHub");
+                routes.MapHub<ChatHub>("/chathub");
             });
             app.UseMvc();
         }

--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Startup.cs
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Startup.cs
@@ -52,7 +52,7 @@ namespace SignalRChat
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
-                endpoints.MapHub<ChatHub>("/chatHub");
+                endpoints.MapHub<ChatHub>("/chathub");
             });
         }
     }


### PR DESCRIPTION
Fixes #18758

* Went lowercase in URL endpoints everywhere (`chathub`).
* There was just one `var client =` to update.