### PR TITLE
Blazor WASM SignalR client logging

### DIFF
--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -826,7 +826,7 @@ Inject an <xref:Microsoft.Extensions.Logging.ILoggerProvider> to add a `WebAssem
 ...
 
 var connection = new HubConnectionBuilder()
-    .WithUrl(NavigationManager.ToAbsoluteUri("/chatHub"))
+    .WithUrl(NavigationManager.ToAbsoluteUri("/chathub"))
     .ConfigureLogging(logging => logging.AddProvider(loggerProvider))
     .Build();
 ```

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -816,7 +816,7 @@ The `Logging` property is of type <xref:Microsoft.Extensions.Logging.ILoggingBui
 
 Logging configuration can be loaded from app settings files. For more information, see <xref:blazor/hosting-model-configuration#logging-configuration>.
 
-#### Blazor WebAssembly SignalR client logging
+#### Blazor WebAssembly SignalR .NET client logging
 
 Inject an instance of <xref:Microsoft.Extensions.Logging.ILoggerProvider>, `loggerProvider` in the following example, and call <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.ConfigureLogging%2A> to add the provider:
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to use the logging framework provided by the Microsoft.Extensions.Logging NuGet package.
 ms.author: riande
 ms.custom: mvc
-ms.date: 5/9/2020
+ms.date: 6/12/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: fundamentals/logging/index
 ---
@@ -815,6 +815,19 @@ builder.Logging.AddProvider(new CustomLoggingProvider());
 The `Logging` property is of type <xref:Microsoft.Extensions.Logging.ILoggingBuilder>, so all of the extension methods available on <xref:Microsoft.Extensions.Logging.ILoggingBuilder> are also available on `Logging`.
 
 Logging configuration can be loaded from app settings files. For more information, see <xref:blazor/hosting-model-configuration#logging-configuration>.
+
+#### Blazor WebAssembly SignalR client logging
+
+Inject an instance of <xref:Microsoft.Extensions.Logging.ILoggerProvider>, `loggerProvider` in the following example, and call <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.ConfigureLogging%2A> to add the provider:
+
+```csharp
+var connection = new HubConnectionBuilder()
+    .WithUrl(NavigationManager.ToAbsoluteUri("/chatHub"))
+    .ConfigureLogging(logging => logging.AddProvider(loggerProvider))
+    .Build();
+```
+
+Injecting the <xref:Microsoft.Extensions.Logging.ILoggerProvider> adds `WebAssemblyConsoleLogger` to the logging providers passed to <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder>. Unlike a traditional <xref:Microsoft.Extensions.Logging.Console.ConsoleLogger>, `WebAssemblyConsoleLogger` is a wrapper around browser-specific logging APIs (for example, `console.log`). Use of `WebAssemblyConsoleLogger` makes logging possible within Mono inside a browser context.
 
 #### Log in Razor components
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -821,7 +821,8 @@ Logging configuration can be loaded from app settings files. For more informatio
 Inject an <xref:Microsoft.Extensions.Logging.ILoggerProvider> to add a `WebAssemblyConsoleLogger` to the logging providers passed to <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder>. Unlike a traditional <xref:Microsoft.Extensions.Logging.Console.ConsoleLogger>, `WebAssemblyConsoleLogger` is a wrapper around browser-specific logging APIs (for example, `console.log`). Use of `WebAssemblyConsoleLogger` makes logging possible within Mono inside a browser context.
 
 ```csharp
-@inject ILoggerProvider loggerprovider;
+@using Microsoft.Extensions.Logging
+@inject ILoggerProvider loggerprovider
 
 ...
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -822,13 +822,13 @@ Inject an <xref:Microsoft.Extensions.Logging.ILoggerProvider> to add a `WebAssem
 
 ```csharp
 @using Microsoft.Extensions.Logging
-@inject ILoggerProvider loggerprovider
+@inject ILoggerProvider Loggerprovider
 
 ...
 
 var connection = new HubConnectionBuilder()
     .WithUrl(NavigationManager.ToAbsoluteUri("/chathub"))
-    .ConfigureLogging(logging => logging.AddProvider(loggerProvider))
+    .ConfigureLogging(logging => logging.AddProvider(LoggerProvider))
     .Build();
 ```
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -822,7 +822,7 @@ Inject an <xref:Microsoft.Extensions.Logging.ILoggerProvider> to add a `WebAssem
 
 ```csharp
 @using Microsoft.Extensions.Logging
-@inject ILoggerProvider Loggerprovider
+@inject ILoggerProvider LoggerProvider
 
 ...
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -818,16 +818,18 @@ Logging configuration can be loaded from app settings files. For more informatio
 
 #### Blazor WebAssembly SignalR .NET client logging
 
-Inject an instance of <xref:Microsoft.Extensions.Logging.ILoggerProvider>, `loggerProvider` in the following example, and call <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilderExtensions.ConfigureLogging%2A> to add the provider:
+Inject an <xref:Microsoft.Extensions.Logging.ILoggerProvider> to add a `WebAssemblyConsoleLogger` to the logging providers passed to <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder>. Unlike a traditional <xref:Microsoft.Extensions.Logging.Console.ConsoleLogger>, `WebAssemblyConsoleLogger` is a wrapper around browser-specific logging APIs (for example, `console.log`). Use of `WebAssemblyConsoleLogger` makes logging possible within Mono inside a browser context.
 
 ```csharp
+@inject ILoggerProvider loggerprovider;
+
+...
+
 var connection = new HubConnectionBuilder()
     .WithUrl(NavigationManager.ToAbsoluteUri("/chatHub"))
     .ConfigureLogging(logging => logging.AddProvider(loggerProvider))
     .Build();
 ```
-
-Injecting the <xref:Microsoft.Extensions.Logging.ILoggerProvider> adds `WebAssemblyConsoleLogger` to the logging providers passed to <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder>. Unlike a traditional <xref:Microsoft.Extensions.Logging.Console.ConsoleLogger>, `WebAssemblyConsoleLogger` is a wrapper around browser-specific logging APIs (for example, `console.log`). Use of `WebAssemblyConsoleLogger` makes logging possible within Mono inside a browser context.
 
 #### Log in Razor components
 

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -100,7 +100,7 @@ If you want to send logs to a custom logging system, you can provide a JavaScrip
 
 To get logs from the .NET client, you can use the `ConfigureLogging` method on `HubConnectionBuilder`. This works the same way as the `ConfigureLogging` method on `WebHostBuilder` and `HostBuilder`. You can configure the same logging providers you use in ASP.NET Core. However, you have to manually install and enable the NuGet packages for the individual logging providers.
 
-To add .NET client logging to a Blazor WebAssembly app, see <xref:fundamentals/logging/index#blazor=webassembly-signalr-client-logging>.
+To add .NET client logging to a Blazor WebAssembly app, see <xref:fundamentals/logging/index#blazor=webassembly-signalr-net-client-logging>.
 
 ### Console logging
 

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -5,7 +5,7 @@ description: Learn how to gather diagnostics from your ASP.NET Core SignalR app.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: anurse
 ms.custom: signalr
-ms.date: 06/08/2020
+ms.date: 06/12/2020
 no-loc: [Blazor, "Identity", "Let's Encrypt", Razor, SignalR]
 uid: signalr/diagnostics
 ---
@@ -99,6 +99,8 @@ If you want to send logs to a custom logging system, you can provide a JavaScrip
 > Client-side logs may contain sensitive information from your app. **Never** post raw logs from production apps to public forums like GitHub.
 
 To get logs from the .NET client, you can use the `ConfigureLogging` method on `HubConnectionBuilder`. This works the same way as the `ConfigureLogging` method on `WebHostBuilder` and `HostBuilder`. You can configure the same logging providers you use in ASP.NET Core. However, you have to manually install and enable the NuGet packages for the individual logging providers.
+
+To add .NET client logging to a Blazor WebAssembly app, see <xref:fundamentals/logging/index#blazor=webassembly-signalr-client-logging>.
 
 ### Console logging
 

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -100,7 +100,7 @@ If you want to send logs to a custom logging system, you can provide a JavaScrip
 
 To get logs from the .NET client, you can use the `ConfigureLogging` method on `HubConnectionBuilder`. This works the same way as the `ConfigureLogging` method on `WebHostBuilder` and `HostBuilder`. You can configure the same logging providers you use in ASP.NET Core. However, you have to manually install and enable the NuGet packages for the individual logging providers.
 
-To add .NET client logging to a Blazor WebAssembly app, see <xref:fundamentals/logging/index#blazor=webassembly-signalr-net-client-logging>.
+To add .NET client logging to a Blazor WebAssembly app, see <xref:fundamentals/logging/index#blazor-webassembly-signalr-net-client-logging>.
 
 ### Console logging
 


### PR DESCRIPTION
Fixes #18744

Note: I hope eventually to have `WebAssemblyConsoleLogger` in the API docs.
