### PR TITLE
Change VS 2019 16.7 requirement to 16.6 for ASP.NET Core 5.0

### DIFF
--- a/aspnetcore/includes/net-core-prereqs-vs-5.0.md
+++ b/aspnetcore/includes/net-core-prereqs-vs-5.0.md
@@ -1,2 +1,2 @@
-* [Visual Studio 2019 16.7 or later](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
+* [Visual Studio 2019 16.6 or later](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
 * [!INCLUDE [.NET 5.0 SDK](~/includes/5.0-SDK.md)]


### PR DESCRIPTION
Update per discussion with Sourabh