### PR TITLE
Fix up API links to ContentResult and Content

### DIFF
--- a/aspnetcore/web-api/advanced/formatting.md
+++ b/aspnetcore/web-api/advanced/formatting.md
@@ -30,7 +30,7 @@ The sample download returns the list of authors. Using the F12 browser developer
 * The response header containing **content-type:** `application/json; charset=utf-8` is displayed.
 * The request headers are displayed. For example, the `Accept` header. The `Accept` header is ignored by the preceding code.
 
-To return plain text formatted data, use <xref:Microsoft.AspNetCore.Mvc.ContentResult.Content> and the <xref:Microsoft.AspNetCore.Mvc.ContentResult.Content> helper:
+To return plain text formatted data, use <xref:Microsoft.AspNetCore.Mvc.ContentResult> and the <xref:Microsoft.AspNetCore.Mvc.ControllerBase.Content%2A> helper:
 
 [!code-csharp[](./formatting/sample/Controllers/AuthorsController.cs?name=snippet_about)]
 


### PR DESCRIPTION
Fixes #18804.

Fxed the link in question but also changed the first to point to `ContentResult`, which I think _might_ have been the original intent.