### PR TITLE
Updated custom-formatters doc to ASP.NET Core 3.1

### DIFF
--- a/aspnetcore/web-api/advanced/custom-formatters.md
+++ b/aspnetcore/web-api/advanced/custom-formatters.md
@@ -97,7 +97,7 @@ For an input formatter example, see the [sample app](https://github.com/dotnet/A
 
 To use a custom formatter, add an instance of the formatter class to the `InputFormatters` or `OutputFormatters` collection.
 
-[!code-csharp[](custom-formatters/sample/Startup.cs?name=mvcoptions&highlight=3-4)]
+[!code-csharp[](custom-formatters/sample3_1/Startup.cs?name=mvcoptions&highlight=3-4)]
 
 Formatters are evaluated in the order you insert them. The first one takes precedence.
 

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Controllers/ContactsController.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Controllers/ContactsController.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using CustomFormatterDemo.Models;
+
+namespace CustomFormatterDemo.Controllers
+{
+    [Route("api/[controller]")]
+    public class ContactsController : Controller
+    {
+        public ContactsController(IContactRepository contacts)
+        {
+            Contacts = contacts;
+        }
+        public IContactRepository Contacts { get; set; }
+
+
+        // GET api/contacts
+        [HttpGet]
+        public IEnumerable<Contact> Get()
+        {
+            return Contacts.GetAll();
+        }
+
+        // GET api/contacts/{guid}
+        [HttpGet("{id}", Name="Get")]
+        public IActionResult Get(string id)
+        {
+            var contact = Contacts.Get(id);
+            if (contact == null)
+            {
+                return NotFound();
+            }
+            return Ok(contact);
+        }
+
+        // POST api/contacts
+        [HttpPost]
+        public IActionResult Post([FromBody]Contact contact)
+        {
+            if (ModelState.IsValid)
+            {
+                Contacts.Add(contact);
+                return CreatedAtRoute("Get", new { id = contact.ID }, contact);
+            }
+            return BadRequest();
+        }
+
+        // PUT api/contacts/{guid}
+        [HttpPut("{id}")]
+        public IActionResult Put(string id, [FromBody]Contact contact)
+        {
+            if (ModelState.IsValid && id == contact.ID)
+            {
+                var contactToUpdate = Contacts.Get(id);
+                if (contactToUpdate != null)
+                {
+                    Contacts.Update(contact);
+                    return new NoContentResult();
+                }
+                return NotFound();
+            }
+            return BadRequest();
+        }
+
+        // DELETE api/contacts/{guid}
+        [HttpDelete("{id}")]
+        public IActionResult Delete(string id)
+        {
+            var contact = Contacts.Get(id);
+            if (contact == null)
+            {
+                return NotFound();
+            }
+
+            Contacts.Remove(id);
+            return NoContent();
+        }
+    }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/CustomFormatterDemo.csproj
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/CustomFormatterDemo.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+
+</Project>

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Formatters/VcardInputFormatter.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Formatters/VcardInputFormatter.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Net.Http.Headers;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using CustomFormatterDemo.Models;
+
+namespace CustomFormatterDemo.Formatters
+{
+    #region classdef
+    public class VcardInputFormatter : TextInputFormatter
+    #endregion
+    {
+        #region ctor
+        public VcardInputFormatter()
+        {
+            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/vcard"));
+
+            SupportedEncodings.Add(Encoding.UTF8);
+            SupportedEncodings.Add(Encoding.Unicode);
+        }
+        #endregion
+
+        #region canreadtype
+        protected override bool CanReadType(Type type)
+        {
+            if (type == typeof(Contact))
+            {
+                return base.CanReadType(type);
+            }
+            return false;
+        }
+        #endregion
+
+        #region readrequest
+        public override async Task<InputFormatterResult> ReadRequestBodyAsync(InputFormatterContext context, Encoding effectiveEncoding)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (effectiveEncoding == null)
+            {
+                throw new ArgumentNullException(nameof(effectiveEncoding));
+            }
+
+            var request = context.HttpContext.Request;
+
+            using (var reader = new StreamReader(request.Body, effectiveEncoding))
+            {
+                try
+                {
+                    await ReadLineAsync("BEGIN:VCARD", reader, context);
+                    await ReadLineAsync("VERSION:2.1", reader, context);
+
+                    var nameLine = await ReadLineAsync("N:", reader, context);
+                    var split = nameLine.Split(";".ToCharArray());
+                    var contact = new Contact() { LastName = split[0].Substring(2), FirstName = split[1] };
+
+                    await ReadLineAsync("FN:", reader, context);
+
+                    var idLine = await ReadLineAsync("UID:", reader, context);
+                    contact.ID = idLine.Substring(4);
+
+                    await ReadLineAsync("END:VCARD", reader, context);
+
+                    return await InputFormatterResult.SuccessAsync(contact);
+                }
+                catch
+                {
+                    return await InputFormatterResult.FailureAsync();
+                }
+            }
+        }
+
+        private async Task<string> ReadLineAsync(string expectedText, StreamReader reader, InputFormatterContext context)
+        {
+            var line = await reader.ReadLineAsync();
+            if (!line.StartsWith(expectedText))
+            {
+                var errorMessage = $"Looked for '{expectedText}' and got '{line}'";
+                context.ModelState.TryAddModelError(context.ModelName, errorMessage);
+                throw new Exception(errorMessage);
+            }
+            return line;
+        }
+        #endregion
+    }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Formatters/VcardOutputFormatter.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Formatters/VcardOutputFormatter.cs
@@ -1,0 +1,76 @@
+﻿using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.AspNetCore.Http;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Text;
+using CustomFormatterDemo.Models;
+using Microsoft.Net.Http.Headers;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+namespace CustomFormatterDemo.Formatters
+{
+    #region classdef
+    public class VcardOutputFormatter : TextOutputFormatter
+    #endregion
+    {
+        #region ctor
+        public VcardOutputFormatter()
+        {
+            SupportedMediaTypes.Add(MediaTypeHeaderValue.Parse("text/vcard"));
+
+            SupportedEncodings.Add(Encoding.UTF8);
+            SupportedEncodings.Add(Encoding.Unicode);
+        }
+        #endregion
+
+        #region canwritetype
+        protected override bool CanWriteType(Type type)
+        {
+            if (typeof(Contact).IsAssignableFrom(type) 
+                || typeof(IEnumerable<Contact>).IsAssignableFrom(type))
+            {
+                return base.CanWriteType(type);
+            }
+            return false;
+        }
+        #endregion
+
+        #region writeresponse
+        public override async Task WriteResponseBodyAsync(OutputFormatterWriteContext context, Encoding selectedEncoding)
+        {
+            IServiceProvider serviceProvider = context.HttpContext.RequestServices;
+            var logger = serviceProvider.GetService(typeof(ILogger<VcardOutputFormatter>)) as ILogger;
+
+            var response = context.HttpContext.Response;
+
+            var buffer = new StringBuilder();
+            if (context.Object is IEnumerable<Contact>)
+            {
+                foreach (Contact contact in context.Object as IEnumerable<Contact>)
+                {
+                    FormatVcard(buffer, contact, logger);
+                }
+            }
+            else
+            {
+                var contact = context.Object as Contact;
+                FormatVcard(buffer, contact, logger);
+            }
+            await response.WriteAsync(buffer.ToString());
+        }
+
+        private static void FormatVcard(StringBuilder buffer, Contact contact, ILogger logger)
+        {
+            buffer.AppendLine("BEGIN:VCARD");
+            buffer.AppendLine("VERSION:2.1");
+            buffer.AppendFormat($"N:{contact.LastName};{contact.FirstName}\r\n");
+            buffer.AppendFormat($"FN:{contact.FirstName} {contact.LastName}\r\n");
+            buffer.AppendFormat($"UID:{contact.ID}\r\n");
+            buffer.AppendLine("END:VCARD");
+            logger.LogInformation("Writing {FirstName} {LastName}", contact.FirstName, contact.LastName);
+        }
+        #endregion
+    }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Models/Contact.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Models/Contact.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CustomFormatterDemo.Models
+{
+    public class Contact
+    {
+        public string ID { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+    }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Models/ContactRepository.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Models/ContactRepository.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CustomFormatterDemo.Models
+{
+    public class ContactRepository : IContactRepository
+    {
+        private static ConcurrentDictionary<string, Contact> _contacts =
+            new ConcurrentDictionary<string, Contact>();
+
+        public ContactRepository()
+        {
+            Add(new Contact() { FirstName = "Nancy", LastName = "Davolio" });
+        }
+
+        public void Add(Contact contact)
+        {
+            contact.ID = Guid.NewGuid().ToString();
+            _contacts[contact.ID] = contact;
+        }
+
+        public Contact Get(string id)
+        {
+            Contact contact;
+            _contacts.TryGetValue(id, out contact);
+            return contact;
+        }
+
+        public IEnumerable<Contact> GetAll()
+        {
+            return _contacts.Values;
+        }
+
+        public Contact Remove(string id)
+        {
+            Contact contact;
+            _contacts.TryRemove(id, out contact);
+            return contact;
+        }
+
+        public void Update(Contact contact)
+        {
+            _contacts[contact.ID] = contact;
+        }
+    }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Models/IContactRepository.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Models/IContactRepository.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace CustomFormatterDemo.Models
+{
+    public interface IContactRepository
+    {
+        void Add(Contact contact);
+        IEnumerable<Contact> GetAll();
+        Contact Get(string key);
+        Contact Remove(string key);
+        void Update(Contact contact);
+    }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Program.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Program.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace CustomFormatterDemo
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Startup.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/Startup.cs
@@ -1,0 +1,56 @@
+using CustomFormatterDemo.Formatters;
+using CustomFormatterDemo.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace CustomFormatterDemo
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            #region mvcoptions
+            services.AddMvc(options =>
+            {
+                options.InputFormatters.Insert(0, new VcardInputFormatter());
+                options.OutputFormatters.Insert(0, new VcardOutputFormatter());
+            });
+            #endregion
+
+            services.AddSingleton<IContactRepository, ContactRepository>();
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/appsettings.Development.json
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/aspnetcore/web-api/advanced/custom-formatters/sample3_1/appsettings.json
+++ b/aspnetcore/web-api/advanced/custom-formatters/sample3_1/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes an issue with the custom-formatters doc. The sample used in the doc references code from ASP.NET Core 2.2 when ASP.NET Core 3.1 is selected.