### PR TITLE
`foreach` variable can be captured.

### DIFF
--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -128,7 +128,7 @@ It's often convenient to close over additional values, such as when iterating ov
 ```
 
 > [!NOTE]
-> Do **not** use a loop variable directly in a lambda expression, such as `i` in the preceding `for` loop example or a reference variable in a `foreach` loop. Otherwise, the same variable is used by all lambda expressions, which results in use of the same value in all lambdas. Always capture the variable's value in a local variable and then use it. In the preceding example, the loop variable `i` is assigned to `buttonNumber`.
+> Do **not** use a loop variable directly in a lambda expression, such as `i` in the preceding `for` loop example. Otherwise, the same variable is used by all lambda expressions, which results in use of the same value in all lambdas. Always capture the variable's value in a local variable and then use it. In the preceding example, the loop variable `i` is assigned to `buttonNumber`.
 
 ## EventCallback
 


### PR DESCRIPTION
Ever since C# 5.0, the `foreach` variable can be captured in a lambda, and it works. [See the breaking changes section from the VS magazine back then.](https://visualstudiomagazine.com/articles/2012/11/01/more-than-just-async.aspx)

I tested it in Blazor, and `foreach` does not break like `for` does.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->