### PR TITLE
Fix EventLog remark

### DIFF
--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -563,7 +563,7 @@ To configure PerfView for collecting events logged by this provider, add the str
 
 The `EventLog` provider sends log output to the Windows Event Log. Unlike the other providers, the `EventLog` provider does ***not*** inherit the default non-provider settings. If `EventLog` log settings aren't specified, they [default to LogLevel.Warning](https://github.com/dotnet/extensions/blob/release/3.1/src/Hosting/Hosting/src/Host.cs#L99-L103).
 
-To log events lower than `Warning`, explicitly set the log level. In the following example, the Event Log log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
+To log events lower than `Warning`, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
 
 ```json
 "Logging": {

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -1461,7 +1461,7 @@ logging.AddEventLog();
 * `SourceName`: ".NET Runtime"
 * `MachineName`: The local machine name is used.
 
-Events are logged for [Warning level and higher](#log-level). To log events lower than <xref:Microsoft.Extensions.Logging.LogLevel.Warning?displayProperty=nameWithType>, explicitly set the log level. To log events lower than `Warning`, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
+Events are logged for [Warning level and higher](#log-level). To log events lower than <xref:Microsoft.Extensions.Logging.LogLevel.Warning?displayProperty=nameWithType>, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
 
 ```json
 "Logging": {

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -561,14 +561,16 @@ To configure PerfView for collecting events logged by this provider, add the str
 
 ### Windows EventLog
 
-The `EventLog` provider sends log output to the Windows Event Log. Unlike the other providers, the `EventLog` provider does ***not*** inherit the default non-provider settings. If `EventLog` log settings are specified, they [default to LogLevel.Warning](https://github.com/dotnet/extensions/blob/release/3.1/src/Hosting/Hosting/src/Host.cs#L99-L103).
+The `EventLog` provider sends log output to the Windows Event Log. Unlike the other providers, the `EventLog` provider does ***not*** inherit the default non-provider settings. If `EventLog` log settings aren't specified, they [default to LogLevel.Warning](https://github.com/dotnet/extensions/blob/release/3.1/src/Hosting/Hosting/src/Host.cs#L99-L103).
 
 To log events lower than `Warning`, explicitly set the log level. For example, add the following to the *appsettings.json* file:
 
 ```json
-"EventLog": {
-  "LogLevel": {
-    "Default": "Information"
+"Logging": {
+  "EventLog": {
+    "LogLevel": {
+      "Default": "Information"
+    }
   }
 }
 ```
@@ -1462,9 +1464,11 @@ logging.AddEventLog();
 Events are logged for [Warning level and higher](#log-level). To log events lower than `Warning`, explicitly set the log level. For example, add the following to the *appsettings.json* file:
 
 ```json
-"EventLog": {
-  "LogLevel": {
-    "Default": "Information"
+"Logging": {
+  "EventLog": {
+    "LogLevel": {
+      "Default": "Information"
+    }
   }
 }
 ```

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -563,7 +563,7 @@ To configure PerfView for collecting events logged by this provider, add the str
 
 The `EventLog` provider sends log output to the Windows Event Log. Unlike the other providers, the `EventLog` provider does ***not*** inherit the default non-provider settings. If `EventLog` log settings aren't specified, they [default to LogLevel.Warning](https://github.com/dotnet/extensions/blob/release/3.1/src/Hosting/Hosting/src/Host.cs#L99-L103).
 
-To log events lower than <xref:Microsoft.Extensions.Logging.LogLevel.Warning?displayProperty=nameWithType>, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
+To log events lower than <xref:Microsoft.Extensions.Logging.LogLevel.Warning?displayProperty=nameWithType>, explicitly set the log level. The following example sets the Event Log default log level to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
 
 ```json
 "Logging": {
@@ -1461,7 +1461,7 @@ logging.AddEventLog();
 * `SourceName`: ".NET Runtime"
 * `MachineName`: The local machine name is used.
 
-Events are logged for [Warning level and higher](#log-level). To log events lower than <xref:Microsoft.Extensions.Logging.LogLevel.Warning?displayProperty=nameWithType>, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
+Events are logged for [Warning level and higher](#log-level). The following example sets the Event Log default log level to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
 
 ```json
 "Logging": {

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -1461,7 +1461,7 @@ logging.AddEventLog();
 * `SourceName`: ".NET Runtime"
 * `MachineName`: The local machine name is used.
 
-Events are logged for [Warning level and higher](#log-level). To log events lower than `Warning`, explicitly set the log level. For example, add the following to the *appsettings.json* file:
+Events are logged for [Warning level and higher](#log-level). To log events lower than `Warning`, explicitly set the log level. To log events lower than `Warning`, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
 
 ```json
 "Logging": {

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -563,7 +563,7 @@ To configure PerfView for collecting events logged by this provider, add the str
 
 The `EventLog` provider sends log output to the Windows Event Log. Unlike the other providers, the `EventLog` provider does ***not*** inherit the default non-provider settings. If `EventLog` log settings aren't specified, they [default to LogLevel.Warning](https://github.com/dotnet/extensions/blob/release/3.1/src/Hosting/Hosting/src/Host.cs#L99-L103).
 
-To log events lower than `Warning`, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
+To log events lower than <xref:Microsoft.Extensions.Logging.LogLevel.Warning?displayProperty=nameWithType>, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
 
 ```json
 "Logging": {
@@ -1461,7 +1461,7 @@ logging.AddEventLog();
 * `SourceName`: ".NET Runtime"
 * `MachineName`: The local machine name is used.
 
-Events are logged for [Warning level and higher](#log-level). To log events lower than `Warning`, explicitly set the log level. To log events lower than `Warning`, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
+Events are logged for [Warning level and higher](#log-level). To log events lower than <xref:Microsoft.Extensions.Logging.LogLevel.Warning?displayProperty=nameWithType>, explicitly set the log level. To log events lower than `Warning`, explicitly set the log level. In the following example, the Event Log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
 
 ```json
 "Logging": {

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to use the logging framework provided by the Microsoft.Extensions.Logging NuGet package.
 ms.author: riande
 ms.custom: mvc
-ms.date: 6/12/2020
+ms.date: 6/29/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: fundamentals/logging/index
 ---
@@ -563,7 +563,7 @@ To configure PerfView for collecting events logged by this provider, add the str
 
 The `EventLog` provider sends log output to the Windows Event Log. Unlike the other providers, the `EventLog` provider does ***not*** inherit the default non-provider settings. If `EventLog` log settings aren't specified, they [default to LogLevel.Warning](https://github.com/dotnet/extensions/blob/release/3.1/src/Hosting/Hosting/src/Host.cs#L99-L103).
 
-To log events lower than `Warning`, explicitly set the log level. For example, add the following to the *appsettings.json* file:
+To log events lower than `Warning`, explicitly set the log level. In the following example, the Event Log log default log level is set to <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>:
 
 ```json
 "Logging": {


### PR DESCRIPTION
Fixes #18997

Corrected typo regarding default log levels for EventLog.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->