### PR TITLE
Convert API link and code in table headers to text

### DIFF
--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -92,7 +92,7 @@ Blazor Server apps are set up by default to prerender the UI on the server befor
 * Is prerendered into the page.
 * Is rendered as static HTML on the page or if it includes the necessary information to bootstrap a Blazor app from the user agent.
 
-| <xref:Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper.RenderMode> | Description |
+| Render mode | Description |
 | --- | --- |
 | <xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.ServerPrerendered> | Renders the component into static HTML and includes a marker for a Blazor Server app. When the user-agent starts, this marker is used to bootstrap a Blazor app. |
 | <xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.Server> | Renders a marker for a Blazor Server app. Output from the component isn't included. When the user-agent starts, this marker is used to bootstrap a Blazor app. |

--- a/aspnetcore/fundamentals/url-rewriting.md
+++ b/aspnetcore/fundamentals/url-rewriting.md
@@ -312,7 +312,7 @@ The middleware supports the following IIS URL Rewrite Module server variables:
 
 Use <xref:Microsoft.AspNetCore.Rewrite.RewriteOptionsExtensions.Add*> to implement your own rule logic in a method. `Add` exposes the <xref:Microsoft.AspNetCore.Rewrite.RewriteContext>, which makes available the <xref:Microsoft.AspNetCore.Http.HttpContext> for use in your method. The [RewriteContext.Result](xref:Microsoft.AspNetCore.Rewrite.RewriteContext.Result*) determines how additional pipeline processing is handled. Set the value to one of the <xref:Microsoft.AspNetCore.Rewrite.RuleResult> fields described in the following table.
 
-| `RewriteContext.Result`              | Action                                                           |
+| Rewrite context result               | Action                                                           |
 | ------------------------------------ | ---------------------------------------------------------------- |
 | `RuleResult.ContinueRules` (default) | Continue applying rules.                                         |
 | `RuleResult.EndResponse`             | Stop applying rules and send the response.                       |
@@ -666,7 +666,7 @@ The middleware supports the following IIS URL Rewrite Module server variables:
 
 Use <xref:Microsoft.AspNetCore.Rewrite.RewriteOptionsExtensions.Add*> to implement your own rule logic in a method. `Add` exposes the <xref:Microsoft.AspNetCore.Rewrite.RewriteContext>, which makes available the <xref:Microsoft.AspNetCore.Http.HttpContext> for use in your method. The [RewriteContext.Result](xref:Microsoft.AspNetCore.Rewrite.RewriteContext.Result*) determines how additional pipeline processing is handled. Set the value to one of the <xref:Microsoft.AspNetCore.Rewrite.RuleResult> fields described in the following table.
 
-| `RewriteContext.Result`              | Action                                                           |
+| Rewrite context result               | Action                                                           |
 | ------------------------------------ | ---------------------------------------------------------------- |
 | `RuleResult.ContinueRules` (default) | Continue applying rules.                                         |
 | `RuleResult.EndResponse`             | Stop applying rules and send the response.                       |


### PR DESCRIPTION
Addresses #19007

I'll just hit two of them in topics that I worked, a Blazor topic and the URL Rewriting topic.