### PR TITLE
Remove confusing Blazor event handling remark

### DIFF
--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -217,8 +217,6 @@ The value of the attribute can also be an expression. In the following example, 
 <input @onkeypress:preventDefault="shouldPreventDefault" />
 ```
 
-An event handler isn't required to prevent the default action. The event handler and prevent default action scenarios can be used independently.
-
 ## Stop event propagation
 
 Use the [`@on{EVENT}:stopPropagation`](xref:mvc/views/razor#oneventstoppropagation) directive attribute to stop event propagation.


### PR DESCRIPTION
Fixes #18827

Thanks @surenazatyan! :rocket:

The remark is confusing, and we generally don't need to document a **_non-conflict_**. All this means is that one can add these prevented actions per the guidance in this section **_in addition to_** a Blazor event handler that prevents the default action for whatever event the handler is handling. I think we'd only need to say something about this if there was a conflict or *gotcha* of some sort.