### PR TITLE
Update Warning section for in Enable Cors

### DIFF
--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -54,7 +54,7 @@ There are three ways to enable CORS:
 Using the [[EnableCors]](#attr) attribute with a named policy provides the finest control in limiting endpoints that support CORS.
 
 > [!WARNING]
-> <xref:Owin.CorsExtensions.UseCors%2A> must be called before <xref:Microsoft.AspNetCore.Builder.ResponseCachingExtensions.UseResponseCaching%2A> when using `UseResponseCaching`.
+> <xref:Owin.CorsExtensions.UseCors%2A> must be called before <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthenticaion%2A> and after <xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A>. Meanwhile if you are using `UseResponseCaching`, place <xref:Microsoft.AspNetCore.Builder.ResponseCachingExtensions.UseResponseCaching%2A> after <xref:Owin.CorsExtensions.UseCors%2A>.
 
 Each approach is detailed in the following sections.
 


### PR DESCRIPTION
according to this github issue reply https://github.com/dotnet/aspnetcore/issues/23004#issuecomment-647755359, I think it is better to warn our developer that usecors need to be placed between UseRouter and UseAuthentication. Typically customer will directly goes to this cors page of asp.net core docs and find it should be placed before UseResponseCache, but the UseRouter and UseAuthentication sequence is as same import as UseResponseCache, so it would be better to add them in warining as well



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->