### PR TITLE
Change to instructions for First Web API tutorial

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -229,11 +229,6 @@ The *database context* is the main class that coordinates Entity Framework funct
 * Select **Microsoft.EntityFrameworkCore.SqlServer** in the left pane.
 * Select the **Project** check box in the right pane and then select **Install**.
 
-* From the **Tools** menu, select **NuGet Package Manager > Manage NuGet Packages for Solution**.
-* Select the **Browse** tab, and then enter **Microsoft.EntityFrameworkCore.InMemory** in the search box.
-* Select **Microsoft.EntityFrameworkCore.InMemory** in the left pane.
-* Select the **Project** check box in the right pane and then select **Install**.
-
 
 ![NuGet Package Manager](first-web-api/_static/vs3NuGet.png)
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -222,7 +222,7 @@ The *database context* is the main class that coordinates Entity Framework funct
 
 # [Visual Studio](#tab/visual-studio)
 
-### Add NuGet packages.
+### Add NuGet packages
 
 * From the **Tools** menu, select **NuGet Package Manager > Manage NuGet Packages for Solution**.
 * Select the **Browse** tab, and then enter **Microsoft.EntityFrameworkCore.SqlServer** in the search box.

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -228,7 +228,7 @@ The *database context* is the main class that coordinates Entity Framework funct
 * Select the **Browse** tab, and then enter **Microsoft.EntityFrameworkCore.SqlServer** in the search box.
 * Select **Microsoft.EntityFrameworkCore.SqlServer** in the left pane.
 * Select the **Project** check box in the right pane and then select **Install**.
-
+* Use the preceding instructions to add the `Microsoft.EntityFrameworkCore.InMemory` NuGet package.
 
 ![NuGet Package Manager](first-web-api/_static/vs3NuGet.png)
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -228,7 +228,13 @@ The *database context* is the main class that coordinates Entity Framework funct
 * Select the **Browse** tab, and then enter **Microsoft.EntityFrameworkCore.SqlServer** in the search box.
 * Select **Microsoft.EntityFrameworkCore.SqlServer** in the left pane.
 * Select the **Project** check box in the right pane and then select **Install**.
-* Use the preceding instructions to add the `Microsoft.EntityFrameworkCore.InMemory` NuGet package.
+
+### Add Microsoft.EntityFrameworkCore.InMemory
+* From the **Tools** menu, select **NuGet Package Manager > Manage NuGet Packages for Solution**.
+* Select the **Browse** tab, and then enter **Microsoft.EntityFrameworkCore.InMemory** in the search box.
+* Select **Microsoft.EntityFrameworkCore.InMemory** in the left pane.
+* Select the **Project** check box in the right pane and then select **Install**.
+
 
 ![NuGet Package Manager](first-web-api/_static/vs3NuGet.png)
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -222,14 +222,13 @@ The *database context* is the main class that coordinates Entity Framework funct
 
 # [Visual Studio](#tab/visual-studio)
 
-### Add Microsoft.EntityFrameworkCore.SqlServer
+### Add NuGet packages.
 
 * From the **Tools** menu, select **NuGet Package Manager > Manage NuGet Packages for Solution**.
 * Select the **Browse** tab, and then enter **Microsoft.EntityFrameworkCore.SqlServer** in the search box.
 * Select **Microsoft.EntityFrameworkCore.SqlServer** in the left pane.
 * Select the **Project** check box in the right pane and then select **Install**.
 
-### Add Microsoft.EntityFrameworkCore.InMemory
 * From the **Tools** menu, select **NuGet Package Manager > Manage NuGet Packages for Solution**.
 * Select the **Browse** tab, and then enter **Microsoft.EntityFrameworkCore.InMemory** in the search box.
 * Select **Microsoft.EntityFrameworkCore.InMemory** in the left pane.


### PR DESCRIPTION
I've updated the install instructions for what packages you need to install.
 
The reason I have added the second lot of instructions is because it wasn't clear you needed to run an install for Microsoft.EntityFrameworkCore.InMemory too. 
The heading only mentioned adding Microsoft.EntityFrameworkCore.SqlServer so once I had did that, I missed the second part of installing Microsoft.EntityFrameworkCore.InMemory.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->