### PR TITLE
StateHasChanged behavior for EventCallback

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -5,7 +5,7 @@ description: Learn how to use Razor component lifecycle methods in ASP.NET Core 
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/01/2020
+ms.date: 07/06/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/components/lifecycle
 ---
@@ -161,6 +161,8 @@ For more information, see <xref:blazor/webassembly-performance-best-practices#av
 ## State changes
 
 <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> notifies the component that its state has changed. When applicable, calling <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> causes the component to be rerendered.
+
+<xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called automatically for <xref:Microsoft.AspNetCore.Components.EventCallback> methods. For more information, see <xref:blazor/components/event-handling#eventcallback>.
 
 ## Handle incomplete async actions at render
 


### PR DESCRIPTION
Fixes #17939

Thanks @mrlife ...

> in one place all ways the lifecycle comes into play

... isn't specifically actionable. We can cross-link the `StateHasChanged` behavior for `EventCallback` in the Lifecycle topic's `StateHasChanged` section (on this PR), but either I don't understand your ask or I don't think that what you're asking for can be done differently than the way that we already handle this using two topics, one on events and one on lifecycle.