### PR TITLE
Revert part of Expander update

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -644,9 +644,7 @@ The `Expander` component is added to a parent component that may call <xref:Micr
     Expander 1 content
 </Expander>
 
-<Expander Expanded="true">
-    Expander 2 content
-</Expander>
+<Expander Expanded="true" />
 
 <button @onclick="StateHasChanged">
     Call StateHasChanged


### PR DESCRIPTION
Address https://github.com/dotnet/AspNetCore.Docs/pull/19102/files#r450232194 ...

The 2nd `Expander` component shouldn't have content in order to demo the behavior described by the text. If I had **_read the text_** during the update, I would've seen that. 🙈 ....... *I'll slow down when I get another 15 issues closed out.* 🏃😅 

Thank you @serpent5 🐢 for catching that.