### PR TITLE
Drop JS Debugger extension guidance

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -92,6 +92,8 @@ While debugging your Blazor WebAssembly app, you can also debug your server code
 
 ## Visual Studio Code
 
+For information on installing Visual Studio Code for Blazor app development, see <xref:blazor/tooling>.
+
 ### Debug standalone Blazor WebAssembly
 
 1. Open the standalone Blazor WebAssembly app in VS Code.

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -5,7 +5,7 @@ description: Learn how to debug Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/25/2020
+ms.date: 07/06/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/debug
 ---
@@ -91,14 +91,6 @@ While debugging your Blazor WebAssembly app, you can also debug your server code
 <a id="vscode"></a>
 
 ## Visual Studio Code
-
-To debug a Blazor WebAssembly app in Visual Studio Code:
- 
-Install the [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) and the [JavaScript Debugger (Nightly)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.js-debug-nightly) extension with `debug.javascript.usePreview` set to `true`.
-
-![Extensions](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vscode-extensions.png)
-
-![JS preview debugger](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vscode-js-use-preview.png)
 
 ### Debug standalone Blazor WebAssembly
 

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -5,7 +5,7 @@ description: Learn about the tooling available to build Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/02/2020
+ms.date: 07/06/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/tooling
 zone_pivot_groups: operating-systems-set-one
@@ -42,9 +42,7 @@ By [Daniel Roth](https://github.com/danroth27) and [Luke Latham](https://github.
 
 1. Install the latest version of [Visual Studio Code](https://code.visualstudio.com/).
 
-1. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) and the [JavaScript Debugger (Nightly)](https://marketplace.visualstudio.com/items?itemName=ms-vscode.js-debug-nightly) extension with `debug.javascript.usePreview` set to `true`.
-
-   To set `debug.javascript.usePreview` to `true` using the VS Code UI, open **File** > **Preferences** > **Settings** and search for `debug javascript use preview`. Select the check box for **Use the new in-preview JavaScript debugger for Node.js and Chrome**.
+1. Install the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
 1. For a Blazor WebAssembly experience, execute the following command in a command shell:
 


### PR DESCRIPTION
Fixes  #19108

They will have very probably already installed the C# extension per our earlier guidance. Therefore, I think we can drop all of this lead-in content.