### PR TITLE
Blazor Server non-root URL hosting

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -23,7 +23,7 @@ Blazor Server is integrated into [ASP.NET Core Endpoint Routing](xref:fundamenta
 
 The most typical configuration is to route all requests to a Razor page, which acts as the host for the server-side part of the Blazor Server app. By convention, the *host* page is usually named `_Host.cshtml`. The route specified in the host file is called a *fallback route* because it operates with a low priority in route matching. The fallback route is considered when other routes don't match. This allows the app to use others controllers and pages without interfering with the Blazor Server app.
 
-For information on configuring <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> for non-root URL server hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
+For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A> for non-root URL server hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
 
 ## Route templates
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -23,7 +23,7 @@ Blazor Server is integrated into [ASP.NET Core Endpoint Routing](xref:fundamenta
 
 The most typical configuration is to route all requests to a Razor page, which acts as the host for the server-side part of the Blazor Server app. By convention, the *host* page is usually named `_Host.cshtml`. The route specified in the host file is called a *fallback route* because it operates with a low priority in route matching. The fallback route is considered when other routes don't match. This allows the app to use others controllers and pages without interfering with the Blazor Server app.
 
-For information on configuring <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> for non-root URL hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
+For information on configuring <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> for non-root URL server hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
 
 ## Route templates
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -23,7 +23,7 @@ Blazor Server is integrated into [ASP.NET Core Endpoint Routing](xref:fundamenta
 
 The most typical configuration is to route all requests to a Razor page, which acts as the host for the server-side part of the Blazor Server app. By convention, the *host* page is usually named `_Host.cshtml`. The route specified in the host file is called a *fallback route* because it operates with a low priority in route matching. The fallback route is considered when other routes don't match. This allows the app to use others controllers and pages without interfering with the Blazor Server app.
 
-For information on configuring <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> for non-root URL hosting, see the [Non-root URL server hosting with Blazor Server apps](#non-root-url-server-hosting-with-blazor-server-apps) section.
+For information on configuring <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> for non-root URL hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
 
 ## Route templates
 
@@ -251,33 +251,3 @@ public void Dispose()
 * <xref:Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs.IsNavigationIntercepted>: If `true`, Blazor intercepted the navigation from the browser. If `false`, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> caused the navigation to occur.
 
 For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
-
-## Non-root URL server hosting with Blazor Server apps
-
-When a Blazor Server app is hosted on the server at a non-root URL, pass the following path to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A>:
-
-```csharp
-endpoints.MapFallbackToPage("/{RELATIVE PATH}/{**path:nonfile}");
-```
-
-The placeholder `{RELATIVE PATH}` is the non-root path on the server. For example, `spa` is the placeholder segment if the non-root URL to the app is `https://{HOST}:{PORT}/spa/`):
-
-```csharp
-endpoints.MapFallbackToPage("/spa/{**path:nonfile}");
-```
-
-Set the [app base path](xref:blazor/host-and-deploy/index#app-base-path). This can be accomplished in a Blazor Server app in either of the following ways:
-
-* Set the `<base>` tag's `href` in the app's `Pages/_Host.cshtml` file. For the preceding example app hosted at `spa/`, the `<base>` tag is:
-
-  ```csthml
-  <base href="/spa/">
-  ```
-
-* Set the app base path using Path Base Middleware by calling <xref:Microsoft.AspNetCore.Builder.UsePathBaseExtensions.UsePathBase*> in the app's request pipeline of `Startup.Configure`:
-
-  ```csharp
-  app.UsePathBase("/spa");
-  ```
-
-For more information on the app base path, see <xref:blazor/host-and-deploy/index#app-base-path>.

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -5,7 +5,7 @@ description: Learn how to route requests in apps and about the NavLink component
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/01/2020
+ms.date: 07/07/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/fundamentals/routing
 ---
@@ -22,6 +22,8 @@ Blazor Server is integrated into [ASP.NET Core Endpoint Routing](xref:fundamenta
 [!code-csharp[](routing/samples_snapshot/3.x/Startup.cs?highlight=5)]
 
 The most typical configuration is to route all requests to a Razor page, which acts as the host for the server-side part of the Blazor Server app. By convention, the *host* page is usually named `_Host.cshtml`. The route specified in the host file is called a *fallback route* because it operates with a low priority in route matching. The fallback route is considered when other routes don't match. This allows the app to use others controllers and pages without interfering with the Blazor Server app.
+
+For information on configuring <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> for non-root URL hosting, see the [Non-root URL server hosting with Blazor Server apps](#non-root-url-server-hosting-with-blazor-server-apps) section.
 
 ## Route templates
 
@@ -249,3 +251,33 @@ public void Dispose()
 * <xref:Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs.IsNavigationIntercepted>: If `true`, Blazor intercepted the navigation from the browser. If `false`, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> caused the navigation to occur.
 
 For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+
+## Non-root URL server hosting with Blazor Server apps
+
+When a Blazor Server app is hosted on the server at a non-root URL, pass the following path to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A>:
+
+```csharp
+endpoints.MapFallbackToPage("/{RELATIVE PATH}/{**path:nonfile}");
+```
+
+The placeholder `{RELATIVE PATH}` is the non-root path on the server. For example, `spa` is the placeholder segment if the non-root URL to the app is `https://{HOST}:{PORT}/spa/`):
+
+```csharp
+endpoints.MapFallbackToPage("/spa/{**path:nonfile}");
+```
+
+Set the [app base path](xref:blazor/host-and-deploy/index#app-base-path). This can be accomplished in a Blazor Server app in either of the following ways:
+
+* Set the `<base>` tag's `href` in the app's `Pages/_Host.cshtml` file. For the preceding example app hosted at `spa/`, the `<base>` tag is:
+
+  ```csthml
+  <base href="/spa/">
+  ```
+
+* Set the app base path using Path Base Middleware by calling <xref:Microsoft.AspNetCore.Builder.UsePathBaseExtensions.UsePathBase*> in the app's request pipeline of `Startup.Configure`:
+
+  ```csharp
+  app.UsePathBase("/spa");
+  ```
+
+For more information on the app base path, see <xref:blazor/host-and-deploy/index#app-base-path>.

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -96,7 +96,7 @@ The Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
 **Blazor Server `MapBlazorHub` configuration**
 
-Pass the following path to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A>:
+Pass the following path to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> in `Startup.Configure`:
 
 ```csharp
 endpoints.MapFallbackToPage("/{RELATIVE PATH}/{**path:nonfile}");

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -94,7 +94,19 @@ dotnet run --pathbase=/CoolApp
 
 The Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
-For information on configuring <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> for non-root URL hosting of Blazor Server apps, see <xref:blazor/fundamentals/routing#non-root-url-server-hosting-with-blazor-server-apps>.
+**Blazor Server `MapBlazorHub` configuration**
+
+Pass the following path to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A>:
+
+```csharp
+endpoints.MapFallbackToPage("/{RELATIVE PATH}/{**path:nonfile}");
+```
+
+The placeholder `{RELATIVE PATH}` is the non-root path on the server. For example, `CoolApp` is the placeholder segment if the non-root URL to the app is `https://{HOST}:{PORT}/CoolApp/`):
+
+```csharp
+endpoints.MapFallbackToPage("/CoolApp/{**path:nonfile}");
+```
 
 ## Deployment
 

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -5,7 +5,7 @@ description: Discover how to host and deploy Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/07/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/host-and-deploy/index
 ---
@@ -93,6 +93,8 @@ dotnet run --pathbase=/CoolApp
 ```
 
 The Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
+
+For information on configuring <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> for non-root URL hosting of Blazor Server apps, see <xref:blazor/fundamentals/routing#non-root-url-server-hosting-with-blazor-server-apps>.
 
 ## Deployment
 

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -94,9 +94,9 @@ dotnet run --pathbase=/CoolApp
 
 The Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
-**Blazor Server `MapBlazorHub` configuration**
+**Blazor Server `MapFallbackToPage` configuration**
 
-Pass the following path to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> in `Startup.Configure`:
+Pass the following path to <xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A> in `Startup.Configure`:
 
 ```csharp
 endpoints.MapFallbackToPage("/{RELATIVE PATH}/{**path:nonfile}");


### PR DESCRIPTION
Fixes #13856
Addresses #14134

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/index?view=aspnetcore-3.1&branch=pr-en-us-19131#app-base-path)

Thanks @jerriep! :rocket: ... Sorry for the delay. We've been busy with a lot of high priority updates over the past several months.

* I add this to the *App base path* section in the *Host and deploy* overview.
* I cross-link to that section from the *Routing* topic.
* Artak, I based this on your engineering remark at https://github.com/dotnet/aspnetcore/issues/13167#issuecomment-521710865. I've only tested the Blazor WASM scenario, not the Blazor Server scenario. Therefore, I haven't confirmed that it works ok. If u feel good about it, we can merge and see if the community sends me a 💀 *Rex Death Threat!* 💀😨 

@mkArtakMSFT ... I'm going to go ahead with this. It's based directly on your remark in the engineering issue.