### PR TITLE
Blazor ToC improvements

### DIFF
--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -60,6 +60,8 @@ In the preceding example:
 * The <xref:Microsoft.AspNetCore.Components.Forms.ValidationSummary> component summarizes validation messages.
 * `HandleValidSubmit` is triggered when the form successfully submits (passes validation).
 
+## Built-in forms components
+
 A set of built-in input components are available to receive and validate user input. Inputs are validated when they're changed and when a form is submitted. Available input components are shown in the following table.
 
 | Input component | Rendered as&hellip; |

--- a/aspnetcore/blazor/layouts.md
+++ b/aspnetcore/blazor/layouts.md
@@ -28,7 +28,7 @@ The following code sample shows the Razor template of a layout component, `MainL
 
 ## `MainLayout` component
 
-In an app based on one of the Blazor app templates, the `MainLayout` component (`MainLayout.razor`) is in the app's `Shared` folder:
+In an app based on one of the Blazor project templates, the `MainLayout` component (`MainLayout.razor`) is in the app's `Shared` folder:
 
 [!code-razor[](./common/samples/3.x/BlazorWebAssemblySample/Shared/MainLayout.razor)]
 

--- a/aspnetcore/blazor/layouts.md
+++ b/aspnetcore/blazor/layouts.md
@@ -26,7 +26,11 @@ The following code sample shows the Razor template of a layout component, `MainL
 
 [!code-razor[](layouts/sample_snapshot/3.x/MainLayout.razor?highlight=1,13)]
 
-In an app based on one of the Blazor app templates, the `MainLayout` component (`MainLayout.razor`) is in the app's `Shared` folder.
+## `MainLayout` component
+
+In an app based on one of the Blazor app templates, the `MainLayout` component (`MainLayout.razor`) is in the app's `Shared` folder:
+
+[!code-razor[](./common/samples/3.x/BlazorWebAssemblySample/Shared/MainLayout.razor)]
 
 ## Default layout
 

--- a/aspnetcore/blazor/security/webassembly/index.md
+++ b/aspnetcore/blazor/security/webassembly/index.md
@@ -43,6 +43,18 @@ The [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.n
   * If the authentication process completes successfully, the user is authenticated and optionally sent back to the original protected URL that the user requested.
   * If the authentication process fails for any reason, the user is sent to the login failed page (`/authentication/login-failed`), and an error is displayed.
 
+## `Authentication` component
+
+The `Authentication` component (`Pages/Authentication.razor`) handles remote authentication operations and permits the app to:
+
+* Configure app routes for authentication states.
+* Set UI content for authentication states.
+* Manage authentication state.
+
+Authentication actions, such as registering or signing in a user, are passed to the Blazor framework's <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorViewCore%601> component, which persists and controls state across authentication operations.
+
+For more information and examples, see <xref:blazor/security/webassembly/additional-scenarios>.
+
 ## Authorization
 
 In Blazor WebAssembly apps, authorization checks can be bypassed because all client-side code can be modified by users. The same is true for all client-side app technologies, including JavaScript SPA frameworks or native apps for any operating system.

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -77,6 +77,9 @@
               uid: tutorials/first-mvc-app/validation
             - name: Examine Details and Delete
               uid: tutorials/first-mvc-app/details
+        - name: Blazor
+          displayName: tutorial
+          uid: tutorials/build-a-blazor-app
     - name: Web API apps
       items:
         - name: Create a web API

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -320,31 +320,31 @@
             - name: Built-in components
               items:
                 - name: App
-                  uid: blazor/templates#blazor-project-structure
+                  uid: blazor/templates.md#blazor-project-structure
                 - name: Authentication
-                  uid: blazor/security/webassembly/index#authentication-component
+                  uid: blazor/security/webassembly/index.md#authentication-component
                 - name: AuthorizeView
-                  uid: blazor/security/index#authorizeview-component
+                  uid: blazor/security/index.md#authorizeview-component
                 - name: InputCheckbox
-                  uid: blazor/forms-validation#built-in-forms-components
+                  uid: blazor/forms-validation.md#built-in-forms-components
                 - name: InputDate
-                  uid: blazor/forms-validation#built-in-forms-components
+                  uid: blazor/forms-validation.md#built-in-forms-components
                 - name: InputNumber
-                  uid: blazor/forms-validation#built-in-forms-components
+                  uid: blazor/forms-validation.md#built-in-forms-components
                 - name: InputSelect
-                  uid: blazor/forms-validation#built-in-forms-components
+                  uid: blazor/forms-validation.md#built-in-forms-components
                 - name: InputText
-                  uid: blazor/forms-validation#built-in-forms-components
+                  uid: blazor/forms-validation.md#built-in-forms-components
                 - name: InputTextArea
-                  uid: blazor/forms-validation#built-in-forms-components
+                  uid: blazor/forms-validation.md#built-in-forms-components
                 - name: MainLayout
-                  uid: blazor/layouts#mainlayout-component
+                  uid: blazor/layouts.md#mainlayout-component
                 - name: NavLink
-                  uid: blazor/fundamentals/routing#navlink-component
+                  uid: blazor/fundamentals/routing.md#navlink-component
                 - name: NavMenu
-                  uid: blazor/fundamentals/routing#navlink-component
+                  uid: blazor/fundamentals/routing.md#navlink-component
                 - name: Router
-                  uid: blazor/fundamentals/routing#route-templates
+                  uid: blazor/fundamentals/routing.md#route-templates
             - name: Cascading values and parameters
               uid: blazor/components/cascading-values-and-parameters
             - name: Data binding

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -77,9 +77,6 @@
               uid: tutorials/first-mvc-app/validation
             - name: Examine Details and Delete
               uid: tutorials/first-mvc-app/details
-        - name: Blazor
-          displayName: tutorial
-          uid: tutorials/build-a-blazor-app
     - name: Web API apps
       items:
         - name: Create a web API

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -320,31 +320,31 @@
             - name: Built-in components
               items:
                 - name: App
-                  uid: blazor/templates
+                  uid: blazor/templates#blazor-project-structure
                 - name: Authentication
-                  uid: blazor/security/webassembly/additional-scenarios
+                  uid: blazor/security/webassembly/index#authentication-component
                 - name: AuthorizeView
-                  uid: blazor/security/index
+                  uid: blazor/security/index#authorizeview-component
                 - name: InputCheckbox
-                  uid: blazor/forms-validation
+                  uid: blazor/forms-validation#built-in-forms-components
                 - name: InputDate
-                  uid: blazor/forms-validation
+                  uid: blazor/forms-validation#built-in-forms-components
                 - name: InputNumber
-                  uid: blazor/forms-validation
+                  uid: blazor/forms-validation#built-in-forms-components
                 - name: InputSelect
-                  uid: blazor/forms-validation
+                  uid: blazor/forms-validation#built-in-forms-components
                 - name: InputText
-                  uid: blazor/forms-validation
+                  uid: blazor/forms-validation#built-in-forms-components
                 - name: InputTextArea
-                  uid: blazor/forms-validation
+                  uid: blazor/forms-validation#built-in-forms-components
                 - name: MainLayout
-                  uid: blazor/layouts
+                  uid: blazor/layouts#mainlayout-component
                 - name: NavLink
-                  uid: blazor/fundamentals/routing
+                  uid: blazor/fundamentals/routing#navlink-component
                 - name: NavMenu
-                  uid: blazor/fundamentals/routing
+                  uid: blazor/fundamentals/routing#navlink-component
                 - name: Router
-                  uid: blazor/fundamentals/routing
+                  uid: blazor/fundamentals/routing#route-templates
             - name: Cascading values and parameters
               uid: blazor/components/cascading-values-and-parameters
             - name: Data binding
@@ -927,16 +927,6 @@
     - name: Health checks
       uid: host-and-deploy/health-checks
       displayName: deploy, publish
-    - name: Blazor
-      items:
-        - name: Overview
-          uid: blazor/host-and-deploy/index
-        - name: Blazor WebAssembly
-          uid: blazor/host-and-deploy/webassembly
-        - name: Blazor Server
-          uid: blazor/host-and-deploy/server
-        - name: Configure the Linker
-          uid: blazor/host-and-deploy/configure-linker
 - name: Security and Identity
   displayName: authentication, authorization
   items:
@@ -1169,42 +1159,6 @@
       uid: security/ip-safelist
     - name: Application security - OWASP
       href: https://cheatsheetseries.owasp.org/cheatsheets/DotNet_Security_Cheat_Sheet.html
-    - name: Blazor
-      items:
-        - name: Overview
-          uid: blazor/security/index
-        - name: Blazor WebAssembly
-          items:
-            - name: Overview
-              uid: blazor/security/webassembly/index
-            - name: Standalone with Authentication library
-              uid: blazor/security/webassembly/standalone-with-authentication-library
-            - name: Standalone with Microsoft Accounts
-              uid: blazor/security/webassembly/standalone-with-microsoft-accounts
-            - name: Standalone with AAD
-              uid: blazor/security/webassembly/standalone-with-azure-active-directory
-            - name: Standalone with AAD B2C
-              uid: blazor/security/webassembly/standalone-with-azure-active-directory-b2c
-            - name: Hosted with AAD
-              uid: blazor/security/webassembly/hosted-with-azure-active-directory
-            - name: Hosted with AAD B2C
-              uid: blazor/security/webassembly/hosted-with-azure-active-directory-b2c
-            - name: Hosted with Identity Server
-              uid: blazor/security/webassembly/hosted-with-identity-server
-            - name: Additional scenarios
-              uid: blazor/security/webassembly/additional-scenarios
-            - name: AAD groups and roles
-              uid: blazor/security/webassembly/aad-groups-roles
-        - name: Blazor Server
-          items:
-            - name: Overview
-              uid: blazor/security/server/index
-            - name: Threat mitigation
-              uid: blazor/security/server/threat-mitigation
-            - name: Additional scenarios
-              uid: blazor/security/server/additional-scenarios
-        - name: Content Security Policy
-          uid: blazor/security/content-security-policy
 - name: Performance
   items:
     - name: Overview
@@ -1229,8 +1183,6 @@
       uid: performance/diagnostic-tools
     - name: Load and stress testing
       uid: test/loadtests
-    - name: Blazor WebAssembly
-      uid: blazor/webassembly-performance-best-practices
 - name: Globalization and localization
   items:
     - name: Overview

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -320,31 +320,31 @@
             - name: Built-in components
               items:
                 - name: App
-                  uid: blazor/templates.md#blazor-project-structure
+                  href: blazor/templates.md#blazor-project-structure
                 - name: Authentication
-                  uid: blazor/security/webassembly/index.md#authentication-component
+                  href: blazor/security/webassembly/index.md#authentication-component
                 - name: AuthorizeView
-                  uid: blazor/security/index.md#authorizeview-component
+                  href: blazor/security/index.md#authorizeview-component
                 - name: InputCheckbox
-                  uid: blazor/forms-validation.md#built-in-forms-components
+                  href: blazor/forms-validation.md#built-in-forms-components
                 - name: InputDate
-                  uid: blazor/forms-validation.md#built-in-forms-components
+                  href: blazor/forms-validation.md#built-in-forms-components
                 - name: InputNumber
-                  uid: blazor/forms-validation.md#built-in-forms-components
+                  href: blazor/forms-validation.md#built-in-forms-components
                 - name: InputSelect
-                  uid: blazor/forms-validation.md#built-in-forms-components
+                  href: blazor/forms-validation.md#built-in-forms-components
                 - name: InputText
-                  uid: blazor/forms-validation.md#built-in-forms-components
+                  href: blazor/forms-validation.md#built-in-forms-components
                 - name: InputTextArea
-                  uid: blazor/forms-validation.md#built-in-forms-components
+                  href: blazor/forms-validation.md#built-in-forms-components
                 - name: MainLayout
-                  uid: blazor/layouts.md#mainlayout-component
+                  href: blazor/layouts.md#mainlayout-component
                 - name: NavLink
-                  uid: blazor/fundamentals/routing.md#navlink-component
+                  href: blazor/fundamentals/routing.md#navlink-component
                 - name: NavMenu
-                  uid: blazor/fundamentals/routing.md#navlink-component
+                  href: blazor/fundamentals/routing.md#navlink-component
                 - name: Router
-                  uid: blazor/fundamentals/routing.md#route-templates
+                  href: blazor/fundamentals/routing.md#route-templates
             - name: Cascading values and parameters
               uid: blazor/components/cascading-values-and-parameters
             - name: Data binding

--- a/aspnetcore/tutorials/build-a-blazor-app.md
+++ b/aspnetcore/tutorials/build-a-blazor-app.md
@@ -129,7 +129,7 @@ In this tutorial, you learned how to:
 > * Use event handling and data binding in components
 > * Use dependency injection (DI) and routing in a Blazor app
 
-Learn about the Blazor project templates:
+Learn about tooling for ASP.NET Core Blazor:
 
 > [!div class="nextstepaction"]
-> <xref:blazor/templates>
+> <xref:blazor/tooling>


### PR DESCRIPTION
Fixes #19124
Fixes #18829

The issues explain the problems that I'm seeking to resolve, including with screenshots in #19124. AFAICT, the sidebar ToC doesn't have any capacity to short-circuit URL matching behavior (https://dotnet.github.io/docfx/tutorial/intro_toc.html). It selects links in ways that are detrimental to desirable navigation:

* The built-in components ToC entries are selected when following cross-links in other contexts.
* Following cross-links within the doc set, the *Security and Identity* node Blazor topics are selected when the reader should see the Blazor ToC node entry for the topics. Seems that the selection is made top-to-bottom and then based on indent level.
* Internal (MS doc search) and external (Google, etc.) referrals result in ToC node topic selection outside of the Blazor ToC.
* When readers land from the new *Get Started* topic in this doc set, we want them to land on the *Build a Blazor app* tutorial **_in the Blazor ToC_** so that they can see where all of the Blazor topics are located.

This PR:

* Adds bookmarks to all of the ToC built-in component links in hopes that they won't match URLs to those topics. [btw - An alternative here might be to place the built-in components node **_last_** in the Blazor ToC node. However, that should be considered as a last resort because these links should be under *Components*.]
* Removes Blazor topics from the ToC for *Security and Identity*, *Host and deploy*, *Performance*, and *Tutorials* so that users will never be outside of the Blazor ToC when they follow cross-links or land in the doc set from search or the new *Get Started* topic.

cc: @danroth27 @mkArtakMSFT 