### PR TITLE
Blazor WASM security topic enhancements

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/08/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/hosted-with-azure-active-directory-b2c
 ---
@@ -21,10 +21,7 @@ This article describes how to create a Blazor WebAssembly standalone app that us
 
 Follow the guidance in [Tutorial: Create an Azure Active Directory B2C tenant](/azure/active-directory-b2c/tutorial-create-tenant) to create an AAD B2C tenant.
 
-Record the following information:
-
-* AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash)
-* AAD B2C Tenant domain (for example, `contoso.onmicrosoft.com`)
+Record the AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash). The instance is the scheme and host of an Azure B2C app registration, which can be found by opening the **Endpoints** window from the **App registrations** page in the Azure portal.
 
 ### Register a server API app
 
@@ -39,9 +36,8 @@ Follow the guidance in [Tutorial: Register an application in Azure Active Direct
 
 Record the following information:
 
-* *Server API app* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
-* Directory ID (Tenant ID) (for example, `222222222-2222-2222-2222-222222222222`)
-* AAD Tenant domain (for example, `contoso.onmicrosoft.com`): The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
+* *Server API app* Application (client) ID (for example, `41451fa7-82d9-4673-8fa5-69eff5a761fd`)
+* AAD Primary/Publisher/Tenant domain (for example, `contoso.onmicrosoft.com`): The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
 
 In **Expose an API**:
 
@@ -55,8 +51,10 @@ In **Expose an API**:
 
 Record the following information:
 
-* App ID URI (for example, `https://contoso.onmicrosoft.com/11111111-1111-1111-1111-111111111111`, `api://11111111-1111-1111-1111-111111111111`, or the custom value that you provided)
+* App ID URI (for example, `https://contoso.onmicrosoft.com/41451fa7-82d9-4673-8fa5-69eff5a761fd`, `api://41451fa7-82d9-4673-8fa5-69eff5a761fd`, or the custom value that you provided)
 * Default scope (for example, `API.Access`)
+
+The App ID URI might require a special configuration in the client app, which is described in the [Access token scopes](#access-token-scopes) section later in this topic.
 
 ### Register a client app
 
@@ -69,7 +67,7 @@ Follow the guidance in [Tutorial: Register an application in Azure Active Direct
 1. Confirm that **Permissions** > **Grant admin consent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
 
-Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
+Record the Application (client) ID (for example, `4369008b-21fa-427c-abaa-9b53bf58e538`).
 
 In **Authentication** > **Platform configurations** > **Web**:
 
@@ -100,10 +98,21 @@ Record the sign-up and sign-in user flow name created for the app (for example, 
 Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
 
 ```dotnetcli
-dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{TENANT DOMAIN}" -ho -ssp "{SIGN UP OR SIGN IN POLICY}" --tenant-id "{TENANT ID}"
+dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{TENANT DOMAIN}" -ho -o {APP NAME} -ssp "{SIGN UP OR SIGN IN POLICY}"
 ```
 
-To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+| Placeholder                   | Azure portal name                                     | Example                                |
+| ----------------------------- | ----------------------------------------------------- | -------------------------------------- |
+| `{AAD B2C INSTANCE}`          | Instance                                              | `https://contoso.b2clogin.com/`        |
+| `{APP NAME}`                  | &mdash;                                               | `BlazorSample`                         |
+| `{CLIENT APP CLIENT ID}`      | Application (client) ID for the *Client app*          | `4369008b-21fa-427c-abaa-9b53bf58e538` |
+| `{DEFAULT SCOPE}`             | Scope name                                            | `API.Access`                           |
+| `{SERVER API APP CLIENT ID}`  | Application (client) ID for the *Server app*          | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+| `{SERVER API APP ID URI}`     | Application ID URI ([see note](#access-token-scopes)) | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+| `{SIGN UP OR SIGN IN POLICY}` | Sign-up/sign-in user flow                             | `B2C_1_signupsignin1`                  |
+| `{TENANT DOMAIN}`             | Primary/Publisher/Tenant domain                       | `contoso.onmicrosoft.com`              |
+
+The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
 
 > [!NOTE]
 > Pass the App ID URI to the `app-id-uri` option, but note a configuration change might be required in the client app, which is described in the [Access token scopes](#access-token-scopes) section.

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -107,7 +107,7 @@ dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" 
 | `{APP NAME}`                  | &mdash;                                               | `BlazorSample`                         |
 | `{CLIENT APP CLIENT ID}`      | Application (client) ID for the *Client app*          | `4369008b-21fa-427c-abaa-9b53bf58e538` |
 | `{DEFAULT SCOPE}`             | Scope name                                            | `API.Access`                           |
-| `{SERVER API APP CLIENT ID}`  | Application (client) ID for the *Server app*          | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+| `{SERVER API APP CLIENT ID}`  | Application (client) ID for the *Server API app*      | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
 | `{SERVER API APP ID URI}`     | Application ID URI ([see note](#access-token-scopes)) | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
 | `{SIGN UP OR SIGN IN POLICY}` | Sign-up/sign-in user flow                             | `B2C_1_signupsignin1`                  |
 | `{TENANT DOMAIN}`             | Primary/Publisher/Tenant domain                       | `contoso.onmicrosoft.com`              |
@@ -122,7 +122,7 @@ The output location specified with the `-o|--output` option creates a project fo
 > [!NOTE]
 > In the Azure portal, the *Client app's* **Authentication** > **Platform configurations** > **Web** > **Redirect URI** is configured for port 5001 for apps that run on the Kestrel server with default settings.
 >
-> If the *Client app* is run on a random IIS Express port, the port for the app can be found in the *Server app's* properties in the **Debug** panel.
+> If the *Client app* is run on a random IIS Express port, the port for the app can be found in the *Server API app's* properties in the **Debug** panel.
 >
 > If the port wasn't configured earlier with the *Client app's* known port, return to the *Client app's* registration in the Azure portal and update the redirect URI with the correct port.
 

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/08/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/hosted-with-azure-active-directory
 ---
@@ -34,9 +34,9 @@ Follow the guidance in [Quickstart: Register an application with the Microsoft i
 
 Record the following information:
 
-* *Server API app* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
-* Directory ID (Tenant ID) (for example, `222222222-2222-2222-2222-222222222222`)
-* AAD Tenant domain (for example, `contoso.onmicrosoft.com`): The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
+* *Server API app* Application (client) ID (for example, `41451fa7-82d9-4673-8fa5-69eff5a761fd`)
+* Directory (tenant) ID (for example, `e86c78e2-8bb4-4c41-aefd-918e0565a45e`)
+* AAD Primary/Publisher/Tenant domain (for example, `contoso.onmicrosoft.com`): The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
 
 In **API permissions**, remove the **Microsoft Graph** > **User.Read** permission, as the app doesn't require sign in or user profile access.
 
@@ -52,8 +52,10 @@ In **Expose an API**:
 
 Record the following information:
 
-* App ID URI (for example, `https://contoso.onmicrosoft.com/11111111-1111-1111-1111-111111111111`, `api://11111111-1111-1111-1111-111111111111`, or the custom value that you provided)
+* App ID URI (for example, `https://contoso.onmicrosoft.com/41451fa7-82d9-4673-8fa5-69eff5a761fd`, `api://41451fa7-82d9-4673-8fa5-69eff5a761fd`, or the custom value that you provided)
 * Default scope (for example, `API.Access`)
+
+The App ID URI might require a special configuration in the client app, which is described in the [Access token scopes](#access-token-scopes) section later in this topic.
 
 ### Register a client app
 
@@ -66,7 +68,7 @@ Follow the guidance in [Quickstart: Register an application with the Microsoft i
 1. Disable the **Permissions** > **Grant admin consent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
-Record the *Client app* Application ID (Client ID) (for example, `33333333-3333-3333-3333-333333333333`).
+Record the *Client app* Application (client) ID (for example, `4369008b-21fa-427c-abaa-9b53bf58e538`).
 
 In **Authentication** > **Platform configurations** > **Web**:
 
@@ -87,13 +89,23 @@ In **API permissions**:
 
 ### Create the app
 
-Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+In an empty folder, replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
 
 ```dotnetcli
-dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{TENANT DOMAIN}" -ho --tenant-id "{TENANT ID}"
+dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}" --app-id-uri "{SERVER API APP ID URI}" --client-id "{CLIENT APP CLIENT ID}" --default-scope "{DEFAULT SCOPE}" --domain "{TENANT DOMAIN}" -ho -o {APP NAME} --tenant-id "{TENANT ID}"
 ```
 
-To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+| Placeholder                  | Azure portal name                                     | Example                                |
+| ---------------------------- | ----------------------------------------------------- | -------------------------------------- |
+| `{APP NAME}`                 | &mdash;                                               | `BlazorSample`                         |
+| `{CLIENT APP CLIENT ID}`     | Application (client) ID for the *Client app*          | `4369008b-21fa-427c-abaa-9b53bf58e538` |
+| `{DEFAULT SCOPE}`            | Scope name                                            | `API.Access`                           |
+| `{SERVER API APP CLIENT ID}` | Application (client) ID for the *Server app*          | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+| `{SERVER API APP ID URI}`    | Application ID URI ([see note](#access-token-scopes)) | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+| `{TENANT DOMAIN}`            | Primary/Publisher/Tenant domain                       | `contoso.onmicrosoft.com`              |
+| `{TENANT ID}`                | Directory (tenant) ID                                 | `e86c78e2-8bb4-4c41-aefd-918e0565a45e` |
+
+The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
 
 > [!NOTE]
 > Pass the App ID URI to the `app-id-uri` option, but note a configuration change might be required in the client app, which is described in the [Access token scopes](#access-token-scopes) section.

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -100,7 +100,7 @@ dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}"
 | `{APP NAME}`                 | &mdash;                                               | `BlazorSample`                         |
 | `{CLIENT APP CLIENT ID}`     | Application (client) ID for the *Client app*          | `4369008b-21fa-427c-abaa-9b53bf58e538` |
 | `{DEFAULT SCOPE}`            | Scope name                                            | `API.Access`                           |
-| `{SERVER API APP CLIENT ID}` | Application (client) ID for the *Server app*          | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+| `{SERVER API APP CLIENT ID}` | Application (client) ID for the *Server API app*      | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
 | `{SERVER API APP ID URI}`    | Application ID URI ([see note](#access-token-scopes)) | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
 | `{TENANT DOMAIN}`            | Primary/Publisher/Tenant domain                       | `contoso.onmicrosoft.com`              |
 | `{TENANT ID}`                | Directory (tenant) ID                                 | `e86c78e2-8bb4-4c41-aefd-918e0565a45e` |
@@ -113,7 +113,7 @@ The output location specified with the `-o|--output` option creates a project fo
 > [!NOTE]
 > In the Azure portal, the *Client app's* **Authentication** > **Platform configurations** > **Web** > **Redirect URI** is configured for port 5001 for apps that run on the Kestrel server with default settings.
 >
-> If the *Client app* is run on a random IIS Express port, the port for the app can be found in the *Server app's* properties in the **Debug** panel.
+> If the *Client app* is run on a random IIS Express port, the port for the app can be found in the *Server API app's* properties in the **Debug** panel.
 >
 > If the port wasn't configured earlier with the *Client app's* known port, return to the *Client app's* registration in the Azure portal and update the redirect URI with the correct port.
 

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -5,7 +5,7 @@ description: To create a new Blazor hosted app with authentication from within V
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/08/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/hosted-with-identity-server
 ---
@@ -17,23 +17,39 @@ This article explains how to create a new Blazor hosted app that uses [IdentityS
 
 # [Visual Studio](#tab/visual-studio)
 
-In Visual Studio:
+To create a new Blazor WebAssembly project with an authentication mechanism:
 
-1. Create a new **Blazor WebAssembly** app.
-1. In the **Create a new Blazor app** dialog, select **Change** in the **Authentication** section.
-1. Select **Individual User Accounts** followed by **OK**.
-1. Select the **ASP.NET Core hosted** checkbox in the **Advanced** section.
-1. Select the **Create** button.
+1. After choosing the **Blazor WebAssembly App** template in the **Create a new ASP.NET Core Web Application** dialog, select **Change** under **Authentication**.
 
-# [.NET Core CLI](#tab/netcore-cli/)
+1. Select **Individual User Accounts** with the **Store user accounts in-app** option to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
 
-To create the app in a command shell, execute the following command:
+1. Select the **ASP.NET Core hosted** check box in the **Advanced** section.
+
+# [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
+
+To create a new Blazor WebAssembly project with an authentication mechanism in an empty folder, specify the `Individual` authentication mechanism with the `-au|--auth` option to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system:
 
 ```dotnetcli
-dotnet new blazorwasm -au Individual -ho
+dotnet new blazorwasm -au Individual -ho -o {APP NAME}
 ```
 
-To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+| Placeholder  | Example        |
+| ------------ | -------------- |
+| `{APP NAME}` | `BlazorSample` |
+
+The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
+
+For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+To create a new Blazor WebAssembly project with an authentication mechanism:
+
+1. On the **Configure your new Blazor WebAssembly App** step, select **Individual Authentication (in-app)** from the **Authentication** drop down.
+
+1. The app is created for individual users stored in the app with ASP.NET Core [Identity](xref:security/authentication/identity).
+
+1. Select the **ASP.NET Core hosted** check box.
 
 ---
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/08/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/standalone-with-authentication-library
 ---
@@ -15,15 +15,41 @@ By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https
 
 *For Azure Active Directory (AAD) and Azure Active Directory B2C (AAD B2C), don't follow the guidance in this topic. See the AAD and AAD B2C topics in this table of contents node.*
 
-To create a Blazor WebAssembly standalone app that uses [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication/) library, execute the following command in a command shell:
+To create a Blazor WebAssembly standalone app that uses [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication/) library, follow the guidance for your choice of tooling.
+
+# [Visual Studio](#tab/visual-studio)
+
+To create a new Blazor WebAssembly project with an authentication mechanism:
+
+1. After choosing the **Blazor WebAssembly App** template in the **Create a new ASP.NET Core Web Application** dialog, select **Change** under **Authentication**.
+
+1. Select **Individual User Accounts** with the **Store user accounts in-app** option to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
+
+# [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
+
+To create a new Blazor WebAssembly project with an authentication mechanism in an empty folder, specify the `Individual` authentication mechanism with the `-au|--auth` option to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system:
 
 ```dotnetcli
-dotnet new blazorwasm -au Individual
+dotnet new blazorwasm -au Individual -o {APP NAME}
 ```
 
-To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+| Placeholder  | Example        |
+| ------------ | -------------- |
+| `{APP NAME}` | `BlazorSample` |
 
-If using Visual Studio to create a Blazor WebAssembly app, set **Authentication** to **Individual User Accounts** with the **Store user accounts in-app** option.
+The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
+
+For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+To create a new Blazor WebAssembly project with an authentication mechanism:
+
+1. On the **Configure your new Blazor WebAssembly App** step, select **Individual Authentication (in-app)** from the **Authentication** drop down.
+
+1. The app is created for individual users stored in the app with ASP.NET Core [Identity](xref:security/authentication/identity).
+
+---
 
 ## Authentication package
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -27,7 +27,7 @@ To create a new Blazor WebAssembly project with an authentication mechanism:
 
 # [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
 
-To create a new Blazor WebAssembly project with an authentication mechanism in an empty folder, specify the `Individual` authentication mechanism with the `-au|--auth` option to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system:
+Create a new Blazor WebAssembly project with an authentication mechanism in an empty folder. Specify the `Individual` authentication mechanism with the `-au|--auth` option to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system:
 
 ```dotnetcli
 dotnet new blazorwasm -au Individual -o {APP NAME}

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/08/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/standalone-with-azure-active-directory-b2c
 ---
@@ -21,8 +21,8 @@ Follow the guidance in the following topics to create a tenant and register a we
 
 Record the following information:
 
-* AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash).
-* AAD B2C Tenant domain (for example, `contoso.onmicrosoft.com`).
+* AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash): The instance is the scheme and host of an Azure B2C app registration, which can be found by opening the **Endpoints** window from the **App registrations** page in the Azure portal.
+* AAD B2C Primary/Publisher/Tenant domain (for example, `contoso.onmicrosoft.com`): The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
 
 Follow the guidance in [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications) again to register an AAD app for the *Client app* and then do the following:
 
@@ -33,7 +33,7 @@ Follow the guidance in [Tutorial: Register an application in Azure Active Direct
 1. Confirm that **Permissions** > **Grant admin consent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
 
-Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
+Record the Application (client) ID (for example, `41451fa7-82d9-4673-8fa5-69eff5a761fd`).
 
 In **Authentication** > **Platform configurations** > **Web**:
 
@@ -50,13 +50,21 @@ At a minimum, select the **Application claims** > **Display Name** user attribut
 
 Record the sign-up and sign-in user flow name created for the app (for example, `B2C_1_signupsignin`).
 
-Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+In an empty folder, replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
 
 ```dotnetcli
-dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --client-id "{CLIENT ID}" --domain "{TENANT DOMAIN}" -ssp "{SIGN UP OR SIGN IN POLICY}"
+dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" --client-id "{CLIENT ID}" --domain "{TENANT DOMAIN}" -o {APP NAME} -ssp "{SIGN UP OR SIGN IN POLICY}"
 ```
 
-To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+| Placeholder                   | Azure portal name               | Example                                |
+| ----------------------------- | ------------------------------- | -------------------------------------- |
+| `{AAD B2C INSTANCE}`          | Instance                        | `https://contoso.b2clogin.com/`        |
+| `{APP NAME}`                  | &mdash;                         | `BlazorSample`                         |
+| `{CLIENT ID}`                 | Application (client) ID         | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+| `{SIGN UP OR SIGN IN POLICY}` | Sign-up/sign-in user flow       | `B2C_1_signupsignin1`                  |
+| `{TENANT DOMAIN}`             | Primary/Publisher/Tenant domain | `contoso.onmicrosoft.com`              |
+
+The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
 
 > [!NOTE]
 > In the Azure portal, the app's **Authentication** > **Platform configurations** > **Web** > **Redirect URI** is configured for port 5001 for apps that run on the Kestrel server with default settings.

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/08/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/standalone-with-azure-active-directory
 ---
@@ -27,8 +27,8 @@ Register a AAD app in the **Azure Active Directory** > **App registrations** are
 
 Record the following information:
 
-* Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`)
-* Directory ID (Tenant ID) (for example, `22222222-2222-2222-2222-222222222222`)
+* Application (client) ID (for example, `41451fa7-82d9-4673-8fa5-69eff5a761fd`)
+* Directory (tenant) ID (for example, `e86c78e2-8bb4-4c41-aefd-918e0565a45e`)
 
 In **Authentication** > **Platform configurations** > **Web**:
 
@@ -37,13 +37,19 @@ In **Authentication** > **Platform configurations** > **Web**:
 1. The remaining defaults for the app are acceptable for this experience.
 1. Select the **Save** button.
 
-Create the app. Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
+Create the app in an empty folder. Replace the placeholders in the following command with the information recorded earlier and execute the command in a command shell:
 
 ```dotnetcli
-dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" --tenant-id "{TENANT ID}"
+dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" -o {APP NAME} --tenant-id "{TENANT ID}"
 ```
 
-To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+| Placeholder   | Azure portal name       | Example                                |
+| ------------- | ----------------------- | -------------------------------------- |
+| `{APP NAME}`  | &mdash;                 | `BlazorSample`                         |
+| `{CLIENT ID}` | Application (client) ID | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+| `{TENANT ID}` | Directory (tenant) ID   | `e86c78e2-8bb4-4c41-aefd-918e0565a45e` |
+
+The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
 
 > [!NOTE]
 > In the Azure portal, the app's **Authentication** > **Platform configurations** > **Web** > **Redirect URI** is configured for port 5001 for apps that run on the Kestrel server with default settings.

--- a/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-accounts.md
@@ -5,7 +5,7 @@ description:
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/08/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/standalone-with-microsoft-accounts
 ---
@@ -25,7 +25,7 @@ Register a AAD app in the **Azure Active Directory** > **App registrations** are
 1. Disable the **Permissions** > **Grant admin consent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
-Record the Application ID (Client ID) (for example, `11111111-1111-1111-1111-111111111111`).
+Record the Application (client) ID (for example, `41451fa7-82d9-4673-8fa5-69eff5a761fd`).
 
 In **Authentication** > **Platform configurations** > **Web**:
 
@@ -37,10 +37,15 @@ In **Authentication** > **Platform configurations** > **Web**:
 Create the app. Replace the placeholders in the following command with the information recorded earlier and execute the following command in a command shell:
 
 ```dotnetcli
-dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" --tenant-id "common"
+dotnet new blazorwasm -au SingleOrg --client-id "{CLIENT ID}" --tenant-id "common" -o {APP NAME}
 ```
 
-To specify the output location, which creates a project folder if it doesn't exist, include the output option in the command with a path (for example, `-o BlazorSample`). The folder name also becomes part of the project's name.
+| Placeholder   | Azure portal name       | Example                                |
+| ------------- | ----------------------- | -------------------------------------- |
+| `{APP NAME}`  | &mdash;                 | `BlazorSample`                         |
+| `{CLIENT ID}` | Application (client) ID | `41451fa7-82d9-4673-8fa5-69eff5a761fd` |
+
+The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
 
 > [!NOTE]
 > In the Azure portal, the app's **Authentication** > **Platform configurations** > **Web** > **Redirect URI** is configured for port 5001 for apps that run on the Kestrel server with default settings.

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -90,12 +90,7 @@ For more information, see the guidance provided by your browser and Linux distro
 
    For information on the two Blazor hosting models, *Blazor WebAssembly* and *Blazor Server*, see <xref:blazor/hosting-models>.
 
-1. Confirm the following configurations:
-
-   * **Target Framework** set to **.NET Core 3.1**.
-   * **Authentication** set to **No Authentication**.
-   
-   Select **Next**.
+1. Confirm that **Authentication** is set to **No Authentication**. Select **Next**.
 
 1. In the **Project Name** field, name the app `WebApplication1`. Select **Create**.
 

--- a/aspnetcore/includes/blazor-security/azure-scope.md
+++ b/aspnetcore/includes/blazor-security/azure-scope.md
@@ -2,11 +2,18 @@
 > If the Azure portal provides the scope URI for the app and the app throws an unhandled exception when it receives a *401 Unauthorized* response from the API, try using a scope URI that doesn't include the scheme and host. For example, the Azure portal may provide one of the following scope URI formats:
 >
 > * `https://{TENANT}.onmicrosoft.com/{API CLIENT ID OR CUSTOM VALUE}/{SCOPE NAME}`
-> * `api://{API CLIENT ID OR CUSTOM VALUE}/{SCOPE NAME}`
+> * `api://{SERVER API CLIENT ID OR CUSTOM VALUE}/{SCOPE NAME}`
 >
 > Try supplying the scope URI without the scheme and host:
 >
 > ```csharp
 > options.ProviderOptions.DefaultAccessTokenScopes.Add(
->     "{API CLIENT ID OR CUSTOM VALUE}/{SCOPE NAME}");
+>     "{SERVER API CLIENT ID OR CUSTOM VALUE}/{SCOPE NAME}");
+> ```
+>
+> For example:
+>
+> ```csharp
+> options.ProviderOptions.DefaultAccessTokenScopes.Add(
+>     "41451fa7-82d9-4673-8fa5-69eff5a761fd/API.Access");
 > ```

--- a/aspnetcore/tutorials/signalr-blazor-webassembly.md
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly.md
@@ -91,14 +91,7 @@ Follow the guidance for your choice of tooling:
 
 1. Choose the **Blazor WebAssembly App** template. Select **Next**.
 
-   Confirm the following configurations:
-
-   * **Target Framework** set to **.NET Core 3.1**.
-   * **Authentication** set to **No Authentication**.
-
-   Select the **ASP.NET Core Hosted** check box.
-
-   Select **Next**.
+1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core Hosted** check box. Select **Next**.
 
 1. In the **Project Name** field, name the app `BlazorSignalRApp`. Select **Create**.
 


### PR DESCRIPTION
Fixes #18379
Fixes #17913
Fixes #19143

Thanks @jlinstrum! :rocket:
Thanks @c0g1t8! :rocket:

* Tooling tabs can only be added for the *auth lib* and *Identity Server* topics because VS hasn't activated single and multi-organization auth options for Blazor WASM apps yet. We'll have to stick with the CLI for now for MS accounts, Azure AD, and Azure AD B2C topics.
* To improve translation of settings from the portal, I attempt to match how the portal names things to the placeholders in the `dotnet new` commands. I do this in the text, and I add a table of placeholders under each command. Combined with showing the app settings files from the apps (already in the topics today), it should be enough to keep devs *mostly* 🤞 on the right track for getting their apps configured.
* I think we'll stick with describing the gestures in the Azure portal. If we throw devs entirely to Azure docs, they'll be overwhelmed and lost. In spite of the costs 💰, it's probably best if we keep these instructions in place.

cc: @mkArtakMSFT 