### PR TITLE
Move docs to gRPC on C# page

### DIFF
--- a/aspnetcore/grpc/basics.md
+++ b/aspnetcore/grpc/basics.md
@@ -4,7 +4,7 @@ author: juntaoluo
 description: Learn the basic concepts when writing gRPC services with C#.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: johluo
-ms.date: 07/03/2019
+ms.date: 07/09/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: grpc/basics
 ---

--- a/aspnetcore/grpc/basics.md
+++ b/aspnetcore/grpc/basics.md
@@ -38,6 +38,13 @@ The *\*.proto* file is included in a project by adding it to the `<Protobuf>` it
 
 [!code-xml[](~/tutorials/grpc/grpc-start/sample/GrpcGreeter/GrpcGreeter.csproj?highlight=2&range=7-9)]
 
+By default, a `<Protobuf>` reference generates a concrete client and a service base class. The reference element's `GrpcServices` attribute can be used to limit C# asset generation. Valid `GrpcServices` options are:
+
+* `Both` (default when not present)
+* `Server`
+* `Client`
+* `None`
+
 ## C# Tooling support for .proto files
 
 The tooling package [Grpc.Tools](https://www.nuget.org/packages/Grpc.Tools/) is required to generate the C# assets from *\*.proto* files. The generated assets (files):

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -5,7 +5,7 @@ description: Troubleshoot errors when using gRPC on .NET Core.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: jamesnk
 ms.custom: mvc
-ms.date: 05/26/2020
+ms.date: 07/09/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: grpc/troubleshoot
 ---

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -123,13 +123,6 @@ gRPC code generation of concrete clients and service base classes requires proto
 
 For more information on generating gRPC C# assets, see <xref:grpc/basics>.
 
-By default, a `<Protobuf>` reference generates a concrete client and a service base class. The reference element's `GrpcServices` attribute can be used to limit C# asset generation. Valid `GrpcServices` options are:
-
-* `Both` (default when not present)
-* `Server`
-* `Client`
-* `None`
-
 An ASP.NET Core web app hosting gRPC services only needs the service base class generated:
 
 ```xml


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/605

Move useful information from troubleshooting page to primary docs