### PR TITLE
Add Blazor SignalR client config

### DIFF
--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -5,7 +5,7 @@ description: Learn about additional scenarios for ASP.NET Core Blazor hosting mo
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/07/2020
+ms.date: 07/10/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/fundamentals/additional-scenarios
 ---
@@ -116,23 +116,104 @@ Rendering server components from a static HTML page isn't supported.
 
 *This section applies to Blazor Server.*
 
-Sometimes, you need to configure the SignalR client used by Blazor Server apps. For example, you might want to configure logging on the SignalR client to diagnose a connection issue.
+Configure the SignalR client used by Blazor Server apps in the `Pages/_Host.cshtml` file. Place a script that calls `Blazor.start` after the `_framework/blazor.server.js` script and inside the `</body>` tag.
 
-To configure the SignalR client in the `Pages/_Host.cshtml` file:
+### Logging
+
+To configure SignalR client logging:
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Call `Blazor.start` and pass in a configuration object that specifies the SignalR builder.
+* Pass in a configuration object (`configureSignalR`) that calls `configureLogging` with the log level on the client builder.
 
-```html
-<script src="_framework/blazor.server.js" autostart="false"></script>
-<script>
-  Blazor.start({
-    configureSignalR: function (builder) {
-      builder.configureLogging("information"); // LogLevel.Information
-    }
-  });
-</script>
+```cshtml
+    ...
+
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script>
+      Blazor.start({
+        configureSignalR: function (builder) {
+          builder.configureLogging("information");
+        }
+      });
+    </script>
+</body>
 ```
+
+In the preceding example, `information` is equilivant to a log level of <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>.
+
+### Modify the reconnection handler
+
+To modify the reconnection handler's circuit connection events:
+
+* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
+* Register callbacks for connection changes for either or both of the following events:
+  * Dropped connection (`onConnectionDown`)
+  * Established/re-established connection (`onConnectionUp`)
+
+```cshtml
+    ...
+
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script>
+      Blazor.start({
+        reconnectionHandler: {
+          onConnectionDown: (options, error) => console.error(error);
+          onConnectionUp: () => console.log("Up, up, and away!");
+        }
+      });
+    </script>
+</body>
+```
+
+### Adjust the reconnection retry count and interval
+
+To adjust the reconnection retry count and interval:
+
+* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
+* Set the number of retries (`maxRetries`) and period in milliseconds permitted for each retry attempt (`retryIntervalMilliseconds`).
+
+```cshtml
+    ...
+
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script>
+      Blazor.start({
+        reconnectionOptions: {
+          maxRetries: 3,
+          retryIntervalMilliseconds: 2000
+        }
+      });
+    </script>
+</body>
+```
+
+### Hide or replace the reconnection display
+
+To hide the reconnection display:
+
+* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
+* Set the reconnection handler's `_reconnectionDisplay` to an empty object (`{}` or `new Object()`).
+
+```cshtml
+    ...
+
+    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script>
+      window.addEventListener('beforeunload', function () {
+        Blazor.defaultReconnectionHandler._reconnectionDisplay = {};
+      });
+    </script>
+</body>
+```
+
+To replace the reconnection display, set `_reconnectionDisplay` in the preceding example to the element for display:
+
+```javascrpt
+Blazor.defaultReconnectionHandler._reconnectionDisplay = 
+  document.getElementById("{ELEMENT ID}");
+```
+
+The placeholder `{ELEMENT ID}` is the ID of the HTML element to display.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -143,12 +143,15 @@ In the preceding example, `information` is equivalent to a log level of <xref:Mi
 
 ### Modify the reconnection handler
 
-To modify the reconnection handler's circuit connection events:
+The reconnection handler's circuit connection events can be modified for custom behaviors, such as:
+
+* To notify the user if the connection is dropped.
+* To perform logging (from the client) when a circuit is connected or reconnected.
+
+To modify the connection events:
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Register callbacks for connection changes for either or both of the following events:
-  * Dropped connection (`onConnectionDown`)
-  * Established/re-established connection (`onConnectionUp`)
+* Register callbacks for connection changes for dropped connections (`onConnectionDown`) and established/re-established connections (`onConnectionUp`). **Both** `onConnectionDown` and `onConnectionUp` must be specified.
 
 ```cshtml
     ...

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -146,7 +146,7 @@ In the preceding example, `information` is equivalent to a log level of <xref:Mi
 The reconnection handler's circuit connection events can be modified for custom behaviors, such as:
 
 * To notify the user if the connection is dropped.
-* To perform logging (from the client) when a circuit is connected or reconnected.
+* To perform logging (from the client) when a circuit is connected.
 
 To modify the connection events:
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -139,7 +139,7 @@ To configure SignalR client logging:
 </body>
 ```
 
-In the preceding example, `information` is equilivant to a log level of <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>.
+In the preceding example, `information` is equivalent to a log level of <xref:Microsoft.Extensions.Logging.LogLevel.Information?displayProperty=nameWithType>.
 
 ### Modify the reconnection handler
 
@@ -208,7 +208,7 @@ To hide the reconnection display:
 
 To replace the reconnection display, set `_reconnectionDisplay` in the preceding example to the element for display:
 
-```javascrpt
+```javascript
 Blazor.defaultReconnectionHandler._reconnectionDisplay = 
   document.getElementById("{ELEMENT ID}");
 ```


### PR DESCRIPTION
Fixes #19153
Addresses #14134

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/additional-scenarios?view=aspnetcore-3.1&branch=pr-en-us-19172#configure-the-signalr-client-for-blazor-server-apps)

* The rubber 🦆 said, "*They all get `autostart="false"` for the `blazor.server.js` script.*" ... Is Mr. 🦆 correct?
* Can we address the first bullet point of https://github.com/dotnet/AspNetCore.Docs/issues/14134 here if ...

  > Manually starting the blazor application

  ... means calling `Blazor.start`? If so, how do we phrase the coverage (e.g., just say 'set autostart to false and call Blazor.start when/where u want the app to start')? Do we need to show an example? If so, what? ... something simple like ...

  ```cshtml
      ...

      <script src="_framework/blazor.server.js" autostart="false"></script>
      <script>
        ...
        Blazor.start();
      </script>
  </body>
  ```

* Generally WRT https://github.com/dotnet/AspNetCore.Docs/issues/14134, are my updated comments in my first comment on that issue correct? I'm trying to figure out how far we've gone and can we close that issue now with the updates on this PR (or what else do we need to do to close #14134)?