### PR TITLE
Closing over loop vars in child content

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/06/2020
+ms.date: 07/14/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/components/index
 ---
@@ -267,6 +267,29 @@ The `ParentComponent` in the sample app can provide content for rendering the `C
 `Pages/ParentComponent.razor`:
 
 [!code-razor[](index/samples_snapshot/ParentComponent.razor?highlight=7-8)]
+
+Due to the way that Blazor renders child content, rendering components inside a `for` loop requires a local index variable if the incrementing loop variable is closed over in the child component's content:
+>
+> ```razor
+> @for (int c = 0; c < 10; c++)
+> {
+>     var current = c;
+>     <ChildComponent Param1="@c">
+>         Child Content: Count: @current
+>     </ChildComponent>
+> }
+> ```
+>
+> Alternatively, use a `foreach` loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType>:
+>
+> ```razor
+> @foreach(var c in Enumerable.Range(0,10))
+> {
+>     <ChildComponent Param1="@c">
+>         Child Content: Count: @c
+>     </ChildComponent>
+> }
+> ```
 
 ## Attribute splatting and arbitrary parameters
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -268,7 +268,7 @@ The `ParentComponent` in the sample app can provide content for rendering the `C
 
 [!code-razor[](index/samples_snapshot/ParentComponent.razor?highlight=7-8)]
 
-Due to the way that Blazor renders child content, rendering components inside a `for` loop requires a local index variable if the incrementing loop variable is closed over in the child component's content:
+Due to the way that Blazor renders child content, rendering components inside a `for` loop requires a local index variable if the incrementing loop variable is used in the child component's content:
 >
 > ```razor
 > @for (int c = 0; c < 10; c++)

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -187,7 +187,7 @@ The following HTML markup is rendered:
 ```
 
 > [!WARNING]
-> Due to the way that Blazor renders child content, rendering `NavLink` components inside a `for` loop requires a local index variable if the incrementing loop variable is closed over in the `NavLink` (child) component's content:
+> Due to the way that Blazor renders child content, rendering `NavLink` components inside a `for` loop requires a local index variable if the incrementing loop variable is used in the `NavLink` (child) component's content:
 >
 > ```razor
 > @for (int c = 0; c < 10; c++)
@@ -201,7 +201,7 @@ The following HTML markup is rendered:
 > }
 > ```
 >
-> Using an index variable in this scenario is a requirement for **any** child component that closes over a loop variable in its [child content](xref:blazor/components/index#child-content), not just the `NavLink` component.
+> Using an index variable in this scenario is a requirement for **any** child component that uses a loop variable in its [child content](xref:blazor/components/index#child-content), not just the `NavLink` component.
 >
 > Alternatively, use a `foreach` loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType>:
 >

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -5,7 +5,7 @@ description: Learn how to route requests in apps and about the NavLink component
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/01/2020
+ms.date: 07/14/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/fundamentals/routing
 ---
@@ -185,6 +185,36 @@ The following HTML markup is rendered:
 ```html
 <a href="my-page" target="_blank">My page</a>
 ```
+
+> [!WARNING]
+> Due to the way that Blazor renders child content, rendering `NavLink` components inside a `for` loop requires a local index variable if the incrementing loop variable is closed over in the `NavLink` (child) component's content:
+>
+> ```csharp
+> @for (int c = 0; c < 10; c++)
+> {
+>     var current = c;
+>     <li ...>
+>         <NavLink ... href="@c">
+>             <span ...></span> @current
+>         </NavLink>
+>     </li>
+> }
+> ```
+>
+> Using an index variable in this scenario is a requirement for **any** child component that closes over a loop variable in its [child content](xref:blazor/components/index#child-content), not just the `NavLink` component.
+>
+> Alternatively, use a `foreach` loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType>:
+>
+> ```csharp
+> @foreach(var c in Enumerable.Range(0,10))
+> {
+>     <li ...>
+>         <NavLink ... href="@c">
+>             <span ...></span> @c
+>         </NavLink>
+>     </li>
+> }
+> ```
 
 ## URI and navigation state helpers
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -189,7 +189,7 @@ The following HTML markup is rendered:
 > [!WARNING]
 > Due to the way that Blazor renders child content, rendering `NavLink` components inside a `for` loop requires a local index variable if the incrementing loop variable is closed over in the `NavLink` (child) component's content:
 >
-> ```csharp
+> ```razor
 > @for (int c = 0; c < 10; c++)
 > {
 >     var current = c;
@@ -205,7 +205,7 @@ The following HTML markup is rendered:
 >
 > Alternatively, use a `foreach` loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType>:
 >
-> ```csharp
+> ```razor
 > @foreach(var c in Enumerable.Range(0,10))
 > {
 >     <li ...>


### PR DESCRIPTION
Fixes #19166 

* [Internal Review Topic (links to section in *Routing*)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-3.1&branch=pr-en-us-19198#navlink-component)
* [Internal Review Topic (links to section in *Components* overview)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components/index?view=aspnetcore-3.1&branch=pr-en-us-19198#child-content)

I'd like to cover this in both *Routing* and *Components* because the *Routing* topic is considered more *fundamental* than the *Components* topic and will often be consumed first. I don't want the reader to *click forward* into the *Components* topic while reading about routing. Therefore, I cover it twice but using different language and examples.

I'm going with a forceful WARNING in the *Routing* topic to separate it from the section content. In the *Components* topic, this is a general concept, so I think I'll lay it out right in the text, not in a NOTE or WARNING.

Thanks @mrlife! :rocket: ... would u like to review this?

@Andrzej-W ... would u like to take a look? I noticed that you commented on the engineering issue.

Artak, I'm going to go ahead on Mr. Life's review. Hit me up :ear: if you feel this needs a patch.