### PR TITLE
Cross-link Blazor WASM IdS to auth lib topic

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -15,6 +15,9 @@ By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https
 
 This article explains how to create a new Blazor hosted app that uses [IdentityServer](https://identityserver.io/) to authenticate users and API calls.
 
+> [!NOTE]
+> To configure a standalone or hosted Blazor WebAssembly app to use an existing, external Identity Server instance, follow the guidance in <xref:blazor/security/webassembly/standalone-with-authentication-library>.
+
 # [Visual Studio](#tab/visual-studio)
 
 To create a new Blazor WebAssembly project with an authentication mechanism:


### PR DESCRIPTION
Fixes #19208
Addresses #19151

Thanks @psiservices-mhart and @Ef0Dev! :rocket: ... Sorry again for my wrong (**_but logical_**) guess. I still don't know if the client config of the *Hosted with IdS* would ✨ *Just Work!*:tm: ✨ or not, but following the *Standalone with auth lib* topic is the supported/recommended approach for this scenario, even if my (incorrect) suggestion does work.

I think we only need to go one-way with the cross-link and not necessarily call out the external IdS scenario in the *Standalone with auth lib* topic. I may mention this there later if readers are still confused. Right now, let's get the scenario surfaced to move the reader to the right spot as soon as they land in the *Hosted with IdS* topic.