### PR TITLE
Blazor WASM lazy load assemblies topic

### DIFF
--- a/aspnetcore/blazor/components/integrate-components.md
+++ b/aspnetcore/blazor/components/integrate-components.md
@@ -86,7 +86,7 @@ To support routable Razor components in Razor Pages apps:
    ```razor
    @using Microsoft.AspNetCore.Components.Routing
 
-   <Router AppAssembly="typeof(Program).Assembly">
+   <Router AppAssembly="@typeof(Program).Assembly">
        <Found Context="routeData">
            <RouteView RouteData="routeData" />
        </Found>
@@ -161,7 +161,7 @@ To support routable Razor components in MVC apps:
    ```razor
    @using Microsoft.AspNetCore.Components.Routing
 
-   <Router AppAssembly="typeof(Program).Assembly">
+   <Router AppAssembly="@typeof(Program).Assembly">
        <Found Context="routeData">
            <RouteView RouteData="routeData" />
        </Found>

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -28,7 +28,7 @@ The most typical configuration is to route all requests to a Razor page, which a
 The <xref:Microsoft.AspNetCore.Components.Routing.Router> component enables routing to each component with a specified route. The <xref:Microsoft.AspNetCore.Components.Routing.Router> component appears in the `App.razor` file:
 
 ```razor
-<Router AppAssembly="typeof(Startup).Assembly">
+<Router AppAssembly="@typeof(Startup).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>
@@ -85,7 +85,7 @@ Use the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblie
 
 ```razor
 <Router
-    AppAssembly="typeof(Program).Assembly"
+    AppAssembly="@typeof(Program).Assembly"
     AdditionalAssemblies="new[] { typeof(Component1).Assembly }">
     ...
 </Router>

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -1,0 +1,163 @@
+---
+title: Lazy load assemblies in ASP.NET Core Blazor WebAssembly
+author: guardrex
+description: Discover how to lazy load assemblies in ASP.NET Core Blazor WebAssembly apps.
+monikerRange: '>= aspnetcore-5.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 07/15/2020
+no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+uid: blazor/webassembly-lazy-load-assemblies
+---
+# Lazy load assemblies in ASP.NET Core Blazor WebAssembly
+
+By [Safia Abdalla](https://safia.rocks) and [Luke Latham](https://github.com/guardrex)
+
+Blazor WebAssembly app startup performance can be improved by dynamically loading assets at runtime when the assets are required, which is called *lazy loading*. For example, assemblies that are only used to render a single component can be set up to load only if the user navigates to that component. After loading, the assemblies are cached client-side and don't require reloading while the app is running.
+
+> [!NOTE]
+> Assembly lazy loading doesn't benefit Blazor Server apps because assemblies aren't downloaded to the client in a Blazor Server app.
+
+## Project file
+
+Mark assemblies for lazy loading in the app's project file (`.csproj`) using the `BlazorWebAssemblyLazyLoad` item. The Blazor framework prevents the assemblies from loading at app launch. The following example marks a large custom assembly (`GrantImaharaRobotControls.dll`) for lazy loading. Add a separate `BlazorWebAssemblyLazyLoad` item for each assembly.
+
+```xml
+<ItemGroup>
+  <BlazorWebAssemblyLazyLoad Include="GrantImaharaRobotControls.dll" />
+</ItemGroup>
+```
+
+Only assemblies that are used by the app can be lazily loaded. The linker strips unused assemblies from published output.
+
+## `Router` component
+
+Code in the `Router` component determines when the assemblies marked for lazy loading are loaded.
+
+In the app's `Router` component (`App.razor`):
+
+* Add an `OnNavigateAsync` callback. The `OnNavigateAsync` handler is invoked when the user visits a route for the first time or navigates to a new route.
+* Add a [List](xref:System.Collections.Generic.List%601)\<<xref:System.Reflection.Assembly>> (for example, named `lazyLoadedAssemblies`) to the component. The assemblies are passed back to the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> collection in case the assemblies contain routable components. The framework searches the assemblies for routes and updates the route collection if any new routes are found.
+
+```razor
+@using System.Reflection
+
+<Router AppAssembly="@typeof(Program).Assembly" 
+    AdditionalAssemblies="@lazyLoadedAssemblies" OnNavigateAsync="@OnNavigateAsync">
+    ...
+</Router>
+
+@code {
+    private List<Assembly> lazyLoadedAssemblies = new List<Assembly>();
+
+    private async Task OnNavigateAsync(NavigationContext args)
+    {
+    }
+}
+```
+
+### Assembly load logic in `OnNavigateAsync`
+
+`OnNavigateAsync` has a `NavigationContext` parameter that provides information about the current asynchronous navigation event, including the target path (`Path`) and the cancellation token (`CancellationToken`):
+
+* The `Path` property is the user's destination path relative to the app's base path, such as `/robot`.
+* The `CancellationToken` can be used to observe the cancellation of the asynchronous task. `OnNavigateAsync` automatically cancels the currently running navigation task when the user navigates away from a page.
+
+Inside `OnNavigateAsync`, implement logic to determine the assemblies to load. Options include:
+
+* Conditional checks inside the `OnNavigateAsync` method.
+* A lookup table that maps routes to assembly names, either injected into the component or implemented within the [`@code`](xref:mvc/views/razor#code) block.
+
+`LazyAssemblyLoader` is a framework-provided singleton service for loading assemblies. Inject `LazyAssemblyLoader` into the `Router` component:
+
+```razor
+...
+@using Microsoft.AspNetCore.Components.WebAssembly.Services
+@inject LazyAssemblyLoader assemblyLoader
+
+...
+```
+
+The `LazyAssemblyLoader` provides the `LoadAssembliesAsync` method that:
+
+* Uses JS interop to fetch assemblies via a network call.
+* Loads assemblies into the runtime executing on WASM in the browser.
+
+> [!NOTE]
+> The framework's lazy loading implementation supports prerendering on the server. During prerendering, all assemblies, including those marked for lazy loading, are assumed to be loaded.
+
+### User interaction with `<Navigating>` content
+
+While loading assemblies, which can take several seconds, the `Router` component can indicate to the user that a page transition is occurring:
+
+* Add an [`@using`](xref:mvc/views/razor#using) directive for the <xref:Microsoft.AspNetCore.Components.Routing?displayProperty=fullName> namespace.
+* Add a `<Navigating>` tag to the component with markup to display during page transition events.
+
+```razor
+...
+@using Microsoft.AspNetCore.Components.Routing
+...
+
+<Router ...>
+    <Navigating>
+        <div style="...">
+            <p>Loading the requested page&hellip;</p>
+        </div>
+    </Navigating>
+</Router>
+
+...
+```
+
+### Complete example
+
+The following complete `Router` component demonstrates loading the `GrantImaharaRobotControls.dll` assembly when the user navigates to `/robot`. During page transitions, a styled message is displayed to the user.
+
+```razor
+@using System.Reflection
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.WebAssembly.Services
+@inject LazyAssemblyLoader assemblyLoader
+
+<Router AppAssembly="@typeof(Program).Assembly" 
+    AdditionalAssemblies="@lazyLoadedAssemblies" OnNavigateAsync="@OnNavigateAsync">
+    <Navigating>
+        <div style="padding:20px;background-color:blue;color:white">
+            <p>Loading the requested page&hellip;</p>
+        </div>
+    </Navigating>
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+    </Found>
+    <NotFound>
+        <LayoutView Layout="@typeof(MainLayout)">
+            <p>Sorry, there's nothing at this address.</p>
+        </LayoutView>
+    </NotFound>
+</Router>
+
+@code {
+    private List<Assembly> lazyLoadedAssemblies = new List<Assembly>();
+
+    private async Task OnNavigateAsync(NavigationContext args)
+    {
+        try
+        {
+            if (args.Path.EndsWith("/robot"))
+            {
+                var assemblies = await assemblyLoader.LoadAssembliesAsync(
+                    new List<string>() { "GrantImaharaRobotControls.dll" });
+                lazyLoadedAssemblies.AddRange(assemblies);
+            }
+        }
+        catch (Exception ex)
+        {
+            ...
+        }
+    }
+}
+```
+
+## Additional resources
+
+* <xref:blazor/webassembly-performance-best-practices>

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -13,7 +13,7 @@ uid: blazor/webassembly-lazy-load-assemblies
 
 By [Safia Abdalla](https://safia.rocks) and [Luke Latham](https://github.com/guardrex)
 
-Blazor WebAssembly app startup performance can be improved by loading assets at runtime when the assets are required, which is called *lazy loading*. For example, assemblies that are only used to render a single component can be set up to load only if the user navigates to that component. After loading, the assemblies are cached client-side and are available for all future navigations.
+Blazor WebAssembly app startup performance can be improved by ldeferring the loading of some application assemblies until they are required, which is called *lazy loading*. For example, assemblies that are only used to render a single component can be set up to load only if the user navigates to that component. After loading, the assemblies are cached client-side and are available for all future navigations.
 
 Blazor's lazy loading feature allows you to mark certain app assemblies as lazy-loadable then load them during runtime when the user navigates to a particular route. The feature consists of changes to the project file and changes to the application's router.
 
@@ -22,7 +22,7 @@ Blazor's lazy loading feature allows you to mark certain app assemblies as lazy-
 
 ## Project file
 
-Mark assemblies for lazy loading in the app's project file (`.csproj`) using the `BlazorWebAssemblyLazyLoad` item. Use the assembly name without the `.dll` extension. The Blazor framework prevents the assemblies specified by this item group from loading at app launch. The following example marks a large custom assembly (`GrantImaharaRobotControls.dll`) for lazy loading.
+Mark assemblies for lazy loading in the app's project file (`.csproj`) using the `BlazorWebAssemblyLazyLoad` item. Use the assembly name without the `.dll` extension. The Blazor framework prevents the assemblies specified by this item group from loading at app launch. The following example marks a large custom assembly (`GrantImaharaRobotControls.dll`) for lazy loading. If an assembly that is marked for lazy-loading has dependencies, they must also be marked for lazy-loading in the project file.
 
 ```xml
 <ItemGroup>

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -133,17 +133,18 @@ If a user navigates to Route A and then immediately to Route B, the app shouldn'
 @code {
     private async Task OnNavigateAsync(NavigationContext context)
     {
-        if (args.Path == "/about") 
+        if (context.Path == "/about") 
         {
             var stats = new Stats = { Page = "/about" };
-            await Http.PostAsJsonAsync("api/visited", stats, args.CancellationToken);
+            await Http.PostAsJsonAsync("api/visited", stats, context.CancellationToken);
         }
-        else if (args.Path == "/store")
+        else if (context.Path == "/store")
         {
             var productIds = [345, 789, 135, 689];
+
             foreach (var productId in productIds) 
             {
-                args.CancellationToken.ThrowIfCancellationRequested();
+                context.CancellationToken.ThrowIfCancellationRequested();
                 Products.Prefetch(productId);
             }
         }

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -34,14 +34,14 @@ Only assemblies that are used by the app can be lazily loaded. The linker strips
 
 ## `Router` component
 
-Blazor's `Router` component is used to designate which assemblies Blazor searches for routeable components in. It's also responsible for rendering the component associated with the router that the user navigates to. The `Router` component supports an `OnNavigateAsync` feature that can be used in conjunction with lazy-loading.
+Blazor's `Router` component is used to designate which assemblies Blazor searches for routable components in. It's also responsible for rendering the component associated with the router that the user navigates to. The `Router` component supports an `OnNavigateAsync` feature that can be used in conjunction with lazy-loading.
 
 In the app's `Router` component (`App.razor`):
 
 * Add an `OnNavigateAsync` callback. The `OnNavigateAsync` handler is invoked when the user:
   * Visits a route for the first time by navigating to it directly from their browser.
   * Navigates to a new route using a link or a <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> invocation.
-* If lazy-loaded assemblies contain routeable components,, Add a [List](xref:System.Collections.Generic.List%601)\<<xref:System.Reflection.Assembly>> (for example, named `lazyLoadedAssemblies`) to the component. The assemblies are passed back to the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> collection in case the assemblies contain routable components. The framework searches the assemblies for routes and updates the route collection if any new routes are found.
+* If lazy-loaded assemblies contain routable components, add a [List](xref:System.Collections.Generic.List%601)\<<xref:System.Reflection.Assembly>> (for example, named `lazyLoadedAssemblies`) to the component. The assemblies are passed back to the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> collection in case the assemblies contain routable components. The framework searches the assemblies for routes and updates the route collection if any new routes are found.
 
 ```razor
 @using System.Reflection

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -43,7 +43,6 @@ In the app's `Router` component (`App.razor`):
   * Navigates to a new route using a link or a <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> invocation.
 * Add a [List](xref:System.Collections.Generic.List%601)\<<xref:System.Reflection.Assembly>> (for example, named `lazyLoadedAssemblies`) to the component. The assemblies are passed back to the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> collection in case the assemblies contain routable components. The framework searches the assemblies for routes and updates the route collection if any new routes are found.
 
-> [!NOTE]
 > If lazy-loaded assemblies don't contain routeable components, omit adding a list of assemblies.
 
 ```razor

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -13,7 +13,7 @@ uid: blazor/webassembly-lazy-load-assemblies
 
 By [Safia Abdalla](https://safia.rocks) and [Luke Latham](https://github.com/guardrex)
 
-Blazor WebAssembly app startup performance can be improved by ldeferring the loading of some application assemblies until they are required, which is called *lazy loading*. For example, assemblies that are only used to render a single component can be set up to load only if the user navigates to that component. After loading, the assemblies are cached client-side and are available for all future navigations.
+Blazor WebAssembly app startup performance can be improved by deferring the loading of some application assemblies until they are required, which is called *lazy loading*. For example, assemblies that are only used to render a single component can be set up to load only if the user navigates to that component. After loading, the assemblies are cached client-side and are available for all future navigations.
 
 Blazor's lazy loading feature allows you to mark certain app assemblies as lazy-loadable then load them during runtime when the user navigates to a particular route. The feature consists of changes to the project file and changes to the application's router.
 
@@ -22,7 +22,7 @@ Blazor's lazy loading feature allows you to mark certain app assemblies as lazy-
 
 ## Project file
 
-Mark assemblies for lazy loading in the app's project file (`.csproj`) using the `BlazorWebAssemblyLazyLoad` item. Use the assembly name without the `.dll` extension. The Blazor framework prevents the assemblies specified by this item group from loading at app launch. The following example marks a large custom assembly (`GrantImaharaRobotControls.dll`) for lazy loading. If an assembly that is marked for lazy-loading has dependencies, they must also be marked for lazy-loading in the project file.
+Mark assemblies for lazy loading in the app's project file (`.csproj`) using the `BlazorWebAssemblyLazyLoad` item. Use the assembly name without the `.dll` extension. The Blazor framework prevents the assemblies specified by this item group from loading at app launch. The following example marks a large custom assembly (`GrantImaharaRobotControls.dll`) for lazy loading. If an assembly that's marked for lazy loading has dependencies, they must also be marked for lazy loading in the project file.
 
 ```xml
 <ItemGroup>

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -15,7 +15,7 @@ By [Safia Abdalla](https://safia.rocks) and [Luke Latham](https://github.com/gua
 
 Blazor WebAssembly app startup performance can be improved by deferring the loading of some application assemblies until they are required, which is called *lazy loading*. For example, assemblies that are only used to render a single component can be set up to load only if the user navigates to that component. After loading, the assemblies are cached client-side and are available for all future navigations.
 
-Blazor's lazy loading feature allows you to mark certain app assemblies as lazy-loadable then load them during runtime when the user navigates to a particular route. The feature consists of changes to the project file and changes to the application's router.
+Blazor's lazy loading feature allows you to mark app assemblies for lazy loading, which loads the assemblies during runtime when the user navigates to a particular route. The feature consists of changes to the project file and changes to the application's router.
 
 > [!NOTE]
 > Assembly lazy loading doesn't benefit Blazor Server apps because assemblies aren't downloaded to the client in a Blazor Server app.
@@ -34,7 +34,7 @@ Only assemblies that are used by the app can be lazily loaded. The linker strips
 
 ## `Router` component
 
-Blazor's `Router` component is used to designate which assemblies Blazor searches for routable components in. It's also responsible for rendering the component associated with the router that the user navigates to. The `Router` component supports an `OnNavigateAsync` feature that can be used in conjunction with lazy-loading.
+Blazor's `Router` component designates which assemblies Blazor searches for routable components. The `Router` component is also responsible for rendering the component for the route where the user navigates. The `Router` component supports an `OnNavigateAsync` feature that can be used in conjunction with lazy loading.
 
 In the app's `Router` component (`App.razor`):
 

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -13,7 +13,7 @@ uid: blazor/webassembly-lazy-load-assemblies
 
 By [Safia Abdalla](https://safia.rocks) and [Luke Latham](https://github.com/guardrex)
 
-Blazor WebAssembly app startup performance can be improved by loading assets at runtime when the assets are required, which is called *lazy loading*. For example, assemblies that are only used to render a single component can be set up to load only if the user navigates to that component. After loading, the assemblies are cached client-side and don't require reloading while the app is running.
+Blazor WebAssembly app startup performance can be improved by loading assets at runtime when the assets are required, which is called *lazy loading*. For example, assemblies that are only used to render a single component can be set up to load only if the user navigates to that component. After loading, the assemblies are cached client-side and are available for all future navigations.
 
 Blazor's lazy loading feature allows you to mark certain app assemblies as lazy-loadable then load them during runtime when the user navigates to a particular route. The feature consists of changes to the project file and changes to the application's router.
 
@@ -131,7 +131,7 @@ If a user navigates to Route A and then immediately to Route B, the app shouldn'
 </Router>
 
 @code {
-    private async Task OnNavigateAsync(NavigationContext args)
+    private async Task OnNavigateAsync(NavigationContext context)
     {
         if (args.Path == "/about") 
         {
@@ -152,7 +152,7 @@ If a user navigates to Route A and then immediately to Route B, the app shouldn'
 ```
 
 > [!NOTE]
-> Not throwing if the cancellation token in `NavigationContext` is set can result in unintended behavior, such as rendering a component from a previous navigation.
+> Not throwing if the cancellation token in `NavigationContext` is canceled can result in unintended behavior, such as rendering a component from a previous navigation.
 
 ### Complete example
 

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -41,9 +41,7 @@ In the app's `Router` component (`App.razor`):
 * Add an `OnNavigateAsync` callback. The `OnNavigateAsync` handler is invoked when the user:
   * Visits a route for the first time by navigating to it directly from their browser.
   * Navigates to a new route using a link or a <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> invocation.
-* Add a [List](xref:System.Collections.Generic.List%601)\<<xref:System.Reflection.Assembly>> (for example, named `lazyLoadedAssemblies`) to the component. The assemblies are passed back to the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> collection in case the assemblies contain routable components. The framework searches the assemblies for routes and updates the route collection if any new routes are found.
-
-> If lazy-loaded assemblies don't contain routeable components, omit adding a list of assemblies.
+* If lazy-loaded assemblies contain routeable components,, Add a [List](xref:System.Collections.Generic.List%601)\<<xref:System.Reflection.Assembly>> (for example, named `lazyLoadedAssemblies`) to the component. The assemblies are passed back to the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> collection in case the assemblies contain routable components. The framework searches the assemblies for routes and updates the route collection if any new routes are found.
 
 ```razor
 @using System.Reflection

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -22,7 +22,7 @@ Blazor's lazy loading feature allows you to mark certain app assemblies as lazy-
 
 ## Project file
 
-Mark assemblies for lazy loading in the app's project file (`.csproj`) using the `BlazorWebAssemblyLazyLoad` item. Use the assembly name without the `.dll` extension. The Blazor framework prevents the assemblies marked under this item group from loading at app launch. The following example marks a large custom assembly (`GrantImaharaRobotControls.dll`) for lazy loading.
+Mark assemblies for lazy loading in the app's project file (`.csproj`) using the `BlazorWebAssemblyLazyLoad` item. Use the assembly name without the `.dll` extension. The Blazor framework prevents the assemblies specified by this item group from loading at app launch. The following example marks a large custom assembly (`GrantImaharaRobotControls.dll`) for lazy loading.
 
 ```xml
 <ItemGroup>
@@ -34,7 +34,7 @@ Only assemblies that are used by the app can be lazily loaded. The linker strips
 
 ## `Router` component
 
-Blazor's `Router` component is used to designate which assemblies Blazor will look for routeable components in. It is also responsible for rendering the component associated with the router that the user navigates to. The `Router` component supports an `OnNavigateAsync` feature that can be used in conjunction with lazy-loading.
+Blazor's `Router` component is used to designate which assemblies Blazor searches for routeable components in. It's also responsible for rendering the component associated with the router that the user navigates to. The `Router` component supports an `OnNavigateAsync` feature that can be used in conjunction with lazy-loading.
 
 In the app's `Router` component (`App.razor`):
 
@@ -44,7 +44,7 @@ In the app's `Router` component (`App.razor`):
 * Add a [List](xref:System.Collections.Generic.List%601)\<<xref:System.Reflection.Assembly>> (for example, named `lazyLoadedAssemblies`) to the component. The assemblies are passed back to the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> collection in case the assemblies contain routable components. The framework searches the assemblies for routes and updates the route collection if any new routes are found.
 
 > [!NOTE]
-> If lazy-loaded assemblies do not contain any routeable components, can omit this step.
+> If lazy-loaded assemblies don't contain routeable components, omit adding a list of assemblies.
 
 ```razor
 @using System.Reflection
@@ -118,15 +118,15 @@ While loading assemblies, which can take several seconds, the `Router` component
 ...
 ```
 
-### Handelling cancellations in `OnNavigateAsync`
+### Handle cancellations in `OnNavigateAsync`
 
-The `NavigationContext` object passed to the `OnNavigateAsync` callback contains a `CancellationToken` that is set when a new navigaiton event occurs. The `OnNavigateAsync` callback must throw when this cancellation token is set to avoid continuing to run the `OnNavigateAsync` callback on a outdated navigation.
+The `NavigationContext` object passed to the `OnNavigateAsync` callback contains a `CancellationToken` that's set when a new navigation event occurs. The `OnNavigateAsync` callback must throw when this cancellation token is set to avoid continuing to run the `OnNavigateAsync` callback on a outdated navigation.
 
-For example, if a user navigates to Route A, then immediatley to Route B, we do not want to continue running the `OnNavigateAsync` callback for Route A if we've already navigated to Route B.
+If a user navigates to Route A and then immediately to Route B, the app shouldn't continue running the `OnNavigateAsync` callback for Route A:
 
 ```razor
 @inject HttpClient Http
-@inject ProductCatalog products
+@inject ProductCatalog Products
 
 <Router AppAssembly="@typeof(Program).Assembly" 
     OnNavigateAsync="@OnNavigateAsync">
@@ -147,17 +147,15 @@ For example, if a user navigates to Route A, then immediatley to Route B, we do 
             foreach (var productId in productIds) 
             {
                 args.CancellationToken.ThrowIfCancellationRequested();
-                products.Prefetch(productId);
+                Products.Prefetch(productId);
             }
-            
         }
-        
     }
 }
 ```
 
 > [!NOTE]
-> Not throwing if the cancellation token in `NavigationContext` is set can result in unintended behavior.
+> Not throwing if the cancellation token in `NavigationContext` is set can result in unintended behavior, such as rendering a component from a previous navigation.
 
 ### Complete example
 
@@ -208,9 +206,9 @@ The following complete `Router` component demonstrates loading the `GrantImahara
 }
 ```
 
-## Troubleshooting
+## Troubleshoot
 
-* If you are seeing unexpected rendering behavior, for example a component from a previous navigation is rendered, check that you are throwing if the cancellation token is set.
+* If unexpected rendering occurs (for example, a component from a previous navigation is rendered), confirm that the code throws if the cancellation token is set.
 * If assemblies are still loaded at application start, check that the assembly is marked as lazy loaded in the project file.
 
 ## Additional resources

--- a/aspnetcore/blazor/webassembly-performance-best-practices.md
+++ b/aspnetcore/blazor/webassembly-performance-best-practices.md
@@ -133,6 +133,10 @@ Blazor WebAssembly offers two additional versions of <xref:Microsoft.JSInterop.I
 dotnet publish -c Release
 ```
 
+### Lazy load assemblies
+
+Dynamically load assemblies at runtime only when the assemblies are needed by components. For more information, see <xref:blazor/webassembly-lazy-load-assemblies>.
+
 ### Compression
 
 When a Blazor WebAssembly app is published, the output is statically compressed during publish to reduce the app's size and remove the overhead for runtime compression. Blazor relies on the server to perform content negotation and serve statically-compressed files.

--- a/aspnetcore/blazor/webassembly-performance-best-practices.md
+++ b/aspnetcore/blazor/webassembly-performance-best-practices.md
@@ -135,7 +135,7 @@ dotnet publish -c Release
 
 ### Lazy load assemblies
 
-Dynamically load assemblies at runtime when the assemblies are required by components. For more information, see <xref:blazor/webassembly-lazy-load-assemblies>.
+Load assemblies at runtime when the assemblies are required by a route. For more information, see <xref:blazor/webassembly-lazy-load-assemblies>.
 
 ### Compression
 

--- a/aspnetcore/blazor/webassembly-performance-best-practices.md
+++ b/aspnetcore/blazor/webassembly-performance-best-practices.md
@@ -135,7 +135,7 @@ dotnet publish -c Release
 
 ### Lazy load assemblies
 
-Dynamically load assemblies at runtime only when the assemblies are needed by components. For more information, see <xref:blazor/webassembly-lazy-load-assemblies>.
+Dynamically load assemblies at runtime when the assemblies are required by components. For more information, see <xref:blazor/webassembly-lazy-load-assemblies>.
 
 ### Compression
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -411,6 +411,8 @@
           uid: blazor/state-management
         - name: Debug WebAssembly
           uid: blazor/debug
+        - name: Lazy load assemblies with WebAssembly
+          uid: blazor/webassembly-lazy-load-assemblies
         - name: WebAssembly performance
           uid: blazor/webassembly-performance-best-practices
         - name: Progressive Web Applications


### PR DESCRIPTION
Fixes #19149

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/webassembly-lazy-load-assemblies?view=aspnetcore-5.0&branch=pr-en-us-19211)

* This is the *hybrid* tutorial-like reference topic approach. We could just plop the complete example down and write thereafter about how it works, but I think there's merit to the approach on the PR that breaks it down into logical sections. This is the approach that you took with the design notes on the PR, and I think it works well here. However, let me know if you'd like to go the other way. I'm not opposed to a rewrite if you think it best.
* I originally pitched this for the *Host and deploy* node, but this is *really, REALLY* important perf that many devs are going to want to use. Therefore, I now recommend that we place it in the open *Blazor* node near the existing WASM perf topic. The PR has been set up that way.
* "Sales" was a bit 🥱 lol, so I started with a kind of Easter egg with "Ion Control" (an `IonControl.dll` assembly and an `/admin/ioncontrol` endpoint). I guess *The Empire Strikes Back* was on my mind. I changed that tho: I think it would be nice to do something in the example to celebrate the life of Grant Imahara, who passed away a few days ago unexpectedly. :cry:

  ![Capture](https://user-images.githubusercontent.com/1622880/87558160-63c11a80-c67e-11ea-94b5-4fea47809bcd.PNG)
  *Grant Imahara (1970-2020) &mdash; Will be greatly missed.*
  https://en.wikipedia.org/wiki/Grant_Imahara
  https://www.imdb.com/name/nm0408017/