### PR TITLE
Blazor Server non-root URL hosting

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -23,6 +23,8 @@ Blazor Server is integrated into [ASP.NET Core Endpoint Routing](xref:fundamenta
 
 The most typical configuration is to route all requests to a Razor page, which acts as the host for the server-side part of the Blazor Server app. By convention, the *host* page is usually named `_Host.cshtml`. The route specified in the host file is called a *fallback route* because it operates with a low priority in route matching. The fallback route is considered when other routes don't match. This allows the app to use others controllers and pages without interfering with the Blazor Server app.
 
+For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A> for non-root URL server hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
+
 ## Route templates
 
 The <xref:Microsoft.AspNetCore.Components.Routing.Router> component enables routing to each component with a specified route. The <xref:Microsoft.AspNetCore.Components.Routing.Router> component appears in the `App.razor` file:

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -5,7 +5,7 @@ description: Discover how to host and deploy Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/19/2020
+ms.date: 07/15/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/host-and-deploy/index
 ---
@@ -93,6 +93,20 @@ dotnet run --pathbase=/CoolApp
 ```
 
 The Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
+
+**Blazor Server `MapFallbackToPage` configuration**
+
+Pass the following path to <xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A> in `Startup.Configure`:
+
+```csharp
+endpoints.MapFallbackToPage("/{RELATIVE PATH}/{**path:nonfile}");
+```
+
+The placeholder `{RELATIVE PATH}` is the non-root path on the server. For example, `CoolApp` is the placeholder segment if the non-root URL to the app is `https://{HOST}:{PORT}/CoolApp/`):
+
+```csharp
+endpoints.MapFallbackToPage("/CoolApp/{**path:nonfile}");
+```
 
 ## Deployment
 


### PR DESCRIPTION
Fixes #13856
Addresses #14134

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/index?view=aspnetcore-3.1&branch=pr-en-us-19215#app-base-path)

Thanks @jerriep! :rocket: ... Sorry for the delay. We've been busy with a lot of high priority updates over the past several months.

* I add this to the *App base path* section in the *Host and deploy* overview.
* I cross-link to that section from the *Routing* topic.
* Based this on Artak's engineering remark at https://github.com/dotnet/aspnetcore/issues/13167#issuecomment-521710865.

  I've only tested the Blazor WASM scenario, not the Blazor Server scenario. I haven't confirmed that it works ok. We'll see if the community sends me a 💀 *Rex Death Threat!* 💀😨 