### PR TITLE
Cross-link Nginx subdirectory hosting post

### DIFF
--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -425,3 +425,4 @@ After upgrading the shared framework on the server, restart the ASP.NET Core app
 * <xref:test/troubleshoot>
 * <xref:host-and-deploy/proxy-load-balancer>
 * [NGINX: Using the Forwarded header](https://www.nginx.com/resources/wiki/start/topics/examples/forwarded/)
+* [ASP.Net Core 3 App Running under a Subdirectory on Nginx](http://www.endycahyono.com/article/aspnetcore3-running-under-subdirectory-on-nginx)

--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -420,6 +420,8 @@ After upgrading the shared framework on the server, restart the ASP.NET Core app
 
 ## Additional resources
 
+<!-- NOTE: If this topic is rewritten, consider adding a section on subdirectory hosting along the lines of the guidance in Endy Cahyono's blog post below. -->
+
 * [Prerequisites for .NET Core on Linux](/dotnet/core/linux-prerequisites)
 * [Nginx: Binary Releases: Official Debian/Ubuntu packages](https://www.nginx.com/resources/wiki/start/topics/tutorials/install/#official-debian-ubuntu-packages)
 * <xref:test/troubleshoot>


### PR DESCRIPTION
Fixes #15464

Sourabh, do you think we can cross-link @ndc's blog post for coverage on Nginx subdirectory hosting? I'm going to leave a comment in the topic here for a future rewrite to consider placing a section on this subject into the topic. I'm *very busy* 🏃😅 right now, so this is the best scenario for me at the moment.

btw - We've successfully used in-topic comments to message ourselves. It eliminates the need to keep an issue on the repo that might (*probably will be*) lost. 