### PR TITLE
Use AddRazorPages(options => ...) where appropriate

### DIFF
--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -411,7 +411,7 @@ The `DisableFormValueModelBindingAttribute` is used to disable model binding:
 
 In the sample app, `GenerateAntiforgeryTokenCookieAttribute` and `DisableFormValueModelBindingAttribute` are applied as filters to the page application models of `/StreamedSingleFileUploadDb` and `/StreamedSingleFileUploadPhysical` in `Startup.ConfigureServices` using [Razor Pages conventions](xref:razor-pages/razor-pages-conventions):
 
-[!code-csharp[](file-uploads/samples/3.x/SampleApp/Startup.cs?name=snippet_AddRazorPages&highlight=8-11,17-20)]
+[!code-csharp[](file-uploads/samples/3.x/SampleApp/Startup.cs?name=snippet_AddRazorPages&highlight=7-10,16-19)]
 
 Since model binding doesn't read the form, parameters that are bound from the form don't bind (query, route, and header continue to work). The action method works directly with the `Request` property. A `MultipartReader` is used to read each section. Key/value data is stored in a `KeyValueAccumulator`. After the multipart sections are read, the contents of the `KeyValueAccumulator` are used to bind the form data to a model type.
 
@@ -608,18 +608,17 @@ public void ConfigureServices(IServiceCollection services)
 In a Razor Pages app, apply the filter with a [convention](xref:razor-pages/razor-pages-conventions) in `Startup.ConfigureServices`:
 
 ```csharp
-services.AddRazorPages()
-    .AddRazorPagesOptions(options =>
-    {
-        options.Conventions
-            .AddPageApplicationModelConvention("/FileUploadPage",
-                model.Filters.Add(
-                    new RequestFormLimitsAttribute()
-                    {
-                        // Set the limit to 256 MB
-                        MultipartBodyLengthLimit = 268435456
-                    });
-    });
+services.AddRazorPages(options =>
+{
+    options.Conventions
+        .AddPageApplicationModelConvention("/FileUploadPage",
+            model.Filters.Add(
+                new RequestFormLimitsAttribute()
+                {
+                    // Set the limit to 256 MB
+                    MultipartBodyLengthLimit = 268435456
+                });
+});
 ```
 
 In a Razor Pages app or an MVC app, apply the filter to the page model or action method:
@@ -656,18 +655,17 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 In a Razor Pages app, apply the filter with a [convention](xref:razor-pages/razor-pages-conventions) in `Startup.ConfigureServices`:
 
 ```csharp
-services.AddRazorPages()
-    .AddRazorPagesOptions(options =>
-    {
-        options.Conventions
-            .AddPageApplicationModelConvention("/FileUploadPage",
-                model =>
-                {
-                    // Handle requests up to 50 MB
-                    model.Filters.Add(
-                        new RequestSizeLimitAttribute(52428800));
-                });
-    });
+services.AddRazorPages(options =>
+{
+    options.Conventions
+        .AddPageApplicationModelConvention("/FileUploadPage",
+            model =>
+            {
+                // Handle requests up to 50 MB
+                model.Filters.Add(
+                    new RequestSizeLimitAttribute(52428800));
+            });
+});
 ```
 
 In a Razor pages app or an MVC app, apply the filter to the page handler class or action method:

--- a/aspnetcore/mvc/models/file-uploads/samples/3.x/SampleApp/Startup.cs
+++ b/aspnetcore/mvc/models/file-uploads/samples/3.x/SampleApp/Startup.cs
@@ -24,28 +24,27 @@ namespace SampleApp
             services.AddControllers();
 
             #region snippet_AddRazorPages
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
-                    {
-                        options.Conventions
-                            .AddPageApplicationModelConvention("/StreamedSingleFileUploadDb",
-                                model =>
-                                {
-                                    model.Filters.Add(
-                                        new GenerateAntiforgeryTokenCookieAttribute());
-                                    model.Filters.Add(
-                                        new DisableFormValueModelBindingAttribute());
-                                });
-                        options.Conventions
-                            .AddPageApplicationModelConvention("/StreamedSingleFileUploadPhysical",
-                                model =>
-                                {
-                                    model.Filters.Add(
-                                        new GenerateAntiforgeryTokenCookieAttribute());
-                                    model.Filters.Add(
-                                        new DisableFormValueModelBindingAttribute());
-                                });
-                    });
+            services.AddRazorPages(options =>
+            {
+                options.Conventions
+                    .AddPageApplicationModelConvention("/StreamedSingleFileUploadDb",
+                        model =>
+                        {
+                            model.Filters.Add(
+                                new GenerateAntiforgeryTokenCookieAttribute());
+                            model.Filters.Add(
+                                new DisableFormValueModelBindingAttribute());
+                        });
+                options.Conventions
+                    .AddPageApplicationModelConvention("/StreamedSingleFileUploadPhysical",
+                        model =>
+                        {
+                            model.Filters.Add(
+                                new GenerateAntiforgeryTokenCookieAttribute());
+                            model.Filters.Add(
+                                new DisableFormValueModelBindingAttribute());
+                        });
+            });
             #endregion
 
             // To list physical files from a path provided by configuration:

--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -566,7 +566,7 @@ The `?` following `handler` means the route parameter is optional.
 
 The configuration and settings in following sections is not required by most apps.
 
-To configure advanced options, use the extension method <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*>:
+To configure advanced options, use the <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages%2A> overload that configures an instance of <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions>:
 
 [!code-csharp[](index/3.0sample/RazorPagesContacts/StartupRPoptions.cs?name=snippet)]
 

--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -566,7 +566,7 @@ The `?` following `handler` means the route parameter is optional.
 
 The configuration and settings in following sections is not required by most apps.
 
-To configure advanced options, use the <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages%2A> overload that configures an instance of <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions>:
+To configure advanced options, use the <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages%2A> overload that configures <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions>:
 
 [!code-csharp[](index/3.0sample/RazorPagesContacts/StartupRPoptions.cs?name=snippet)]
 

--- a/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupRPoptions.cs
+++ b/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupRPoptions.cs
@@ -20,12 +20,11 @@ namespace RazorPagesContacts
         #region snippet
         public void ConfigureServices(IServiceCollection services)
         {            
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
-                {
-                    options.RootDirectory = "/MyPages";
-                    options.Conventions.AuthorizeFolder("/MyPages/Admin");
-                });
+            services.AddRazorPages(options =>
+            {
+                options.RootDirectory = "/MyPages";
+                options.Conventions.AuthorizeFolder("/MyPages/Admin");
+            });
         }
         #endregion
 

--- a/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupWithRazorPagesAtContentRoot.cs
+++ b/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupWithRazorPagesAtContentRoot.cs
@@ -20,8 +20,8 @@ namespace RazorPagesContacts
         #region snippet
         public void ConfigureServices(IServiceCollection services)
         {            
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
+            services
+                .AddRazorPages(options =>
                 {
                     options.Conventions.AuthorizeFolder("/MyPages/Admin");
                 })

--- a/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupWithRazorPagesAtContentRoot.cs
+++ b/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupWithRazorPagesAtContentRoot.cs
@@ -20,8 +20,7 @@ namespace RazorPagesContacts
         #region snippet
         public void ConfigureServices(IServiceCollection services)
         {            
-            services
-                .AddRazorPages(options =>
+            services.AddRazorPages(options =>
                 {
                     options.Conventions.AuthorizeFolder("/MyPages/Admin");
                 })

--- a/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupWithRazorPagesRoot.cs
+++ b/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupWithRazorPagesRoot.cs
@@ -20,8 +20,8 @@ namespace RazorPagesContacts
         #region snippet
         public void ConfigureServices(IServiceCollection services)
         {            
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
+            services
+                .AddRazorPages(options =>
                 {
                     options.Conventions.AuthorizeFolder("/MyPages/Admin");
                 })

--- a/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupWithRazorPagesRoot.cs
+++ b/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/StartupWithRazorPagesRoot.cs
@@ -20,8 +20,7 @@ namespace RazorPagesContacts
         #region snippet
         public void ConfigureServices(IServiceCollection services)
         {            
-            services
-                .AddRazorPages(options =>
+            services.AddRazorPages(options =>
                 {
                     options.Conventions.AuthorizeFolder("/MyPages/Admin");
                 })

--- a/aspnetcore/razor-pages/razor-pages-conventions.md
+++ b/aspnetcore/razor-pages/razor-pages-conventions.md
@@ -29,7 +29,7 @@ There are reserved words that can't be used as route segments or parameter names
 | [Page route action conventions](#page-route-action-conventions)<ul><li>AddFolderRouteModelConvention</li><li>AddPageRouteModelConvention</li><li>AddPageRoute</li></ul> | Add a route template to pages in a folder and to a single page. |
 | [Page model action conventions](#page-model-action-conventions)<ul><li>AddFolderApplicationModelConvention</li><li>AddPageApplicationModelConvention</li><li>ConfigureFilter (filter class, lambda expression, or filter factory)</li></ul> | Add a header to pages in a folder, add a header to a single page, and configure a [filter factory](xref:mvc/controllers/filters#ifilterfactory) to add a header to an app's pages. |
 
-Razor Pages conventions are added and configured using the <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages%2A> overload on the service collection in the `Startup` class that configures an instance of <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions>. The following convention examples are explained later in this topic:
+Razor Pages conventions are configured using an <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages%2A> overload that configures <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions> in `Startup.ConfigureServices`. The following convention examples are explained later in this topic:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)

--- a/aspnetcore/razor-pages/razor-pages-conventions.md
+++ b/aspnetcore/razor-pages/razor-pages-conventions.md
@@ -29,28 +29,27 @@ There are reserved words that can't be used as route segments or parameter names
 | [Page route action conventions](#page-route-action-conventions)<ul><li>AddFolderRouteModelConvention</li><li>AddPageRouteModelConvention</li><li>AddPageRoute</li></ul> | Add a route template to pages in a folder and to a single page. |
 | [Page model action conventions](#page-model-action-conventions)<ul><li>AddFolderApplicationModelConvention</li><li>AddPageApplicationModelConvention</li><li>ConfigureFilter (filter class, lambda expression, or filter factory)</li></ul> | Add a header to pages in a folder, add a header to a single page, and configure a [filter factory](xref:mvc/controllers/filters#ifilterfactory) to add a header to an app's pages. |
 
-Razor Pages conventions are added and configured using the <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> extension method to <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddMvc*> on the service collection in the `Startup` class. The following convention examples are explained later in this topic:
+Razor Pages conventions are added and configured using the <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages%2A> overload on the service collection in the `Startup` class that configures an instance of <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions>. The following convention examples are explained later in this topic:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddRazorPages()
-        .AddRazorPagesOptions(options =>
-        {
-            options.Conventions.Add( ... );
-            options.Conventions.AddFolderRouteModelConvention(
-                "/OtherPages", model => { ... });
-            options.Conventions.AddPageRouteModelConvention(
-                "/About", model => { ... });
-            options.Conventions.AddPageRoute(
-                "/Contact", "TheContactPage/{text?}");
-            options.Conventions.AddFolderApplicationModelConvention(
-                "/OtherPages", model => { ... });
-            options.Conventions.AddPageApplicationModelConvention(
-                "/About", model => { ... });
-            options.Conventions.ConfigureFilter(model => { ... });
-            options.Conventions.ConfigureFilter( ... );
-        });
+    services.AddRazorPages(options =>
+    {
+        options.Conventions.Add( ... );
+        options.Conventions.AddFolderRouteModelConvention(
+            "/OtherPages", model => { ... });
+        options.Conventions.AddPageRouteModelConvention(
+            "/About", model => { ... });
+        options.Conventions.AddPageRoute(
+            "/Contact", "TheContactPage/{text?}");
+        options.Conventions.AddFolderApplicationModelConvention(
+            "/OtherPages", model => { ... });
+        options.Conventions.AddPageApplicationModelConvention(
+            "/About", model => { ... });
+        options.Conventions.ConfigureFilter(model => { ... });
+        options.Conventions.ConfigureFilter( ... );
+    });
 }
 ```
 
@@ -94,7 +93,7 @@ The <xref:Microsoft.AspNetCore.Mvc.ApplicationModels.AttributeRouteModel.Order*>
 
 Wherever possible, don't set the `Order`, which results in `Order = 0`. Rely on routing to select the correct route.
 
-Razor Pages options, such as adding <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions.Conventions>, are added when MVC is added to the service collection in `Startup.ConfigureServices`. For an example, see the [sample app](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/razor-pages/razor-pages-conventions/samples/).
+Razor Pages options, such as adding <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions.Conventions>, are added when Razor Pages is added to the service collection in `Startup.ConfigureServices`. For an example, see the [sample app](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/razor-pages/razor-pages-conventions/samples/).
 
 [!code-csharp[](razor-pages-conventions/samples/3.x/SampleApp/Startup.cs?name=snippet1)]
 
@@ -179,13 +178,12 @@ The `PageRouteTransformerConvention` is registered as an option in `Startup.Conf
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddRazorPages()
-        .AddRazorPagesOptions(options =>
-        {
-            options.Conventions.Add(
-                new PageRouteTransformerConvention(
-                    new SlugifyParameterTransformer()));
-        });
+    services.AddRazorPages(options =>
+    {
+        options.Conventions.Add(
+            new PageRouteTransformerConvention(
+                new SlugifyParameterTransformer()));
+    });
 }
 ```
 

--- a/aspnetcore/razor-pages/razor-pages-conventions/samples/3.x/SampleApp/Startup.cs
+++ b/aspnetcore/razor-pages/razor-pages-conventions/samples/3.x/SampleApp/Startup.cs
@@ -32,100 +32,99 @@ namespace SampleApp
             services.AddDbContext<AppDbContext>(options => 
                 options.UseInMemoryDatabase("InMemoryDb"));
 
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
+            services.AddRazorPages(options =>
+            {
+                #region snippet1
+                options.Conventions.Add(new GlobalTemplatePageRouteModelConvention());
+                #endregion
+
+                #region snippet2
+                options.Conventions.Add(new GlobalHeaderPageApplicationModelConvention());
+                #endregion
+
+                #region snippet3
+                options.Conventions.AddFolderRouteModelConvention("/OtherPages", model =>
                 {
-                    #region snippet1
-                    options.Conventions.Add(new GlobalTemplatePageRouteModelConvention());
-                    #endregion
-
-                    #region snippet2
-                    options.Conventions.Add(new GlobalHeaderPageApplicationModelConvention());
-                    #endregion
-
-                    #region snippet3
-                    options.Conventions.AddFolderRouteModelConvention("/OtherPages", model =>
+                    var selectorCount = model.Selectors.Count;
+                    for (var i = 0; i < selectorCount; i++)
                     {
-                        var selectorCount = model.Selectors.Count;
-                        for (var i = 0; i < selectorCount; i++)
+                        var selector = model.Selectors[i];
+                        model.Selectors.Add(new SelectorModel
                         {
-                            var selector = model.Selectors[i];
-                            model.Selectors.Add(new SelectorModel
+                            AttributeRouteModel = new AttributeRouteModel
                             {
-                                AttributeRouteModel = new AttributeRouteModel
-                                {
-                                    Order = 2,
-                                    Template = AttributeRouteModel.CombineTemplates(
-                                        selector.AttributeRouteModel.Template, 
-                                        "{otherPagesTemplate?}"),
-                                }
-                            });
-                        }
-                    });
-                    #endregion
-
-                    #region snippet4
-                    options.Conventions.AddPageRouteModelConvention("/About", model =>
-                    {
-                        var selectorCount = model.Selectors.Count;
-                        for (var i = 0; i < selectorCount; i++)
-                        {
-                            var selector = model.Selectors[i];
-                            model.Selectors.Add(new SelectorModel
-                            {
-                                AttributeRouteModel = new AttributeRouteModel
-                                {
-                                    Order = 2,
-                                    Template = AttributeRouteModel.CombineTemplates(
-                                        selector.AttributeRouteModel.Template, 
-                                        "{aboutTemplate?}"),
-                                }
-                            });
-                        }
-                    });
-                    #endregion
-
-                    #region snippet5
-                    options.Conventions.AddPageRoute("/Contact", "TheContactPage/{text?}");
-                    #endregion
-
-                    #region snippet6
-                    options.Conventions.AddFolderApplicationModelConvention("/OtherPages", model =>
-                    {
-                        model.Filters.Add(new AddHeaderAttribute(
-                            "OtherPagesHeader", new string[] { "OtherPages Header Value" }));
-                    });
-                    #endregion
-
-                    #region snippet7
-                    options.Conventions.AddPageApplicationModelConvention("/About", model =>
-                    {
-                        model.Filters.Add(new AddHeaderAttribute(
-                            "AboutHeader", new string[] { "About Header Value" }));
-                    });
-                    #endregion
-
-                    #region snippet8
-                    options.Conventions.ConfigureFilter(model =>
-                    {
-                        if (model.RelativePath.Contains("OtherPages/Page2"))
-                        {
-                            return new AddHeaderAttribute(
-                                "OtherPagesPage2Header", 
-                                new string[] { "OtherPages/Page2 Header Value" });
-                        }
-                        return new EmptyFilter();
-                    });
-                    #endregion
-
-                    #region snippet9
-                    options.Conventions.ConfigureFilter(new AddHeaderWithFactory());
-                    #endregion
-
-                    #region snippet10
-                    options.Conventions.Add(new GlobalPageHandlerModelConvention());
-                    #endregion
+                                Order = 2,
+                                Template = AttributeRouteModel.CombineTemplates(
+                                    selector.AttributeRouteModel.Template, 
+                                    "{otherPagesTemplate?}"),
+                            }
+                        });
+                    }
                 });
+                #endregion
+
+                #region snippet4
+                options.Conventions.AddPageRouteModelConvention("/About", model =>
+                {
+                    var selectorCount = model.Selectors.Count;
+                    for (var i = 0; i < selectorCount; i++)
+                    {
+                        var selector = model.Selectors[i];
+                        model.Selectors.Add(new SelectorModel
+                        {
+                            AttributeRouteModel = new AttributeRouteModel
+                            {
+                                Order = 2,
+                                Template = AttributeRouteModel.CombineTemplates(
+                                    selector.AttributeRouteModel.Template, 
+                                    "{aboutTemplate?}"),
+                            }
+                        });
+                    }
+                });
+                #endregion
+
+                #region snippet5
+                options.Conventions.AddPageRoute("/Contact", "TheContactPage/{text?}");
+                #endregion
+
+                #region snippet6
+                options.Conventions.AddFolderApplicationModelConvention("/OtherPages", model =>
+                {
+                    model.Filters.Add(new AddHeaderAttribute(
+                        "OtherPagesHeader", new string[] { "OtherPages Header Value" }));
+                });
+                #endregion
+
+                #region snippet7
+                options.Conventions.AddPageApplicationModelConvention("/About", model =>
+                {
+                    model.Filters.Add(new AddHeaderAttribute(
+                        "AboutHeader", new string[] { "About Header Value" }));
+                });
+                #endregion
+
+                #region snippet8
+                options.Conventions.ConfigureFilter(model =>
+                {
+                    if (model.RelativePath.Contains("OtherPages/Page2"))
+                    {
+                        return new AddHeaderAttribute(
+                            "OtherPagesPage2Header", 
+                            new string[] { "OtherPages/Page2 Header Value" });
+                    }
+                    return new EmptyFilter();
+                });
+                #endregion
+
+                #region snippet9
+                options.Conventions.ConfigureFilter(new AddHeaderWithFactory());
+                #endregion
+
+                #region snippet10
+                options.Conventions.Add(new GlobalPageHandlerModelConvention());
+                #endregion
+            });
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/aspnetcore/security/authentication/cookie/samples/3.x/CookieSample/Startup.cs
+++ b/aspnetcore/security/authentication/cookie/samples/3.x/CookieSample/Startup.cs
@@ -11,11 +11,10 @@ namespace CookieSample
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
-                {
-                    options.Conventions.AuthorizePage("/Contact");
-                });
+            services.AddRazorPages(options =>
+            {
+                options.Conventions.AuthorizePage("/Contact");
+            });
 
             #region snippet1
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)

--- a/aspnetcore/security/authentication/social/additional-claims/samples/3.x/ClaimsSample/Startup.cs
+++ b/aspnetcore/security/authentication/social/additional-claims/samples/3.x/ClaimsSample/Startup.cs
@@ -64,13 +64,12 @@ namespace ClaimsSample
             });
             #endregion
 
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
-                {
-                    options.Conventions.AuthorizeFolder("/Account/Manage");
-                    options.Conventions.AuthorizePage("/Account/Logout");
-                    options.Conventions.AuthorizePage("/MyClaims");
-                });
+            services.AddRazorPages(options =>
+            {
+                options.Conventions.AuthorizeFolder("/Account/Manage");
+                options.Conventions.AuthorizePage("/Account/Logout");
+                options.Conventions.AuthorizePage("/MyClaims");
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/aspnetcore/security/authorization/razor-pages-authorization.md
+++ b/aspnetcore/security/authorization/razor-pages-authorization.md
@@ -21,9 +21,9 @@ The sample app uses [cookie authentication without ASP.NET Core Identity](xref:s
 
 ## Require authorization to access a page
 
-Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizePage*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to the page at the specified path:
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizePage*> convention to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to the page at the specified path:
 
-[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=2,4)]
+[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=3)]
 
 The specified path is the View Engine path, which is the Razor Pages root relative path without an extension and containing only forward slashes.
 
@@ -38,9 +38,9 @@ options.Conventions.AuthorizePage("/Contact", "AtLeast21");
 
 ## Require authorization to access a folder of pages
 
-Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeFolder*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to all of the pages in a folder at the specified path:
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeFolder*> convention to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to all of the pages in a folder at the specified path:
 
-[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=2,5)]
+[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=4)]
 
 The specified path is the View Engine path, which is the Razor Pages root relative path.
 
@@ -52,7 +52,7 @@ options.Conventions.AuthorizeFolder("/Private", "AtLeast21");
 
 ## Require authorization to access an area page
 
-Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeAreaPage*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to the area page at the specified path:
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeAreaPage*> convention to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to the area page at the specified path:
 
 ```csharp
 options.Conventions.AuthorizeAreaPage("Identity", "/Manage/Accounts");
@@ -68,7 +68,7 @@ options.Conventions.AuthorizeAreaPage("Identity", "/Manage/Accounts", "AtLeast21
 
 ## Require authorization to access a folder of areas
 
-Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeAreaFolder*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to all of the areas in a folder at the specified path:
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AuthorizeAreaFolder*> convention to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AuthorizeFilter> to all of the areas in a folder at the specified path:
 
 ```csharp
 options.Conventions.AuthorizeAreaFolder("Identity", "/Manage");
@@ -84,17 +84,17 @@ options.Conventions.AuthorizeAreaFolder("Identity", "/Manage", "AtLeast21");
 
 ## Allow anonymous access to a page
 
-Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AllowAnonymousToPage*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AllowAnonymousFilter> to a page at the specified path:
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AllowAnonymousToPage*> convention to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AllowAnonymousFilter> to a page at the specified path:
 
-[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=2,6)]
+[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=5)]
 
 The specified path is the View Engine path, which is the Razor Pages root relative path without an extension and containing only forward slashes.
 
 ## Allow anonymous access to a folder of pages
 
-Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AllowAnonymousToFolder*> convention via <xref:Microsoft.Extensions.DependencyInjection.MvcRazorPagesMvcBuilderExtensions.AddRazorPagesOptions*> to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AllowAnonymousFilter> to all of the pages in a folder at the specified path:
+Use the <xref:Microsoft.Extensions.DependencyInjection.PageConventionCollectionExtensions.AllowAnonymousToFolder*> convention to add an <xref:Microsoft.AspNetCore.Mvc.Authorization.AllowAnonymousFilter> to all of the pages in a folder at the specified path:
 
-[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=2,7)]
+[!code-csharp[](razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs?name=snippet1&highlight=6)]
 
 The specified path is the View Engine path, which is the Razor Pages root relative path.
 

--- a/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs
+++ b/aspnetcore/security/authorization/razor-pages-authorization/samples/3.x/AuthorizationSample/Startup.cs
@@ -13,14 +13,13 @@ namespace AuthorizationSample
             services.AddControllers();
 
             #region snippet1
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
-                {
-                    options.Conventions.AuthorizePage("/Contact");
-                    options.Conventions.AuthorizeFolder("/Private");
-                    options.Conventions.AllowAnonymousToPage("/Private/PublicPage");
-                    options.Conventions.AllowAnonymousToFolder("/Private/PublicPages");
-                });
+            services.AddRazorPages(options =>
+            {
+                options.Conventions.AuthorizePage("/Contact");
+                options.Conventions.AuthorizeFolder("/Private");
+                options.Conventions.AllowAnonymousToPage("/Private/PublicPage");
+                options.Conventions.AllowAnonymousToFolder("/Private/PublicPages");
+            });
             #endregion
 
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)

--- a/aspnetcore/test/integration-tests/samples/3.x/IntegrationTestsSample/src/RazorPagesProject/Startup.cs
+++ b/aspnetcore/test/integration-tests/samples/3.x/IntegrationTestsSample/src/RazorPagesProject/Startup.cs
@@ -29,11 +29,10 @@ namespace RazorPagesProject
                 .AddEntityFrameworkStores<ApplicationDbContext>();
 
             #region snippet1
-            services.AddRazorPages()
-                .AddRazorPagesOptions(options =>
-                {
-                    options.Conventions.AuthorizePage("/SecurePage");
-                });
+            services.AddRazorPages(options =>
+            {
+                options.Conventions.AuthorizePage("/SecurePage");
+            });
             #endregion
 
             services.AddHttpClient<IGithubClient, GithubClient>(client =>


### PR DESCRIPTION
Fixes #19245.

Created as a draft because:

1. I need to run through the changes I've made again tomorrow.
1. I can also replace all the `/dotnet/api` links with `xref:` links in the files I've touched. Let me know and I'll happily do so. There's a few unescaped `*`s in there, too.

cc @guardrex, @Rick-Anderson 