### PR TITLE
Add missing nuget reference for razor pages

### DIFF
--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -97,7 +97,7 @@ Razor Pages is designed to make common patterns used with web browsers easy to i
 
 For the samples in this document, the `DbContext` is initialized in the [Startup.cs](https://github.com/dotnet/AspNetCore.Docs/blob/master/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/Startup.cs#L23-L24) file.
 
-Using the in memory database requires installing the Microsoft.EntityFrameworkCore.InMemory nuget package.
+Using the in memory database requires installing the `Microsoft.EntityFrameworkCore.InMemory` NuGet package.
 
 [!code-csharp[](index/3.0sample/RazorPagesContacts/Startup.cs?name=snippet)]
 

--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -97,6 +97,8 @@ Razor Pages is designed to make common patterns used with web browsers easy to i
 
 For the samples in this document, the `DbContext` is initialized in the [Startup.cs](https://github.com/dotnet/AspNetCore.Docs/blob/master/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/Startup.cs#L23-L24) file.
 
+Using the in memory database requires installing the Microsoft.EntityFrameworkCore.InMemory nuget package.
+
 [!code-csharp[](index/3.0sample/RazorPagesContacts/Startup.cs?name=snippet)]
 
 The data model:

--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -97,7 +97,7 @@ Razor Pages is designed to make common patterns used with web browsers easy to i
 
 For the samples in this document, the `DbContext` is initialized in the [Startup.cs](https://github.com/dotnet/AspNetCore.Docs/blob/master/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/Startup.cs#L23-L24) file.
 
-Using the in memory database requires installing the `Microsoft.EntityFrameworkCore.InMemory` NuGet package.
+The in memory database requires installing the `Microsoft.EntityFrameworkCore.InMemory` NuGet package.
 
 [!code-csharp[](index/3.0sample/RazorPagesContacts/Startup.cs?name=snippet)]
 

--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -97,7 +97,7 @@ Razor Pages is designed to make common patterns used with web browsers easy to i
 
 For the samples in this document, the `DbContext` is initialized in the [Startup.cs](https://github.com/dotnet/AspNetCore.Docs/blob/master/aspnetcore/razor-pages/index/3.0sample/RazorPagesContacts/Startup.cs#L23-L24) file.
 
-The in memory database requires installing the `Microsoft.EntityFrameworkCore.InMemory` NuGet package.
+The in memory database requires the `Microsoft.EntityFrameworkCore.InMemory` NuGet package.
 
 [!code-csharp[](index/3.0sample/RazorPagesContacts/Startup.cs?name=snippet)]
 


### PR DESCRIPTION
Following the guide as written results in an error. UseInMemoryDatabase is provided by an additional package, and VS wasn't smart enough to be able to pull this down.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->