### PR TITLE
Fix for 400 responses inconsistency

### DIFF
--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -219,6 +219,12 @@ The `ValidationProblemDetails` type:
 
 ::: moniker-end
 
+::: moniker range=">= aspnetcore-2.1"
+
+In order to make auromatic and custom responses consistent you can return [`ValidationProblem()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.validationproblem?view=aspnetcore-2.1#Microsoft_AspNetCore_Mvc_ControllerBase_ValidationProblem) method instead of `BadRequest()`. It returns `ValidationProblemDetails` as well.
+
+::: moniker-end
+
 ### Log automatic 400 responses
 
 See [How to log automatic 400 responses on model validation errors (aspnet/AspNetCore.Docs #12157)](https://github.com/dotnet/AspNetCore.Docs/issues/12157).


### PR DESCRIPTION
Potential fix for inconsistency between automatic `[ApiController]` 400 response and `BadRequest()` result.
Fixes #19258

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->