### PR TITLE
 Fix 400 responses inconsistency

### DIFF
--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -221,7 +221,7 @@ The `ValidationProblemDetails` type:
 
 ::: moniker range=">= aspnetcore-2.1"
 
-In order to make auromatic and custom responses consistent you can return [`ValidationProblem()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.validationproblem?view=aspnetcore-2.1#Microsoft_AspNetCore_Mvc_ControllerBase_ValidationProblem) method instead of `BadRequest()`. It returns `ValidationProblemDetails` as well.
+In order to make automatic and custom responses consistent you can use [`ValidationProblem()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.validationproblem?view=aspnetcore-2.1#Microsoft_AspNetCore_Mvc_ControllerBase_ValidationProblem) method instead of `BadRequest()`. It returns `ValidationProblemDetails` as well as automatic one.
 
 ::: moniker-end
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -85,16 +85,12 @@ The *Problem details for error status codes* feature requires a [compatibility v
 
 ::: moniker-end
 
-::: moniker range="= aspnetcore-2.1"
-
 * [Attribute routing requirement](#attribute-routing-requirement)
 * [Automatic HTTP 400 responses](#automatic-http-400-responses)
 * [Binding source parameter inference](#binding-source-parameter-inference)
 * [Multipart/form-data request inference](#multipartform-data-request-inference)
 
 These features require a [compatibility version](xref:mvc/compatibility-version) of 2.1 or later.
-
-::: moniker-end
 
 ### Attribute on specific controllers
 
@@ -219,11 +215,7 @@ The `ValidationProblemDetails` type:
 
 ::: moniker-end
 
-::: moniker range=">= aspnetcore-2.1"
-
 In order to make automatic and custom responses consistent you can use [`ValidationProblem()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.validationproblem?view=aspnetcore-2.1#Microsoft_AspNetCore_Mvc_ControllerBase_ValidationProblem) method instead of `BadRequest()`. It returns `ValidationProblemDetails` as well as automatic one.
-
-::: moniker-end
 
 ### Log automatic 400 responses
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -219,6 +219,12 @@ The `ValidationProblemDetails` type:
 
 ::: moniker-end
 
+::: moniker range=">= aspnetcore-2.1"
+
+In order to make auromatic and custom responses consistent you can return [`ValidationProblem()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.validationproblem?view=aspnetcore-2.1#Microsoft_AspNetCore_Mvc_ControllerBase_ValidationProblem) method instead of `BadRequest()`. It returns `ValidationProblemDetails` as well.
+
+::: moniker-end
+
 ### Log automatic 400 responses
 
 See [How to log automatic 400 responses on model validation errors (aspnet/AspNetCore.Docs #12157)](https://github.com/dotnet/AspNetCore.Docs/issues/12157).

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -215,7 +215,7 @@ The `ValidationProblemDetails` type:
 
 ::: moniker-end
 
-To make automatic and custom responses consistent, call the <xref:Microsoft.AspNetCore.Mvc.ControllerBase.ValidationProblem%2A> method instead of `BadRequest()`. `ValidationProblem` returns a <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> object as well as the automatic response.
+To make automatic and custom responses consistent, call the <xref:Microsoft.AspNetCore.Mvc.ControllerBase.ValidationProblem%2A> method instead of <xref:System.Web.Http.ApiController.BadRequest%2A>. `ValidationProblem` returns a <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> object as well as the automatic response.
 
 ### Log automatic 400 responses
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -5,7 +5,7 @@ description: Learn the basics of creating a web API in ASP.NET Core.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 02/02/2020
+ms.date: 07/20/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: web-api/index
 ---
@@ -215,11 +215,11 @@ The `ValidationProblemDetails` type:
 
 ::: moniker-end
 
-In order to make automatic and custom responses consistent you can use [`ValidationProblem()`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.controllerbase.validationproblem?view=aspnetcore-2.1#Microsoft_AspNetCore_Mvc_ControllerBase_ValidationProblem) method instead of `BadRequest()`. It returns `ValidationProblemDetails` as well as automatic one.
+To make automatic and custom responses consistent, call the <xref:Microsoft.AspNetCore.Mvc.ControllerBase.ValidationProblem%2A> method instead of `BadRequest()`. `ValidationProblem` returns a <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> object as well as the automatic response.
 
 ### Log automatic 400 responses
 
-See [How to log automatic 400 responses on model validation errors (aspnet/AspNetCore.Docs #12157)](https://github.com/dotnet/AspNetCore.Docs/issues/12157).
+See [How to log automatic 400 responses on model validation errors (dotnet/AspNetCore.Docs#12157)](https://github.com/dotnet/AspNetCore.Docs/issues/12157).
 
 ### Disable automatic 400 response
 


### PR DESCRIPTION
Potential fix for inconsistency between automatic `[ApiController]` 400 response and `BadRequest()` result.
Fixes #19258

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->