### PR TITLE
Update integration tests sample app

### DIFF
--- a/aspnetcore/test/integration-tests/samples/3.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs
+++ b/aspnetcore/test/integration-tests/samples/3.x/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs
@@ -17,27 +17,19 @@ namespace RazorPagesProject.Tests
         {
             builder.ConfigureServices(services =>
             {
-                // Remove the app's ApplicationDbContext registration.
                 var descriptor = services.SingleOrDefault(
                     d => d.ServiceType ==
                         typeof(DbContextOptions<ApplicationDbContext>));
 
-                if (descriptor != null)
-                {
-                    services.Remove(descriptor);
-                }
+                services.Remove(descriptor);
 
-                // Add ApplicationDbContext using an in-memory database for testing.
                 services.AddDbContext<ApplicationDbContext>(options =>
                 {
                     options.UseInMemoryDatabase("InMemoryDbForTesting");
                 });
 
-                // Build the service provider.
                 var sp = services.BuildServiceProvider();
 
-                // Create a scope to obtain a reference to the database
-                // context (ApplicationDbContext).
                 using (var scope = sp.CreateScope())
                 {
                     var scopedServices = scope.ServiceProvider;
@@ -45,12 +37,10 @@ namespace RazorPagesProject.Tests
                     var logger = scopedServices
                         .GetRequiredService<ILogger<CustomWebApplicationFactory<TStartup>>>();
 
-                    // Ensure the database is created.
                     db.Database.EnsureCreated();
 
                     try
                     {
-                        // Seed the database with test data.
                         Utilities.InitializeDbForTests(db);
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Fixes #19263

Thanks @MatsyshynAnton! :rocket: ... we'll get a nice little update here based on your issue.

**_Confirmed_** ... a `null` descriptor doesn't break `Remove`. It returns `false` for `null` or a unmatched service descriptor.

Also, the content in the code comments is explained in localized topic text following the code example, so the code comments can be ...

**_Banished to the land of wind and ghosts._** - Ryan Nowak, 2019