### PR TITLE
 [Preview 8] [READY] Blazor HTML <head> tag control

### DIFF
--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/additional-scenarios
 ---
 # ASP.NET Core Blazor hosting model configuration
 
-By [Daniel Roth](https://github.com/danroth27) and [Luke Latham](https://github.com/guardrex)
+By [Daniel Roth](https://github.com/danroth27), [Mackinnon Buck](https://github.com/MackinnonBuck), and [Luke Latham](https://github.com/guardrex)
 
 This article covers hosting model configuration.
 
@@ -236,7 +236,7 @@ When rendered, the `Title`, `Link`, and `Meta` components add or update data in 
 
 In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCRIPTION}` are sting values, Razor variables, or Razor expressions.
 
-The follow characteristics apply:
+The following characteristics apply:
 
 * Server-side prerendering is supported.
 * The `Value` parameter is only valid with the `Title` component. For `Meta` and `Link` components, all provided parameters are reflected in the rendered HTML tags.

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -242,7 +242,7 @@ The following characteristics apply:
 * The `Value` parameter is the only valid parameter for the `Title` component.
 * HTML attributes provided to the `Meta` and `Link` components are captured in [additional attributes](xref:blazor/components/index#attribute-splatting-and-arbitrary-parameters) and passed through to the rendered HTML tag.
 * For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component rendered.
-* If multiple `Meta` or `Link` components are included with identical attributes, there is exactly one HTML tag rendered per `Meta` or `Link` component. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
+* If multiple `Meta` or `Link` components are included with identical attributes, there's exactly one HTML tag rendered per `Meta` or `Link` component. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
 * Changes to the parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
 * Disposing a `Meta` or `Link` component removes its rendered HTML tag.
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -246,10 +246,10 @@ The following characteristics apply:
 * Changes to the parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
 * When the `Link` or `Meta` components are no longer rendered and thus disposed by the framework, their rendered HTML tags are removed.
 
-When one of the framework components is used in a child component, the rendered HTML tag influences any other child component of the parent component as long as the child component containing the framework component is rendered. The distinction between using the one of these framework components in a child component and placing a an HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that:
+When one of the framework components is used in a child component, the rendered HTML tag influences any other child component of the parent component as long as the child component containing the framework component is rendered. The distinction between using the one of these framework components in a child component and placing a an HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that a framework component's rendered HTML tag:
 
-* An HTML tag created from one of the framework components can be modified by application state. A hard-coded HTML tag can't be modified by applcation state.
-* An HTML tag created from one of the framework components is removed from the HTML `<head>` when the parent component is no longer rendered.
+* Can be modified by application state. A hard-coded HTML tag can't be modified by application state.
+* Is removed from the HTML `<head>` when the parent component is no longer rendered.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -244,7 +244,7 @@ The following characteristics apply:
 * For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component rendered.
 * If multiple `Meta` or `Link` components are included with identical attributes, there's exactly one HTML tag rendered per `Meta` or `Link` component. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
 * Changes to the parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
-* Disposing a `Meta` or `Link` component removes its rendered HTML tag.
+* When the `Link` or `Meta` components are no longer rendered and thus disposed by the framework, their rendered HTML tags are removed.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -239,7 +239,7 @@ In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCR
 The following characteristics apply:
 
 * Server-side prerendering is supported.
-* The `Value` parameter is only valid with the `Title` component.
+* The `Value` parameter is only valid for the `Title` component.
 * All provided attributes are reflected in the rendered HTML tags.
 * For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component in the Razor markup.
 * If there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -240,7 +240,7 @@ The following characteristics apply:
 
 * Server-side prerendering is supported.
 * The `Value` parameter is the only valid parameter for the `Title` component.
-* All parameters provided to the `Meta` and `Link` components will be reflected in the rendered HTML tags.
+* HTML attributes provided to the `Meta` and `Link` components are captured in [additional attributes](xref:blazor/components/index#attribute-splatting-and-arbitrary-parameters) and passed through to the rendered HTML tags.
 * For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component to be rendered.
 * Even if there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
 * Changes to parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -239,7 +239,7 @@ In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCR
 The following characteristics apply:
 
 * Server-side prerendering is supported.
-* The `Value` parameter is only valid with the `Title` component. For `Meta` and `Link` components, all provided parameters are reflected in the rendered HTML tags.
+* The `Value` parameter is only valid with the `Title` component. For `Meta` and `Link` components, all provided attributes are reflected in the rendered HTML tags.
 * For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component in the Razor markup.
 * If there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
 * Changes to parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -240,9 +240,9 @@ The following characteristics apply:
 
 * Server-side prerendering is supported.
 * The `Value` parameter is the only valid parameter for the `Title` component.
-* HTML attributes provided to the `Meta` and `Link` components are captured in [additional attributes](xref:blazor/components/index#attribute-splatting-and-arbitrary-parameters) and passed through to the rendered HTML tags.
+* HTML attributes provided to the `Meta` and `Link` components are captured in [additional attributes](xref:blazor/components/index#attribute-splatting-and-arbitrary-parameters) and passed through to the rendered HTML tag.
 * For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component rendered.
-* Even if there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
+* If multiple `Meta` or `Link` components are included with identical attributes, there is exactly one HTML tag rendered per `Meta` or `Link` component. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
 * Changes to the parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
 * Disposing a `Meta` or `Link` component removes its rendered HTML tag.
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -246,6 +246,11 @@ The following characteristics apply:
 * Changes to the parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
 * When the `Link` or `Meta` components are no longer rendered and thus disposed by the framework, their rendered HTML tags are removed.
 
+When one of the framework components is used in a child component, the rendered HTML tag influences any other child component of the parent component as long as the child component containing the framework component is rendered. The distinction between using the one of these framework components in a child component and placing a an HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that:
+
+* An HTML tag created from one of the framework components can be modified by application state. A hard-coded HTML tag can't be modified by applcation state.
+* An HTML tag created from one of the framework components is removed from the HTML `<head>` when the parent component is no longer rendered.
+
 ::: moniker-end
 
 ## Additional resources

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -241,9 +241,9 @@ The following characteristics apply:
 * Server-side prerendering is supported.
 * The `Value` parameter is the only valid parameter for the `Title` component.
 * HTML attributes provided to the `Meta` and `Link` components are captured in [additional attributes](xref:blazor/components/index#attribute-splatting-and-arbitrary-parameters) and passed through to the rendered HTML tags.
-* For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component to be rendered.
+* For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component rendered.
 * Even if there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
-* Changes to parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
+* Changes to the parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
 * Disposing a `Meta` or `Link` component removes its rendered HTML tag.
 
 ::: moniker-end

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -234,7 +234,7 @@ When rendered, the `Title`, `Link`, and `Meta` components add or update data in 
 <Meta content="{DESCRIPTION}" name="description" />
 ```
 
-In the preceding example, placeholders for `{TITLE}`, `{URL}`, and `{DESCRIPTION}` are sting values, Razor variables, or Razor expressions.
+In the preceding example, placeholders for `{TITLE}`, `{URL}`, and `{DESCRIPTION}` are string values, Razor variables, or Razor expressions.
 
 The following characteristics apply:
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -227,7 +227,7 @@ The placeholder `{ELEMENT ID}` is the ID of the HTML element to display.
 When rendered, the `Title`, `Link`, and `Meta` components add or update data in the HTML `<head>` tag elements:
 
 ```razor
-@using Microsoft.AspNetCore.Components.Web.Extensions
+@using Microsoft.AspNetCore.Components.Web.Extensions.Head
 
 <Title Value="{TITLE}" />
 <Link rel="stylesheet" href="{FILE NAME}" />

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -234,10 +234,7 @@ When rendered, the `Title`, `Link`, and `Meta` components add or update data in 
 <Meta name="description" content="{DESCRIPTION}" />
 ```
 
-In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCRIPTION}` are either of the following:
-
-* Sting values.
-* Razor variables or expressions that produce string values.
+In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCRIPTION}` are sting values, Razor variables, or Razor expressions.
 
 The follow characteristics apply:
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -218,6 +218,38 @@ Blazor.defaultReconnectionHandler._reconnectionDisplay =
 
 The placeholder `{ELEMENT ID}` is the ID of the HTML element to display.
 
+::: moniker range=">= aspnetcore-5.0"
+
+## Influence HTML `<head>` tag elements
+
+*This section applies to Blazor WebAssembly and Blazor Server.*
+
+When rendered, the `Title`, `Link`, and `Meta` components add or update data in the HTML `<head>` tag elements:
+
+```razor
+@using Microsoft.AspNetCore.Components.Web.Extensions
+
+<Title Value="{TITLE}" />
+<Link rel="stylesheet" href="{FILE NAME}" />
+<Meta name="description" content="{DESCRIPTION}" />
+```
+
+In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCRIPTION}` are either of the following:
+
+* Sting values.
+* Razor variables or expressions that produce string values.
+
+The follow characteristics apply:
+
+* Server-side prerendering is supported.
+* The `Value` parameter is only valid with the `Title` component. For `Meta` and `Link` components, all provided parameters are reflected in the rendered HTML tags.
+* For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component in the Razor markup.
+* If there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
+* Changes to parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
+* Disposing a `Meta` or `Link` component removes its rendered HTML tag.
+
+::: moniker-end
+
 ## Additional resources
 
 * <xref:fundamentals/logging/index>

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -239,10 +239,10 @@ In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCR
 The following characteristics apply:
 
 * Server-side prerendering is supported.
-* The `Value` parameter is only valid for the `Title` component.
-* All provided attributes are reflected in the rendered HTML tags.
-* For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component in the Razor markup.
-* If there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
+* The `Value` parameter is the only valid parameter for the `Title` component.
+* All parameters provided to the `Meta` and `Link` components will be reflected in the rendered HTML tags.
+* For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component to be rendered.
+* Even if there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
 * Changes to parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.
 * Disposing a `Meta` or `Link` component removes its rendered HTML tag.
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -128,7 +128,7 @@ To configure SignalR client logging:
 ```cshtml
     ...
 
-    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script autostart="false" src="_framework/blazor.server.js"></script>
     <script>
       Blazor.start({
         configureSignalR: function (builder) {
@@ -156,7 +156,7 @@ To modify the connection events:
 ```cshtml
     ...
 
-    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script autostart="false" src="_framework/blazor.server.js"></script>
     <script>
       Blazor.start({
         reconnectionHandler: {
@@ -178,7 +178,7 @@ To adjust the reconnection retry count and interval:
 ```cshtml
     ...
 
-    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script autostart="false" src="_framework/blazor.server.js"></script>
     <script>
       Blazor.start({
         reconnectionOptions: {
@@ -200,7 +200,7 @@ To hide the reconnection display:
 ```cshtml
     ...
 
-    <script src="_framework/blazor.server.js" autostart="false"></script>
+    <script autostart="false" src="_framework/blazor.server.js"></script>
     <script>
       window.addEventListener('beforeunload', function () {
         Blazor.defaultReconnectionHandler._reconnectionDisplay = {};
@@ -230,11 +230,11 @@ When rendered, the `Title`, `Link`, and `Meta` components add or update data in 
 @using Microsoft.AspNetCore.Components.Web.Extensions.Head
 
 <Title Value="{TITLE}" />
-<Link rel="stylesheet" href="{FILE NAME}" />
-<Meta name="description" content="{DESCRIPTION}" />
+<Link href="{URL}" rel="stylesheet" />
+<Meta content="{DESCRIPTION}" name="description" />
 ```
 
-In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCRIPTION}` are sting values, Razor variables, or Razor expressions.
+In the preceding example, placeholders for `{TITLE}`, `{URL}`, and `{DESCRIPTION}` are sting values, Razor variables, or Razor expressions.
 
 The following characteristics apply:
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -239,7 +239,8 @@ In the preceding example, placeholders for `{TITLE}`, `{FILE NAME}`, and `{DESCR
 The following characteristics apply:
 
 * Server-side prerendering is supported.
-* The `Value` parameter is only valid with the `Title` component. For `Meta` and `Link` components, all provided attributes are reflected in the rendered HTML tags.
+* The `Value` parameter is only valid with the `Title` component.
+* All provided attributes are reflected in the rendered HTML tags.
 * For multiple `Title` components, the title of the page reflects the `Value` of the last `Title` component in the Razor markup.
 * If there are multiple `Meta` or `Link` components rendered with identical attributes, there is exactly one tag per component rendered. Two `Meta` or `Link` components can't refer to the same rendered HTML tag.
 * Changes to parameters of existing `Meta` or `Link` components are reflected in their rendered HTML tags.

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -337,14 +337,20 @@
                   href: blazor/forms-validation.md#built-in-forms-components
                 - name: InputTextArea
                   href: blazor/forms-validation.md#built-in-forms-components
+                - name: Link
+                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
                 - name: MainLayout
                   href: blazor/layouts.md#mainlayout-component
+                - name: Meta
+                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
                 - name: NavLink
                   href: blazor/fundamentals/routing.md#navlink-component
                 - name: NavMenu
                   href: blazor/fundamentals/routing.md#navlink-component
                 - name: Router
                   href: blazor/fundamentals/routing.md#route-templates
+                - name: Title
+                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
             - name: Cascading values and parameters
               uid: blazor/components/cascading-values-and-parameters
             - name: Data binding


### PR DESCRIPTION
Fixes #19265

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/additional-scenarios?view=aspnetcore-3.1&branch=pr-en-us-19276#influence-html-head-tag-elements)

@MackinnonBuck, check carefully my translation of your "characteristics" notes. It's very easy for me to make a mistake when translating engineering notes. For example ...

> Only the `Value` parameter is valid in `Title`. For `Meta` and `Link`, all provided parameters will be reflected in the DOM.

... could mean a few different things depending on interpretation, so we might need to do a little more work here if I guessed wrong.

Sorry for the *update noise* 🙉 ... kept seeing little nits to touch.

I'll put this on draft until we get to Preview 8 and merge at that time. It can be reviewed now.