### PR TITLE
Add JustMockLite to additional resources

### DIFF
--- a/aspnetcore/mvc/controllers/testing.md
+++ b/aspnetcore/mvc/controllers/testing.md
@@ -5,7 +5,7 @@ description: Learn how to test controller logic in ASP.NET Core with Moq and xUn
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 22/07/2020
+ms.date: 7/22/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: mvc/controllers/testing
 ---
@@ -344,5 +344,5 @@ For a valid session `id`, the final test confirms that:
 * <xref:test/integration-tests>
 * [Create and run unit tests with Visual Studio](/visualstudio/test/unit-test-your-code)
 * [MyTested.AspNetCore.Mvc - Fluent Testing Library for ASP.NET Core MVC](https://github.com/ivaylokenov/MyTested.AspNetCore.Mvc): Strongly-typed unit testing library, providing a fluent interface for testing MVC and web API apps. (*Not maintained or supported by Microsoft.*)
-* [JustMockLite](https://github.com/telerik/JustMockLite): The most powerful free mocking framework available for .NET developers. (*Not maintained or supported by Microsoft.*)
+* [JustMockLite](https://github.com/telerik/JustMockLite): A mocking framework for .NET developers. (*Not maintained or supported by Microsoft.*)
 

--- a/aspnetcore/mvc/controllers/testing.md
+++ b/aspnetcore/mvc/controllers/testing.md
@@ -5,7 +5,7 @@ description: Learn how to test controller logic in ASP.NET Core with Moq and xUn
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/07/2019
+ms.date: 22/07/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: mvc/controllers/testing
 ---
@@ -344,4 +344,5 @@ For a valid session `id`, the final test confirms that:
 * <xref:test/integration-tests>
 * [Create and run unit tests with Visual Studio](/visualstudio/test/unit-test-your-code)
 * [MyTested.AspNetCore.Mvc - Fluent Testing Library for ASP.NET Core MVC](https://github.com/ivaylokenov/MyTested.AspNetCore.Mvc): Strongly-typed unit testing library, providing a fluent interface for testing MVC and web API apps. (*Not maintained or supported by Microsoft.*)
+* [JustMockLite](https://github.com/telerik/JustMockLite): The most powerful free mocking framework available for .NET developers. (*Not maintained or supported by Microsoft.*)
 

--- a/aspnetcore/test/razor-pages-tests.md
+++ b/aspnetcore/test/razor-pages-tests.md
@@ -5,7 +5,7 @@ description: Learn how to create unit tests for Razor Pages apps.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/14/2019
+ms.date: 22/07/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: test/razor-pages-tests
 ---
@@ -376,5 +376,6 @@ Other tests in this group create page model objects that include the <xref:Micro
 * [Getting started with xUnit.net: Using .NET Core with the .NET SDK command line](https://xunit.github.io/docs/getting-started-dotnet-core)
 * [Moq](https://github.com/moq/moq4)
 * [Moq Quickstart](https://github.com/Moq/moq4/wiki/Quickstart)
+* [JustMockLite](https://github.com/telerik/JustMockLite): The most powerful free mocking framework available for .NET developers. (*Not maintained or supported by Microsoft.*)
 
 ::: moniker-end

--- a/aspnetcore/test/razor-pages-tests.md
+++ b/aspnetcore/test/razor-pages-tests.md
@@ -5,7 +5,7 @@ description: Learn how to create unit tests for Razor Pages apps.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 22/07/2020
+ms.date: 7/22/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: test/razor-pages-tests
 ---
@@ -376,6 +376,6 @@ Other tests in this group create page model objects that include the <xref:Micro
 * [Getting started with xUnit.net: Using .NET Core with the .NET SDK command line](https://xunit.github.io/docs/getting-started-dotnet-core)
 * [Moq](https://github.com/moq/moq4)
 * [Moq Quickstart](https://github.com/Moq/moq4/wiki/Quickstart)
-* [JustMockLite](https://github.com/telerik/JustMockLite): The most powerful free mocking framework available for .NET developers. (*Not maintained or supported by Microsoft.*)
+* [JustMockLite](https://github.com/telerik/JustMockLite): A mocking framework for .NET developers. (*Not maintained or supported by Microsoft.*)
 
 ::: moniker-end


### PR DESCRIPTION
Fixes #19223

As discussed in the issue, I am adding JustMockLite to links in the additional resources section.
Please have in mind that I also changed the "Razor Pages unit tests in ASP.NET Core" article to include the same link in the additional resources section.