### PR TITLE
Configuration updates

### DIFF
--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -19,7 +19,29 @@ Blazor WebAssembly loads configuration from:
 * App settings files by default:
   * `wwwroot/appsettings.json`
   * `wwwroot/appsettings.{ENVIRONMENT}.json`
-* Other [configuration providers](xref:fundamentals/configuration/index) registered by the app. Not all providers are appropriate for Blazor WebAssembly apps. Clarification on which providers are supported for Blazor WebAssembly is tracked by [Clarify configuration providers for Blazor WASM (dotnet/AspNetCore.Docs #18134)](https://github.com/dotnet/AspNetCore.Docs/issues/18134).
+* Other [configuration providers](xref:fundamentals/configuration/index) registered by the app. Not all providers or provider features are appropriate for Blazor WebAssembly apps:
+  * [Azure Key Vault configuration provider](xref:security/key-vault-configuration): The provider isn't supported for managed identity and application (client) ID with client secret scenarios. Application ID with a client secret isn't recommended for any ASP.NET Core app, especially Blazor WebAssembly apps because the client secret can't be secured on the client to access to the service.
+  * [Azure App configuration provider](/azure/azure-app-configuration/quickstart-aspnet-core-app): The provider isn't appropriate for Blazor WebAssembly apps because Blazor WebAssembly apps don't run on a server in Azure.
+  * [Custom configuration provider with EF Core](xref:fundamentals/configuration/index#custom-configuration-provider)
+    * Add the example's configuration provider with the following code in `Program.Main` (`Program.cs`):
+
+      ```csharp
+      builder.Configuration.AddEFConfiguration(
+          options => options.UseInMemoryDatabase("InMemoryDb"));
+      ```
+
+    * Inject an <xref:Microsoft.Extensions.Configuration.IConfiguration> instance into a component to access the configuration data:
+
+      ```razor
+      @using Microsoft.Extensions.Configuration
+      @inject IConfiguration Configuration
+
+      <ul>
+          <li>@Configuration["quote1"]</li>
+          <li>@Configuration["quote2"]</li>
+          <li>@Configuration["quote3"]</li>
+      </ul>
+      ```
 
 > [!WARNING]
 > Configuration in a Blazor WebAssembly app is visible to users. **Don't store app secrets or credentials in configuration.**

--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -5,7 +5,7 @@ description: Learn about configuration of Blazor apps, including app settings, a
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/10/2020
+ms.date: 07/29/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/fundamentals/configuration
 ---
@@ -14,34 +14,17 @@ uid: blazor/fundamentals/configuration
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, see <xref:fundamentals/configuration/index>.
 
-Blazor WebAssembly loads configuration from:
+Blazor WebAssembly loads configuration from app settings files by default:
 
-* App settings files by default:
-  * `wwwroot/appsettings.json`
-  * `wwwroot/appsettings.{ENVIRONMENT}.json`
-* Other [configuration providers](xref:fundamentals/configuration/index) registered by the app. Not all providers or provider features are appropriate for Blazor WebAssembly apps:
-  * [Azure Key Vault configuration provider](xref:security/key-vault-configuration): The provider isn't supported for managed identity and application (client) ID with client secret scenarios. Application ID with a client secret isn't recommended for any ASP.NET Core app, especially Blazor WebAssembly apps because the client secret can't be secured on the client to access to the service.
-  * [Azure App configuration provider](/azure/azure-app-configuration/quickstart-aspnet-core-app): The provider isn't appropriate for Blazor WebAssembly apps because Blazor WebAssembly apps don't run on a server in Azure.
-  * [Custom configuration provider with EF Core](xref:fundamentals/configuration/index#custom-configuration-provider)
-    * Add the example's configuration provider with the following code in `Program.Main` (`Program.cs`):
+* `wwwroot/appsettings.json`
+* `wwwroot/appsettings.{ENVIRONMENT}.json`
 
-      ```csharp
-      builder.Configuration.AddEFConfiguration(
-          options => options.UseInMemoryDatabase("InMemoryDb"));
-      ```
+Other configuration providers registered by the app can also provide configuration.
 
-    * Inject an <xref:Microsoft.Extensions.Configuration.IConfiguration> instance into a component to access the configuration data:
+Not all providers or provider features are appropriate for Blazor WebAssembly apps:
 
-      ```razor
-      @using Microsoft.Extensions.Configuration
-      @inject IConfiguration Configuration
-
-      <ul>
-          <li>@Configuration["quote1"]</li>
-          <li>@Configuration["quote2"]</li>
-          <li>@Configuration["quote3"]</li>
-      </ul>
-      ```
+* [Azure Key Vault configuration provider](xref:security/key-vault-configuration): The provider isn't supported for managed identity and application ID (client ID) with client secret scenarios. Application ID with a client secret isn't recommended for any ASP.NET Core app, especially Blazor WebAssembly apps because the client secret can't be secured client-side to access to the service.
+* [Azure App configuration provider](/azure/azure-app-configuration/quickstart-aspnet-core-app): The provider isn't appropriate for Blazor WebAssembly apps because Blazor WebAssembly apps don't run on a server in Azure.
 
 > [!WARNING]
 > Configuration in a Blazor WebAssembly app is visible to users. **Don't store app secrets or credentials in configuration.**
@@ -70,7 +53,31 @@ Inject an <xref:Microsoft.Extensions.Configuration.IConfiguration> instance into
 <p>Message: @Configuration["message"]</p>
 ```
 
-## Provider configuration
+## Custom configuration provider with EF Core
+
+The custom configuration provider with EF Core demonstrated in <xref:fundamentals/configuration/index#custom-configuration-provider> works with Blazor WebAssembly apps.
+
+Add the example's configuration provider with the following code in `Program.Main` (`Program.cs`):
+
+```csharp
+builder.Configuration.AddEFConfiguration(
+    options => options.UseInMemoryDatabase("InMemoryDb"));
+```
+
+Inject an <xref:Microsoft.Extensions.Configuration.IConfiguration> instance into a component to access the configuration data:
+
+```razor
+@using Microsoft.Extensions.Configuration
+@inject IConfiguration Configuration
+
+<ul>
+    <li>@Configuration["quote1"]</li>
+    <li>@Configuration["quote2"]</li>
+    <li>@Configuration["quote3"]</li>
+</ul>
+```
+
+## Memory Configuration Source
 
 The following example uses a <xref:Microsoft.Extensions.Configuration.Memory.MemoryConfigurationSource> to supply additional configuration:
 

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -662,7 +662,7 @@ An `AddEFConfiguration` extension method permits adding the configuration source
 
 The following code shows how to use the custom `EFConfigurationProvider` in *Program.cs*:
 
-[!code-csharp[](index/samples/3.x/ConfigurationSample/Program.cs?name=snippet_Program&highlight=29-30)]
+[!code-csharp[](index/samples_snippets/3.x/ConfigurationSample/Program.cs?highlight=7-8)]
 
 <a name="acs"></a>
 

--- a/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationContext.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationContext.cs
@@ -4,6 +4,8 @@ using ConfigurationSample.Models;
 namespace ConfigurationSample.EFConfigurationProvider
 {
     #region snippet1
+    // using Microsoft.EntityFrameworkCore;
+
     public class EFConfigurationContext : DbContext
     {
         public EFConfigurationContext(DbContextOptions options) : base(options)

--- a/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationProvider.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationProvider.cs
@@ -8,6 +8,9 @@ using ConfigurationSample.Models;
 namespace ConfigurationSample.EFConfigurationProvider
 {
     #region snippet1
+    // using Microsoft.EntityFrameworkCore;
+    // using Microsoft.Extensions.Configuration;
+
     public class EFConfigurationProvider : ConfigurationProvider
     {
         public EFConfigurationProvider(Action<DbContextOptionsBuilder> optionsAction)
@@ -17,7 +20,6 @@ namespace ConfigurationSample.EFConfigurationProvider
 
         Action<DbContextOptionsBuilder> OptionsAction { get; }
 
-        // Load config data from EF DB.
         public override void Load()
         {
             var builder = new DbContextOptionsBuilder<EFConfigurationContext>();

--- a/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationSource.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/EFConfigurationProvider/EFConfigurationSource.cs
@@ -5,6 +5,9 @@ using Microsoft.Extensions.Configuration;
 namespace ConfigurationSample.EFConfigurationProvider
 {
     #region snippet1
+    // using Microsoft.EntityFrameworkCore;
+    // using Microsoft.Extensions.Configuration;
+
     public class EFConfigurationSource : IConfigurationSource
     {
         private readonly Action<DbContextOptionsBuilder> _optionsAction;

--- a/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/Extensions/EntityFrameworkExtensions.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigurationSample/Extensions/EntityFrameworkExtensions.cs
@@ -6,6 +6,9 @@ using ConfigurationSample.EFConfigurationProvider;
 namespace ConfigurationSample.Extensions
 {
     #region snippet1
+    // using Microsoft.EntityFrameworkCore;
+    // using Microsoft.Extensions.Configuration;
+
     public static class EntityFrameworkExtensions
     {
         public static IConfigurationBuilder AddEFConfiguration(

--- a/aspnetcore/fundamentals/configuration/index/samples_snippets/3.x/ConfigurationSample/Program.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples_snippets/3.x/ConfigurationSample/Program.cs
@@ -1,0 +1,9 @@
+// using Microsoft.EntityFrameworkCore;
+
+public static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureAppConfiguration((hostingContext, config) =>
+        {
+            config.AddEFConfiguration(
+                options => options.UseInMemoryDatabase("InMemoryDb"));
+        })


### PR DESCRIPTION
Fixes #18134

Internal Review Topics:

* [ASP.NET Core Configuration (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/configuration?view=aspnetcore-3.1&branch=pr-en-us-19293#custom-configuration-provider)
* [Blazor Configuration (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/index?view=aspnetcore-2.1&branch=pr-en-us-19293#aspnet-core-blazor-configuration)

Notes:

* The EF Core config provider **_seems ok_**. `Load` is called once at startup. The example doesn't implement a reload-on-change feature, so it *might be* ok wrt the db context concurrency concern. Let me know if we need to totally warn off of this provider for some reason. :ear:
* I add the namespaces to the example in the ASP.NET Core config doc while I'm here.