### PR TITLE
[Preview 8] [READY] Blazor RCL stylesheet and Link component

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -5,7 +5,7 @@ description: Discover how components can be included in Blazor apps from an exte
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/23/2020
+ms.date: 07/27/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/components/class-libraries
 ---
@@ -28,7 +28,7 @@ Just as components are regular .NET types, components provided by an RCL are nor
 1. Create a new project.
 1. Select **Razor Class Library**. Select **Next**.
 1. In the **Create a new Razor class library** dialog, select **Create**.
-1. Provide a project name in the **Project name** field or accept the default project name. The examples in this topic use the project name `MyComponentLib1`. Select **Create**.
+1. Provide a project name in the **Project name** field or accept the default project name. The examples in this topic use the project name `ComponentLibrary`. Select **Create**.
 1. Add the RCL to a solution:
    1. Right-click the solution. Select **Add** > **Existing Project**.
    1. Navigate to the RCL's project file.
@@ -48,10 +48,10 @@ Just as components are regular .NET types, components provided by an RCL are nor
 
 # [.NET Core CLI](#tab/netcore-cli)
 
-1. Use the **Razor Class Library** template (`razorclasslib`) with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell. In the following example, an RCL is created named `MyComponentLib1`. The folder that holds `MyComponentLib1` is created automatically when the command is executed:
+1. Use the **Razor Class Library** template (`razorclasslib`) with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell. In the following example, an RCL is created named `ComponentLibrary`. The folder that holds `ComponentLibrary` is created automatically when the command is executed:
 
    ```dotnetcli
-   dotnet new razorclasslib -o MyComponentLib1
+   dotnet new razorclasslib -o ComponentLibrary
    ```
 
    > [!NOTE]
@@ -78,31 +78,61 @@ In order to consume components defined in a library in another project, use eith
 * Use the full type name with the namespace.
 * Use Razor's [`@using`](xref:mvc/views/razor#using) directive. Individual components can be added by name.
 
-In the following examples, `MyComponentLib1` is a component library containing a `SalesReport` component.
+In the following examples, `ComponentLibrary` is a component library containing the `Component1` component (`Component1.razor`), which is an example component automatically added by the RCL project template when the library is created.
 
-The `SalesReport` component can be referenced using its full type name with namespace:
+Reference the `Component1` component using its namespace:
 
 ```razor
 <h1>Hello, world!</h1>
 
 Welcome to your new app.
 
-<MyComponentLib1.SalesReport />
+<ComponentLibrary.Component1 />
 ```
 
-The component can also be referenced if the library is brought into scope with an `@using` directive:
+Alternatively, bring the library into scope with an [`@using`](xref:mvc/views/razor#using) directive and use the component without its namespace:
 
 ```razor
-@using MyComponentLib1
+@using ComponentLibrary
 
 <h1>Hello, world!</h1>
 
 Welcome to your new app.
 
-<SalesReport />
+<Component1 />
 ```
 
-Include the `@using MyComponentLib1` directive in the top-level `_Import.razor` file to make the library's components available to an entire project. Add the directive to an `_Import.razor` file at any level to apply the namespace to a single page or set of pages within a folder.
+Optionally, include the `@using ComponentLibrary` directive in the top-level `_Import.razor` file to make the library's components available to an entire project. Add the directive to an `_Import.razor` file at any level to apply the namespace to a single component or set of components within a folder.
+
+::: moniker range=">= aspnetcore-5.0"
+
+To provide `Component1`'s `my-component` CSS class, link to the library's stylesheet using the framework's `Link` component in `Component1.razor`:
+
+```razor
+<div class="my-component">
+
+    <Link href="_content/ComponentLibrary/styles.css" rel="stylesheet" />
+
+    <p>
+        This Blazor component is defined in the <strong>ComponentLibrary</strong> package.
+    </p>
+</div>
+```
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+To provide `Component1`'s `my-component` CSS class, link to the library's stylesheet in the app's `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+
+```html
+<head>
+    ...
+    <link href="_content/ComponentLibrary/styles.css" rel="stylesheet" />
+</head>
+```
+
+::: moniker-end
 
 ## Create a Razor components class library with static assets
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -118,7 +118,7 @@ To provide `Component1`'s `my-component` CSS class to the component, link to the
 </div>
 ```
 
-To provide the stylesheet across the app, link to the library's stylesheet in the app's `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+To provide the stylesheet across the app, you can alternatively link to the library's stylesheet in the app's `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
 ```html
 <head>

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -110,7 +110,6 @@ To provide `Component1`'s `my-component` CSS class to the component, link to the
 
 ```razor
 <div class="my-component">
-
     <Link href="_content/ComponentLibrary/styles.css" rel="stylesheet" />
 
     <p>

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -78,7 +78,7 @@ In order to consume components defined in a library in another project, use eith
 * Use the full type name with the namespace.
 * Use Razor's [`@using`](xref:mvc/views/razor#using) directive. Individual components can be added by name.
 
-In the following examples, `ComponentLibrary` is a component library containing the `Component1` component (`Component1.razor`), which is an example component automatically added by the RCL project template when the library is created.
+In the following examples, `ComponentLibrary` is a component library containing the `Component1` component (`Component1.razor`). The `Component1` component is an example component automatically added by the RCL project template when the library is created.
 
 Reference the `Component1` component using its namespace:
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -119,11 +119,6 @@ To provide `Component1`'s `my-component` CSS class to the component, link to the
 </div>
 ```
 
-When the `Link` component is used in a child component, the linked asset is also available to any other child component of the parent component as long as the child with the `Link` component is rendered. The distinction between using the `Link` component in a component and placing a `<link>` HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that a `<link>` tag created from the `Link` component:
-
-* Can be modified by application state. A hard-coded `<link>` HTML tag can't be modified by applcation state.
-* Is removed from the HTML `<head>` when the parent component is no longer rendered.
-
 To provide the stylesheet across the app, link to the library's stylesheet in the app's `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
 ```html
@@ -132,6 +127,11 @@ To provide the stylesheet across the app, link to the library's stylesheet in th
     <link href="_content/ComponentLibrary/styles.css" rel="stylesheet" />
 </head>
 ```
+
+When the `Link` component is used in a child component, the linked asset is also available to any other child component of the parent component as long as the child with the `Link` component is rendered. The distinction between using the `Link` component in a component and placing a `<link>` HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that a `<link>` tag created from the `Link` component:
+
+* Can be modified by application state. A hard-coded `<link>` HTML tag can't be modified by applcation state.
+* Is removed from the HTML `<head>` when the parent component is no longer rendered.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -106,7 +106,7 @@ Optionally, include the `@using ComponentLibrary` directive in the top-level `_I
 
 ::: moniker range=">= aspnetcore-5.0"
 
-To provide `Component1`'s `my-component` CSS class only to the component, link to the library's stylesheet using the framework's `Link` component in `Component1.razor`:
+To provide `Component1`'s `my-component` CSS class only to the component, link to the library's stylesheet using the framework's [`Link` component](xref:blazor/fundamentals/additional-scenarios#influence-html-head-tag-elements) in `Component1.razor`:
 
 ```razor
 <div class="my-component">

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -106,7 +106,7 @@ Optionally, include the `@using ComponentLibrary` directive in the top-level `_I
 
 ::: moniker range=">= aspnetcore-5.0"
 
-To provide `Component1`'s `my-component` CSS class, link to the library's stylesheet using the framework's `Link` component in `Component1.razor`:
+To provide `Component1`'s `my-component` CSS class only to the component, link to the library's stylesheet using the framework's `Link` component in `Component1.razor`:
 
 ```razor
 <div class="my-component">
@@ -117,6 +117,15 @@ To provide `Component1`'s `my-component` CSS class, link to the library's styles
         This Blazor component is defined in the <strong>ComponentLibrary</strong> package.
     </p>
 </div>
+```
+
+To provide the stylesheet across the app, link to the library's stylesheet in the app's `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+
+```html
+<head>
+    ...
+    <link href="_content/ComponentLibrary/styles.css" rel="stylesheet" />
+</head>
 ```
 
 ::: moniker-end

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -128,10 +128,10 @@ To provide the stylesheet across the app, link to the library's stylesheet in th
 </head>
 ```
 
-When the `Link` component is used in a child component, the linked asset is also available to any other child component of the parent component as long as the child with the `Link` component is rendered. The distinction between using the `Link` component in a component and placing a `<link>` HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that a `<link>` tag created from the `Link` component:
+When the `Link` component is used in a child component, the linked asset is also available to any other child component of the parent component as long as the child with the `Link` component is rendered. The distinction between using the `Link` component in a child component and placing a `<link>` HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that:
 
-* Can be modified by application state. A hard-coded `<link>` HTML tag can't be modified by applcation state.
-* Is removed from the HTML `<head>` when the parent component is no longer rendered.
+* A `<link>` tag created from the `Link` component can be modified by application state. A hard-coded `<link>` HTML tag can't be modified by applcation state.
+* A `<link>` tag created from the `Link` component is removed from the HTML `<head>` when the parent component is no longer rendered.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -127,10 +127,10 @@ To provide the stylesheet across the app, link to the library's stylesheet in th
 </head>
 ```
 
-When the `Link` component is used in a child component, the linked asset is also available to any other child component of the parent component as long as the child with the `Link` component is rendered. The distinction between using the `Link` component in a child component and placing a `<link>` HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that:
+When the `Link` component is used in a child component, the linked asset is also available to any other child component of the parent component as long as the child with the `Link` component is rendered. The distinction between using the `Link` component in a child component and placing a `<link>` HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that a framework component's rendered HTML tag:
 
-* A `<link>` tag created from the `Link` component can be modified by application state. A hard-coded `<link>` HTML tag can't be modified by applcation state.
-* A `<link>` tag created from the `Link` component is removed from the HTML `<head>` when the parent component is no longer rendered.
+* Can be modified by application state. A hard-coded `<link>` HTML tag can't be modified by application state.
+* Is removed from the HTML `<head>` when the parent component is no longer rendered.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -106,7 +106,7 @@ Optionally, include the `@using ComponentLibrary` directive in the top-level `_I
 
 ::: moniker range=">= aspnetcore-5.0"
 
-To provide `Component1`'s `my-component` CSS class only to the component, link to the library's stylesheet using the framework's [`Link` component](xref:blazor/fundamentals/additional-scenarios#influence-html-head-tag-elements) in `Component1.razor`:
+To provide `Component1`'s `my-component` CSS class to the component, link to the library's stylesheet using the framework's [`Link` component](xref:blazor/fundamentals/additional-scenarios#influence-html-head-tag-elements) in `Component1.razor`:
 
 ```razor
 <div class="my-component">
@@ -118,6 +118,11 @@ To provide `Component1`'s `my-component` CSS class only to the component, link t
     </p>
 </div>
 ```
+
+When the `Link` component is used in a child component, the linked asset is also available to any other child component of the parent component as long as the child with the `Link` component is rendered. The distinction between using the `Link` component in a component and placing a `<link>` HTML tag in `wwwroot/index.html` or `Pages/_Host.cshtml` is that a `<link>` tag created from the `Link` component:
+
+* Can be modified by application state. A hard-coded `<link>` HTML tag can't be modified by applcation state.
+* Is removed from the HTML `<head>` when the parent component is no longer rendered.
 
 To provide the stylesheet across the app, link to the library's stylesheet in the app's `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 


### PR DESCRIPTION
Fixes #19317

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries?view=aspnetcore-3.1&branch=pr-en-us-19333)

* Adds the `Link` component to the Blazor RCL content.
* Explains how to get the stylesheet applied to components: 5.0+ with `Link` component or `<link>` tag and <5.0 with a `<link>` tag.
* Better naming: I've been leaning away from `My`-named things these days, so I name the lib `ComponentLibrary`. Also, I go with the project template-generated example component in the RCL named `Component1.razor`.
* I went ahead and cross-linked the `Link` component. There's no build warning on the premature link here, but the coverage won't be there until [[Preview 8] Blazor HTML <head> tag control (dotnet/AspNetCore.Docs &num;19276)](https://github.com/dotnet/AspNetCore.Docs/pull/19276) goes in.