### PR TITLE
Version Blazor JS interop circular references content

### DIFF
--- a/aspnetcore/blazor/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/call-javascript-from-dotnet.md
@@ -458,9 +458,11 @@ For more information on resource exhaustion, see <xref:blazor/security/server/th
 
 [!INCLUDE[](~/includes/blazor-share-interop-code.md)]
 
+::: moniker range="< aspnetcore-5.0"
+
 ## Avoid circular object references
 
-Objects that contain circular references can't be serialized on the client for either:
+In versions of .NET Core prior to 5.0, objects that contain circular references can't be serialized on the client for either:
 
 * .NET method calls.
 * JavaScript method calls from C# when the return type has circular references.
@@ -469,6 +471,8 @@ For more information, see the following issues:
 
 * [Circular references are not supported, take two (dotnet/aspnetcore #20525)](https://github.com/dotnet/aspnetcore/issues/20525)
 * [Proposal: Add mechanism to handle circular references when serializing (dotnet/runtime #30820)](https://github.com/dotnet/runtime/issues/30820)
+
+::: moniker-end
 
 ## Additional resources
 


### PR DESCRIPTION
Fixes #17651

I have a suspicion that Blazor must react to the runtime's updates at https://github.com/dotnet/runtime/issues/30820 based on DR's remark at https://github.com/dotnet/aspnetcore/issues/20525#issuecomment-623865683.

If Blazor requires more work, then we can either:

* Close this and put the issue back on hold if updates aren't going to make it for 5.0.
* Go ahead and merge if the work in Blazor has been done for 5.0.