### PR TITLE
Fix broken sample links pointing to release/2.2

### DIFF
--- a/aspnetcore/security/authentication/samples.md
+++ b/aspnetcore/security/authentication/samples.md
@@ -38,11 +38,11 @@ The [ASP.NET Core repository](https://github.com/dotnet/AspNetCore) contains the
 
 * [Claims transformation](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/ClaimsTransformation)
 * [Cookie authentication](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/Cookies)
-* [Custom policy provider - IAuthorizationPolicyProvider](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/CustomPolicyProvider)
+* [Custom policy provider - IAuthorizationPolicyProvider](https://github.com/dotnet/AspNetCore/tree/2.1.3/src/Security/samples/CustomPolicyProvider)
 * [Dynamic authentication schemes and options](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/DynamicSchemes)
 * [External claims](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/Identity.ExternalClaims)
 * [Selecting between cookie and another authentication scheme based on the request](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/PathSchemeSelection)
-* [Restricts access to static files](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/StaticFilesAuth)
+* [Restricts access to static files](https://github.com/dotnet/AspNetCore/tree/2.1.3/src/Security/samples/StaticFilesAuth)
 
 ## Run the samples
 

--- a/aspnetcore/security/authentication/samples.md
+++ b/aspnetcore/security/authentication/samples.md
@@ -36,17 +36,17 @@ The [ASP.NET Core repository](https://github.com/dotnet/AspNetCore) contains the
 
 The [ASP.NET Core repository](https://github.com/dotnet/AspNetCore) contains the following authentication samples in the *AspNetCore/src/Security/samples* folder:
 
-* [Claims transformation](https://github.com/dotnet/AspNetCore/tree/release/2.2/src/Security/samples/ClaimsTransformation)
-* [Cookie authentication](https://github.com/dotnet/AspNetCore/tree/release/2.2/src/Security/samples/Cookies)
-* [Custom policy provider - IAuthorizationPolicyProvider](https://github.com/dotnet/AspNetCore/tree/release/2.2/src/Security/samples/CustomPolicyProvider)
-* [Dynamic authentication schemes and options](https://github.com/dotnet/AspNetCore/tree/release/2.2/src/Security/samples/DynamicSchemes)
-* [External claims](https://github.com/dotnet/AspNetCore/tree/release/2.2/src/Security/samples/Identity.ExternalClaims)
-* [Selecting between cookie and another authentication scheme based on the request](https://github.com/dotnet/AspNetCore/tree/release/2.2/src/Security/samples/PathSchemeSelection)
-* [Restricts access to static files](https://github.com/dotnet/AspNetCore/tree/release/2.2/src/Security/samples/StaticFilesAuth)
+* [Claims transformation](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/ClaimsTransformation)
+* [Cookie authentication](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/Cookies)
+* [Custom policy provider - IAuthorizationPolicyProvider](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/CustomPolicyProvider)
+* [Dynamic authentication schemes and options](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/DynamicSchemes)
+* [External claims](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/Identity.ExternalClaims)
+* [Selecting between cookie and another authentication scheme based on the request](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/PathSchemeSelection)
+* [Restricts access to static files](https://github.com/dotnet/AspNetCore/tree/release/2.1/src/Security/samples/StaticFilesAuth)
 
 ## Run the samples
 
-* Select a [branch](https://github.com/dotnet/AspNetCore). For example, `release/2.2`
+* Select a [branch](https://github.com/dotnet/AspNetCore). For example, `release/2.1`
 * Clone or download the [ASP.NET Core repository](https://github.com/dotnet/AspNetCore).
 * Verify you have installed the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core) version matching the clone of the ASP.NET Core repository.
 * Navigate to a sample in *AspNetCore/src/Security/samples* and run the sample with `dotnet run`.


### PR DESCRIPTION
Fixes #19093

Most of the samples exist in `release/2.1`, but the changes in 15cae94e247f69c489c594a52730bf7fb3c1f75b show the two examples that don't exist for that branch. I changed them to the `2.1.3` branch, which has them, but there are also a number of `v2.1.x` tags that would work as well. 

Additionally, I wasn't sure if these should be excluded since they don't exist on the release branch or if the other examples should be changed as well so that all the samples are coming from the same branch (this might be desirable given the directions in the Run the Samples section).

I can make changes as needed.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->