### PR TITLE
Blazor WASM breakpoints in OnInitialized

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -5,7 +5,7 @@ description: Learn how to debug Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 07/27/2020
+ms.date: 07/30/2020
 no-loc: [Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/debug
 ---
@@ -220,6 +220,21 @@ In the preceding example, `MyHostedApp.Server.dll` is the *Server* app's assembl
 1. In component code (`.razor` files) and C# code files (`.cs`), breakpoints that you set are hit when code executes. After a breakpoint is hit, single-step (<kbd>F10</kbd>) through the code or resume (<kbd>F8</kbd>) code execution normally.
 
 Blazor provides a debugging proxy that implements the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) and augments the protocol with .NET-specific information. When debugging keyboard shortcut is pressed, Blazor points the Chrome DevTools at the proxy. The proxy connects to the browser window you're seeking to debug (hence the need to enable remote debugging).
+
+## Breakpoints in `OnInitialized{Async}` not hit
+
+The Blazor framework's debugging proxy takes a short time to launch, so breakpoints in the [`OnInitialized{Async}` lifecycle method](xref:blazor/components/lifecycle#component-initialization-methods) might not be hit. We recommend adding a delay at the start of the method body to give the debug proxy some time to launch before the breakpoint is hit. You can include the delay based on an [`if` compiler directive](/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-if) to ensure that it isn't present for a release configuration of the app:
+
+```csharp
+protected override void OnInitialized()
+{
+#if DEBUG
+    xxxx
+#endif
+
+    ...
+}
+```
 
 ## Browser source maps
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -221,21 +221,6 @@ In the preceding example, `MyHostedApp.Server.dll` is the *Server* app's assembl
 
 Blazor provides a debugging proxy that implements the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) and augments the protocol with .NET-specific information. When debugging keyboard shortcut is pressed, Blazor points the Chrome DevTools at the proxy. The proxy connects to the browser window you're seeking to debug (hence the need to enable remote debugging).
 
-## Breakpoints in `OnInitialized{Async}` not hit
-
-The Blazor framework's debugging proxy takes a short time to launch, so breakpoints in the [`OnInitialized{Async}` lifecycle method](xref:blazor/components/lifecycle#component-initialization-methods) might not be hit. We recommend adding a delay at the start of the method body to give the debug proxy some time to launch before the breakpoint is hit. You can include the delay based on an [`if` compiler directive](/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-if) to ensure that the delay isn't present for a release build of the app:
-
-```csharp
-protected override void OnInitialized()
-{
-#if DEBUG
-    xxxx
-#endif
-
-    ...
-}
-```
-
 ## Browser source maps
 
 Browser source maps allow the browser to map compiled files back to their original source files and are commonly used for client-side debugging. However, Blazor doesn't currently map C# directly to JavaScript/WASM. Instead, Blazor does IL interpretation within the browser, so source maps aren't relevant.
@@ -247,3 +232,33 @@ If you're running into errors, the following tips may help:
 * In the **Debugger** tab, open the developer tools in your browser. In the console, execute `localStorage.clear()` to remove any breakpoints.
 * Confirm that you've installed and trusted the ASP.NET Core HTTPS development certificate. For more information, see <xref:security/enforcing-ssl#troubleshoot-certificate-problems>.
 * Visual Studio requires the **Enable JavaScript debugging for ASP.NET (Chrome, Edge and IE)** option in **Tools** > **Options** > **Debugging** > **General**. This is the default setting for Visual Studio. If debugging isn't working, confirm that the option is selected.
+
+### Breakpoints in `OnInitialized{Async}` not hit
+
+The Blazor framework's debugging proxy takes a short time to launch, so breakpoints in the [`OnInitialized{Async}` lifecycle method](xref:blazor/components/lifecycle#component-initialization-methods) might not be hit. We recommend adding a delay at the start of the method body to give the debug proxy some time to launch before the breakpoint is hit. You can include the delay based on an [`if` compiler directive](/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-if) to ensure that the delay isn't present for a release build of the app.
+
+<xref:Microsoft.AspNetCore.Components.ComponentBase.OnInitialized%2A>:
+
+```csharp
+protected override void OnInitialized()
+{
+#if DEBUG
+    Thread.Sleep(2000)
+#endif
+
+    ...
+}
+```
+
+<xref:Microsoft.AspNetCore.Components.ComponentBase.OnInitializedAsync%2A>:
+
+```csharp
+protected override async Task OnInitializedAsync()
+{
+#if DEBUG
+    await Task.Delay(2000)
+#endif
+
+    ...
+}
+```

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -243,7 +243,7 @@ The Blazor framework's debugging proxy takes a short time to launch, so breakpoi
 protected override void OnInitialized()
 {
 #if DEBUG
-    Thread.Sleep(2000)
+    Thread.Sleep(10000)
 #endif
 
     ...
@@ -256,7 +256,7 @@ protected override void OnInitialized()
 protected override async Task OnInitializedAsync()
 {
 #if DEBUG
-    await Task.Delay(2000)
+    await Task.Delay(10000)
 #endif
 
     ...

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -223,7 +223,7 @@ Blazor provides a debugging proxy that implements the [Chrome DevTools Protocol]
 
 ## Breakpoints in `OnInitialized{Async}` not hit
 
-The Blazor framework's debugging proxy takes a short time to launch, so breakpoints in the [`OnInitialized{Async}` lifecycle method](xref:blazor/components/lifecycle#component-initialization-methods) might not be hit. We recommend adding a delay at the start of the method body to give the debug proxy some time to launch before the breakpoint is hit. You can include the delay based on an [`if` compiler directive](/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-if) to ensure that it isn't present for a release configuration of the app:
+The Blazor framework's debugging proxy takes a short time to launch, so breakpoints in the [`OnInitialized{Async}` lifecycle method](xref:blazor/components/lifecycle#component-initialization-methods) might not be hit. We recommend adding a delay at the start of the method body to give the debug proxy some time to launch before the breakpoint is hit. You can include the delay based on an [`if` compiler directive](/dotnet/csharp/language-reference/preprocessor-directives/preprocessor-if) to ensure that the delay isn't present for a release build of the app:
 
 ```csharp
 protected override void OnInitialized()


### PR DESCRIPTION
Fixes #19377

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/debug?view=aspnetcore-3.1&branch=pr-en-us-19378)

* I prefer a compiler directive for this because a conditional check based on environment would run all the time. `DEBUG` is built-in. Idk if this will work in a Razor file like this. If there's any doubt on it, I'll run a test and confirm that the approach works. Let me know if I should run such a test. :ear:
* What do we show for the recommended delay line?
* Won't we need **_two examples_** of whatever the delay line is? ... one for synch and one for async.