### PR TITLE
Add anti-patterns example in DI recommendations

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -574,7 +574,7 @@ The factory method of single service, such as the second argument to [AddSinglet
 
 * Avoid call services.BuildServiceProvider() method in ConfigureServices. This usually happens when developer want to resolve service in ConfigureServices phase. Some code that a developer will use like below.
 
-**Incorrect:**
+**❌Incorrect:**
 
 ```csharp
 public void ConfigureService(IServiceCollection services)
@@ -594,7 +594,7 @@ public void ConfigureService(IServiceCollection services)
 ```
 Calling BuildServiceProvider would creating a second container, this can create torn singletons and cause reference to object graphs across multiple containers. A correct way of doing so is utilizing DI embedded option pattern, sample code as below
 
-**Correct:**
+**✔️Correct:**
 ```csharp
 services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie();
@@ -1192,7 +1192,7 @@ The factory method of single service, such as the second argument to [AddSinglet
 
 * Avoid call services.BuildServiceProvider() method in ConfigureServices. This usually happens when developer want to resolve service in ConfigureServices phase. Some code that a developer will use like below.
 
-**Incorrect:**
+**❌Incorrect:**
 
 ```csharp
 public void ConfigureService(IServiceCollection services)
@@ -1212,7 +1212,7 @@ public void ConfigureService(IServiceCollection services)
 ```
 Calling BuildServiceProvider would creating a second container, this can create torn singletons and cause reference to object graphs across multiple containers. A correct way of doing so is utilizing DI embedded option pattern, sample code as below
 
-**Correct:**
+**✔️Correct:**
 ```csharp
 services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie();

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -572,6 +572,41 @@ The factory method of single service, such as the second argument to [AddSinglet
 
 * Avoid static access to `HttpContext` (for example, [IHttpContextAccessor.HttpContext](xref:Microsoft.AspNetCore.Http.IHttpContextAccessor.HttpContext)).
 
+* Avoid call services.BuildServiceProvider() method in ConfigureServices. This usually happens when developer want to resolve service in ConfigureServices phase. Some code that a developer will use like below.
+
+**Incorrect:**
+
+```csharp
+public void ConfigureService(IServiceCollection services)
+{
+    // Configure the services
+    services.AddTransient<IMyService, MyService>();    
+    // Build an intermediate service provider in ConfigureServices, which is not recommended 
+    using (var serviceProvider = services.BuildServiceProvider())
+    {
+        var myService=serviceProvider.GetRequiredService<IMyService>();
+        services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie(options =>
+            {
+                options.LoginPath = myService.GetLoginPath();
+            });
+    };
+}
+```
+Calling BuildServiceProvider would creating a second container, this can create torn singletons and cause reference to object graphs across multiple containers. A correct way of doing so is utilizing DI embedded option pattern, sample code as below
+
+**Correct:**
+```csharp
+services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie();
+
+services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
+    .Configure<IMyService>((options, myService) =>
+    {
+        options.LoginPath = myService.GetLoginPath();
+    });
+```
+
+
 Like all sets of recommendations, you may encounter situations where ignoring a recommendation is required. Exceptions are rare, mostly special cases within the framework itself.
 
 DI is an *alternative* to static/global object access patterns. You may not be able to realize the benefits of DI if you mix it with static object access.
@@ -1151,9 +1186,43 @@ The factory method of single service, such as the second argument to [AddSinglet
     }
     ```
 
-  * Avoid injecting a factory that resolves dependencies at runtime using <xref:System.IServiceProvider.GetService*>.
+    * Avoid injecting a factory that resolves dependencies at runtime using <xref:System.IServiceProvider.GetService*>.
 
 * Avoid static access to `HttpContext` (for example, [IHttpContextAccessor.HttpContext](xref:Microsoft.AspNetCore.Http.IHttpContextAccessor.HttpContext)).
+
+* Avoid call services.BuildServiceProvider() method in ConfigureServices. This usually happens when developer want to resolve service in ConfigureServices phase. Some code that a developer will use like below.
+
+**Incorrect:**
+
+```csharp
+public void ConfigureService(IServiceCollection services)
+{
+    // Configure the services
+    services.AddTransient<IMyService, MyService>();    
+    // Build an intermediate service provider in ConfigureServices, which is not recommended 
+    using (var serviceProvider = services.BuildServiceProvider())
+    {
+        var myService=serviceProvider.GetRequiredService<IMyService>();
+        services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie(options =>
+            {
+                options.LoginPath = myService.GetLoginPath();
+            });
+    };
+}
+```
+Calling BuildServiceProvider would creating a second container, this can create torn singletons and cause reference to object graphs across multiple containers. A correct way of doing so is utilizing DI embedded option pattern, sample code as below
+
+**Correct:**
+```csharp
+services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie();
+
+services.AddOptions<CookieAuthenticationOptions>(CookieAuthenticationDefaults.AuthenticationScheme)
+    .Configure<IMyService>((options, myService) =>
+    {
+        options.LoginPath = myService.GetLoginPath();
+    });
+```
 
 Like all sets of recommendations, you may encounter situations where ignoring a recommendation is required. Exceptions are rare, mostly special cases within the framework itself.
 


### PR DESCRIPTION
According to https://github.com/dotnet/AspNetCore.Docs/pull/19156, we'd like to add a new anti-patterns to DI recommendations in DI docs. The reason is in Stackoverflow, some community member is suggesting to call BuildServiceProvider to resolve service instance in ConfigureService method(https://stackoverflow.com/questions/31863981/how-to-resolve-instance-inside-configureservices-in-asp-net-core), which will result to couple issues as described in this PR. So it is better to add this as an anti-patterns in recommendations and provide an alternative way to address developers requirement.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->