### PR TITLE
Add link to open a general docs platform issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: docs.microsoft.com site feedback
+    url: https://github.com/MicrosoftDocs/feedback/issues/new/choose
+    about: Log general docs.microsoft.com site issues here
+  - name: .NET platform and other product feedback
+    url: https://developercommunity.visualstudio.com/spaces/61/index.html
+    about: Log product issues here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: docs.microsoft.com site feedback
     url: https://github.com/MicrosoftDocs/feedback/issues/new/choose
     about: Log general docs.microsoft.com site issues here
-  - name: .NET platform and other product feedback
-    url: https://developercommunity.visualstudio.com/spaces/61/index.html
-    about: Log product issues here


### PR DESCRIPTION
Add a link to open an issue related to the docs.microsoft.com platform. The .NET docs team is already doing this. This option will be available to anyone clicking the **New issue** button:

![image](https://user-images.githubusercontent.com/10702007/89698320-2d299900-d8e6-11ea-9a01-30e93dbd5fc5.png)

See a live example at https://github.com/dotnet/docs/issues/new/choose.