### PR TITLE
Update additional-scenarios.md - "Attach tokens to outgoing requests"

### DIFF
--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -30,6 +30,7 @@ In the following example:
 
 ```csharp
 using System.Net.Http;
+using Microsoft.Extensions.Http
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 
 ...


### PR DESCRIPTION
With the PR, I have simply added a using directive to the "Attach tokens to outgoing requests" sections in the first sample. 
I have noticed that it is not possible to call ```builder.Services.AddHttpClient()``` without the additional using.

It is not very hard to figure out the missing packages NuGet name but maybe referring to it in the documentation, makes it easier for beginners to get started.

If there is a better way to mention it, feel free to change the request as you want. 

**Details:**

The Call [HttpClientFactoryServiceCollectionExtensions.AddHttpClient Method](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.httpclientfactoryservicecollectionextensions.addhttpclient?view=dotnet-plat-ext-3.1) is part of the NuGet Package [Microsoft.Extensions.Http](https://www.nuget.org/packages/Microsoft.Extensions.Http/). 

The Http Extension Package is not used in my vanilla Blazor Project template, so I needed to add it manually. 

Feel free to reach out for further questions.
Thanks for your support and the great Documentation!