### PR TITLE
Updated metadata for C# .NET + Azure topic

### DIFF
--- a/aspnetcore/azure/devops/cicd.md
+++ b/aspnetcore/azure/devops/cicd.md
@@ -4,7 +4,7 @@ author: CamSoper
 description: Continuous integration and deployment in DevOps with ASP.NET Core and Azure
 ms.author: scaddie
 ms.date: 10/24/2018
-ms.custom: "mvc, seodec18"
+ms.custom: "devx-track-csharp, mvc, seodec18"
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: azure/devops/cicd
 ---

--- a/aspnetcore/azure/devops/deploying-to-app-service.md
+++ b/aspnetcore/azure/devops/deploying-to-app-service.md
@@ -3,7 +3,7 @@ title: Deploy an app to App Service - DevOps with ASP.NET Core and Azure
 author: CamSoper
 description: Deploy an ASP.NET Core app to Azure App Service, the first step for DevOps with ASP.NET Core and Azure.
 ms.author: casoper
-ms.custom: "mvc, seodec18"
+ms.custom: "devx-track-csharp, mvc, seodec18"
 ms.date: 10/24/2018
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: azure/devops/deploy-to-app-service

--- a/aspnetcore/azure/devops/index.md
+++ b/aspnetcore/azure/devops/index.md
@@ -4,7 +4,7 @@ author: CamSoper
 description: A guide that provides end-to-end guidance on building a DevOps pipeline for an ASP.NET Core app hosted in Azure.
 ms.author: casoper
 ms.date: 08/07/2018
-ms.custom: "mvc, seodec18"
+ms.custom: "devx-track-csharp, mvc, seodec18"
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: azure/devops/index
 ---

--- a/aspnetcore/azure/devops/monitoring.md
+++ b/aspnetcore/azure/devops/monitoring.md
@@ -3,7 +3,7 @@ title: Monitor and debug - DevOps with ASP.NET Core and Azure
 author: CamSoper
 description: Monitoring and debugging your code as part of a DevOps solution with ASP.NET Core and Azure
 ms.author: casoper
-ms.custom: "mvc, seodec18"
+ms.custom: "devx-track-csharp, mvc, seodec18"
 ms.date: 07/10/2019
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: azure/devops/monitor

--- a/aspnetcore/azure/devops/next-steps.md
+++ b/aspnetcore/azure/devops/next-steps.md
@@ -3,7 +3,7 @@ title: Next steps - DevOps with ASP.NET Core and Azure
 author: CamSoper
 description: Additional learning paths for DevOps with ASP.NET Core and Azure.
 ms.author: casoper
-ms.custom: "mvc, seodec18"
+ms.custom: "devx-track-csharp, mvc, seodec18"
 ms.date: 10/24/2018
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: azure/devops/next-steps

--- a/aspnetcore/azure/devops/tools-and-downloads.md
+++ b/aspnetcore/azure/devops/tools-and-downloads.md
@@ -3,7 +3,7 @@ title: Tools and downloads - DevOps with ASP.NET Core and Azure
 author: CamSoper
 description: Tools and downloads required for DevOps with ASP.NET Core and Azure.
 ms.author: casoper
-ms.custom: "mvc, seodec18"
+ms.custom: "devx-track-csharp, mvc, seodec18"
 ms.date: 10/24/2018
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: azure/devops/tools-and-downloads

--- a/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to configure Blazor WebAssembly to use Azure Active Directory groups and roles.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
-ms.custom: mvc
+ms.custom: "devx-track-csharp, mvc"
 ms.date: 07/28/2020
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/aad-groups-roles

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -4,7 +4,7 @@ author: guardrex
 description: 
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
-ms.custom: mvc
+ms.custom: "devx-track-csharp, mvc"
 ms.date: 07/08/2020
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/hosted-with-azure-active-directory

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
@@ -4,7 +4,7 @@ author: guardrex
 description: 
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
-ms.custom: mvc
+ms.custom: "devx-track-csharp, mvc"
 ms.date: 07/08/2020
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/standalone-with-azure-active-directory

--- a/aspnetcore/host-and-deploy/azure-apps/azure-continuous-deployment.md
+++ b/aspnetcore/host-and-deploy/azure-apps/azure-continuous-deployment.md
@@ -3,7 +3,7 @@ title: Continuous deployment to Azure with Visual Studio and Git with ASP.NET Co
 author: rick-anderson
 description: Learn how to create an ASP.NET Core web app using Visual Studio and deploy it to Azure App Service using Git for continuous deployment.
 ms.author: riande
-ms.custom: mvc
+ms.custom: "devx-track-csharp, mvc"
 ms.date: 12/06/2018
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: host-and-deploy/azure-apps/azure-continuous-deployment

--- a/aspnetcore/security/authentication/azure-ad-b2c.md
+++ b/aspnetcore/security/authentication/azure-ad-b2c.md
@@ -3,7 +3,7 @@ title: Cloud authentication with Azure Active Directory B2C in ASP.NET Core
 author: camsoper
 description: Discover how to set up Azure Active Directory B2C authentication with ASP.NET Core.
 ms.author: casoper
-ms.custom: mvc
+ms.custom: "devx-track-csharp, mvc"
 ms.date: 01/21/2019
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/authentication/azure-ad-b2c

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -4,7 +4,7 @@ author: anurse
 description: Learn how to gather diagnostics from your ASP.NET Core SignalR app.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: anurse
-ms.custom: signalr
+ms.custom: "devx-track-csharp, signalr"
 ms.date: 06/12/2020
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: signalr/diagnostics

--- a/aspnetcore/tutorials/publish-to-azure-webapp-using-vs.md
+++ b/aspnetcore/tutorials/publish-to-azure-webapp-using-vs.md
@@ -3,7 +3,7 @@ title: Publish an ASP.NET Core app to Azure with Visual Studio
 author: rick-anderson
 description: Learn how to publish an ASP.NET Core app to Azure App Service using Visual Studio.
 ms.author: riande
-ms.custom: mvc
+ms.custom: "devx-track-csharp, mvc"
 ms.date: 07/10/2019
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: tutorials/publish-to-azure-webapp-using-vs

--- a/aspnetcore/tutorials/publish-to-azure-webapp-using-vscode.md
+++ b/aspnetcore/tutorials/publish-to-azure-webapp-using-vscode.md
@@ -3,7 +3,7 @@ title: Publish an ASP.NET Core app to Azure with Visual Studio Code
 author: rick-anderson
 description: Learn how to publish an ASP.NET Core app to Azure App Service using Visual Studio Code
 ms.author: riserrad
-ms.custom: mvc
+ms.custom: "devx-track-csharp, mvc"
 ms.date: 07/10/2019
 no-loc: [cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: tutorials/publish-to-azure-webapp-using-vscode


### PR DESCRIPTION
Fixes #19467 19467

A temporary custom meta data value of "devx-track-csharp" is being used for identifying .NET + Azure topics (non-reference).

Added "devx-track-csharp" to ms.custom.