### PR TITLE
Remove ref to MS.AspNetCore.Diagnostics nuget

### DIFF
--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -19,7 +19,7 @@ This article covers common approaches to handling errors in ASP.NET Core web app
 
 ## Developer Exception Page
 
-The *Developer Exception Page* displays detailed information about request exceptions. The page is made available by the [Microsoft.AspNetCore.Diagnostics](https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/) package, which is in the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app). Add code to the `Startup.Configure` method to enable the page when the app is running in the Development [environment](xref:fundamentals/environments):
+The *Developer Exception Page* displays detailed information about request exceptions. The page is made available by the Microsoft.AspNetCore.Diagnostics assembly, which is in the [Microsoft.AspNetCore.App shared framework](xref:fundamentals/metapackage-app). Add code to the `Startup.Configure` method to enable the page when the app is running in the Development [environment](xref:fundamentals/environments):
 
 [!code-csharp[](error-handling/samples/2.x/ErrorHandlingSample/Startup.cs?name=snippet_DevPageAndHandlerPage&highlight=1-4)]
 

--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -19,7 +19,7 @@ This article covers common approaches to handling errors in ASP.NET Core web app
 
 ## Developer Exception Page
 
-The *Developer Exception Page* displays detailed information about request exceptions. The page is made available by the Microsoft.AspNetCore.Diagnostics assembly, which is in the [Microsoft.AspNetCore.App shared framework](xref:fundamentals/metapackage-app). Add code to the `Startup.Configure` method to enable the page when the app is running in the Development [environment](xref:fundamentals/environments):
+The *Developer Exception Page* displays detailed information about request exceptions. The page is made available by the `Microsoft.AspNetCore.Diagnostics` assembly, which is in the [`Microsoft.AspNetCore.App` shared framework](xref:fundamentals/metapackage-app). Add code to the `Startup.Configure` method to enable the page when the app is running in the Development [environment](xref:fundamentals/environments):
 
 [!code-csharp[](error-handling/samples/2.x/ErrorHandlingSample/Startup.cs?name=snippet_DevPageAndHandlerPage&highlight=1-4)]
 


### PR DESCRIPTION
Microsoft.AspNetCore.Diagnostics is now part of shared framework and not distributed separatedly via nuget



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->