### PR TITLE
trust linux cert anchor

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -347,6 +347,14 @@ dotnet dev-certs https --help
 
 See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/6199).
 
+<a name="ssl-linux"></a>
+
+## Trust HTTPS certificate on Linux
+
+<!-- Instructions to be updated by engineering team after 5.0 RTM. -->
+
+For instructions on Linux, refer to the distribution documentation.
+
 <a name="wsl"></a>
 
 ## Trust HTTPS certificate from Windows Subsystem for Linux


### PR DESCRIPTION
@danroth27  can I change the target URL: 
https://docs.microsoft.com/aspnet/core/security/enforcing-ssl                  <-- Current
https://docs.microsoft.com/aspnet/core/security/enforcing-ssl#ssl-linux   <-- Proposed







