### PR TITLE
Revert "RazorTemplateEngine removed/Migration doc"

### DIFF
--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -1230,7 +1230,6 @@ Review breaking changes:
 * [Complete list of breaking changes in the ASP.NET Core 3.0 release](https://github.com/aspnet/Announcements/issues?page=1&q=is%3Aissue+is%3Aopen+label%3A%22Breaking+change%22+label%3A3.0.0)
 * [Breaking API changes in Antiforgery, CORS, Diagnostics, MVC, and Routing](https://github.com/aspnet/Announcements/issues/387). This list includes breaking changes for compatibility switches.
 * For a summary of 2.2-to-3.0 breaking changes across .NET Core, ASP.NET Core, and Entity Framework Core, see [Breaking changes for migration from version 2.2 to 3.0](/dotnet/core/compatibility/2.2-3.0).
-* [RazorTemplateEngine](/dotnet/api/microsoft.aspnetcore.razor.language.razortemplateengine) [removed](https://github.com/dotnet/aspnetcore/issues/5079).
 
 ## Endpoint routing with catch-all parameter
 


### PR DESCRIPTION
Reverts dotnet/AspNetCore.Docs#19596