### PR TITLE
[HOLD, RC1] Blazor WASM Debug query param

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -112,9 +112,6 @@ While debugging your Blazor WebAssembly app, you can also debug your server code
 
 1. Start debugging using the <kbd>F5</kbd> keyboard shortcut or the menu item.
 
-   > [!NOTE]
-   > **Start Without Debugging** (<kbd>Ctrl</kbd>+<kbd>F5</kbd>) isn't supported. When the app is run in Debug configuration, debugging overhead always results in a small performance reduction.
-
 1. When prompted, select the **Blazor WebAssembly Debug** option to start debugging.
 
    ![List of available debug options](index/_static/blazor-vscode-debugtypes.png)


### PR DESCRIPTION
Fixes #19545

*Guessing* that the update allows the NOTE to be removed ...

> \> \[!NOTE]
> \> \*\*Start Without Debugging\*\* (\<kbd>Ctrl\</kbd>+\<kbd>F5\</kbd>) isn't supported. When the app is run in Debug configuration, debugging overhead always results in a small performance reduction.

Even if so, what else does the topic require to cover the API changes?

It might be best if you edit this PR directly, then I'll **_Rexerize_**:tm: the updated text. 😁