### PR TITLE
Blazor Debug WASM updates: VS4Mac guidance

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -223,7 +223,7 @@ To debug a Blazor WebAssembly app in Visual Studio for Mac:
    > **Start Without Debugging** (<kbd>&#8997;</kbd>+<kbd>&#8984;</kbd>+<kbd>&#8617;</kbd>) isn't supported. When the app is run in Debug configuration, debugging overhead always results in a small performance reduction.
 
    > [!IMPORTANT]
-   > Google Chrome must be the selected browser for the debugging session.
+   > Google Chrome or Microsoft Edge must be the selected browser for the debugging session.
 
 1. In the *Client* app, set a breakpoint on the `currentCount++;` line in `Pages/Counter.razor`.
 1. In the browser, navigate to `Counter` page and select the **Click me** button to hit the breakpoint:

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -22,9 +22,9 @@ Blazor WebAssembly apps can be debugged using the browser dev tools in Chromium-
 Available scenarios include:
 
 * Set and remove breakpoints.
-* Run the app with debugging support in Visual Studio and Visual Studio Code.
+* Run the app with debugging support in IDEs.
 * Single-step through the code.
-* Resume code execution with a keyboard shortcut in Visual Studio or Visual Studio Code.
+* Resume code execution with a keyboard shortcut in IDEs.
 * In the *Locals* window, observe the values of local variables.
 * See the call stack, including call chains between JavaScript and .NET.
 
@@ -43,7 +43,7 @@ Debugging requires either of the following browsers:
 Visual Studio for Mac requires version 8.8 (build 1532) or later:
 
 1. Install the latest release of Visual Studio for Mac by selecting the **Download Visual Studio for Mac** button at [Microsoft: Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
-1. Select the **Preview* channel from within Visual Studio. For more information, see [Install a preview version of Visual Studio for Mac](/visualstudio/mac/install-preview).
+1. Select the *Preview* channel from within Visual Studio. For more information, see [Install a preview version of Visual Studio for Mac](/visualstudio/mac/install-preview).
 
 > [!NOTE]
 > Apple Safari on macOS isn't currently supported.

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -86,7 +86,7 @@ While debugging a Blazor WebAssembly app, you can also debug server code:
 1. Press <kbd>F5</kbd> to continue execution and then hit the breakpoint on the server in the `WeatherForecastController`.
 1. Press <kbd>F5</kbd> again to let execution continue and see the weather forecast table rendered in the browser.
 
-> [NOTE]
+> [!NOTE]
 > Breakpoints are **not** hit during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` methods](xref:blazor/components/lifecycle#component-initialization-methods) of components that are loaded by the first page requested from the app.
 
 # [Visual Studio Code](#tab/visual-studio-code)
@@ -120,7 +120,7 @@ While debugging a Blazor WebAssembly app, you can also debug server code:
 
 1. In the browser, navigate to `Counter` page and select the **Click me** button to hit the breakpoint.
 
-> [NOTE]
+> [!NOTE]
 > Breakpoints are **not** hit during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` methods](xref:blazor/components/lifecycle#component-initialization-methods) of components that are loaded by the first page requested from the app.
 
 ## Debug hosted Blazor WebAssembly
@@ -234,7 +234,7 @@ While debugging a Blazor WebAssembly app, you can also debug server code:
 1. Press <kbd>&#8984;</kbd>+<kbd>&#8617;</kbd> to continue execution and then hit the breakpoint on the server in the `WeatherForecastController`.
 1. Press <kbd>&#8984;</kbd>+<kbd>&#8617;</kbd> again to let execution continue and see the weather forecast table rendered in the browser.
 
-> [NOTE]
+> [!NOTE]
 > Breakpoints are **not** hit during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` methods](xref:blazor/components/lifecycle#component-initialization-methods) of components that are loaded by the first page requested from the app.
 
 For more information, see [Debugging with Visual Studio for Mac](/visualstudio/mac/debugging?view=vsmac-2019).

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -13,7 +13,11 @@ uid: blazor/debug
 
 [Daniel Roth](https://github.com/danroth27)
 
-Blazor WebAssembly apps can be debugged using the browser dev tools in Chromium-based browsers (Edge/Chrome). Alternatively, you can debug your app using Visual Studio or Visual Studio Code.
+Blazor WebAssembly apps can be debugged using the browser dev tools in Chromium-based browsers (Edge/Chrome). You can also debug your app using the following integrated development environments (IDEs):
+
+* Visual Studio
+* Visual Studio for Mac
+* Visual Studio Code
 
 Available scenarios include:
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -5,7 +5,7 @@ description: Learn how to debug Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/17/2020
+ms.date: 08/26/2020
 no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/debug
 ---
@@ -18,18 +18,16 @@ Blazor WebAssembly apps can be debugged using the browser dev tools in Chromium-
 Available scenarios include:
 
 * Set and remove breakpoints.
-* Run the app with debugging support in Visual Studio and Visual Studio Code (<kbd>F5</kbd> support).
-* Single-step (<kbd>F10</kbd>) through the code.
-* Resume code execution with <kbd>F8</kbd> in a browser or <kbd>F5</kbd> in Visual Studio or Visual Studio Code.
-* In the *Locals* display, observe the values of local variables.
-* See the call stack, including call chains that go from JavaScript into .NET and from .NET to JavaScript.
+* Run the app with debugging support in Visual Studio and Visual Studio Code.
+* Single-step through the code.
+* Resume code execution with a keyboard shortcut in Visual Studio or Visual Studio Code.
+* In the *Locals* window, observe the values of local variables.
+* See the call stack, including call chains between JavaScript and .NET.
 
 For now, you *can't*:
 
 * Break on unhandled exceptions.
 * Hit breakpoints during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` methods](xref:blazor/components/lifecycle#component-initialization-methods) of components that are loaded by the first page requested from the app.
-
-We will continue to improve the debugging experience in upcoming releases.
 
 ## Prerequisites
 
@@ -38,7 +36,15 @@ Debugging requires either of the following browsers:
 * Google Chrome (version 70 or later) (default)
 * Microsoft Edge (version 80 or later)
 
-## Enable debugging for Visual Studio and Visual Studio Code
+Visual Studio for Mac requires version 8.8 (build 1532) or later:
+
+1. Install the latest release of Visual Studio for Mac by selecting the **Download Visual Studio for Mac** button at [Microsoft: Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
+1. Select the **Preview* channel from within Visual Studio. For more information, see [Install a preview version of Visual Studio for Mac](/visualstudio/mac/install-preview).
+
+> [!NOTE]
+> Apple Safari on macOS isn't currently supported.
+
+## Enable debugging
 
 To enable debugging for an existing Blazor WebAssembly app, update the `launchSettings.json` file in the startup project to include the following `inspectUri` property in each launch profile:
 
@@ -57,7 +63,7 @@ The `inspectUri` property:
 
 The placeholder values for the WebSockets protocol (`wsProtocol`), host (`url.hostname`), port (`url.port`), and inspector URI on the launched browser (`browserInspectUri`) are provided by the framework.
 
-## Visual Studio
+# [Visual Studio](#tab/visual-studio)
 
 To debug a Blazor WebAssembly app in Visual Studio:
 
@@ -67,43 +73,34 @@ To debug a Blazor WebAssembly app in Visual Studio:
    > [!NOTE]
    > **Start Without Debugging** (<kbd>Ctrl</kbd>+<kbd>F5</kbd>) isn't supported. When the app is run in Debug configuration, debugging overhead always results in a small performance reduction.
 
-1. Set a breakpoint in `Pages/Counter.razor` in the `IncrementCount` method.
-1. Browse to the **`Counter`** tab and select the button to hit the breakpoint:
-
-   ![Debug Counter](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vs-debug-counter.png)
-
-1. Check out the value of the `currentCount` field in the locals window:
-
-   ![View locals](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vs-debug-locals.png)
-
+1. In the *Client* app, set a breakpoint on the `currentCount++;` line in `Pages/Counter.razor`.
+1. In the browser, navigate to `Counter` page and select the **Click me** button to hit the breakpoint.
+1. In Visual Studio, inspect the value of the `currentCount` field in the **Locals** window.
 1. Press <kbd>F5</kbd> to continue execution.
 
-While debugging your Blazor WebAssembly app, you can also debug your server code:
+While debugging a Blazor WebAssembly app, you can also debug server code:
 
 1. Set a breakpoint in the `Pages/FetchData.razor` page in <xref:Microsoft.AspNetCore.Components.ComponentBase.OnInitializedAsync%2A>.
 1. Set a breakpoint in the `WeatherForecastController` in the `Get` action method.
-1. Browse to the **`Fetch Data`** tab to hit the first breakpoint in the `FetchData` component just before it issues an HTTP request to the server:
+1. Browse to the `Fetch Data` page to hit the first breakpoint in the `FetchData` component just before it issues an HTTP request to the server.
+1. Press <kbd>F5</kbd> to continue execution and then hit the breakpoint on the server in the `WeatherForecastController`.
+1. Press <kbd>F5</kbd> again to let execution continue and see the weather forecast table rendered in the browser.
 
-   ![Debug Fetch Data](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vs-debug-fetch-data.png)
+> [NOTE]
+> Breakpoints are **not** hit during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` methods](xref:blazor/components/lifecycle#component-initialization-methods) of components that are loaded by the first page requested from the app.
 
-1. Press <kbd>F5</kbd> to continue execution and then hit the breakpoint on the server in the `WeatherForecastController`:
-
-   ![Debug server](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vs-debug-server.png)
-
-1. Press <kbd>F5</kbd> again to let execution continue and see the weather forecast table rendered.
+# [Visual Studio Code](#tab/visual-studio-code)
 
 <a id="vscode"></a>
 
-## Visual Studio Code
-
-### Debug standalone Blazor WebAssembly
+## Debug standalone Blazor WebAssembly
 
 1. Open the standalone Blazor WebAssembly app in VS Code.
 
-   You may receive the following notification that additional setup is required to enable debugging:
-   
-   ![Additional setup required](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vscode-additional-setup.png)
-   
+   You may receive a notification that additional setup is required to enable debugging:
+
+   > Additional setup is required to debug Blazor WebAssembly applications.
+
    If you receive the notification:
 
    * Confirm that the latest [C# for Visual Studio Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) is installed. To inspect the installed extensions, open **View** > **Extensions** from the menu bar or select the **Extensions** icon in the **Activity** sidebar.
@@ -117,27 +114,28 @@ While debugging your Blazor WebAssembly app, you can also debug your server code
 
 1. When prompted, select the **Blazor WebAssembly Debug** option to start debugging.
 
-   ![List of available debug options](index/_static/blazor-vscode-debugtypes.png)
-
 1. The standalone app is launched, and a debugging browser is opened.
 
-1. Set a breakpoint in the `IncrementCount` method in the `Counter` component and then select the button to hit the breakpoint:
+1. In the *Client* app, set a breakpoint on the `currentCount++;` line in `Pages/Counter.razor`.
 
-   ![Debug Counter in VS Code](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vscode-debug-counter.png)
+1. In the browser, navigate to `Counter` page and select the **Click me** button to hit the breakpoint.
 
-### Debug hosted Blazor WebAssembly
+> [NOTE]
+> Breakpoints are **not** hit during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` methods](xref:blazor/components/lifecycle#component-initialization-methods) of components that are loaded by the first page requested from the app.
+
+## Debug hosted Blazor WebAssembly
 
 1. Open the hosted Blazor WebAssembly app's solution folder in VS Code.
 
 1. If there's no launch configuration set for the project, the following notification appears. Select **Yes**.
 
-   ![Add required assets](https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2020/03/vscode-required-assets.png)
+   > Required assets to build and debug are missing from '{APPLICATION NAME}'. Add them?
 
 1. In the command palette at the top of the window, select the *Server* project within the hosted solution.
 
 A `launch.json` file is generated with the launch configuration for launching the debugger.
 
-### Attach to an existing debugging session
+## Attach to an existing debugging session
 
 To attach to a running Blazor app, create a `launch.json` file with the following configuration:
 
@@ -152,7 +150,7 @@ To attach to a running Blazor app, create a `launch.json` file with the followin
 > [!NOTE]
 > Attaching to a debugging session is only supported for standalone apps. To use full-stack debugging, you must launch the app from VS Code.
 
-### Launch configuration options
+## Launch configuration options
 
 The following launch configuration options are supported for the `blazorwasm` debug type (`.vscode/launch.json`).
 
@@ -169,9 +167,9 @@ The following launch configuration options are supported for the `blazorwasm` de
 | `cwd`     | The working directory to launch the app under. Must be set if `hosted` is `true`. |
 | `env`     | The environment variables to provide to the launched process. Only applicable if `hosted` is set to `true`. |
 
-### Example launch configurations
+## Example launch configurations
 
-#### Launch and debug a standalone Blazor WebAssembly app
+### Launch and debug a standalone Blazor WebAssembly app
 
 ```json
 {
@@ -181,7 +179,7 @@ The following launch configuration options are supported for the `blazorwasm` de
 }
 ```
 
-#### Attach to a running app at a specified URL
+### Attach to a running app at a specified URL
 
 ```json
 {
@@ -192,7 +190,7 @@ The following launch configuration options are supported for the `blazorwasm` de
 }
 ```
 
-#### Launch and debug a hosted Blazor WebAssembly app with Microsoft Edge
+### Launch and debug a hosted Blazor WebAssembly app with Microsoft Edge
 
 Browser configuration defaults to Google Chrome. When using Microsoft Edge for debugging, set `browser` to `edge`. To use Google Chrome, either don't set the `browser` option or set the option's value to `chrome`.
 
@@ -210,17 +208,61 @@ Browser configuration defaults to Google Chrome. When using Microsoft Edge for d
 
 In the preceding example, `MyHostedApp.Server.dll` is the *Server* app's assembly. The `.vscode` folder is located in the solution's folder next to the `Client`, `Server`, and `Shared` folders.
 
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+To debug a Blazor WebAssembly app in Visual Studio for Mac:
+
+1. Create a new ASP.NET Core hosted Blazor WebAssembly app.
+1. Press <kbd>&#8984;</kbd>+<kbd>&#8617;</kbd> to run the app in the debugger.
+
+   > [!NOTE]
+   > **Start Without Debugging** (<kbd>&#8997;</kbd>+<kbd>&#8984;</kbd>+<kbd>&#8617;</kbd>) isn't supported. When the app is run in Debug configuration, debugging overhead always results in a small performance reduction.
+
+   > [!IMPORTANT]
+   > Google Chrome must be the selected browser for the debugging session.
+
+1. In the *Client* app, set a breakpoint on the `currentCount++;` line in `Pages/Counter.razor`.
+1. In the browser, navigate to `Counter` page and select the **Click me** button to hit the breakpoint:
+1. In Visual Studio, inspect the value of the `currentCount` field in the **Locals** window.
+1. Press <kbd>&#8984;</kbd>+<kbd>&#8617;</kbd> to continue execution.
+
+While debugging a Blazor WebAssembly app, you can also debug server code:
+
+1. Set a breakpoint in the `Pages/FetchData.razor` page in <xref:Microsoft.AspNetCore.Components.ComponentBase.OnInitializedAsync%2A>.
+1. Set a breakpoint in the `WeatherForecastController` in the `Get` action method.
+1. Browse to the `Fetch Data` page to hit the first breakpoint in the `FetchData` component just before it issues an HTTP request to the server.
+1. Press <kbd>&#8984;</kbd>+<kbd>&#8617;</kbd> to continue execution and then hit the breakpoint on the server in the `WeatherForecastController`.
+1. Press <kbd>&#8984;</kbd>+<kbd>&#8617;</kbd> again to let execution continue and see the weather forecast table rendered in the browser.
+
+> [NOTE]
+> Breakpoints are **not** hit during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` methods](xref:blazor/components/lifecycle#component-initialization-methods) of components that are loaded by the first page requested from the app.
+
+For more information, see [Debugging with Visual Studio for Mac](/visualstudio/mac/debugging?view=vsmac-2019).
+
+---
+
 ## Debug in the browser
+
+*The guidance in this section applies to Google Chrome and Microsoft Edge running on Windows.*
 
 1. Run a Debug build of the app in the Development environment.
 
 1. Launch a browser and navigate to the app's URL (for example, `https://localhost:5001`).
 
-1. In the browser, attempt to commence remote debugging by pressing <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>D</kbd>.
+1. In the browser, attempt to commence remote debugging by pressing <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>d</kbd>.
 
    The browser must be running with remote debugging enabled, which isn't the default. If remote debugging is disabled, an **Unable to find debuggable browser tab** error page is rendered with instructions for launching the browser with the debugging port open. Follow the instructions for your browser, which opens a new browser window. Close the previous browser window.
 
-1. Once the browser is running with remote debugging enabled, the debugging keyboard shortcut (<kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>D</kbd>) opens a new debugger tab.
+<!-- HOLD 
+1. In the browser, attempt to commence remote debugging by pressing:
+
+   * <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>d</kbd> on Windows.
+   * <kbd>Shift</kbd>+<kbd>&#8984;</kbd>+<kbd>d</kbd> on macOS.
+
+   The browser must be running with remote debugging enabled, which isn't the default. If remote debugging is disabled, an **Unable to find debuggable browser tab** error page is rendered with instructions for launching the browser with the debugging port open. Follow the instructions for your browser, which opens a new browser window. Close the previous browser window.
+-->
+
+1. Once the browser is running with remote debugging enabled, the debugging keyboard shortcut in the previous step opens a new debugger tab.
 
 1. After a moment, the **Sources** tab shows a list of the app's .NET assemblies within the `file://` node.
 
@@ -270,7 +312,7 @@ protected override async Task OnInitializedAsync()
 }
 ```
 
-### Visual Studio timeout
+### Visual Studio (Windows) timeout
 
 If Visual Studio throws an exception that the debug adapter failed to launch mentioning that the timeout was reached, you can adjust the timeout with a Registry setting:
 


### PR DESCRIPTION
Fixes #19465

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/debug?view=aspnetcore-3.1&branch=pr-en-us-19659)

* Idk if we need to touch the [*Browser source maps* section](https://docs.microsoft.com/en-us/aspnet/core/blazor/debug?view=aspnetcore-3.1#browser-source-maps). Do we need to qualify those remarks now that VS4Mac is in the topic?
* I couldn't get the **Debug in the browser** guidance to fully work. <kbd>Shift</kbd>+<kbd>&#8984;</kbd>+<kbd>d</kbd> gets the ball rolling with the **Unable to find debuggable browser tab** error page and the command seems to run. I can't get anywhere with it after that, and there is no `file://` node in **Sources**. I added a remark on this PR that says the guidance is only for Chrome or Edge on Windows.
* We'll have tooling tabs now.
* I 🔪 the images. We have really, really, **_REALLY_** bad outcomes with IDE and Azure images around here. We don't have the staffing to support them. They go stale ... we get issues/confusion from readers ... we get time-crunched 🤯 trying to recreate them. I tailor the text here to avoid them. I await orders (at 👦🔫 **_gunpoint!_** 👦🔫 preferably 😄) for any that you feel we really need.  
* ~Is there matching *Visual Studio (Windows) timeout* guidance for VS4Mac?~ *Answered*

**We should get this in and live quickly. Idk that the plan was to put a live link to the docs into the blog post.**

Thanks @mrward!