### PR TITLE
Rebrand Office 365 to Microsoft 365: User Story 1737442, Part 10

### DIFF
--- a/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
@@ -17,7 +17,7 @@ Azure Active Directory (AAD) provides several authorization approaches that can 
 
 * User-defined groups
   * Security
-  * O365
+  * Microsoft 365
   * Distribution
 * Roles
   * Built-in Administrative Roles


### PR DESCRIPTION

Fixes #1737442

Addresses rebranding "Office 365" to "Microsoft 365".

I'll add a comment when the PR is ready for review. I'll leave the PR open for 48 hours and address any feedback. After that, I'll sign off for merge.

Thanks -