### PR TITLE
Use GetTestClient() instead of GetTestServer().CreateClient()

### DIFF
--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -43,6 +43,7 @@ In the test project, create a test:
 [!code-csharp[](middleware/samples_snapshot/3.x/setup.cs?highlight=4-18)]
 
 ## Send requests with HttpClient
+
 Send a request using <xref:System.Net.Http.HttpClient>:
 
 [!code-csharp[](middleware/samples_snapshot/3.x/request.cs?highlight=20)]
@@ -51,7 +52,7 @@ Assert the result. First, make an assertion the opposite of the result that you 
 
 In the following example, the middleware should return a 404 status code (*Not Found*) when the root endpoint is requested. Make the first test run with `Assert.NotEqual( ... );`, which should fail:
 
-[!code-csharp[](middleware/samples_snapshot/3.x/false-failure-check.cs?highlight=22)]
+[!code-csharp[](middleware/samples_snapshot/3.x/false-failure-check.cs?highlight=20)]
 
 Change the assertion to test the middleware under normal operating conditions. The final test uses `Assert.Equal( ... );`. Run the test again to confirm that it passes.
 

--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -2,6 +2,7 @@
 title: Test ASP.NET Core middleware
 author: tratcher
 description: Learn how to test ASP.NET Core middleware with TestServer.
+monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
 ms.date: 5/12/2020
@@ -52,7 +53,7 @@ Assert the result. First, make an assertion the opposite of the result that you 
 
 In the following example, the middleware should return a 404 status code (*Not Found*) when the root endpoint is requested. Make the first test run with `Assert.NotEqual( ... );`, which should fail:
 
-[!code-csharp[](middleware/samples_snapshot/3.x/false-failure-check.cs?highlight=20)]
+[!code-csharp[](middleware/samples_snapshot/3.x/false-failure-check.cs?highlight=22)]
 
 Change the assertion to test the middleware under normal operating conditions. The final test uses `Assert.Equal( ... );`. Run the test again to confirm that it passes.
 

--- a/aspnetcore/test/middleware/samples_snapshot/3.x/false-failure-check.cs
+++ b/aspnetcore/test/middleware/samples_snapshot/3.x/false-failure-check.cs
@@ -17,10 +17,7 @@ public async Task MiddlewareTest_ReturnsNotFoundForRequest()
         })
         .StartAsync();
 
-    var testServer = host.GetTestServer();
-    
-    var testClient = testServer.CreateClient();
-    var response = await testClient.GetAsync("/");
+    var response = await host.GetTestClient().GetAsync("/");
 
     Assert.NotEqual(HttpStatusCode.NotFound, response.StatusCode);
 }

--- a/aspnetcore/test/middleware/samples_snapshot/3.x/final-test.cs
+++ b/aspnetcore/test/middleware/samples_snapshot/3.x/final-test.cs
@@ -17,7 +17,7 @@ public async Task MiddlewareTest_ReturnsNotFoundForRequest()
         })
         .StartAsync();
 
-    var response = await host.GetTestServer().CreateClient().GetAsync("/");
+    var response = await host.GetTestClient().GetAsync("/");
 
     Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
 }

--- a/aspnetcore/test/middleware/samples_snapshot/3.x/request.cs
+++ b/aspnetcore/test/middleware/samples_snapshot/3.x/request.cs
@@ -17,7 +17,7 @@ public async Task MiddlewareTest_ReturnsNotFoundForRequest()
         })
         .StartAsync();
 
-    var response = await host.GetTestServer().CreateClient().GetAsync("/");
+    var response = await host.GetTestClient().GetAsync("/");
 
     ...
 }


### PR DESCRIPTION
Fixes #19645.

I'm not sure that the original highlights are quite right. i.e. There's a highlight for the _CreateClient + Get_, then just the _CreateClient_, then the _Assert_. I'd say the first should be the (new) _CreateTestClient + Get_ line (there's no Assert), then the next should be the _Assert.NotEqual_ line, and then the _Assert.Equal_ line. Does that make sense?

cc @guardrex