### PR TITLE
Escaped HTML code renders as plain text

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -121,11 +121,7 @@ The code renders the following HTML:
 &lt;span&gt;Hello World&lt;/span&gt;
 ```
 
-The HTML is shown in the browser as:
-
-```html
-<span>Hello World</span>
-```
+The HTML is shown in the browser as plain text: &lsquo;&lt;span&gt;Hello World&lt;/span&gt;&lsquo;.
 
 `HtmlHelper.Raw` output isn't encoded but rendered as HTML markup.
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -121,7 +121,7 @@ The code renders the following HTML:
 &lt;span&gt;Hello World&lt;/span&gt;
 ```
 
-The HTML is shown in the browser as plain text: &lsquo;&lt;span&gt;Hello World&lt;/span&gt;&lsquo;.
+The HTML is shown in the browser as plain text: <q >&lt;span&gt;Hello World&lt;/span&gt;</q >.
 
 `HtmlHelper.Raw` output isn't encoded but rendered as HTML markup.
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -115,13 +115,15 @@ C# expressions that evaluate to a string are HTML encoded. C# expressions that e
 @("<span>Hello World</span>")
 ```
 
-The code renders the following HTML:
+The preceding code renders the following HTML:
 
 ```html
 &lt;span&gt;Hello World&lt;/span&gt;
 ```
 
-The HTML is shown in the browser as plain text: <q >&lt;span&gt;Hello World&lt;/span&gt;</q >.
+The HTML is shown in the browser as plain text:
+
+&lt;span&gt;Hello World&lt;/span&gt;
 
 `HtmlHelper.Raw` output isn't encoded but rendered as HTML markup.
 


### PR DESCRIPTION
The use of an HTML code section to display plain text rendered in the browser is misleading because browsers do not colour tags in plain text.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->