### PR TITLE
Remove .NET Platform org. from what's new config

### DIFF
--- a/.whatsnew.json
+++ b/.whatsnew.json
@@ -7,7 +7,6 @@
   },
   "inclusionCriteria": {
     "additionalMicrosoftOrgs": [
-      ".NET Platform",
       "ASP.NET"
     ],
     "minAdditionsToFile": 60


### PR DESCRIPTION
With Bill's changes in the following PR, the ".NET Platform" GitHub org. no longer has to be listed in the config file: https://dev.azure.com/mseng/TechnicalContent/_git/dotnet-docs-tools/pullrequest/571943