### PR TITLE
New topic why migrate wcf to gRPC

### DIFF
--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -15,7 +15,7 @@ This article provides a summary outlining why ASP.NET Core gRPC is a good fit fo
 
 ## Similarity to WCF
 
-Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. The underlying goal is the same: make it possible to code as though the client and server are on the same platform, without needing to worry about networking.
+Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. WCF and gRPC are both RPC (remote procedure call) frameworks and the underlying goal is the same: make it possible to code as though the client and server are on the same platform, without needing to worry about networking.
 
 Both platforms share the principle of declaring and then implementing an interface, even though the process for declaring that interface is different. And as you'll see in chapter 5, the different types of RPC calls that gRPC supports map well to the bindings available to WCF services.
 

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -1,7 +1,7 @@
 ---
 title: Why migrate WCF to ASP.NET Core gRPC
 author: markrendle
-description: A summary of why ASP.NET Core gRPC is a good fit for WCF developers who want to migrate to modern architectures and platforms.
+description: A summary of why ASP.NET Core gRPC is a good fit for Windows Communication Foundation (WCF) developers who want to migrate to modern architectures and platforms.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: wpickett
 ms.date: 09/02/2020
@@ -9,15 +9,15 @@ no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blaz
 uid: grpc/wcf
 ---
 
-# Why we recommend gRPC for WCF developers
+# Why we recommend gRPC for Windows Communication Foundation (WCF) developers
 
-This article provides a summary outlining why ASP.NET Core gRPC is a good fit for WCF developers who want to migrate to modern architectures and platforms.
+This article provides a summary of why ASP.NET Core gRPC is a good fit for Windows Communication Foundation (WCF) developers who want to migrate to modern architectures and platforms.
 
 ## Similarity to WCF
 
 Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. WCF and gRPC are both RPC (remote procedure call) frameworks and the underlying goal is the same: make it possible to code as though the client and server are on the same platform, without needing to worry about networking.
 
-Both platforms share the principle of declaring and then implementing an interface, even though the process for declaring that interface is different. And as you'll see in chapter 5, the different types of RPC calls that gRPC supports map well to the bindings available to WCF services.
+Both platforms share the principle of declaring and then implementing an interface, even though the process for declaring that interface is different. The different types of RPC calls that gRPC supports map well to the bindings available to WCF services. For more information and examples, see [Migrate a WCF solution to gRPC](https://docs.microsoft.com/dotnet/architecture/grpc-for-wcf-developers/migrate-wcf-to-grpc).
 
 ## Benefits of gRPC
 
@@ -25,7 +25,7 @@ gRPC stands above other solutions for the following reasons.
 
 ### Performance
 
-gRPC uses HTTP/2, a smaller, faster binary protocol than HTTP/1.1. This is more efficient for computers to parse. HTTP/2 also supports multiplexing requests over a single connection. Multiplexing enables multiple requests to be sent over one connection without requests blocking each other. (In HTTP/1.1, this issue is known as "head-of-line (HOL) blocking.") gRPC uses the Protobuf, an efficient binary format, to serialize messages. Protobuf messages are very small in size and use less bandwidth than text based formats. gRPC is a good solution to use for mobile devices and over slower networks where bandwidth is important.
+gRPC uses HTTP/2.  HTTP/2 is a smaller, faster binary protocol than HTTP/1.1, which is more efficient for computers to parse. HTTP/2 also supports multiplexing requests over a single connection. Multiplexing enables multiple requests to be sent over one connection without requests blocking each other. (In HTTP/1.1, this issue is known as "head-of-line (HOL) blocking.") gRPC uses the Protobuf, an efficient binary format, to serialize messages. Protobuf messages are small in size and use less bandwidth than text-based formats. gRPC is a good solution to use for mobile devices and over slower networks where bandwidth is important.
 
 ### Interoperability
 
@@ -41,12 +41,16 @@ gRPC has full bidirectional streaming, which provides similar functionality to W
 
 ### Deadline/timeouts and cancellation
 
-gRPC allows clients to specify a maximum time for an RPC to finish. If the specified deadline is exceeded, the server can cancel the operation independently of the client. Deadlines and cancellations can be propagated through further gRPC calls to help enforce resource usage limits. Clients can also stop operations when a deadline is exceeded, or earlier if necessary (for example, because of a user interaction).
+gRPC allows clients to specify a maximum time for an RPC to finish. If the specified deadline is exceeded, the server can cancel the operation independently of the client. Deadlines and cancellations can be propagated through further gRPC calls to help enforce resource usage limits. Clients can stop operations when a deadline is exceeded, or earlier if necessary (for example, because of a user interaction).
 
 ### Security
 
 gRPC can use TLS and HTTP/2 to provide an end-to-end encrypted connection between the client and the server. Support for client certificate authentication further increases security and trust between client and server.
 
-# Get Started
+## gRPC as a migration path for WCF to .NET Core and .NET 5
+
+The release of .NET Core 3.0 marked a shift in the way that Microsoft delivers remote communication solutions to developers who want to deliver services across a range of platforms. .NET Core and .NET 5 will not offer server-side support for the Windows Communication Foundation (WCF). With the release of ASP.NET Core 3.0, it does however provide built-in gRPC functionality.
+
+## Get Started
 
 For detailed guidance on building gRPC services in ASP.NET Core for WCF developers, see [ASP.NET Core gRPC for WCF Developers](https://docs.microsoft.com/dotnet/architecture/grpc-for-wcf-developers/)

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -9,18 +9,18 @@ no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blaz
 uid: grpc/wcf
 ---
 
-# Why we recommend gRPC for Windows Communication Foundation (WCF) developers
+# gRPC for Windows Communication Foundation (WCF) developers
 
 This article provides a summary of why ASP.NET Core gRPC is a good fit for Windows Communication Foundation (WCF) developers who want to migrate to modern architectures and platforms.
 
-## Similarity to WCF
+## Comparison to WCF
 
-Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. WCF and gRPC are RPC (remote procedure call) frameworks with the same goal: 
+Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. WCF and gRPC are RPC (remote procedure call) frameworks with the same goals:
 
 * Make it possible to code as though the client and server are on the same platform.
 * Provide a simplified portable networking API.
 
-Both platforms share the requirement of declaring and implementing an interface, although the process for declaring the interface is different. The many types of RPC calls that gRPC supports map well to the bindings available to WCF services. For more information and examples, see [Migrate a WCF solution to gRPC](/dotnet/architecture/grpc-for-wcf-developers/migrate-wcf-to-grpc)
+Both platforms share the requirement of declaring and implementing an interface, although the process for declaring the interface is different. The many types of RPC calls that gRPC supports map well to the bindings available to WCF services. For more information and examples, see [Migrate a WCF solution to gRPC](/dotnet/architecture/grpc-for-wcf-developers/migrate-wcf-to-grpc).
 
 ## Benefits of gRPC
 
@@ -28,21 +28,21 @@ gRPC provides a better framework than other approaches for the following reasons
 
 ### Performance
 
-gRPC uses HTTP/2.  HTTP/2 compared to HTTP/1.1, HTTP/2:
+gRPC uses HTTP/2. In contrast to HTTP/1.1, HTTP/2:
 
 * Is a smaller, faster binary protocol.
 * Is more efficient for computers to parse.
 * Supports multiplexing requests over a single connection. Multiplexing enables multiple requests to be sent over one connection without requests blocking each other. In HTTP/1.1, the blocking is known as "head-of-line (HOL) blocking."
 
-gRPC uses the Protobuf, an efficient binary format, to serialize messages. Protobuf messages are:
-* Small in size.
+gRPC uses Protobuf, an efficient binary format, to serialize messages. Protobuf messages are:
+* Fast to serialize and deserialize.
 * Use less bandwidth than text-based formats. 
 
-gRPC is a good solution to use for mobile devices and over slower networks where bandwidth is important.
+gRPC is a good solution for mobile devices and networks with bandwidth restrictions.
 
 ### Interoperability
 
-There are gRPC tools and libraries for all major programming languages and platforms, including .NET, Java, Python, Go, C++, Node.js, Swift, Dart, Ruby, and PHP. Thanks to the Protocol Buffers binary wire format and the efficient code generation for each platform, developers can build cross-platform performant apps.
+There are gRPC tools and libraries for all major programming languages and platforms, including .NET, Java, Python, Go, C++, Node.js, Swift, Dart, Ruby, and PHP. Thanks to the Protobuf binary wire format and the efficient code generation for each platform, developers can build cross-platform, performant apps.
 
 ### Usability and productivity
 
@@ -52,9 +52,9 @@ gRPC is a comprehensive RPC solution. It works consistently across multiple lang
 
 gRPC has full bidirectional streaming, which provides similar functionality to WCF's full duplex services. gRPC streaming can operate over regular internet connections, load balancers, and service meshes.
 
-### Deadlines, timeouts and cancellation
+### Deadlines, timeouts, and cancellation
 
-gRPC allows clients to specify a maximum time for an RPC to finish. If the specified deadline is exceeded, the server can cancel the operation independently of the client. Deadlines and cancellations can be propagated through further gRPC calls to help enforce resource usage limits. Clients can stop operations when a deadline is exceeded, or earlier if necessary. For example,  clients can stop operations because of a user interaction.
+gRPC allows clients to specify a maximum time for an RPC to finish. If the specified deadline is exceeded, the server can cancel the operation independently of the client. Deadlines and cancellations can be propagated through subsequent gRPC calls to help enforce resource usage limits. Clients can stop operations when a deadline is exceeded, or earlier if necessary. For example, clients can stop operations because of a user interaction.
 
 ### Security
 
@@ -62,8 +62,8 @@ gRPC can use TLS and HTTP/2 to provide an end-to-end encrypted connection betwee
 
 ## gRPC as a migration path for WCF to .NET Core and .NET 5
 
-The release of .NET Core 3.0 marked a shift in the way that Microsoft delivers remote communication solutions to developers who want to deliver services across a range of platforms. .NET Core and .NET 5 will not offer server-side support for the Windows Communication Foundation (WCF). With the release of ASP.NET Core 3.0, it does however provide built-in gRPC functionality.
+The release of .NET Core 3.0 marked a shift in the way that Microsoft delivers remote communication solutions to developers who want to deliver services across a range of platforms. .NET Core and .NET 5 won't offer server-side support for WCF. With the release of ASP.NET Core 3.0, it does however provide built-in gRPC functionality.
 
 ## Get started
 
-For detailed guidance on building gRPC services in ASP.NET Core for WCF developers, see [ASP.NET Core gRPC for WCF Developers](https://docs.microsoft.com/dotnet/architecture/grpc-for-wcf-developers/)
+For detailed guidance on building gRPC services in ASP.NET Core for WCF developers, see [ASP.NET Core gRPC for WCF Developers](/dotnet/architecture/grpc-for-wcf-developers)

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -17,7 +17,7 @@ This article provides a summary of why ASP.NET Core gRPC is a good fit for Windo
 
 Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. WCF and gRPC are RPC (remote procedure call) frameworks with the same goal: 
 
-•*Make it possible to code as though the client and server are on the same platform.
+* Make it possible to code as though the client and server are on the same platform.
 * Provide a simplified portable networking API.
 
 Both platforms share the requirement of declaring and implementing an interface, although the process for declaring the interface is different. The many types of RPC calls that gRPC supports map well to the bindings available to WCF services. For more information and examples, see [Migrate a WCF solution to gRPC](/dotnet/architecture/grpc-for-wcf-developers/migrate-wcf-to-grpc)
@@ -34,7 +34,11 @@ gRPC uses HTTP/2.  HTTP/2 compared to HTTP/1.1, HTTP/2:
 * Is more efficient for computers to parse.
 * Supports multiplexing requests over a single connection. Multiplexing enables multiple requests to be sent over one connection without requests blocking each other. In HTTP/1.1, the blocking is known as "head-of-line (HOL) blocking."
 
-gRPC uses the Protobuf, an efficient binary format, to serialize messages. Protobuf messages are small in size and use less bandwidth than text-based formats. gRPC is a good solution to use for mobile devices and over slower networks where bandwidth is important.
+gRPC uses the Protobuf, an efficient binary format, to serialize messages. Protobuf messages are:
+* Small in size.
+* Use less bandwidth than text-based formats. 
+
+gRPC is a good solution to use for mobile devices and over slower networks where bandwidth is important.
 
 ### Interoperability
 

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -33,7 +33,7 @@ There are gRPC tools and libraries for all major programming languages and platf
 
 ### Usability and productivity
 
-gRPC is a comprehensive RPC solution. It works consistently across multiple languages and platforms. It also provides excellent tooling, with much of the necessary boilerplate code automatically generated. So more developer time is freed up to focus on business logic.
+gRPC is a comprehensive RPC solution. It works consistently across multiple languages and platforms. It also provides excellent tooling, with much of the necessary boilerplate code automatically generated. Like WCF, gRPC automatically generates messages and a strongly typed client for you. Developer time is freed up to focus on business logic.
 
 ### Streaming
 

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -45,7 +45,7 @@ gRPC allows clients to specify a maximum time for an RPC to finish. If the speci
 
 ### Security
 
-gRPC is implicitly secure when it's using HTTP/2 over a TLS end-to-end encrypted connection. Support for client certificate authentication further increases security and trust between client and server.
+gRPC can use TLS and HTTP/2 to provide an end-to-end encrypted connection between the client and the server. Support for client certificate authentication further increases security and trust between client and server.
 
 # Get Started
 

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -62,7 +62,13 @@ gRPC can use TLS and HTTP/2 to provide an end-to-end encrypted connection betwee
 
 ## gRPC as a migration path for WCF to .NET Core and .NET 5
 
-The release of .NET Core 3.0 marked a shift in the way that Microsoft delivers remote communication solutions to developers who want to deliver services across a range of platforms. .NET Core and .NET 5 won't offer server-side support for WCF. With the release of ASP.NET Core 3.0, it does however provide built-in gRPC functionality.
+.NET Core and .NET 5 marks a shift in the way that Microsoft delivers remote communication solutions to developers who want to deliver services across a range of platforms. .NET Core and .NET 5 support [calling WCF services](/dotnet/core/additional-tools/wcf-web-service-reference-guide), but won't offer server-side support for hosting WCF.
+
+There are two recommended paths for modernizing WCF apps:
+
+* gRPC is built on modern technologies and has emerged as the most popular choice across the developer community for RPC apps. Starting with .NET Core 3.0, modern .NET platforms have excellent support for gRPC. Migrating WCF services to use gRPC helps provide the RPC features, performance, an interoperability needed in modern apps.
+
+* [CoreWCF](https://github.com/CoreWCF/CoreWCF) is a community effort to bring support for hosting WCF services to .NET Core and .NET 5. A preview release is available and the project is working towards being production ready. CoreWCF only supports a subset of WCF's features, and .NET Framework apps that migrate to use it will need code changes and testing to be successful. CoreWCF is a good choice if an app has to maintain compatibility with existing clients that call WCF services.
 
 ## Get started
 

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -25,7 +25,7 @@ gRPC stands above other solutions for the following reasons.
 
 ### Performance
 
-Using HTTP/2 rather than HTTP/1.1 removes the requirement for human-readable messages and instead uses the smaller, faster binary protocol. This is more efficient for computers to parse. HTTP/2 also supports multiplexing requests over a single connection. This support enables responses to be sent as soon as they're ready without the need to wait in a queue. (In HTTP/1.1, this issue is known as "head-of-line (HOL) blocking.") You need fewer resources when using gRPC, which makes it a good solution to use for mobile devices and over slower networks.
+gRPC uses HTTP/2, a smaller, faster binary protocol than HTTP/1.1. This is more efficient for computers to parse. HTTP/2 also supports multiplexing requests over a single connection. Multiplexing enables multiple requests to be sent over one connection without requests blocking each other. (In HTTP/1.1, this issue is known as "head-of-line (HOL) blocking.") gRPC uses the Protobuf, an efficient binary format, to serialize messages. Protobuf messages are very small in size and use less bandwidth than text based formats. gRPC is a good solution to use for mobile devices and over slower networks where bandwidth is important.
 
 ### Interoperability
 

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -1,7 +1,7 @@
 ---
 title: Why migrate WCF to ASP.NET Core gRPC
 author: markrendle
-description: A summary of why ASP.NET Core gRPC is a good fit for Windows Communication Foundation (WCF) developers who want to migrate to modern architectures and platforms.
+description: This article provides a summary of why ASP.NET Core gRPC is a good fit for Windows Communication Foundation (WCF) developers who want to migrate to modern architectures and platforms.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: wpickett
 ms.date: 09/02/2020

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -1,0 +1,52 @@
+---
+title: Why migrate WCF to ASP.NET Core gRPC
+author: markrendle
+description: A summary of why ASP.NET Core gRPC is a good fit for WCF developers who want to migrate to modern architectures and platforms.
+monikerRange: '>= aspnetcore-3.0'
+ms.author: wpickett
+ms.date: 09/02/2020
+no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+uid: grpc/wcf
+---
+
+# Why we recommend gRPC for WCF developers
+
+This article provides a summary outlining why ASP.NET Core gRPC is a good fit for WCF developers who want to migrate to modern architectures and platforms.
+
+## Similarity to WCF
+
+Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. The underlying goal is the same: make it possible to code as though the client and server are on the same platform, without needing to worry about networking.
+
+Both platforms share the principle of declaring and then implementing an interface, even though the process for declaring that interface is different. And as you'll see in chapter 5, the different types of RPC calls that gRPC supports map well to the bindings available to WCF services.
+
+## Benefits of gRPC
+
+gRPC stands above other solutions for the following reasons.
+
+### Performance
+
+Using HTTP/2 rather than HTTP/1.1 removes the requirement for human-readable messages and instead uses the smaller, faster binary protocol. This is more efficient for computers to parse. HTTP/2 also supports multiplexing requests over a single connection. This support enables responses to be sent as soon as they're ready without the need to wait in a queue. (In HTTP/1.1, this issue is known as "head-of-line (HOL) blocking.") You need fewer resources when using gRPC, which makes it a good solution to use for mobile devices and over slower networks.
+
+### Interoperability
+
+There are gRPC tools and libraries for all major programming languages and platforms, including .NET, Java, Python, Go, C++, Node.js, Swift, Dart, Ruby, and PHP. Thanks to the Protocol Buffers binary wire format and the efficient code generation for each platform, developers can build performant apps while still enjoying full cross-platform support.
+
+### Usability and productivity
+
+gRPC is a comprehensive RPC solution. It works consistently across multiple languages and platforms. It also provides excellent tooling, with much of the necessary boilerplate code automatically generated. So more developer time is freed up to focus on business logic.
+
+### Streaming
+
+gRPC has full bidirectional streaming, which provides similar functionality to WCF's full duplex services. gRPC streaming can operate over regular internet connections, load balancers, and service meshes.
+
+### Deadline/timeouts and cancellation
+
+gRPC allows clients to specify a maximum time for an RPC to finish. If the specified deadline is exceeded, the server can cancel the operation independently of the client. Deadlines and cancellations can be propagated through further gRPC calls to help enforce resource usage limits. Clients can also stop operations when a deadline is exceeded, or earlier if necessary (for example, because of a user interaction).
+
+### Security
+
+gRPC is implicitly secure when it's using HTTP/2 over a TLS end-to-end encrypted connection. Support for client certificate authentication further increases security and trust between client and server.
+
+# Get Started
+
+For detailed guidance on building gRPC services in ASP.NET Core for WCF developers, see [ASP.NET Core gRPC for WCF Developers](https://docs.microsoft.com/dotnet/architecture/grpc-for-wcf-developers/)

--- a/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
+++ b/aspnetcore/grpc/why-migrate-wcf-to-dotnet-grpc.md
@@ -15,33 +15,42 @@ This article provides a summary of why ASP.NET Core gRPC is a good fit for Windo
 
 ## Similarity to WCF
 
-Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. WCF and gRPC are both RPC (remote procedure call) frameworks and the underlying goal is the same: make it possible to code as though the client and server are on the same platform, without needing to worry about networking.
+Although the implementation and approach are different for gRPC, the experience of developing and consuming services with gRPC should be intuitive for WCF developers. WCF and gRPC are RPC (remote procedure call) frameworks with the same goal: 
 
-Both platforms share the principle of declaring and then implementing an interface, even though the process for declaring that interface is different. The different types of RPC calls that gRPC supports map well to the bindings available to WCF services. For more information and examples, see [Migrate a WCF solution to gRPC](https://docs.microsoft.com/dotnet/architecture/grpc-for-wcf-developers/migrate-wcf-to-grpc).
+•*Make it possible to code as though the client and server are on the same platform.
+* Provide a simplified portable networking API.
+
+Both platforms share the requirement of declaring and implementing an interface, although the process for declaring the interface is different. The many types of RPC calls that gRPC supports map well to the bindings available to WCF services. For more information and examples, see [Migrate a WCF solution to gRPC](/dotnet/architecture/grpc-for-wcf-developers/migrate-wcf-to-grpc)
 
 ## Benefits of gRPC
 
-gRPC stands above other solutions for the following reasons.
+gRPC provides a better framework than other approaches for the following reasons.
 
 ### Performance
 
-gRPC uses HTTP/2.  HTTP/2 is a smaller, faster binary protocol than HTTP/1.1, which is more efficient for computers to parse. HTTP/2 also supports multiplexing requests over a single connection. Multiplexing enables multiple requests to be sent over one connection without requests blocking each other. (In HTTP/1.1, this issue is known as "head-of-line (HOL) blocking.") gRPC uses the Protobuf, an efficient binary format, to serialize messages. Protobuf messages are small in size and use less bandwidth than text-based formats. gRPC is a good solution to use for mobile devices and over slower networks where bandwidth is important.
+gRPC uses HTTP/2.  HTTP/2 compared to HTTP/1.1, HTTP/2:
+
+* Is a smaller, faster binary protocol.
+* Is more efficient for computers to parse.
+* Supports multiplexing requests over a single connection. Multiplexing enables multiple requests to be sent over one connection without requests blocking each other. In HTTP/1.1, the blocking is known as "head-of-line (HOL) blocking."
+
+gRPC uses the Protobuf, an efficient binary format, to serialize messages. Protobuf messages are small in size and use less bandwidth than text-based formats. gRPC is a good solution to use for mobile devices and over slower networks where bandwidth is important.
 
 ### Interoperability
 
-There are gRPC tools and libraries for all major programming languages and platforms, including .NET, Java, Python, Go, C++, Node.js, Swift, Dart, Ruby, and PHP. Thanks to the Protocol Buffers binary wire format and the efficient code generation for each platform, developers can build performant apps while still enjoying full cross-platform support.
+There are gRPC tools and libraries for all major programming languages and platforms, including .NET, Java, Python, Go, C++, Node.js, Swift, Dart, Ruby, and PHP. Thanks to the Protocol Buffers binary wire format and the efficient code generation for each platform, developers can build cross-platform performant apps.
 
 ### Usability and productivity
 
-gRPC is a comprehensive RPC solution. It works consistently across multiple languages and platforms. It also provides excellent tooling, with much of the necessary boilerplate code automatically generated. Like WCF, gRPC automatically generates messages and a strongly typed client for you. Developer time is freed up to focus on business logic.
+gRPC is a comprehensive RPC solution. It works consistently across multiple languages and platforms. It also provides excellent tooling, with much of the boilerplate code automatically generated. Like WCF, gRPC automatically generates messages and a strongly typed client. Developer time is freed up to focus on business logic.
 
 ### Streaming
 
 gRPC has full bidirectional streaming, which provides similar functionality to WCF's full duplex services. gRPC streaming can operate over regular internet connections, load balancers, and service meshes.
 
-### Deadline/timeouts and cancellation
+### Deadlines, timeouts and cancellation
 
-gRPC allows clients to specify a maximum time for an RPC to finish. If the specified deadline is exceeded, the server can cancel the operation independently of the client. Deadlines and cancellations can be propagated through further gRPC calls to help enforce resource usage limits. Clients can stop operations when a deadline is exceeded, or earlier if necessary (for example, because of a user interaction).
+gRPC allows clients to specify a maximum time for an RPC to finish. If the specified deadline is exceeded, the server can cancel the operation independently of the client. Deadlines and cancellations can be propagated through further gRPC calls to help enforce resource usage limits. Clients can stop operations when a deadline is exceeded, or earlier if necessary. For example,  clients can stop operations because of a user interaction.
 
 ### Security
 
@@ -51,6 +60,6 @@ gRPC can use TLS and HTTP/2 to provide an end-to-end encrypted connection betwee
 
 The release of .NET Core 3.0 marked a shift in the way that Microsoft delivers remote communication solutions to developers who want to deliver services across a range of platforms. .NET Core and .NET 5 will not offer server-side support for the Windows Communication Foundation (WCF). With the release of ASP.NET Core 3.0, it does however provide built-in gRPC functionality.
 
-## Get Started
+## Get started
 
 For detailed guidance on building gRPC services in ASP.NET Core for WCF developers, see [ASP.NET Core gRPC for WCF Developers](https://docs.microsoft.com/dotnet/architecture/grpc-for-wcf-developers/)

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -740,14 +740,14 @@
       uid: grpc/dotnet-grpc
     - name: Migrate gRPC services from C-core
       uid: grpc/migration
+    - name: Why migrate WCF to ASP.NET Core gRPC
+      uid: grpc/wcf
     - name: Compare gRPC services with HTTP APIs
       uid: grpc/comparison
     - name: Samples
       href: https://github.com/grpc/grpc-dotnet/tree/master/examples
     - name: Troubleshoot
       uid: grpc/troubleshoot
-    - name: Why migrate WCF to ASP.NET Core gRPC
-      uid: grpc/wcf
 - name: Test, debug, and troubleshoot
   items:
     - name: Razor Pages unit tests

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -746,6 +746,8 @@
       href: https://github.com/grpc/grpc-dotnet/tree/master/examples
     - name: Troubleshoot
       uid: grpc/troubleshoot
+    - name: Why migrate WCF to ASP.NET Core gRPC
+      uid: grpc/wcf
 - name: Test, debug, and troubleshoot
   items:
     - name: Razor Pages unit tests

--- a/aspnetcore/tutorials/first-mvc-app/details.md
+++ b/aspnetcore/tutorials/first-mvc-app/details.md
@@ -49,7 +49,7 @@ public async Task<IActionResult> Delete(int id, bool notUsed)
 
 ### Publish to Azure
 
-For information on deploying to Azure, see [Tutorial: Build a .NET Core and SQL Database web app in Azure App Service](/azure/app-service/app-service-web-tutorial-dotnetcore-sqldb).
+For information on deploying to Azure, see [Tutorial: Build an ASP.NET Core and SQL Database app in Azure App Service](/azure/app-service/tutorial-dotnetcore-sqldb-app).
 
 > [!div class="step-by-step"]
 > [Previous](validation.md)


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/grpc/why-migrate-wcf-to-dotnet-grpc?view=aspnetcore-5.0&branch=pr-en-us-19768)

Fixes #19011 

This new topic is simply a short summary of the advantages of gRPC for WCF developers that also points them to the extensive eBook published for extensive guidance if the reader chooses to get started migrating.   The content here is the summary of advantages taken directly out of the book, and at the end of the summary it points to the eBook.

We generally really like to avoid copying content to put in two places, it affects SEO a bit for starters and they become out of sync. However the summary in the book is already short and to the point of what is needed here.  I put the eBook author in the "author" metadata.