### PR TITLE
Blazor *Server app* API authz for groups+roles

### DIFF
--- a/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
@@ -467,7 +467,7 @@ services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationSche
 {
     options.Events = new JwtBearerEvents()
     {
-        OnAuthenticationFailed = (context) =>
+        OnAuthenticationFailed = context =>
         {
             // Optional: Log the exception
 

--- a/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
@@ -452,8 +452,6 @@ When configuring <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEv
 > [!WARNING]
 > <xref:Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII?displayProperty=nameWithType> provides Personally Identifiable Information (PII) in logging messages. Only activate PII for debugging with test user accounts.
 
-In the following example, note that the authentication services scheme of <xref:Microsoft.AspNetCore.Authentication.AzureAD.UI.AzureADDefaults.BearerAuthenticationScheme?displayProperty=nameWithType> in a default app based on the Blazor Hosted WebAssembly app template is changed to <xref:Microsoft.AspNetCore.Authentication.AzureAD.UI.AzureADDefaults.JwtBearerAuthenticationScheme?displayProperty=nameWithType>.
-
 In `Startup.ConfigureServices`:
 
 ```csharp
@@ -461,7 +459,7 @@ In `Startup.ConfigureServices`:
 IdentityModelEventSource.ShowPII = true;
 #endif
 
-services.AddAuthentication(AzureADDefaults.JwtBearerAuthenticationScheme)
+services.AddAuthentication(AzureADDefaults.BearerAuthenticationScheme)
     .AddAzureADBearer(options => Configuration.Bind("AzureAd", options));
 
 services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, 

--- a/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
@@ -9,7 +9,7 @@ ms.date: 07/28/2020
 no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/webassembly/aad-groups-roles
 ---
-# Azure AD Groups, Administrative Roles, and user-defined roles
+# Azure Active Directory (AAD) groups, Administrator Roles, and user-defined roles
 
 By [Luke Latham](https://github.com/guardrex) and [Javier Calvarro Nelson](https://github.com/javiercn)
 
@@ -20,7 +20,7 @@ Azure Active Directory (AAD) provides several authorization approaches that can 
   * Microsoft 365
   * Distribution
 * Roles
-  * Built-in Administrative Roles
+  * AAD Administrator Roles
   * User-defined roles
 
 The guidance in this article applies to the Blazor WebAssembly AAD deployment scenarios described in the following topics:
@@ -31,7 +31,7 @@ The guidance in this article applies to the Blazor WebAssembly AAD deployment sc
 
 ## Microsoft Graph API permission
 
-A [Microsoft Graph API](/graph/use-the-api) call is required for any app user with more than five built-in AAD Administrator role and security group memberships.
+A [Microsoft Graph API](/graph/use-the-api) call is required for any app user with more than five AAD Administrator role and security group memberships.
 
 To permit Graph API calls, give the standalone or client app of a hosted Blazor solution any of the following [Graph API permissions](/graph/permissions-reference) in the Azure portal:
 
@@ -41,18 +41,18 @@ To permit Graph API calls, give the standalone or client app of a hosted Blazor 
 
 `Directory.Read.All` is the least-privileged permission and is the permission used for the example described in this article.
 
-## User-defined groups and built-in Administrative Roles
+## User-defined groups and Administrator Roles
 
-To configure the app in the Azure portal to provide a `groups` membership claim, see the following Azure articles. Assign users to user-defined AAD groups and built-in Administrative Roles.
+To configure the app in the Azure portal to provide a `groups` membership claim, see the following Azure articles. Assign users to user-defined AAD groups and AAD Administrator Roles.
 
 * [Roles using Azure AD security groups](/azure/architecture/multitenant-identity/app-roles#roles-using-azure-ad-security-groups)
 * [`groupMembershipClaims` attribute](/azure/active-directory/develop/reference-app-manifest#groupmembershipclaims-attribute)
 
-The following examples assume that a user is assigned to the AAD built-in *Billing Administrator* role.
+The following examples assume that a user is assigned to the AAD *Billing Administrator* role.
 
 The single `groups` claim sent by AAD presents the user's groups and roles as Object IDs (GUIDs) in a JSON array. The app must convert the JSON array of groups and roles into individual `group` claims that the app can build [policies](xref:security/authorization/policies) against.
 
-When the number of assigned built-in Azure Administrative Roles and user-defined groups exceeds five, AAD sends a `hasgroups` claim with a `true` value instead of sending a `groups` claim. Any app that may have more than five roles and groups assigned to its users must make a separate Graph API call to obtain a user's roles and groups. The example implementation provided in this article addresses this scenario. For more information, see the `groups` and `hasgroups` claims information in [Microsoft identity platform access tokens: Payload claims](/azure/active-directory/develop/access-tokens#payload-claims) article.
+When the number of assigned AAD Administrator Roles and user-defined groups exceeds five, AAD sends a `hasgroups` claim with a `true` value instead of sending a `groups` claim. Any app that may have more than five roles and groups assigned to its users must make a separate Graph API call to obtain a user's roles and groups. The example implementation provided in this article addresses this scenario. For more information, see the `groups` and `hasgroups` claims information in [Microsoft identity platform access tokens: Payload claims](/azure/active-directory/develop/access-tokens#payload-claims) article.
 
 Extend <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount> to include array properties for groups and roles. Assign an empty array to each property so that checking for `null` isn't required when these properties are used in `foreach` loops later.
 
@@ -251,7 +251,7 @@ builder.Services.AddMsalAuthentication<RemoteAuthenticationState,
     CustomUserFactory>();
 ```
 
-Create a [policy](xref:security/authorization/policies) for each group or role in `Program.Main`. The following example creates a policy for the AAD built-in *Billing Administrator* role:
+Create a [policy](xref:security/authorization/policies) for each group or role in `Program.Main`. The following example creates a policy for the AAD *Billing Administrator* role:
 
 ```csharp
 builder.Services.AddAuthorizationCore(options =>
@@ -261,7 +261,7 @@ builder.Services.AddAuthorizationCore(options =>
 });
 ```
 
-For the complete list of AAD role Object IDs, see the [AAD Adminstrative Role Group IDs](#aad-adminstrative-role-group-ids) section.
+For the complete list of AAD role Object IDs, see the [AAD Administrator Role Object IDs](#aad-administrator-role-object-ids) section.
 
 In the following examples, the app uses the preceding policy to authorize the user.
 
@@ -271,7 +271,7 @@ The [`AuthorizeView` component](xref:blazor/security/index#authorizeview-compone
 <AuthorizeView Policy="BillingAdministrator">
     <Authorized>
         <p>
-            The user is in the 'Billing Administrator' AAD Administrative Role
+            The user is in the 'Billing Administrator' AAD Administrator Role
             and can see this content.
         </p>
     </Authorized>
@@ -332,6 +332,286 @@ A policy check can also be [performed in code with procedural logic](xref:blazor
 }
 ```
 
+## Authorize server API access for user-defined groups and Administrator Roles
+
+In addition to authorizing users in the client-side WebAssembly app to access pages and resources, the server API can authorize users for access to secure API endpoints. After the *Server* app validates the user's access token:
+
+* The app uses the User Principal Name claim (`upn`) to obtain an access token for Graph API.
+* A Graph API call obtains the user's Azure security group and Administrator Role memberships.
+* Memberships are used to establish additional `group` claims.
+* An [authorization policy](xref:security/authorization/policies) limits user access to server API endpoints.
+
+> [!NOTE]
+> This guidance doesn't currently include authorizing users on the basis of their [User-defined roles](#user-defined-roles).
+
+### Packages
+
+Add package references to the *Server* app for the following packages:
+
+* [Microsoft.Graph](https://www.nuget.org/packages/Microsoft.Graph)
+* [Microsoft.IdentityModel.Clients.ActiveDirectory](https://www.nuget.org/packages?q=Microsoft.IdentityModel.Clients.ActiveDirectory)
+
+### Azure configuration
+
+* Confirm that the *Server* app registration is given API access to the Graph API permission for `Directory.Read.All`, which is the least-privileged access level for security groups. Confirm that admin consent is applied to the permission after making the permission assignment.
+* Assign a new client secret to the *Server* app. Note the secret for the app's configuration in the [App settings](#app-settings) section.
+
+## App settings
+
+In the app settings file (`appsettings.json` or `appsettings.Production.json`), create a `ClientSecret` entry with the *Server* app's client secret from the Azure portal:
+
+```json
+"AzureAd": {
+  "Instance": "https://login.microsoftonline.com/",
+  "Domain": "XXXXXXXXXXXX.onmicrosoft.com",
+  "TenantId": "{GUID}",
+  "ClientId": "{GUID}",
+  "ClientSecret": "{CLIENT SECRET}"
+},
+```
+
+For example:
+
+```json
+"AzureAd": {
+  "Instance": "https://login.microsoftonline.com/",
+  "Domain": "contoso.onmicrosoft.com",
+  "TenantId": "34bf0ec1-7aeb-4b5d-ba42-82b059b3abe8",
+  "ClientId": "05d198e0-38c6-4efc-a67c-8ee87ed9bd3d",
+  "ClientSecret": "54uE~9a.-wW91fe8cRR25ag~-I5gEq_92~"
+},
+```
+
+## Authorization policies
+
+Create [authorization policies](xref:security/authorization/policies) for AAD security groups and AAD Administrator Roles in the *Server* app's `Startup.ConfigureServices` based on group object IDs and [AAD Administrator Role Object IDs](#aad-administrator-role-object-ids).
+
+For example, an Azure Billing Administrator Role policy has the following configuration:
+
+```csharp
+services.AddAuthorization(options =>
+{
+    options.AddPolicy("BillingAdmin", policy => 
+        policy.RequireClaim("group", "69ff516a-b57d-4697-a429-9de4af7b5609"));
+});
+```
+
+For more information, see <xref:security/authorization/policies>.
+
+## Controller access
+
+Require policies on the *Server* app's controllers.
+
+The following example limits access to billing data from the `BillingDataController` to Azure Billing Administrators with a policy name of `BillingAdmin`:
+
+```csharp
+[Authorize(Policy = "BillingAdmin")]
+[ApiController]
+[Route("[controller]")]
+public class BillingDataController : ControllerBase
+{
+    ...
+}
+```
+
+## Service configuration
+
+In the *Server* app's `Startup.ConfigureServices` method add logic to make the Graph API call and establish user `group` claims for the user's security groups and roles.
+
+> [!NOTE]
+> The example code in this section uses the Active Directory Authentication Library (ADAL), which is based on Microsoft Identity Platform v1.0. This topic will be updated for Identity v2.0 for .NET 5. Track progress on this work by monitoring [[RC1] Microsoft Identity Platform 2.0 for Blazor (dotnet/AspNetCore.Docs #19503)](https://github.com/dotnet/AspNetCore.Docs/issues/19503).
+
+Additional namespaces are required for the code in the `Startup` class of the *Server* app. The following indicates the full set of namespaces for the code that follows in this section:
+
+```csharp
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Graph;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.IdentityModel.Logging;
+```
+
+In `Startup.ConfigureServices`, provide logic for <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents.OnAuthenticationFailed?displayProperty=nameWithType> (optional) and <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents.OnTokenValidated?displayProperty=nameWithType>:
+
+* <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents.OnAuthenticationFailed>: Optionally, log failed authentication events.
+* <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerEvents.OnTokenValidated>: Make a Graph API call to obtain the user's groups and roles.
+
+> [!WARNING]
+> <xref:Microsoft.IdentityModel.Logging.IdentityModelEventSource.ShowPII?displayProperty=nameWithType> provides Personally Identifiable Information (PII) in logging messages. Only activate PII for debugging with test user accounts.
+
+In the following example, note that the authentication services scheme of <xref:Microsoft.AspNetCore.Authentication.AzureAD.UI.AzureADDefaults.BearerAuthenticationScheme?displayProperty=nameWithType> in a default app based on the Blazor Hosted WebAssembly app template is changed to <xref:Microsoft.AspNetCore.Authentication.AzureAD.UI.AzureADDefaults.JwtBearerAuthenticationScheme?displayProperty=nameWithType>.
+
+```csharp
+#if DEBUG
+IdentityModelEventSource.ShowPII = true;
+#endif
+
+services.AddAuthentication(AzureADDefaults.JwtBearerAuthenticationScheme)
+    .AddAzureADBearer(options => Configuration.Bind("AzureAd", options));
+
+services.Configure<JwtBearerOptions>(AzureADDefaults.JwtBearerAuthenticationScheme, 
+    options =>
+{
+    options.Events = new JwtBearerEvents()
+    {
+        OnAuthenticationFailed = (context) =>
+        {
+            // Optional: Log the exception
+
+#if DEBUG
+            Console.WriteLine($"OnAuthenticationFailed: {context.Exception}");
+#endif
+
+            return Task.CompletedTask;
+        },
+        OnTokenValidated = async context =>
+        {
+            var accessToken = context.SecurityToken as JwtSecurityToken;
+            var upn = accessToken.Claims.FirstOrDefault(x => x.Type == "upn")?
+                .Value;
+
+            if (!string.IsNullOrEmpty(upn))
+            {
+                var authContext = new AuthenticationContext(
+                    Configuration["AzureAd:Instance"] +
+                    Configuration["AzureAd:TenantId"]);
+                AuthenticationResult authResult = null;
+
+                try
+                {
+                    authResult = await authContext.AcquireTokenSilentAsync(
+                        "https://graph.microsoft.com", 
+                        Configuration["AzureAd:ClientId"]);
+                }
+                catch (AdalException adalException)
+                {
+                    if (adalException.ErrorCode == 
+                        AdalError.FailedToAcquireTokenSilently || 
+                        adalException.ErrorCode == 
+                        AdalError.UserInteractionRequired)
+                    {
+                        var userAssertion = new UserAssertion(accessToken.RawData,
+                            "urn:ietf:params:oauth:grant-type:jwt-bearer", upn);
+                        var clientCredential = new ClientCredential(
+                            Configuration["AzureAd:ClientId"],
+                            Configuration["AzureAd:ClientSecret"]);
+                        authResult = await authContext.AcquireTokenAsync(
+                            "https://graph.microsoft.com", clientCredential, 
+                            userAssertion);
+                    }
+                }
+
+                var graphClient = new GraphServiceClient(
+                    new DelegateAuthenticationProvider(async requestMessage => {
+                        requestMessage.Headers.Authorization =
+                            new AuthenticationHeaderValue("Bearer", 
+                                authResult.AccessToken);
+
+                        await Task.CompletedTask;
+                    }));
+
+                var userIdentity = (ClaimsIdentity)context.Principal.Identity;
+
+                IUserMemberOfCollectionWithReferencesPage groupsAndAzureRoles = 
+                    null;
+
+                try
+                {
+                    groupsAndAzureRoles = await graphClient.Users[upn].MemberOf
+                        .Request().GetAsync();
+                }
+                catch (ServiceException serviceException)
+                {
+                    // Optional: Log the error
+
+#if DEBUG
+                    Console.WriteLine(
+                        "OnTokenValidated: Service Exception: " +
+                        $"{serviceException.Message}");
+#endif
+                }
+
+                if (groupsAndAzureRoles != null)
+                {
+                    foreach (var entry in groupsAndAzureRoles)
+                    {
+                        userIdentity.AddClaim(new Claim("group", entry.Id));
+                    }
+                }
+            }
+            else
+            {
+                // Optional: Log missing UPN claim
+
+#if DEBUG
+                Console.WriteLine($"OnTokenValidated: UPN missing: " +
+                    $"{accessToken.RawData}");
+#endif
+            }
+
+            await Task.CompletedTask;
+        }
+    };
+});
+```
+
+The code in `OnTokenValidated` doesn't obtain transient memberships. To change the code to obtain direct and transient memberships:
+
+* For the code line:
+
+  ```csharp
+  IUserMemberOfCollectionWithReferencesPage groupsAndAzureRoles = null;
+  ```
+
+  Replace the preceding line with:
+
+  ```csharp
+  IUserTransitiveMemberOfCollectionWithReferencesPage groupsAndRoles = null;
+  ```
+
+* For the code line:
+
+  ```csharp
+  groupsAndAzureRoles = await graphClient.Users[upn].MemberOf.Request().GetAsync();
+  ```
+
+  Replace the preceding line with:
+
+  ```csharp
+  groupsAndAzureRoles = await graphClient.Users[upn].TransitiveMemberOf.Request()
+      .GetAsync();
+  ```
+
+The code in `OnTokenValidated` doesn't distinguish between AAD security groups and AAD Administrator Roles when creating claims. For the app to distinguish between groups and roles, check the `entry.ODataType` when iterating through the groups and roles. For example, to create security group claims separately (`group` claim) from role claims (`role` claim), use code similar to the following:
+
+```csharp
+foreach (var entry in groupsAndAzureRoles)
+{
+    if (entry.ODataType == "#microsoft.graph.group")
+    {
+        userIdentity.AddClaim(new Claim("group", entry.Id));
+    }
+    else
+    {
+        // entry.ODataType == "#microsoft.graph.directoryRole"
+        userIdentity.AddClaim(new Claim("role", entry.Id));
+    }
+}
+```
+
 ## User-defined roles
 
 An AAD-registered app can also be configured to use user-defined roles.
@@ -350,7 +630,7 @@ The following example assumes that an app is configured with two roles:
 
 The single `roles` claim sent by AAD presents the user-defined roles as the `appRoles`'s `value`s in a JSON array. The app must convert the JSON array of roles into individual `role` claims.
 
-The `CustomUserFactory` shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-built-in-administrative-roles) section is set up to act on a `roles` claim with a JSON array value. Add and register the `CustomUserFactory` in the standalone app or client app of a hosted Blazor solution as shown in the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-built-in-administrative-roles) section. There's no need to provide code to remove the original `roles` claim because it's automatically removed by the framework.
+The `CustomUserFactory` shown in the [User-defined groups and AAD Administrator Roles](#user-defined-groups-and-administrator-roles) section is set up to act on a `roles` claim with a JSON array value. Add and register the `CustomUserFactory` in the standalone app or client app of a hosted Blazor solution as shown in the [User-defined groups and AAD Administrator Roles](#user-defined-groups-and-administrator-roles) section. There's no need to provide code to remove the original `roles` claim because it's automatically removed by the framework.
 
 In `Program.Main` of the standalone app or client app of a hosted Blazor solution, specify the claim named "`role`" as the role claim:
 
@@ -378,11 +658,11 @@ Component authorization approaches are functional at this point. Any of the auth
   }
   ```
 
-## AAD Adminstrative Role Group IDs
+## AAD Administrator Role Object IDs
 
-The Object IDs presented in the following table are used to create [policies](xref:security/authorization/policies) for `group` claims. Policies permit an app to authorize users for various activities in an app. For more information, see the [User-defined groups and AAD built-in Administrative Roles](#user-defined-groups-and-built-in-administrative-roles) section.
+The Object IDs presented in the following table are used to create [policies](xref:security/authorization/policies) for `group` claims. Policies permit an app to authorize users for various activities in an app. For more information, see the [User-defined groups and AAD Administrator Roles](#user-defined-groups-and-administrator-roles) section.
 
-AAD Administrative Role | Object ID
+AAD Administrator Role | Object ID
 --- | ---
 Application administrator | fa11557b-4f15-4ddd-85d5-313c7cd74047
 Application developer | 68adcbb8-9504-44f6-89f2-5cd48dc74a2c

--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -20,7 +20,7 @@ An authorization policy consists of one or more requirements. It's registered as
 
 In the preceding example, an "AtLeast21" policy is created. It has a single requirement&mdash;that of a minimum age, which is supplied as a parameter to the requirement.
 
-## IAuthorizationService 
+## IAuthorizationService
 
 The primary service that determines if authorization is successful is <xref:Microsoft.AspNetCore.Authorization.IAuthorizationService>:
 


### PR DESCRIPTION
Fixes #19573

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/azure-active-directory-groups-and-roles?view=aspnetcore-3.1&branch=pr-en-us-19774#authorize-server-api-access-for-user-defined-groups-and-administrator-roles)

Thanks @swannet! 🌴

The framework returns JWT bearer events using three code approaches:

* `Task.FromResult(0)`
* `Task.FromResult<object>(null);`
* `Task.CompletedTask`

Framework tests uses the first (and that's what's on the PR). However, the default assignment uses the last. Which is correct ... or merely preferred ... here? :ear:

cc: @blowdart ... Just as an **_FYI only_** that there's security guidance on this one.