### PR TITLE
Enhance Blazor start content

### DIFF
--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -121,7 +121,7 @@ Configure the manual start of a Blazor Server app's [SignalR circuit](xref:blazo
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
 * Place a script that calls `Blazor.start` after the `blazor.server.js` script's tag and inside the closing `</body>` tag.
 
-When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. For example, component methods fail to execute when called while the circuit is disconnected.
+When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. For example, component methods fail to execute while the circuit is disconnected.
 
 ### Initialize Blazor when the document is ready
 

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -116,16 +116,20 @@ Rendering server components from a static HTML page isn't supported.
 
 *This section applies to Blazor Server.*
 
-Configure the manual start of a Blazor Server app in the `Pages/_Host.cshtml` file:
+Configure the manual start of a Blazor Server app's [SignalR circuit](xref:blazor/hosting-models#circuits) in the `Pages/_Host.cshtml` file:
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Place a script that calls `Blazor.start` after the `_framework/blazor.server.js` script and inside the closing `</body>` tag.
+* Place a script that calls `Blazor.start` after the `blazor.server.js` script's tag and inside the closing `</body>` tag.
+
+When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. For example, component methods fail to execute when called while the circuit is disconnected.
 
 ### Initialize Blazor when the document is ready
 
 To initialize the Blazor app when the document is ready:
 
 ```cshtml
+<body>
+
     ...
 
     <script autostart="false" src="_framework/blazor.server.js"></script>
@@ -142,6 +146,8 @@ To initialize the Blazor app when the document is ready:
 To perform additional tasks, such as JS interop initialization, use `then` to chain to the `Promise` that results from a manual Blazor app start:
 
 ```cshtml
+<body>
+
     ...
 
     <script autostart="false" src="_framework/blazor.server.js"></script>
@@ -160,6 +166,8 @@ To perform additional tasks, such as JS interop initialization, use `then` to ch
 To configure SignalR client logging, pass in a configuration object (`configureSignalR`) that calls `configureLogging` with the log level on the client builder:
 
 ```cshtml
+<body>
+
     ...
 
     <script autostart="false" src="_framework/blazor.server.js"></script>
@@ -190,6 +198,8 @@ To modify the connection events, register callbacks for the following connection
 **Both** `onConnectionDown` and `onConnectionUp` must be specified:
 
 ```cshtml
+<body>
+
     ...
 
     <script autostart="false" src="_framework/blazor.server.js"></script>
@@ -209,6 +219,8 @@ To modify the connection events, register callbacks for the following connection
 To adjust the reconnection retry count and interval, set the number of retries (`maxRetries`) and period in milliseconds permitted for each retry attempt (`retryIntervalMilliseconds`):
 
 ```cshtml
+<body>
+
     ...
 
     <script autostart="false" src="_framework/blazor.server.js"></script>
@@ -228,6 +240,8 @@ To adjust the reconnection retry count and interval, set the number of retries (
 To hide the reconnection display, set the reconnection handler's `_reconnectionDisplay` to an empty object (`{}` or `new Object()`):
 
 ```cshtml
+<body>
+
     ...
 
     <script autostart="false" src="_framework/blazor.server.js"></script>

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -269,7 +269,7 @@ The placeholder `{ELEMENT ID}` is the ID of the HTML element to display.
 Customize the delay before the reconnection display appears by setting the `transition-delay` property in the app's CSS (`wwwroot/css/site.css`) for the modal element. The following example sets the transition delay from 500 ms (default) to 1,000 ms (1 second):
 
 ```css
-#transition-delay {
+#components-reconnect-modal {
     transition: visibility 0s linear 1000ms;
 }
 ```

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -112,18 +112,52 @@ Blazor Server apps are set up by default to prerender the UI on the server befor
 
 Rendering server components from a static HTML page isn't supported.
 
-## Configure the SignalR client for Blazor Server apps
+## Manual start of the Blazor app
 
 *This section applies to Blazor Server.*
 
-Configure the SignalR client used by Blazor Server apps in the `Pages/_Host.cshtml` file. Place a script that calls `Blazor.start` after the `_framework/blazor.server.js` script and inside the `</body>` tag.
-
-### Logging
-
-To configure SignalR client logging:
+Configure the manual start of a Blazor Server app in the `Pages/_Host.cshtml` file:
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Pass in a configuration object (`configureSignalR`) that calls `configureLogging` with the log level on the client builder.
+* Place a script that calls `Blazor.start` after the `_framework/blazor.server.js` script and inside the closing `</body>` tag.
+
+### Initialize Blazor when the document is ready
+
+To initialize the Blazor app when the document is ready:
+
+```cshtml
+    ...
+
+    <script autostart="false" src="_framework/blazor.server.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        Blazor.start();
+      });
+    </script>
+</body>
+```
+
+### Chain to the `Promise` that results from a manual start
+
+To perform additional tasks, such as JS interop initialization, use `then` to chain to the `Promise` that results from a manual Blazor app start:
+
+```cshtml
+    ...
+
+    <script autostart="false" src="_framework/blazor.server.js"></script>
+    <script>
+      Blazor.start().then(function () {
+        ...
+      });
+    </script>
+</body>
+```
+
+### Configure the SignalR client
+
+#### Logging
+
+To configure SignalR client logging, pass in a configuration object (`configureSignalR`) that calls `configureLogging` with the log level on the client builder:
 
 ```cshtml
     ...
@@ -148,10 +182,12 @@ The reconnection handler's circuit connection events can be modified for custom 
 * To notify the user if the connection is dropped.
 * To perform logging (from the client) when a circuit is connected.
 
-To modify the connection events:
+To modify the connection events, register callbacks for the following connection changes:
 
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Register callbacks for connection changes for dropped connections (`onConnectionDown`) and established/re-established connections (`onConnectionUp`). **Both** `onConnectionDown` and `onConnectionUp` must be specified.
+* Dropped connections use `onConnectionDown`.
+* Established/re-established connections use `onConnectionUp`.
+
+**Both** `onConnectionDown` and `onConnectionUp` must be specified:
 
 ```cshtml
     ...
@@ -170,10 +206,7 @@ To modify the connection events:
 
 ### Adjust the reconnection retry count and interval
 
-To adjust the reconnection retry count and interval:
-
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Set the number of retries (`maxRetries`) and period in milliseconds permitted for each retry attempt (`retryIntervalMilliseconds`).
+To adjust the reconnection retry count and interval, set the number of retries (`maxRetries`) and period in milliseconds permitted for each retry attempt (`retryIntervalMilliseconds`):
 
 ```cshtml
     ...
@@ -190,12 +223,9 @@ To adjust the reconnection retry count and interval:
 </body>
 ```
 
-### Hide or replace the reconnection display
+## Hide or replace the reconnection display
 
-To hide the reconnection display:
-
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Set the reconnection handler's `_reconnectionDisplay` to an empty object (`{}` or `new Object()`).
+To hide the reconnection display, set the reconnection handler's `_reconnectionDisplay` to an empty object (`{}` or `new Object()`):
 
 ```cshtml
     ...
@@ -205,6 +235,8 @@ To hide the reconnection display:
       window.addEventListener('beforeunload', function () {
         Blazor.defaultReconnectionHandler._reconnectionDisplay = {};
       });
+
+      Blazor.start();
     </script>
 </body>
 ```

--- a/aspnetcore/blazor/fundamentals/additional-scenarios.md
+++ b/aspnetcore/blazor/fundamentals/additional-scenarios.md
@@ -112,7 +112,7 @@ Blazor Server apps are set up by default to prerender the UI on the server befor
 
 Rendering server components from a static HTML page isn't supported.
 
-## Manual start of the Blazor app
+## Initialize the Blazor circuit
 
 *This section applies to Blazor Server.*
 
@@ -121,7 +121,7 @@ Configure the manual start of a Blazor Server app's [SignalR circuit](xref:blazo
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
 * Place a script that calls `Blazor.start` after the `blazor.server.js` script's tag and inside the closing `</body>` tag.
 
-When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. For example, component methods fail to execute while the circuit is disconnected.
+When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 ### Initialize Blazor when the document is ready
 
@@ -263,6 +263,18 @@ Blazor.defaultReconnectionHandler._reconnectionDisplay =
 ```
 
 The placeholder `{ELEMENT ID}` is the ID of the HTML element to display.
+
+::: moniker range=">= aspnetcore-5.0"
+
+Customize the delay before the reconnection display appears by setting the `transition-delay` property in the app's CSS (`wwwroot/css/site.css`) for the modal element. The following example sets the transition delay from 500 ms (default) to 1,000 ms (1 second):
+
+```css
+#transition-delay {
+    transition: visibility 0s linear 1000ms;
+}
+```
+
+::: moniker-end
 
 ## Influence HTML `<head>` tag elements
 


### PR DESCRIPTION
Fixes #15373

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/additional-scenarios?view=aspnetcore-3.1&branch=pr-en-us-19778#manual-start-of-the-blazor-app)

😕 ... I've run into a point of confusion that's even blocking this PR ...

Our content implies (and I was under the assumption) that when `autostart="false"` is placed on the script that calling `Blazor.start()` is absolutely required to get the app going. Testing here seems to indicate that that's not so. When I set the `_Host.cshtml` page up with **_only_** the following ...

```cshtml
<script autostart="false" src="_framework/blazor.server.js"></script>
```

and no call to `Blazor.start()`, the **_app still starts and runs normally_**, which I don't expect to happen.

What am I missing? ..... I'll adjust the PR accordingly to head off the (**_my_** :smile:) confusion.