### PR TITLE
Blazor binding updates

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -129,37 +129,22 @@ Specifying a format for the `date` field type isn't recommended because Blazor h
 
 Component parameters permit binding properties and fields of a parent component with `@bind-{PROPERTY OR FIELD}` syntax.
 
-The following `Child` component (`Child.razor`) has a `Year` component parameter and `YearChanged` callback:
+The following `Child` component (`Shared/Child.razor`) has a `Year` component parameter and `YearChanged` callback:
 
 ```razor
 <div class="card bg-light mt-3" style="width:18rem ">
     <div class="card-body">
         <h3 class="card-title">Child Component</h3>
         <p class="card-text">Child <code>Year</code>: @Year</p>
-        <p>
-            <button @onclick="UpdateYear">
-                Update Child <code>Year</code> and call 
-                <code>YearChanged.InvokeAsync(Year)</code>
-            </button>
-        </p>
     </div>
 </div>
 
 @code {
-    private Random r = new Random();
-
     [Parameter]
     public int Year { get; set; }
 
     [Parameter]
     public EventCallback<int> YearChanged { get; set; }
-
-    private Task UpdateYear()
-    {
-        Year = r.Next(10050, 12021);
-
-        return YearChanged.InvokeAsync(Year);
-    }
 }
 ```
 
@@ -180,7 +165,7 @@ In the following `Parent` component (`Parent.razor`), the `year` field is bound 
 
 @code {
     private Random r = new Random();
-    private int year = 1978;
+    private int year = 1979;
 
     private void UpdateYear()
     {
@@ -205,19 +190,19 @@ A chained bind can't be implemented with [`@bind`](xref:mvc/views/razor#bind) sy
 
 The following `PasswordField` component (`PasswordField.razor`):
 
-* Sets an `<input>` element's value to a `Password` property.
-* Exposes changes of the `Password` property to a parent component with an [`EventCallback`](xref:blazor/components/event-handling#eventcallback).
+* Sets an `<input>` element's value to a `password` field.
+* Exposes changes of a `Password` property to a parent component with an [`EventCallback`](xref:blazor/components/event-handling#eventcallback) that passes in the current value of the child's `password` field as its argument.
 * Uses the `onclick` event to trigger the `ToggleShowPassword` method. For more information, see <xref:blazor/components/event-handling>.
 
 ```razor
-<h1>Child Component</h1>
+<h1>Provide your password</h1>
 
 Password:
 
 <input @oninput="OnPasswordChanged" 
        required 
        type="@(showPassword ? "text" : "password")" 
-       value="@Password" />
+       value="@password" />
 
 <button class="btn btn-primary" @onclick="ToggleShowPassword">
     Show password
@@ -225,6 +210,7 @@ Password:
 
 @code {
     private bool showPassword;
+    private string password;
 
     [Parameter]
     public string Password { get; set; }
@@ -234,9 +220,9 @@ Password:
 
     private Task OnPasswordChanged(ChangeEventArgs e)
     {
-        Password = e.Value.ToString();
+        password = e.Value.ToString();
 
-        return PasswordChanged.InvokeAsync(Password);
+        return PasswordChanged.InvokeAsync(password);
     }
 
     private void ToggleShowPassword()
@@ -260,12 +246,7 @@ The `PasswordField` component is used in another component:
 }
 ```
 
-To perform checks or trap errors on the password in the preceding example:
-
-* Create a backing field for `Password` (`password` in the following example code).
-* Perform the checks or trap errors in the `Password` setter.
-
-The following example provides immediate feedback to the user if a space is used in the password's value:
+Perform checks or trap errors in the method that invokes the binding's delegate. The following example provides immediate feedback to the user if a space is used in the password's value:
 
 ```razor
 <h1>Child Component</h1>
@@ -275,7 +256,7 @@ Password:
 <input @oninput="OnPasswordChanged" 
        required 
        type="@(showPassword ? "text" : "password")" 
-       value="@Password" />
+       value="@password" />
 
 <button class="btn btn-primary" @onclick="ToggleShowPassword">
     Show password
@@ -289,34 +270,25 @@ Password:
     private string validationMessage;
 
     [Parameter]
-    public string Password
-    {
-        get { return password ?? string.Empty; }
-        set
-        {
-            if (password != value)
-            {
-                if (value.Contains(' '))
-                {
-                    validationMessage = "Spaces not allowed!";
-                }
-                else
-                {
-                    password = value;
-                    validationMessage = string.Empty;
-                }
-            }
-        }
-    }
+    public string Password { get; set; }
 
     [Parameter]
     public EventCallback<string> PasswordChanged { get; set; }
 
     private Task OnPasswordChanged(ChangeEventArgs e)
     {
-        Password = e.Value.ToString();
+        if (password.Contains(' '))
+        {
+            validationMessage = "Spaces not allowed!";
 
-        return PasswordChanged.InvokeAsync(Password);
+            return Task.CompletedTask;
+        }
+        else
+        {
+            validationMessage = string.Empty;
+
+            return PasswordChanged.InvokeAsync(password);
+        }
     }
 
     private void ToggleShowPassword()


### PR DESCRIPTION
Fixes #19789

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?view=aspnetcore-3.1&branch=pr-en-us-19799#child-to-parent-binding-with-chained-bind)

* The approaches now avoid writing to a component parameter and use a backing field instead.
* Using the *getter/setter* approach that [Ryan showed](https://github.com/dotnet/AspNetCore.Docs/issues/14144#issue-489386131) seems to only work when the component writes to the param per his original example. For this PR, I have the method that calls the binding delegate (`OnPasswordChanged`) make the checks. If that's not right, let me know how to handle that scenario. :ear: Even if that is the right spot, is calling `return Task.CompletedTask;` the right thing for a validation failure there? :ear: It *seems* to work well.

cc: @mrlife