### PR TITLE
Blazor WASM security updates

### DIFF
--- a/aspnetcore/blazor/security/server/additional-scenarios.md
+++ b/aspnetcore/blazor/security/server/additional-scenarios.md
@@ -107,25 +107,31 @@ In the `App` component (`App.razor`), resolve the service and initialize it with
 }
 ```
 
+Add a package reference to the app for the [Microsoft.AspNet.WebApi.Client](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client) NuGet package.
+
 In the service that makes a secure API request, inject the token provider and retrieve the token to call the API:
 
 ```csharp
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
 public class WeatherForecastService
 {
-    private readonly TokenProvider _store;
+    private readonly TokenProvider store;
 
     public WeatherForecastService(IHttpClientFactory clientFactory, 
         TokenProvider tokenProvider)
     {
         Client = clientFactory.CreateClient();
-        _store = tokenProvider;
+        store = tokenProvider;
     }
 
     public HttpClient Client { get; }
 
     public async Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
     {
-        var token = _store.AccessToken;
+        var token = store.AccessToken;
         var request = new HttpRequestMessage(HttpMethod.Get, 
             "https://localhost:5003/WeatherForecast");
         request.Headers.Add("Authorization", $"Bearer {token}");

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -164,7 +164,7 @@ For a Blazor app based on the Blazor WebAssembly Hosted project template, <xref:
 In the following example, a named <xref:System.Net.Http.HttpClient> for Graph API is used to obtain a user's mobile phone number to process a call. After adding the Microsoft Graph API `User.Read` permission in the AAD area of the Azure portal, the scope is configured for the named client in the standalone app or Client app of a hosted Blazor solution.
 
 > [!NOTE]
-> The example in this section obtains Graph API data for the user in *component code*. To create user claims when the user is authenticated for use *globally across the app* from Graph API, see the following resources:
+> The example in this section obtains Graph API data for the user in *component code*. To create user claims from Graph API, see the following resources:
 >
 > * [Customize the user](#customize-the-user) section
 > * <xref:blazor/security/webassembly/aad-groups-roles>
@@ -430,7 +430,7 @@ builder.Services.AddMsalAuthentication(options =>
 }
 ```
 
-The `{CUSTOM SCOPE 1}` and `{CUSTOM SCOPE 2}` placeholders in the preceding example are the custom scopes.
+The `{CUSTOM SCOPE 1}` and `{CUSTOM SCOPE 2}` placeholders in the preceding example are custom scopes.
 
 The `IAccessTokenProvider.RequestToken` method provides an overload that allows an app to provision an access token with a given set of scopes.
 
@@ -454,7 +454,7 @@ if (tokenResult.TryGetToken(out var token))
 }
 ```
 
-The `{CUSTOM SCOPE 1}` and `{CUSTOM SCOPE 2}` placeholders in the preceding example are the custom scopes.
+The `{CUSTOM SCOPE 1}` and `{CUSTOM SCOPE 2}` placeholders in the preceding example are custom scopes.
 
 <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.AccessTokenResult.TryGetToken%2A?displayProperty=nameWithType> returns:
 
@@ -1023,7 +1023,7 @@ public class CustomAccountFactory
 }
 ```
 
-In `Program.Main` (`Program.cs`), configure the app to use the custom factory. If a custom user account class that extends <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>, swap the custom user account class for <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount> in the following code:
+In `Program.Main` (`Program.cs`), configure the app to use the custom factory. If the app uses a custom user account class that extends <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount>, swap the custom user account class for <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteUserAccount> in the following code:
 
 ```csharp
 using Microsoft.Extensions.Configuration;
@@ -1041,7 +1041,7 @@ builder.Services.AddMsalAuthentication<RemoteAuthenticationState,
         CustomAccountFactory>();
 ```
 
-The preceding example is for an app that uses AAD authentication with MSAL. Similar patterns exist for general OIDC and API authentication. For more information, see the examples at the end of the [Customize the user with a payload claim](#customize-the-user-with-a-payload-claim) section.
+The preceding example is for an app that uses AAD authentication with MSAL. Similar patterns exist for OIDC and API authentication. For more information, see the examples at the end of the [Customize the user with a payload claim](#customize-the-user-with-a-payload-claim) section.
 
 ### AAD security groups and roles with a custom user account class
 

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -195,20 +195,20 @@ builder.Services.AddHttpClient("GraphAPI",
     .AddHttpMessageHandler<GraphAPIAuthorizationMessageHandler>();
 ```
 
-In a Razor component (`Pages/CallCrewMember.razor`):
+In a Razor component (`Pages/CallUser.razor`):
 
 ```razor
-@page "/CallCrewMember"
+@page "/CallUser"
 @using System.ComponentModel.DataAnnotations
 @using System.Text.Json.Serialization
 @using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using Microsoft.Extensions.Logging
 @inject IAccessTokenProvider TokenProvider
 @inject IHttpClientFactory ClientFactory
-@inject ILogger<CallCrewMember> Logger
-@inject IStarfleetCallProcessor CallProcessor
+@inject ILogger<CallUser> Logger
+@inject ICallProcessor CallProcessor
 
-<h3>Starfleet Red Alert Call</h3>
+<h3>Call User</h3>
 
 <EditForm Model="@callInfo" OnValidSubmit="@HandleValidSubmit">
     <DataAnnotationsValidator />
@@ -216,7 +216,7 @@ In a Razor component (`Pages/CallCrewMember.razor`):
 
     <p>
         <label>
-            Red Alert Message:
+            Message:
             <InputTextArea @bind-Value="callInfo.Message" />
         </label>
     </p>
@@ -225,12 +225,6 @@ In a Razor component (`Pages/CallCrewMember.razor`):
 
     <p>
         @formStatus
-    </p>
-
-    <p>
-        <a href="http://www.startrek.com/">Star Trek</a>,
-        &copy;1966-2019 CBS Studios, Inc. and
-        <a href="https://www.paramount.com">Paramount Pictures</a>
     </p>
 </EditForm>
 
@@ -254,12 +248,12 @@ In a Razor component (`Pages/CallCrewMember.razor`):
 
             if (userInfo != null)
             {
-                CallProcessor.Send(userInfo.Communicator, callInfo.Message);
+                CallProcessor.Send(userInfo.MobilePhone, callInfo.Message);
 
                 formStatus = "Form successfully processed.";
                 Logger.LogInformation(
                     $"Form successfully processed at {DateTime.Now} " +
-                    $"Communicator: {userInfo.Communicator}");
+                    $"Mobile Phone: {userInfo.MobilePhone}");
             }
         }
         else
@@ -279,13 +273,13 @@ In a Razor component (`Pages/CallCrewMember.razor`):
     private class UserInfo
     {
         [JsonPropertyName("mobilePhone")]
-        public string Communicator { get; set; }
+        public string MobilePhone { get; set; }
     }
 }
 ```
 
 > [!NOTE]
-> In the preceding example, the developer implements the `IStarfleetCallProcessor` (`CallProcessor`) to queue and then place automated calls.
+> In the preceding example, the developer implements the `ICallProcessor` (`CallProcessor`) to queue and then place automated calls.
 
 ## Typed `HttpClient`
 

--- a/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
@@ -147,16 +147,16 @@ using Microsoft.Extensions.Logging;
 public class CustomUserFactory
     : AccountClaimsPrincipalFactory<CustomUserAccount>
 {
-    private readonly ILogger<CustomUserFactory> _logger;
-    private readonly IHttpClientFactory _clientFactory;
+    private readonly ILogger<CustomUserFactory> logger;
+    private readonly IHttpClientFactory clientFactory;
 
     public CustomUserFactory(IAccessTokenProviderAccessor accessor, 
         IHttpClientFactory clientFactory, 
         ILogger<CustomUserFactory> logger)
         : base(accessor)
     {
-        _clientFactory = clientFactory;
-        _logger = logger;
+        this.clientFactory = clientFactory;
+        this.logger = logger;
     }
 
     public async override ValueTask<ClaimsPrincipal> CreateUserAsync(
@@ -178,7 +178,7 @@ public class CustomUserFactory
             {
                 try
                 {
-                    var client = _clientFactory.CreateClient("GraphAPI");
+                    var client = clientFactory.CreateClient("GraphAPI");
 
                     var response = await client.GetAsync("v1.0/me/memberOf");
 
@@ -199,13 +199,13 @@ public class CustomUserFactory
                     }
                     else
                     {
-                        _logger.LogError("Graph API request failure: {REASON}", 
+                        logger.LogError("Graph API request failure: {REASON}", 
                             response.ReasonPhrase);
                     }
                 }
                 catch (AccessTokenNotAvailableException exception)
                 {
-                    _logger.LogError("Graph API access token failure: {MESSAGE}", 
+                    logger.LogError("Graph API access token failure: {MESSAGE}", 
                         exception.Message);
                 }
             }

--- a/aspnetcore/blazor/security/webassembly/index.md
+++ b/aspnetcore/blazor/security/webassembly/index.md
@@ -83,6 +83,13 @@ Refresh tokens can't be secured client-side in Blazor WebAssembly apps. Therefor
 
 Refresh tokens can be maintained and used by the server-side app in a Hosted Blazor WebAssembly solution to access third-party APIs. For more information, see <xref:blazor/security/webassembly/additional-scenarios#authenticate-users-with-a-third-party-provider-and-call-protected-apis-on-the-host-server-and-the-third-party>.
 
+## Establish claims for users
+
+Apps often require claims for users based on a web API call to a server. For example, claims are frequently used to [establish authorization](xref:blazor/security/index#authorization) in an app. In these scenarios, the app requests an access token to access the service and uses the token to obtain the user data for the claims. For examples, see the following resources:
+
+* [Additional scenarios: Customize the user](xref:blazor/security/webassembly/additional-scenarios#customize-the-user)
+* <xref:blazor/security/webassembly/aad-groups-roles>
+
 ## Implementation guidance
 
 Articles under this *Overview* provide information on authenticating users in Blazor WebAssembly apps against specific providers.


### PR DESCRIPTION
Fixes #19803

Thanks @taylorchasewhite! :rocket:

The enhancements include ...

* Flesh out a Graph API call from a component that's based on a named `HttpClient`. The existing content is *generic* for a named client and a custom `AuthorizationMessageHandler` class. This new example (AAD mobile phone number in component code) shows a specific implementation with those features that will work in a real app.
* Add a customize the user example (claims for users) based on Graph API. The existing customize the user coverage only deals with an access token claim (`amr`) that doesn't require a separate access token request. This new example (a claim for the AAD mobile phone number), similar to the example in the AAD groups and roles topic, shows a specific implementation with a separate Graph API call that will work in a real app.
* Improve topic cross-links, including from the WASM overview topic.
* Fix up a few other nits in other text+examples.

I'm going to wait before engaging further with data storage. The [State management](https://docs.microsoft.com/aspnet/core/blazor/state-management) topic focuses on it, so let's take more feedback before working further with it. I'll review that topic in detail later ... hopefully in the holidays :gift: period after .NET 5 releases.