### PR TITLE
Blazor forms updates

### DIFF
--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -91,7 +91,7 @@ A set of built-in components are available to receive and validate user input. I
 | <xref:Microsoft.AspNetCore.Components.Forms.InputTextArea> | `<textarea>` |
 
 > [!NOTE]
-> The `InputRadio` and `InputRadioGroup` components are new for ASP.NET Core 5.0. For more information, select a 5.0 or later version of this article.
+> The `InputRadio` and `InputRadioGroup` components are available in ASP.NET Core 5.0 or later. For more information, select a 5.0 or later version of this article.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -90,6 +90,9 @@ A set of built-in components are available to receive and validate user input. I
 | <xref:Microsoft.AspNetCore.Components.Forms.InputText> | `<input>` |
 | <xref:Microsoft.AspNetCore.Components.Forms.InputTextArea> | `<textarea>` |
 
+> [!NOTE]
+> The `InputRadio` and `InputRadioGroup` components are new for ASP.NET Core 5.0. For more information, select a 5.0 or later version of this article.
+
 ::: moniker-end
 
 All of the input components, including <xref:Microsoft.AspNetCore.Components.Forms.EditForm>, support arbitrary attributes. Any attribute that doesn't match a component parameter is added to the rendered HTML element.
@@ -374,7 +377,7 @@ In the following example:
 
 When validation messages are set in the component, they're added to the validator's <xref:Microsoft.AspNetCore.Components.Forms.ValidationMessageStore> and shown in the <xref:Microsoft.AspNetCore.Components.Forms.EditForm>:
 
-```csharp
+```razor
 @page "/FormsValidation"
 
 <h1>Starfleet Starship Database</h1>
@@ -565,7 +568,7 @@ In the client project, add the validator component shown in the [Validator compo
 
 In the client project, the *Starfleet Starship Database* form is updated to show server validation errors with help of the `CustomValidator` component. When the server API returns validation messages, they're added to the `CustomValidator` component's <xref:Microsoft.AspNetCore.Components.Forms.ValidationMessageStore>. The errors are available in the form's <xref:Microsoft.AspNetCore.Components.Forms.EditContext> for display by the form's <xref:Microsoft.AspNetCore.Components.Forms.ValidationSummary>:
 
-```csharp
+```razor
 @page "/FormValidation"
 @using System.Net
 @using System.Net.Http.Json


### PR DESCRIPTION
Fixes #19850

Thanks @Paul-Dempsey! :rocket:

* I fixed the code languages.
* I decided to add a NOTE for the new radio button components to the current version content that instructs the reader that those two are new for 5.0 and to select a 5.0 or later version of the article for more info. I like that better than mucking up the ToC entries. I don't even think that I'll revert this NOTE at 5.0 GA. I think I'll just leave that there in case even after GA someone hits this topic at 3.x looking for those two components.
* I slept on the cross-links to the section with the table versus converting over to a section for each component. I changed my mind and think that *for the time being* we'll continue to link to the section. The purpose of the ToC entries is to get the reader to the right spot in the Blazor docs. I don't have anything else to convey on these at this time that ...
  * The API docs don't cover (via the cross-links here).
  * The examples don't cover following this section.

  We may have sections later tho. I'll consider this again when I get to https://github.com/dotnet/AspNetCore.Docs/issues/19286.