### PR TITLE
Group gRPC client topics under a TOC parent

### DIFF
--- a/aspnetcore/grpc/client.md
+++ b/aspnetcore/grpc/client.md
@@ -17,7 +17,7 @@ A .NET gRPC client library is available in the [Grpc.Net.Client](https://www.nug
 
 ## Configure gRPC client
 
-gRPC clients are concrete client types that are [generated from *\*.proto* files](xref:grpc/basics#generated-c-assets). The concrete gRPC client has methods that translate to the gRPC service in the *\*.proto* file. For example, a service called `Greeter` generates a type called `GreeterClient`.
+gRPC clients are concrete client types that are [generated from *\*.proto* files](xref:grpc/basics#generated-c-assets). The concrete gRPC client has methods that translate to the gRPC service in the *\*.proto* file. For example, a service called `Greeter` generates a `GreeterClient` type with methods to call the service.
 
 A gRPC client is created from a channel. Start by using `GrpcChannel.ForAddress` to create a channel, and then use the channel to create a gRPC client:
 
@@ -41,7 +41,7 @@ var counterClient = new Count.CounterClient(channel);
 
 A gRPC client must use the same connection-level security as the called service. gRPC client Transport Layer Security (TLS) is configured when the gRPC channel is created. A gRPC client throws an error when it calls a service and the connection-level security of the channel and service don't match.
 
-To configure a gRPC channel to use TLS, ensure the server address starts with `https`. For example, `GrpcChannel.ForAddress("https://localhost:5001")` uses HTTPS protocol. The gRPC channel automatically negotates a connection secured by TLS and uses a secure connection to make gRPC calls.
+To configure a gRPC channel to use TLS, ensure the server address starts with `https`. For example, `GrpcChannel.ForAddress("https://localhost:5001")` uses HTTPS protocol. The gRPC channel automatically negotiates a connection secured by TLS and uses a secure connection to make gRPC calls.
 
 > [!TIP]
 > gRPC supports client certificate authentication over TLS. For information on configuring client certificates with a gRPC channel, see <xref:grpc/authn-and-authz#client-certificate-authentication>.

--- a/aspnetcore/grpc/client.md
+++ b/aspnetcore/grpc/client.md
@@ -17,7 +17,7 @@ A .NET gRPC client library is available in the [Grpc.Net.Client](https://www.nug
 
 ## Configure gRPC client
 
-gRPC clients are concrete client types that are [generated from *\*.proto* files](xref:grpc/basics#generated-c-assets). The concrete gRPC client has methods that translate to the gRPC service in the *\*.proto* file.
+gRPC clients are concrete client types that are [generated from *\*.proto* files](xref:grpc/basics#generated-c-assets). The concrete gRPC client has methods that translate to the gRPC service in the *\*.proto* file. For example, a service called `Greeter` generates a type called `GreeterClient`.
 
 A gRPC client is created from a channel. Start by using `GrpcChannel.ForAddress` to create a channel, and then use the channel to create a gRPC client:
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -714,16 +714,20 @@
           uid: grpc/services
         - name: Create Protobuf messages
           uid: grpc/protobuf
+        - name: Versioning gRPC services
+          uid: grpc/versioning
+    - name: Call gRPC services with C#
+      items:
+        - name: Overview
+          uid: grpc/client
+        - name: gRPC client factory integration
+          uid: grpc/clientfactory
+        - name: Deadlines and cancellation
+          uid: grpc/deadlines-cancellation
     - name: gRPC services with ASP.NET Core
       uid: grpc/aspnetcore
-    - name: Call gRPC services with .NET client
-      uid: grpc/client
-    - name: gRPC client factory integration
-      uid: grpc/clientfactory
     - name: Use gRPC in browser apps
       uid: grpc/browser
-    - name: Deadlines and cancellation
-      uid: grpc/deadlines-cancellation
     - name: Configuration
       uid: grpc/configuration
     - name: Authentication and authorization
@@ -734,8 +738,6 @@
       uid: grpc/security
     - name: Performance best practices
       uid: grpc/performance
-    - name: Versioning gRPC services
-      uid: grpc/versioning
     - name: Manage Protobuf references with dotnet-grpc
       uid: grpc/dotnet-grpc
     - name: Test services with gRPC tools


### PR DESCRIPTION
Group topics under client and server to keep the top level menu clean.