### PR TITLE
19795 microsoft account oauth options

### DIFF
--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -25,6 +25,8 @@ If you don't have a Microsoft account, select **Create one**. After signing in, 
 * Select **New registration**
 * Enter a **Name**.
 * Select an option for **Supported account types**.  <!-- Accounts for any org work with MS domain accounts. Most folks probably want the last option, personal MS accounts. It took 24 hours after setting this up for the keys to work -->
+  * The `MicrosoftAccount` package supports App Registrations created using "Accounts in any organizational directory" or "Accounts in any organizational directory and Microsoft accounts" options by default.
+  * To use other options, set `AuthorizationEndpoint` and `TokenEndpoint` members of `MicrosoftAccountOptions` used to initialize the Microsoft Account authentication to the URLs displayed on **Endpoints** page of the App Registration after it is created (available by clicking Endpoints on the **Overview** page).
 * Under **Redirect URI**, enter your development URL with `/signin-microsoft` appended. For example, `https://localhost:5001/signin-microsoft`. The Microsoft authentication scheme configured later in this sample will automatically handle requests at `/signin-microsoft` route to implement the OAuth flow.
 * Select **Register**
 


### PR DESCRIPTION
Fixes #19795: common endpoint error

This pull request adds two sub-bullet points to App Registration setup on Azure dashboard:

- App Registration types supported by Microsoft Account NuGet package by default
- What to do if you would like to use other App Registration types

Without this information, developers will receive a cryptic error message, which is the scenario that prompted the creation of #19795.

I tried to make this really short: often a little goes a long way. Long help pages often force me to read too fast and miss details. More text can be added on request.