### PR TITLE
Blazor Virtualize component

### DIFF
--- a/aspnetcore/blazor/components/component-virtualization.md
+++ b/aspnetcore/blazor/components/component-virtualization.md
@@ -1,0 +1,154 @@
+---
+title: ASP.NET Core Blazor component virtualization
+author: guardrex
+description: Learn how to use component virtualization in ASP.NET Core Blazor apps.
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 09/16/2020
+no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+uid: blazor/components/virtualization
+---
+# ASP.NET Core Blazor component virtualization
+
+By [Daniel Roth](https://github.com/danroth27)
+
+Improve the perceived performance of component rendering using the Blazor framework's built-in virtualization support. Virtualization is a technique for limiting UI rendering to just the parts that are currently visible. For example, virtualization is helpful when the app must render a long list or a table with many rows and only a subset of items is required to be visible at any given time. Blazor provides the `Virtualize` component that can be used to add virtualization to an app's components.
+
+::: moniker range=">= aspnetcore-5.0"
+
+Without virtualization, a typical list or table-based component might use a C# [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop to render each item in the list or each row in the table:
+
+```razor
+<table>
+    @foreach (var employee in employees)
+    {
+        <tr>
+            <td>@employee.FirstName</td>
+            <td>@employee.LastName</td>
+            <td>@employee.JobTitle</td>
+        </tr>
+    }
+</table>
+```
+
+If the list contains thousands of items, then rendering the list may take a long time. The user may experience a noticeable UI lag.
+
+Instead of rendering each item in the list all at one time, replace the [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop with the `Virtualize` component and specify a fixed item source with `Items`. Only the items that are currently visible are rendered:
+
+```razor
+<table>
+    <Virtualize Context="employee" Items="@employees">
+        <tr>
+            <td>@employee.FirstName</td>
+            <td>@employee.LastName</td>
+            <td>@employee.JobTitle</td>
+        </tr>
+    </Virtualize>
+</table>
+```
+
+If not specifying a context to the component with `Context`, use the `context` value (`@context.{PROPERTY}`) in the item content template:
+
+```razor
+<table>
+    <Virtualize Items="@employees">
+        <tr>
+            <td>@context.FirstName</td>
+            <td>@context.LastName</td>
+            <td>@context.JobTitle</td>
+        </tr>
+    </Virtualize>
+</table>
+```
+
+The `Virtualize` component calculates how many items to render based on the height of the container and the size of the rendered items.
+
+## Item provider delegate
+
+If you don't want to load all of the items into memory, you can specify an items provider delegate method to the component's `ItemsProvider` parameter that asynchronously retrieves the requested items on demand:
+
+```razor
+<table>
+    <Virtualize Context="employee" ItemsProvider="@LoadEmployees">
+         <tr>
+            <td>@employee.FirstName</td>
+            <td>@employee.LastName</td>
+            <td>@employee.JobTitle</td>
+        </tr>
+    </Virtualize>
+</table>
+```
+
+The items provider receives an `ItemsProviderRequest`, which specifies the required number of items starting at a specific start index. The items provider then retrieves the requested items from a database or other service and returns them as an `ItemsProviderResult<TItem>` along with a count of the total items. The items provider can choose to retrieve the items with each request or cache them so that they're readily available. Don't attempt to use an items provider and assign a collection to `Items` for the same `Virtualize` component.
+
+The following example loads employees from an `EmployeeService`:
+
+```csharp
+private async ValueTask<ItemsProviderResult<Employee>> LoadEmployees(ItemsProviderRequest request)
+{
+    var numEmployees = Math.Min(request.Count, totalEmployees - request.StartIndex);
+    var employees = await EmployeesService.GetEmployeesAsync(request.StartIndex, 
+        numEmployees, request.CancellationToken);
+
+    return new ItemsProviderResult<Employee>(employees, totalEmployees);
+}
+```
+
+## Placeholder
+
+Because requesting items from a remote data source might take some time, you have the option to render a placeholder (`<Placeholder>...</Placeholder>`) until the item data is available:
+
+```razor
+<table>
+    <Virtualize Context="employee" ItemsProvider="@LoadEmployees">
+        <ItemContent>
+            <tr>
+                <td>@employee.FirstName</td>
+                <td>@employee.LastName</td>
+                <td>@employee.JobTitle</td>
+            </tr>
+        </ItemContent>
+        <Placeholder>
+            <tr>
+                <td>Loading...</td>
+            </tr>
+        </Placeholder>
+    </Virtualize>
+</table>
+```
+
+## Item size
+
+The size of each item in pixels can be set with `ItemSize` (default: 50px):
+
+```razor
+<table>
+    <Virtualize Context="employee" Items="@employees" ItemSize="25">
+        ...
+    </Virtualize>
+</table>
+```
+
+## Overscan count
+
+`OverscanCount` determines how many additional items are rendered before and after the visible region. This setting helps to reduce the frequency of rendering during scrolling. However, higher values result in more elements rendered in the page (default: 3):
+
+```razor
+<table>
+    <Virtualize Context="employee" Items="@employees" OverscanCount="4">
+        ...
+    </Virtualize>
+</table>
+```
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+For example, a grid or list that renders hundreds of rows containing components is processor intensive to render. Consider virtualizing a grid or list layout so that only a subset of the components is rendered at any given time. For an example of component subset rendering, see the following components in the [`Virtualization` sample app (aspnet/samples GitHub repository)](https://github.com/aspnet/samples/tree/master/samples/aspnetcore/blazor/Virtualization):
+
+* `Virtualize` component ([`Shared/Virtualize.razor`](https://github.com/aspnet/samples/blob/master/samples/aspnetcore/blazor/Virtualization/Shared/Virtualize.cs)): A component written in C# that implements <xref:Microsoft.AspNetCore.Components.ComponentBase> to render a set of weather data rows based on user scrolling.
+* `FetchData` component ([`Pages/FetchData.razor`](https://github.com/aspnet/samples/blob/master/samples/aspnetcore/blazor/Virtualization/Pages/FetchData.razor)): Uses the `Virtualize` component to display 25 rows of weather data at a time.
+
+::: moniker-end

--- a/aspnetcore/blazor/components/component-virtualization.md
+++ b/aspnetcore/blazor/components/component-virtualization.md
@@ -85,7 +85,8 @@ The items provider receives an `ItemsProviderRequest`, which specifies the requi
 The following example loads employees from an `EmployeeService`:
 
 ```csharp
-private async ValueTask<ItemsProviderResult<Employee>> LoadEmployees(ItemsProviderRequest request)
+private async ValueTask<ItemsProviderResult<Employee>> LoadEmployees(
+    ItemsProviderRequest request)
 {
     var numEmployees = Math.Min(request.Count, totalEmployees - request.StartIndex);
     var employees = await EmployeesService.GetEmployeesAsync(request.StartIndex, 

--- a/aspnetcore/blazor/webassembly-performance-best-practices.md
+++ b/aspnetcore/blazor/webassembly-performance-best-practices.md
@@ -65,10 +65,7 @@ For more information, see <xref:blazor/components/lifecycle#after-component-rend
 
 Components offer a convenient approach to produce re-usable fragments of code and markup. In general, we recommend authoring individual components that best align with the app's requirements. One caveat is that each additional child component contributes to the total time it takes to render a parent component. For most apps, the additional overhead is negligible. Apps that produce a large number of components should consider using strategies to reduce processing overhead, such as limiting the number of rendered components.
 
-For example, a grid or list that renders hundreds of rows containing components is processor intensive to render. Consider virtualizing a grid or list layout so that only a subset of the components is rendered at any given time. For an example of component subset rendering, see the following components in the [`Virtualization` sample app (aspnet/samples GitHub repository)](https://github.com/aspnet/samples/tree/master/samples/aspnetcore/blazor/Virtualization):
-
-* `Virtualize` component ([`Shared/Virtualize.razor`](https://github.com/aspnet/samples/blob/master/samples/aspnetcore/blazor/Virtualization/Shared/Virtualize.cs)): A component written in C# that implements <xref:Microsoft.AspNetCore.Components.ComponentBase> to render a set of weather data rows based on user scrolling.
-* `FetchData` component ([`Pages/FetchData.razor`](https://github.com/aspnet/samples/blob/master/samples/aspnetcore/blazor/Virtualization/Pages/FetchData.razor)): Uses the `Virtualize` component to display 25 rows of weather data at a time.
+For more information, see <xref:blazor/components/virtualization>.
 
 ## Avoid JavaScript interop to marshal data
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -371,6 +371,8 @@
               uid: blazor/components/event-handling
             - name: Lifecycle
               uid: blazor/components/lifecycle
+            - name: Component virtualization
+              uid: blazor/components/virtualization
             - name: Templated components
               uid: blazor/components/templated-components
             - name: Integrate components


### PR DESCRIPTION
Fixes #19871

Three concerns on this one:

* Consistency (I guess since it works either way) ... but there's still flexibility in how objects are assigned to component parameters in samples and examples. The blog post (and other assorted examples) assign **_without_** the `@` symbol, but we've been moving docs consistently to using `@` when the attribute isn't prefixed with `@`...

  * `Items="@collection"` ... because what's in quotes isn't necessarily C# for a Blazor parameter. However, the framework seems to accept it without `@`. The examples in [the blog post](https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-5-release-candidate-1/#blazor-component-virtualization) don't use `@` ... `<Virtualize Items="employees" Context="employee">`.
  * `@bind="collection"` :+1:, **_NOT_** `@bind="@collection"` :x: ... because it's C# in the quotes per Razor syntax.

  The examples on this PR currently **use** the `@` on the collection, as we do elsewhere throughout these docs based on our prior convo. Proceed? ... or revert everywhere?

* The blog post doesn't place `<table>` tags around the `Virtualize` component for the item templates that contain `<tr>` elements. I think it was left out just to abbreviate the examples ... keep them short. For completeness, I placed an example into a sample app and am surprised to see `<div>` elements rendered inside the `<table>` tags. I don't think that's permissible under HTML5. Thoughts? ... and btw ... this would also be a problem for `<li>` elements in a template with a `<ul>` or `<ol>` around the `Virtualize` component ... `<div>` tags between them should be an HTML spec problem.

  ```razor
  <table>
      <Virtualize Items="@employees" Context="employee">
          <tr>
              <td>@employee.FirstName</td>
              <td>@employee.LastName</td>
          </tr>
      </Virtualize>
  </table>
  ```

  ```html
  <table>
      <!--!-->
      <div style="height: 0px;" _bl_2=""></div>
      <tr>
          <td>Sally</td>
          <!--!-->
          <td>Hurricane</td>
      </tr>
      <tr>
          <td>Big</td>
          <!--!-->
          <td>Mess</td>
      </tr>
      <div style="height: 0px;" _bl_3=""></div>
  </table>
  ```

* Finally, we had some content on this for 3.2. I left that on the PR for <5.0. Should it be left as I have it here? ... or should I strike that 3.x versioned content and version the whole topic for 5.0+?
