### PR TITLE
Add ToC link to DevOps with GitHub Actions Learn module

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -174,6 +174,9 @@
             - name: Implement resiliency >>
               displayName: tutorial, kubernetes, aks, acr, docker
               href: /learn/modules/microservices-resiliency-aspnet-core/
+            - name: Deploy with GitHub Actions >>
+              display: tutorial, kubernetes, aks, acr, docker, devops
+              href: /learn/modules/microservices-devops-aspnet-core/
         - name: Data access >>
           displayName: tutorial, ef, entity framework
           href: /learn/modules/persist-data-ef-core/


### PR DESCRIPTION
Closes https://github.com/dotnet/AspNetCore.Docs/issues/19341

Add a link to the "Deploy a cloud-native ASP.NET Core microservice with GitHub Actions" MS Learn module.

The module is expected to publish on Tuesday, 9/22. Confirm module is live before merging this PR.