### PR TITLE
Move Blazor built-in components down in ToC

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -325,48 +325,6 @@
           items:
             - name: Overview
               uid: blazor/components/index
-            - name: Built-in components
-              items:
-                - name: App
-                  href: blazor/templates.md#blazor-project-structure
-                - name: Authentication
-                  href: blazor/security/webassembly/index.md#authentication-component
-                - name: AuthorizeView
-                  href: blazor/security/index.md#authorizeview-component
-                - name: InputCheckbox
-                  href: blazor/forms-validation.md#built-in-forms-components
-                - name: InputDate
-                  href: blazor/forms-validation.md#built-in-forms-components
-                - name: InputFile
-                  href: blazor/file-uploads.md
-                - name: InputNumber
-                  href: blazor/forms-validation.md#built-in-forms-components
-                - name: InputRadio
-                  href: blazor/forms-validation.md#built-in-forms-components
-                - name: InputRadioGroup
-                  href: blazor/forms-validation.md#built-in-forms-components
-                - name: InputSelect
-                  href: blazor/forms-validation.md#built-in-forms-components
-                - name: InputText
-                  href: blazor/forms-validation.md#built-in-forms-components
-                - name: InputTextArea
-                  href: blazor/forms-validation.md#built-in-forms-components
-                - name: Link
-                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
-                - name: MainLayout
-                  href: blazor/layouts.md#mainlayout-component
-                - name: Meta
-                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
-                - name: NavLink
-                  href: blazor/fundamentals/routing.md#navlink-component
-                - name: NavMenu
-                  href: blazor/fundamentals/routing.md#navlink-component
-                - name: Router
-                  href: blazor/fundamentals/routing.md#route-templates
-                - name: Title
-                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
-                - name: Virtualize
-                  href: blazor/components/virtualization.md
             - name: Cascading values and parameters
               uid: blazor/components/cascading-values-and-parameters
             - name: Data binding
@@ -461,6 +419,48 @@
           uid: blazor/blazor-server-ef-core
         - name: Advanced scenarios
           uid: blazor/advanced-scenarios
+        - name: Built-in components
+          items:
+            - name: App
+              href: blazor/templates.md#blazor-project-structure
+            - name: Authentication
+              href: blazor/security/webassembly/index.md#authentication-component
+            - name: AuthorizeView
+              href: blazor/security/index.md#authorizeview-component
+            - name: InputCheckbox
+              href: blazor/forms-validation.md#built-in-forms-components
+            - name: InputDate
+              href: blazor/forms-validation.md#built-in-forms-components
+            - name: InputFile
+              uid: blazor/file-uploads
+            - name: InputNumber
+              href: blazor/forms-validation.md#built-in-forms-components
+            - name: InputRadio
+              href: blazor/forms-validation.md#built-in-forms-components
+            - name: InputRadioGroup
+              href: blazor/forms-validation.md#built-in-forms-components
+            - name: InputSelect
+              href: blazor/forms-validation.md#built-in-forms-components
+            - name: InputText
+              href: blazor/forms-validation.md#built-in-forms-components
+            - name: InputTextArea
+              href: blazor/forms-validation.md#built-in-forms-components
+            - name: Link
+              href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
+            - name: MainLayout
+              href: blazor/layouts.md#mainlayout-component
+            - name: Meta
+              href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
+            - name: NavLink
+              href: blazor/fundamentals/routing.md#navlink-component
+            - name: NavMenu
+              href: blazor/fundamentals/routing.md#navlink-component
+            - name: Router
+              href: blazor/fundamentals/routing.md#route-templates
+            - name: Title
+              href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
+            - name: Virtualize
+              uid: blazor/components/virtualization
     - name: Client-side development
       items:
         - name: Single Page Apps


### PR DESCRIPTION
Scott ...

I'm still not getting the best behavior out of the ToC with the built-in component links embedded near the top of the *Components* node. The problem is still that when a reader selects one they end up with a highlighted ToC entry of the component in the *Built-in components* list and not the highlighted ToC entry of **_the topic where that link sent them_**.

I think what's happening is that it's matching the first `href`/`uid` (URL) it comes to down the ToC. I think that by moving the whole node to the bottom of the Blazor ToC that it will start matching, thus highlighting, the **_topic_** where the component is described.

If you think I'm right, let's give this PR shot. If you have a better plan to achieve the behavior I seek, I'm all :ear::ear::ear::ear::ear:.

**UPDATE**: What about setting `topicHref`?

> If topicHref is set for this TOC Item, it will be considered as the href of the expanded TOC Item.

... that sounds good if I'm interpreting it correctly as matching my goal (i.e., set it to the landing topic). 🤔 Depends on what they mean by "it" ... pronouns ... they're great ... *until they aren't*. :smile: