### PR TITLE
Revert Blazor ToC back to original location

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -367,22 +367,22 @@
                   href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
                 - name: Virtualize
                   uid: blazor/components/virtualization
-                - name: Cascading values and parameters
-                  uid: blazor/components/cascading-values-and-parameters
-                - name: Data binding
-                  uid: blazor/components/data-binding
-                - name: Event handling
-                  uid: blazor/components/event-handling
-                - name: Lifecycle
-                  uid: blazor/components/lifecycle
-                - name: Component virtualization
-                  uid: blazor/components/virtualization
-                - name: Templated components
-                  uid: blazor/components/templated-components
-                - name: Integrate components
-                  uid: blazor/components/integrate-components-into-razor-pages-and-mvc-apps
-                - name: Component libraries
-                  uid: blazor/components/class-libraries
+            - name: Cascading values and parameters
+              uid: blazor/components/cascading-values-and-parameters
+            - name: Data binding
+              uid: blazor/components/data-binding
+            - name: Event handling
+              uid: blazor/components/event-handling
+            - name: Lifecycle
+              uid: blazor/components/lifecycle
+            - name: Component virtualization
+              uid: blazor/components/virtualization
+            - name: Templated components
+              uid: blazor/components/templated-components
+            - name: Integrate components
+              uid: blazor/components/integrate-components-into-razor-pages-and-mvc-apps
+            - name: Component libraries
+              uid: blazor/components/class-libraries
         - name: Globalization and localization
           uid: blazor/globalization-localization
         - name: Layouts

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -325,22 +325,64 @@
           items:
             - name: Overview
               uid: blazor/components/index
-            - name: Cascading values and parameters
-              uid: blazor/components/cascading-values-and-parameters
-            - name: Data binding
-              uid: blazor/components/data-binding
-            - name: Event handling
-              uid: blazor/components/event-handling
-            - name: Lifecycle
-              uid: blazor/components/lifecycle
-            - name: Component virtualization
-              uid: blazor/components/virtualization
-            - name: Templated components
-              uid: blazor/components/templated-components
-            - name: Integrate components
-              uid: blazor/components/integrate-components-into-razor-pages-and-mvc-apps
-            - name: Component libraries
-              uid: blazor/components/class-libraries
+            - name: Built-in components
+              items:
+                - name: App
+                  href: blazor/templates.md#blazor-project-structure
+                - name: Authentication
+                  href: blazor/security/webassembly/index.md#authentication-component
+                - name: AuthorizeView
+                  href: blazor/security/index.md#authorizeview-component
+                - name: InputCheckbox
+                  href: blazor/forms-validation.md#built-in-forms-components
+                - name: InputDate
+                  href: blazor/forms-validation.md#built-in-forms-components
+                - name: InputFile
+                  uid: blazor/file-uploads
+                - name: InputNumber
+                  href: blazor/forms-validation.md#built-in-forms-components
+                - name: InputRadio
+                  href: blazor/forms-validation.md#built-in-forms-components
+                - name: InputRadioGroup
+                  href: blazor/forms-validation.md#built-in-forms-components
+                - name: InputSelect
+                  href: blazor/forms-validation.md#built-in-forms-components
+                - name: InputText
+                  href: blazor/forms-validation.md#built-in-forms-components
+                - name: InputTextArea
+                  href: blazor/forms-validation.md#built-in-forms-components
+                - name: Link
+                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
+                - name: MainLayout
+                  href: blazor/layouts.md#mainlayout-component
+                - name: Meta
+                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
+                - name: NavLink
+                  href: blazor/fundamentals/routing.md#navlink-component
+                - name: NavMenu
+                  href: blazor/fundamentals/routing.md#navlink-component
+                - name: Router
+                  href: blazor/fundamentals/routing.md#route-templates
+                - name: Title
+                  href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
+                - name: Virtualize
+                  uid: blazor/components/virtualization
+                - name: Cascading values and parameters
+                  uid: blazor/components/cascading-values-and-parameters
+                - name: Data binding
+                  uid: blazor/components/data-binding
+                - name: Event handling
+                  uid: blazor/components/event-handling
+                - name: Lifecycle
+                  uid: blazor/components/lifecycle
+                - name: Component virtualization
+                  uid: blazor/components/virtualization
+                - name: Templated components
+                  uid: blazor/components/templated-components
+                - name: Integrate components
+                  uid: blazor/components/integrate-components-into-razor-pages-and-mvc-apps
+                - name: Component libraries
+                  uid: blazor/components/class-libraries
         - name: Globalization and localization
           uid: blazor/globalization-localization
         - name: Layouts
@@ -419,48 +461,6 @@
           uid: blazor/blazor-server-ef-core
         - name: Advanced scenarios
           uid: blazor/advanced-scenarios
-        - name: Built-in components
-          items:
-            - name: App
-              href: blazor/templates.md#blazor-project-structure
-            - name: Authentication
-              href: blazor/security/webassembly/index.md#authentication-component
-            - name: AuthorizeView
-              href: blazor/security/index.md#authorizeview-component
-            - name: InputCheckbox
-              href: blazor/forms-validation.md#built-in-forms-components
-            - name: InputDate
-              href: blazor/forms-validation.md#built-in-forms-components
-            - name: InputFile
-              uid: blazor/file-uploads
-            - name: InputNumber
-              href: blazor/forms-validation.md#built-in-forms-components
-            - name: InputRadio
-              href: blazor/forms-validation.md#built-in-forms-components
-            - name: InputRadioGroup
-              href: blazor/forms-validation.md#built-in-forms-components
-            - name: InputSelect
-              href: blazor/forms-validation.md#built-in-forms-components
-            - name: InputText
-              href: blazor/forms-validation.md#built-in-forms-components
-            - name: InputTextArea
-              href: blazor/forms-validation.md#built-in-forms-components
-            - name: Link
-              href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
-            - name: MainLayout
-              href: blazor/layouts.md#mainlayout-component
-            - name: Meta
-              href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
-            - name: NavLink
-              href: blazor/fundamentals/routing.md#navlink-component
-            - name: NavMenu
-              href: blazor/fundamentals/routing.md#navlink-component
-            - name: Router
-              href: blazor/fundamentals/routing.md#route-templates
-            - name: Title
-              href: blazor/fundamentals/additional-scenarios.md#influence-html-head-tag-elements
-            - name: Virtualize
-              uid: blazor/components/virtualization
     - name: Client-side development
       items:
         - name: Single Page Apps


### PR DESCRIPTION
@scottaddie ... No 🎲🎲 ... I tried both ...

* Using `topicHref`.
* Moving the node to the bottom.

It's not matching the first link to the landing page in the `toc.yml` file. It always matches the selected ToC entry.

I'm going to open a DocFX issue to ask them if the behavior I seek is possible.

If they say it isn't possible to achieve this behavior today, I'll ask them if they'll consider creating such a DocFX feature.

Thanks for your help. 