### PR TITLE
Debug WASM w/o changing base href

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -137,8 +137,7 @@ In the following examples, the app is hosted at `/OAT` with an app base path con
 "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/OAT/_framework/debug/ws-proxy?browser={browserInspectUri}",
 ```
 
-> [!NOTE]
-> Using a custom app base path for Blazor WebAssembly apps requires special configuration, including a configuration in the app's `Program.Main` (`Program.cs`). For more information, see <xref:blazor/host-and-deploy/index#app-base-path>.
+For information on using a custom app base path for Blazor WebAssembly apps, see <xref:blazor/host-and-deploy/index#app-base-path>.
 
 # [Visual Studio Code](#tab/visual-studio-code)
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -137,6 +137,9 @@ In the following examples, the app is hosted at `/OAT` with an app base path con
 "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/OAT/_framework/debug/ws-proxy?browser={browserInspectUri}",
 ```
 
+> [!NOTE]
+> Using a custom app base path for Blazor WebAssembly apps requires special configuration, including a configuration in the app's `Program.Main` (`Program.cs`). For more information, see <xref:blazor/host-and-deploy/index#app-base-path>.
+
 # [Visual Studio Code](#tab/visual-studio-code)
 
 <h2 id="vscode">Debug standalone Blazor WebAssembly</h2>

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -93,11 +93,53 @@ While debugging a Blazor WebAssembly app, you can also debug server code:
 > [!NOTE]
 > Breakpoints are **not** hit during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` methods](xref:blazor/components/lifecycle#component-initialization-methods) of components that are loaded by the first page requested from the app.
 
+If the app is hosted at a different [app base path](xref:blazor/host-and-deploy/index#app-base-path) than `/`, update the following properties in `Properties/launchSettings.json` to reflect the app's base path:
+
+* `applicationUrl`:
+
+  ```json
+  "iisSettings": {
+    ...
+    "iisExpress": {
+      "applicationUrl": "http://localhost:{INSECURE PORT}/{APP BASE PATH}/",
+      "sslPort": {SECURE PORT}
+    }
+  },
+  ```
+
+* `inspectUri` of each profile:
+
+  ```json
+  "profiles": {
+    ...
+    "{PROFILE 1, 2, ... N}": {
+      ...
+      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/{APP BASE PATH}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      ...
+    }
+  }
+  ```
+
+The placeholders in the preceding settings:
+
+* `{INSECURE PORT}`: The insecure port. A random value is provided by default, but a custom port is permitted.
+* `{APP BASE PATH}`: The app's base path.
+* `{SECURE PORT}`: The secure port. A random value is provided by default, but a custom port is permitted.
+* `{PROFILE 1, 2, ... N}`: Launch settings profiles. Usually, an app specifies more than one profile by default (for example, a profile for IIS Express and a project profile, which is used by Kestrel server).
+
+In the following examples, the app is hosted at `/OAT` with an app base path configured in `wwwroot/index.html` as `<base href="/OAT/">`:
+
+```json
+"applicationUrl": "http://localhost:{INSECURE PORT}/OAT/",
+```
+
+```json
+"inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/OAT/_framework/debug/ws-proxy?browser={browserInspectUri}",
+```
+
 # [Visual Studio Code](#tab/visual-studio-code)
 
-<a id="vscode"></a>
-
-## Debug standalone Blazor WebAssembly
+<h2 id="vscode">Debug standalone Blazor WebAssembly</h2>
 
 1. Open the standalone Blazor WebAssembly app in VS Code.
 


### PR DESCRIPTION
Fixes #19970

Thanks @gfs ... I immortalize "OAT" (whatever that is :smile:) in the examples.

Safia, should we also address this for VS Code `url` and `webRoot` in `.vscode/launch.json`?

Also, we don't (*yet*) version anything here. I think if we don't version sections of the topic (if needed) that we should go ahead and version this whole topic for 5.0. Thoughts?