### PR TITLE
Added missing step causing compilation issue

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -200,9 +200,10 @@ dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 * Create a *Protos* folder in the gRPC client project.
 * Copy the *Protos\greet.proto* file from the gRPC Greeter service to the gRPC client project.
 * Update namespace inside your greet.proto file to your project namespace:
-```
-option csharp_namespace = "GrpcGreeterClient";
-```
+
+  ```
+  option csharp_namespace = "GrpcGreeterClient";
+  ```
 
 * Edit the *GrpcGreeterClient.csproj* project file:
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -199,7 +199,7 @@ dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 
 * Create a *Protos* folder in the gRPC client project.
 * Copy the *Protos\greet.proto* file from the gRPC Greeter service to the gRPC client project.
-* Update namespace inside your greet.proto file to your project namespace:
+* Update the namespace inside the `greet.proto` file to the project's namespace:
 
   ```
   option csharp_namespace = "GrpcGreeterClient";

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -199,6 +199,11 @@ dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 
 * Create a *Protos* folder in the gRPC client project.
 * Copy the *Protos\greet.proto* file from the gRPC Greeter service to the gRPC client project.
+* Update namespace inside your greet.proto file to your project namespace:
+```
+option csharp_namespace = "GrpcGreeterClient";
+```
+
 * Edit the *GrpcGreeterClient.csproj* project file:
 
   # [Visual Studio](#tab/visual-studio)


### PR DESCRIPTION
Fixed guide to remove compilation issue caused by incorrect namespace in greet.proto.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->