### PR TITLE
Blazor file uploads topic updates

### DIFF
--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -24,7 +24,7 @@ Use the `InputFile` component to read browser file data into .NET code, includin
 
 The `InputFile` component renders as an HTML input of type `file`.
 
-By default, the user selects single files. Add the `multiple` attribute to permit the user to upload multiple files at once. When one or more files is selected by the user, the `InputFile` component fires an `OnChange` event and passes in an `FileChangeEventArgs` that provides access to the selected file list and details about each file.
+By default, the user selects single files. Add the `multiple` attribute to permit the user to upload multiple files at once. When one or more files is selected by the user, the `InputFile` component fires an `OnChange` event and passes in an `InputFileChangeEventArgs` that provides access to the selected file list and details about each file.
 
 To read data from a user-selected file:
 
@@ -33,7 +33,7 @@ To read data from a user-selected file:
 
 A component that receives an image file can call the `RequestImageFileAsync` convenience method on the file to resize the image data within the browser's JavaScript runtime before the image is streamed into the app.
 
-The following example demonstrates multiple image file upload in a component. `FileChangeEventArgs.GetMultipleFiles` allows reading multiple files. Specify the maximum number of files you expect to read to prevent a malicious user from uploading a larger number of files than the app expects. FileChangeEventArgs.File allows reading the first and only file if the file upload does not support multiple files.
+The following example demonstrates multiple image file upload in a component. `InputFileChangeEventArgs.GetMultipleFiles` allows reading multiple files. Specify the maximum number of files you expect to read to prevent a malicious user from uploading a larger number of files than the app expects. `InputFileChangeEventArgs.File` allows reading the first and only file if the file upload does not support multiple files.
 
 ```razor
 <h3>Upload PNG images</h3>
@@ -59,7 +59,7 @@ The following example demonstrates multiple image file upload in a component. `F
 @code {
     IList<string> imageDataUrls = new List<string>();
 
-    private async Task OnInputFileChange(FileChangeEventArgs e)
+    private async Task OnInputFileChange(InputFileChangeEventArgs e)
     {
         var maxAllowedFiles = 3;
         var format = "image/png";
@@ -84,13 +84,7 @@ The following example demonstrates multiple image file upload in a component. `F
 
 In a Blazor WebAssembly app, the data is streamed directly into the .NET code within the browser.
 
-In a Blazor Server app, the file data is streamed over the SignalR connection into .NET code on the server as the file is read from the stream. In the following table, `Forms.RemoteBrowserFileStreamOptions` allows configuring file upload characteristics for Blazor Server.
-
-| Blazor Server Property | Description | Default |
-| ---------------------- | ----------- | ------- |
-| `MaxBufferSize` | Maximum internal buffer size for unread data sent over a SignalR circuit. | 20,480 KB (20 KB) |
-| `MaxSegmentSize` | Maximum segment size for file data sent over a SignalR circuit. The maximum permitted value is 32,768 KB (32 KB). | 1,048,576 KB (1 MB) |
-| `SegmentFetchTimeout` | Time limit for fetching a segment of file data. | 1 minute |
+In a Blazor Server app, the file data is streamed over the SignalR connection into .NET code on the server as the file is read from the stream. [`Forms.RemoteBrowserFileStreamOptions`](https://github.com/dotnet/aspnetcore/blob/master/src/Components/Web/src/Forms/InputFile/InputFileChangeEventArgs.cs) allows configuring file upload characteristics for Blazor Server.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -84,7 +84,7 @@ The following example demonstrates multiple image file upload in a component. `I
 
 In a Blazor WebAssembly app, the data is streamed directly into the .NET code within the browser.
 
-In a Blazor Server app, the file data is streamed over the SignalR connection into .NET code on the server as the file is read from the stream. [`Forms.RemoteBrowserFileStreamOptions`](https://github.com/dotnet/aspnetcore/blob/master/src/Components/Web/src/Forms/InputFile/InputFileChangeEventArgs.cs) allows configuring file upload characteristics for Blazor Server.
+In a Blazor Server app, the file data is streamed over the SignalR connection into .NET code on the server as the file is read from the stream. [`Forms.RemoteBrowserFileStreamOptions`](https://github.com/dotnet/aspnetcore/blob/master/src/Components/Web/src/Forms/InputFile/RemoteBrowserFileStreamOptions.cs) allows configuring file upload characteristics for Blazor Server.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/file-uploads/samples/5.x/Components/FilePreview.razor
+++ b/aspnetcore/blazor/file-uploads/samples/5.x/Components/FilePreview.razor
@@ -2,7 +2,7 @@
 @using System.IO;
 @using Microsoft.AspNetCore.Components.Forms
 
-<h1>File preview</h1>
+<h3>File Preview Component</h3>
 
 Max file size:
 <br />

--- a/aspnetcore/blazor/file-uploads/samples/5.x/Components/FilePreview.razor
+++ b/aspnetcore/blazor/file-uploads/samples/5.x/Components/FilePreview.razor
@@ -1,0 +1,105 @@
+@page "/FilePreview"
+@using System.IO;
+@using Microsoft.AspNetCore.Components.Forms
+
+<h1>File preview</h1>
+
+Max file size:
+<br />
+<input type="number" id="max-file-size" @bind-value="@maxFileSize" />
+<br />
+
+Max allowed files:
+<br />
+<input type="number" id="max-allowed-files" @bind-value="@maxAllowedFiles" />
+<br />
+
+<InputFile OnChange="LoadFiles" id="input-file" multiple />
+<br />
+
+<span id="exception-message">@exceptionMessage</span>
+
+@if (isLoading)
+{
+    <p>Loading...</p>
+    <br />
+}
+
+@foreach (var (file, content) in loadedFiles)
+{
+    <p id="file-@(file.Name)">
+        <strong>Name:</strong> <span id="file-name">@(file.Name)</span><br />
+        <strong>Last modified:</strong> <span id="file-last-modified">@(file.LastModified.ToString())</span><br />
+        <strong>Size (bytes):</strong> <span id="file-size">@(file.Size)</span><br />
+        <strong>Content type:</strong> <span id="file-content-type">@(file.ContentType)</span><br />
+        <strong>Content:</strong> <span id="file-content">@content</span><br />
+    </p>
+}
+
+<h1>Image upload</h1>
+
+<InputFile OnChange="LoadImage" id="input-image" />
+<br />
+
+@if (imageDataUri != null)
+{
+    <p>
+        Uploaded image:<br />
+        <img id="image-uploaded" src="@imageDataUri" />
+    </p>
+}
+
+<p>
+    Source image:<br />
+    <img id="image-source" src="images/blazor_logo_1000x.png" />
+</p>
+
+@code {
+    Dictionary<IBrowserFile, string> loadedFiles = new Dictionary<IBrowserFile, string>();
+
+    long maxFileSize = 1024 * 1024 * 15;
+    int maxAllowedFiles = 3;
+
+    bool isLoading;
+
+    string imageDataUri;
+
+    string exceptionMessage;
+
+    async Task LoadFiles(InputFileChangeEventArgs e)
+    {
+        isLoading = true;
+        loadedFiles.Clear();
+        exceptionMessage = string.Empty;
+
+        try
+        {
+            foreach (var file in e.GetMultipleFiles(maxAllowedFiles))
+            {
+                StateHasChanged();
+
+                using var reader = new StreamReader(file.OpenReadStream(maxFileSize));
+
+                loadedFiles.Add(file, await reader.ReadToEndAsync());
+            }
+        }
+        catch (Exception ex)
+        {
+            exceptionMessage = ex.Message;
+        }
+
+        isLoading = false;
+    }
+
+    async Task LoadImage(InputFileChangeEventArgs e)
+    {
+        var format = "image/jpeg";
+        var imageFile = await e.File.RequestImageFileAsync(format, 640, 480);
+
+        using var fileStream = imageFile.OpenReadStream(maxFileSize);
+        using var memoryStream = new MemoryStream();
+        await fileStream.CopyToAsync(memoryStream);
+
+        imageDataUri = $"data:{format};base64,{Convert.ToBase64String(memoryStream.ToArray())}";
+    }
+}

--- a/aspnetcore/blazor/file-uploads/samples/5.x/Components/FileUpload.razor
+++ b/aspnetcore/blazor/file-uploads/samples/5.x/Components/FileUpload.razor
@@ -1,0 +1,118 @@
+@page "/FileUpload"
+@using System.ComponentModel.DataAnnotations
+@using System.IO
+@using System.Linq
+@using System.Threading
+@implements IDisposable
+
+<h3>File Upload Component</h3>
+
+<EditForm EditContext="editContext" OnValidSubmit="OnSubmit">
+    <DataAnnotationsValidator />
+
+    <div class="form-group">
+        Name: <InputText @bind-Value="@person.Name" class="form-control" />
+        <ValidationMessage For="() => person.Name" />
+    </div>
+
+    <div class="form-group">
+        Picture: <InputFile OnChange="OnChange" class="form-control" />
+        <ValidationMessage For="() => person.Picture" />
+
+        @{
+            var progressCss = "progress " + (displayProgress ? "" : "d-none");
+            var progressWidthStyle = progressPercent + "%";
+        }
+
+        <div class="@progressCss">
+            <div class="progress-bar" role="progressbar" style="width:@progressWidthStyle" area-valuenow="@progressPercent" aria-minvalue="0" aria-maxvalue="100"></div>
+        </div>
+    </div>
+
+    <button>Submit</button>
+</EditForm>
+
+@code
+{
+    private CancellationTokenSource cancelation;
+    private bool displayProgress;
+    private EditContext editContext;
+    private Person person;
+    private int progressPercent;
+
+    protected override void OnInitialized()
+    {
+        cancelation = new CancellationTokenSource();
+        editContext = new EditContext(person);
+        person = new Person();
+    }
+
+    private void OnChange(InputFileChangeEventArgs eventArgs)
+    {
+        person.Picture = eventArgs.File;
+        editContext.NotifyFieldChanged(FieldIdentifier.Create(() => person.Picture));
+    }
+
+    private async Task OnSubmit()
+    {
+        using var file = File.OpenWrite(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
+        using var stream = person.Picture.OpenReadStream();
+
+        var buffer = new byte[4 * 1096];
+        private int bytesRead;
+        private double totalRead = 0;
+
+        displayProgress = true;
+
+        while ((bytesRead = await stream.ReadAsync(buffer, cancelation.Token)) != 0)
+        {
+            totalRead += bytesRead;
+            await file.WriteAsync(buffer, cancelation.Token);
+
+            progressPercent = (int)((totalRead / person.Picture.Size) * 100);
+            StateHasChanged();
+        }
+
+        displayProgress = false;
+    }
+
+    public void Dispose()
+    {
+        cancelation.Cancel();
+    }
+
+    public class Person
+    {
+        [Required]
+        [StringLength(20, MinimumLength = 2)]
+        public string Name { get; set; } = "Pranav";
+
+        [Required]
+        [FileValidation(new[] { ".png", ".jpg" })]
+        public IBrowserFile Picture { get; set; }
+    }
+
+    private class FileValidationAttribute : ValidationAttribute
+    {
+        public FileValidationAttribute(string[] allowedExtensions)
+        {
+            AllowedExtensions = allowedExtensions;
+        }
+
+        private string[] AllowedExtensions { get; }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            var file = (IBrowserFile)value;
+
+            var extension = System.IO.Path.GetExtension(file.Name);
+
+            if (!AllowedExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+            {
+                return new ValidationResult($"File must have one of the following extensions: {string.Join(", ", AllowedExtensions)}.", new[] { validationContext.MemberName });
+            }
+
+            return ValidationResult.Success;
+        }
+    }
+}

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -1194,6 +1194,10 @@ When assigning a <xref:Microsoft.AspNetCore.Components.Forms.EditForm.Model> to 
 private ExampleModel exampleModel = new ExampleModel();
 ```
 
+::: moniker range=">= aspnetcore-5.0"
+
 ## Additional resources
 
 * <xref:blazor/file-uploads>
+
+::: moniker-end


### PR DESCRIPTION
Fixes #20035

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/file-uploads?view=aspnetcore-5.0&branch=pr-en-us-20046)

* Initial content of the [current live topic](https://docs.microsoft.com/aspnet/core/blazor/file-uploads?view=aspnetcore-5.0) is based on DR's blog post ... it turned out to be a good start.
* Recommend that we keep the bare bones example in the topic and include your example **_and the framework's example_** as cross-linked sample code (this is all on this PR). This gives the reader immediate access to examples of various approaches/features without loading the topic down with code.
* Check the code carefully tho. I set this up quickly without local testing 🏃 so that I could get on to other issues that need to be addressed. I may have 💥😢 something. I will check this again when I get to this topic on the UE passes on https://github.com/dotnet/AspNetCore.Docs/issues/19286.
* Cross-links are here between the file uploads topic and the file validation topic. I think they'll be visible either way, but see if you agree on that point.
* I placed file uploads into its own new topic and not into the forms validation topic in the first place because this component works outside of a form and it seems like there's enough 🍖 here to warrant its own topic. It's visible in the ToC immediately after the forms validation topic. I think this is best, but let's discuss and change it if not. :ear:

<img width="213" alt="Capture" src="https://user-images.githubusercontent.com/1622880/94565362-bbf3cb80-022e-11eb-8c35-595e71c3420a.PNG">