### PR TITLE
Update StartupUseWhen.cs (docs) for ILogger to work with .NET Core 3+

### DIFF
--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupUseWhen.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupUseWhen.cs
@@ -1,4 +1,4 @@
-﻿public class Startup
+public class Startup
 {
     private void HandleBranchAndRejoin(IApplicationBuilder app, ILogger<Startup> logger)
     {

--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupUseWhen.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupUseWhen.cs
@@ -1,18 +1,11 @@
 ﻿public class Startup
 {
-    private readonly ILogger<Startup> _logger;
-
-    public Startup(ILogger<Startup> logger)
-    {
-        _logger = logger;
-    }
-
-    private void HandleBranchAndRejoin(IApplicationBuilder app)
+    private void HandleBranchAndRejoin(IApplicationBuilder app, ILogger<Startup> logger)
     {
         app.Use(async (context, next) =>
         {
             var branchVer = context.Request.Query["branch"];
-            _logger.LogInformation("Branch used = {branchVer}", branchVer);
+            logger.LogInformation("Branch used = {branchVer}", branchVer);
 
             // Do work that doesn't write to the Response.
             await next();
@@ -20,10 +13,10 @@
         });
     }
 
-    public void Configure(IApplicationBuilder app)
+    public void Configure(IApplicationBuilder app, ILogger<Startup> logger)
     {
         app.UseWhen(context => context.Request.Query.ContainsKey("branch"),
-                               HandleBranchAndRejoin);
+                               appBuilder => HandleBranchAndRejoin(appBuilder, logger));
 
         app.Run(async context =>
         {


### PR DESCRIPTION
According to https://github.com/dotnet/extensions/issues/1096, in .NET Core 3+ you can no longer resolve ILogger when activating Startup and need to pass ILogger as parameter in Configure method.

This change is similar to this change to the docs - https://github.com/MicrosoftDocs/azure-docs/pull/33059



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->