### PR TITLE
Tweak Blazor authentication docs for .NET 5

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -2,7 +2,7 @@
 title: Secure an ASP.NET Core Blazor WebAssembly hosted app with Azure Active Directory B2C
 author: guardrex
 description: Learn how to secure an ASP.NET Core Blazor WebAssembly hosted app with Azure Active Directory B2C.
-monikerRange: '>= aspnetcore-3.1'
+monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 07/08/2020
@@ -63,16 +63,16 @@ Follow the guidance in [Tutorial: Register an application in Azure Active Direct
 1. In **Azure Active Directory** > **App registrations**, select **New registration**.
 1. Provide a **Name** for the app (for example, **Blazor Client AAD B2C**).
 1. For **Supported account types**, select the multi-tenant option: **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.**
-1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the Server app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears in the [Create the app](#create-the-app) section to remind IIS Express users to update the redirect URI.
+1.  Set the **Redirect URI** drop down to **Single-page application (SPA)** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the Server app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears in the [Create the app](#create-the-app) section to remind IIS Express users to update the redirect URI.
 1. Confirm that **Permissions** > **Grant admin consent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
 
 Record the Application (client) ID (for example, `4369008b-21fa-427c-abaa-9b53bf58e538`).
 
-In **Authentication** > **Platform configurations** > **Web**:
+In **Authentication** > **Platform configurations** > **Single-page application**:
 
 1. Confirm the **Redirect URI** of `https://localhost:{PORT}/authentication/login-callback` is present.
-1. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.
+1. For **Implicit grant**, ensure that the check boxes for **Access tokens** and **ID tokens** are __not__ checked.
 1. The remaining defaults for the app are acceptable for this experience.
 1. Select the **Save** button.
 

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -64,16 +64,16 @@ Follow the guidance in [Quickstart: Register an application with the Microsoft i
 1. In **Azure Active Directory** > **App registrations**, select **New registration**.
 1. Provide a **Name** for the app (for example, **Blazor Client AAD**).
 1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** (single tenant) for this experience.
-1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the Server app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears in the [Create the app](#create-the-app) section to remind IIS Express users to update the redirect URI.
+1. Set the **Redirect URI** drop down to **Single-page application (SPA)** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the Server app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears in the [Create the app](#create-the-app) section to remind IIS Express users to update the redirect URI.
 1. Disable the **Permissions** > **Grant admin consent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
 Record the *Client app* Application (client) ID (for example, `4369008b-21fa-427c-abaa-9b53bf58e538`).
 
-In **Authentication** > **Platform configurations** > **Web**:
+In **Authentication** > **Platform configurations** > **Single-page application**:
 
 1. Confirm the **Redirect URI** of `https://localhost:{PORT}/authentication/login-callback` is present.
-1. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.
+1. For **Implicit grant**, ensure that the check boxes for **Access tokens** and **ID tokens** are __not__ checked.
 1. The remaining defaults for the app are acceptable for this experience.
 1. Select the **Save** button.
 
@@ -111,7 +111,7 @@ The output location specified with the `-o|--output` option creates a project fo
 > Pass the App ID URI to the `app-id-uri` option, but note a configuration change might be required in the client app, which is described in the [Access token scopes](#access-token-scopes) section.
 
 > [!NOTE]
-> In the Azure portal, the *Client app's* **Authentication** > **Platform configurations** > **Web** > **Redirect URI** is configured for port 5001 for apps that run on the Kestrel server with default settings.
+> In the Azure portal, the *Client app's* **Authentication** > **Platform configurations** > **Single-page application** > **Redirect URI** is configured for port 5001 for apps that run on the Kestrel server with default settings.
 >
 > If the *Client app* is run on a random IIS Express port, the port for the app can be found in the *Server API app's* properties in the **Debug** panel.
 >

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -29,16 +29,16 @@ Follow the guidance in [Tutorial: Register an application in Azure Active Direct
 1. In **Azure Active Directory** > **App registrations**, select **New registration**.
 1. Provide a **Name** for the app (for example, **Blazor Standalone AAD B2C**).
 1. For **Supported account types**, select the multi-tenant option: **Accounts in any organizational directory or any identity provider. For authenticating users with Azure AD B2C.**
-1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears later in this topic to remind IIS Express users to update the redirect URI.
+1. Set the **Redirect URI** drop down to **Single-page application** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears later in this topic to remind IIS Express users to update the redirect URI.
 1. Confirm that **Permissions** > **Grant admin consent to openid and offline_access permissions** is enabled.
 1. Select **Register**.
 
 Record the Application (client) ID (for example, `41451fa7-82d9-4673-8fa5-69eff5a761fd`).
 
-In **Authentication** > **Platform configurations** > **Web**:
+In **Authentication** > **Platform configurations** > **Single-page application**:
 
 1. Confirm the **Redirect URI** of `https://localhost:{PORT}/authentication/login-callback` is present.
-1. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.
+1. For **Implicit grant**, ensure that the check boxes for **Access tokens** and **ID tokens** are __not__ checked.
 1. The remaining defaults for the app are acceptable for this experience.
 1. Select the **Save** button.
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
@@ -21,7 +21,7 @@ Register a AAD app in the **Azure Active Directory** > **App registrations** are
 
 1. Provide a **Name** for the app (for example, **Blazor Standalone AAD**).
 1. Choose a **Supported account types**. You may select **Accounts in this organizational directory only** for this experience.
-1. Leave the **Redirect URI** drop down set to **Web** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears later in this topic to remind IIS Express users to update the redirect URI.
+1. Set the **Redirect URI** drop down to **Single-page Applicaton (SPA)** and provide the following redirect URI: `https://localhost:{PORT}/authentication/login-callback`. The default port for an app running on Kestrel is 5001. If the app is run on a different Kestrel port, use the app's port. For IIS Express, the randomly generated port for the app can be found in the app's properties in the **Debug** panel. Since the app doesn't exist at this point and the IIS Express port isn't known, return to this step after the app is created and update the redirect URI. A remark appears later in this topic to remind IIS Express users to update the redirect URI.
 1. Disable the **Permissions** > **Grant admin consent to openid and offline_access permissions** check box.
 1. Select **Register**.
 
@@ -33,7 +33,7 @@ Record the following information:
 In **Authentication** > **Platform configurations** > **Web**:
 
 1. Confirm the **Redirect URI** of `https://localhost:{PORT}/authentication/login-callback` is present.
-1. For **Implicit grant**, select the check boxes for **Access tokens** and **ID tokens**.
+1. For **Implicit grant**, ensure that the check boxes for **Access tokens** and **ID tokens** are __not__ checked.
 1. The remaining defaults for the app are acceptable for this experience.
 1. Select the **Save** button.
 


### PR DESCRIPTION
@guardrex Opening this as draft since I'm not totally sure what the strategy is for 3.1/5.0 docs. It looks like we might just be able to distinguish the different behavior with callouts.