### PR TITLE
Update hosted-with-identity-server.md

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -301,12 +301,18 @@ public class CustomUserFactory
         {
             var identity = (ClaimsIdentity)user.Identity;
             var roleClaims = identity.FindAll(identity.RoleClaimType);
+            var claimsToRemove = new List<Claim>();
 
             if (roleClaims != null && roleClaims.Any())
             {
                 foreach (var existingClaim in roleClaims)
                 {
-                    identity.RemoveClaim(existingClaim);
+                    claimsToRemove.Add(existingClaim);                   
+                }
+                
+                foreach(var c in claimsToRemove)
+                {
+                    identity.RemoveClaim(c);
                 }
 
                 var rolesElem = account.AdditionalProperties[identity.RoleClaimType];

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -300,19 +300,13 @@ public class CustomUserFactory
         if (user.Identity.IsAuthenticated)
         {
             var identity = (ClaimsIdentity)user.Identity;
-            var roleClaims = identity.FindAll(identity.RoleClaimType);
-            var claimsToRemove = new List<Claim>();
+            var roleClaims = identity.FindAll(identity.RoleClaimType).ToArray();
 
             if (roleClaims != null && roleClaims.Any())
             {
                 foreach (var existingClaim in roleClaims)
                 {
-                    claimsToRemove.Add(existingClaim);                   
-                }
-                
-                foreach(var c in claimsToRemove)
-                {
-                    identity.RemoveClaim(c);
+                    identity.RemoveClaim(existingClaim);
                 }
 
                 var rolesElem = account.AdditionalProperties[identity.RoleClaimType];


### PR DESCRIPTION
[EDIT by guardrex to add the fixes]

Fixes #19935

The code identity.RemoveClaim(existingClaim); was throwing an exception that the collection was being altered. When I commented that line of code out everything was fine but claims were not being removed. The modification above creates a separate list so as not to involve the Claims collection on User.Identity.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->