### PR TITLE
Blazor Server auth topic updates for 5.0

### DIFF
--- a/aspnetcore/blazor/security/server/additional-scenarios.md
+++ b/aspnetcore/blazor/security/server/additional-scenarios.md
@@ -38,16 +38,6 @@ services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =
 
 Optionally, additional scopes are added with `options.Scope.Add("{SCOPE}");`, where the placeholder `{SCOPE}` is the additional scope to add.
 
-Define a class to pass in the initial app state with the access and refresh tokens:
-
-```csharp
-public class InitialApplicationState
-{
-    public string AccessToken { get; set; }
-    public string RefreshToken { get; set; }
-}
-```
-
 Define a **scoped** token provider service that can be used within the Blazor app to resolve the tokens from [dependency injection (DI)](xref:blazor/fundamentals/dependency-injection):
 
 ```csharp
@@ -66,6 +56,16 @@ In `Startup.ConfigureServices`, add services for:
 ```csharp
 services.AddHttpClient();
 services.AddScoped<TokenProvider>();
+```
+
+Define a class to pass in the initial app state with the access and refresh tokens:
+
+```csharp
+public class InitialApplicationState
+{
+    public string AccessToken { get; set; }
+    public string RefreshToken { get; set; }
+}
 ```
 
 In the `_Host.cshtml` file, create and instance of `InitialApplicationState` and pass it as a parameter to the app:
@@ -309,7 +309,7 @@ endpoints.MapBlazorHub().RequireAuthorization(
 
 ## Use OpenID Connect (OIDC) v2.0 endpoints
 
-The authentication library and Blazor templates use OpenID Connect (OIDC) v1.0 endpoints in versions of ASP.NET Core prior to 5.0. To use a v2.0 endpoint with versions of ASP.NET Core prior to 5.0, configure the <xref:Microsoft.AspNetCore.Builder.OpenIdConnectOptions.Authority?displayProperty=nameWithType> option in the <xref:Microsoft.AspNetCore.Builder.OpenIdConnectOptions>:
+In versions of ASP.NET Core prior to 5.0, the authentication library and Blazor templates use OpenID Connect (OIDC) v1.0 endpoints. To use a v2.0 endpoint with versions of ASP.NET Core prior to 5.0, configure the <xref:Microsoft.AspNetCore.Builder.OpenIdConnectOptions.Authority?displayProperty=nameWithType> option in the <xref:Microsoft.AspNetCore.Builder.OpenIdConnectOptions>:
 
 ```csharp
 services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, 

--- a/aspnetcore/blazor/security/server/additional-scenarios.md
+++ b/aspnetcore/blazor/security/server/additional-scenarios.md
@@ -5,7 +5,7 @@ description: Learn how to configure Blazor Server for additional security scenar
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/04/2020
+ms.date: 10/06/2020
 no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/server/additional-scenarios
 ---
@@ -13,26 +13,179 @@ uid: blazor/security/server/additional-scenarios
 
 By [Javier Calvarro Nelson](https://github.com/javiercn)
 
-## Pass tokens to a Blazor Server app
+::: moniker range=">= aspnetcore-5.0"
 
-Tokens available outside of the Razor components in a Blazor Server app can be passed to components with the approach described in this section. For sample code, including a complete `Startup.ConfigureServices` example, see the [Passing tokens to a server-side Blazor application](https://github.com/javiercn/blazor-server-aad-sample).
+<h2 id="pass-tokens-to-a-blazor-server-app">Pass tokens to a Blazor Server app</h2>
+
+Tokens available outside of the Razor components in a Blazor Server app can be passed to components with the approach described in this section.
 
 Authenticate the Blazor Server app as you would with a regular Razor Pages or MVC app. Provision and save the tokens to the authentication cookie. For example:
 
 ```csharp
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 ...
 
 services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
 {
-    options.ResponseType = "code";
+    options.ResponseType = OpenIdConnectResponseType.Code;
     options.SaveTokens = true;
 
     options.Scope.Add("offline_access");
-    options.Scope.Add("{SCOPE}");
-    options.Resource = "{RESOURCE}";
 });
+```
+
+Optionally, additional scopes are added with `options.Scope.Add("{SCOPE}");`, where the placeholder `{SCOPE}` is the additional scope to add.
+
+Define a class to pass in the initial app state with the access and refresh tokens:
+
+```csharp
+public class InitialApplicationState
+{
+    public string AccessToken { get; set; }
+    public string RefreshToken { get; set; }
+}
+```
+
+Define a **scoped** token provider service that can be used within the Blazor app to resolve the tokens from [dependency injection (DI)](xref:blazor/fundamentals/dependency-injection):
+
+```csharp
+public class TokenProvider
+{
+    public string AccessToken { get; set; }
+    public string RefreshToken { get; set; }
+}
+```
+
+In `Startup.ConfigureServices`, add services for:
+
+* `IHttpClientFactory`
+* `TokenProvider`
+
+```csharp
+services.AddHttpClient();
+services.AddScoped<TokenProvider>();
+```
+
+In the `_Host.cshtml` file, create and instance of `InitialApplicationState` and pass it as a parameter to the app:
+
+```cshtml
+@using Microsoft.AspNetCore.Authentication
+
+...
+
+@{
+    var tokens = new InitialApplicationState
+    {
+        AccessToken = await HttpContext.GetTokenAsync("access_token"),
+        RefreshToken = await HttpContext.GetTokenAsync("refresh_token")
+    };
+}
+
+<component type="typeof(App)" param-InitialState="tokens" 
+    render-mode="ServerPrerendered" />
+```
+
+In the `App` component (`App.razor`), resolve the service and initialize it with the data from the parameter:
+
+```razor
+@inject TokenProvider TokenProvider
+
+...
+
+@code {
+    [Parameter]
+    public InitialApplicationState InitialState { get; set; }
+
+    protected override Task OnInitializedAsync()
+    {
+        TokenProvider.AccessToken = InitialState.AccessToken;
+        TokenProvider.RefreshToken = InitialState.RefreshToken;
+
+        return base.OnInitializedAsync();
+    }
+}
+```
+
+Add a package reference to the app for the [`Microsoft.AspNet.WebApi.Client`](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client) NuGet package.
+
+In the service that makes a secure API request, inject the token provider and retrieve the token for the API request:
+
+```csharp
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public class WeatherForecastService
+{
+    private readonly HttpClient client;
+    private readonly TokenProvider tokenProvider;
+
+    public WeatherForecastService(IHttpClientFactory clientFactory, 
+        TokenProvider tokenProvider)
+    {
+        client = clientFactory.CreateClient();
+        this.tokenProvider = tokenProvider;
+    }
+
+    public async Task<WeatherForecast[]> GetForecastAsync()
+    {
+        var token = tokenProvider.AccessToken;
+        var request = new HttpRequestMessage(HttpMethod.Get, 
+            "https://localhost:5003/WeatherForecast");
+        request.Headers.Add("Authorization", $"Bearer {token}");
+        var response = await client.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+
+        return await response.Content.ReadAsAsync<WeatherForecast[]>();
+    }
+}
+```
+
+<h2 id="set-the-authentication-scheme">Set the authentication scheme</h2>
+
+For an app that uses more than one Authentication Middleware and thus has more than one authentication scheme, the scheme that Blazor uses can be explicitly set in the endpoint configuration of `Startup.Configure`. The following example sets the Azure Active Directory scheme:
+
+```csharp
+endpoints.MapBlazorHub().RequireAuthorization(
+    new AuthorizeAttribute 
+    {
+        AuthenticationSchemes = AzureADDefaults.AuthenticationScheme
+    });
+```
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+<h2 id="pass-tokens-to-a-blazor-server-app">Pass tokens to a Blazor Server app</h2>
+
+Tokens available outside of the Razor components in a Blazor Server app can be passed to components with the approach described in this section.
+
+Authenticate the Blazor Server app as you would with a regular Razor Pages or MVC app. Provision and save the tokens to the authentication cookie. For example:
+
+```csharp
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+...
+
+services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, options =>
+{
+    options.ResponseType = OpenIdConnectResponseType.Code;
+    options.SaveTokens = true;
+
+    options.Scope.Add("offline_access");
+});
+```
+
+Optionally, additional scopes are added with `options.Scope.Add("{SCOPE}");`, where the placeholder `{SCOPE}` is the additional scope to add.
+
+Optionally, the resource is specified with `options.Resource = "{RESOURCE}";`, where the placeholder `{RESOURCE}` is the resource. For example:
+
+```csharp
+options.Resource = "https://graph.microsoft.com";
 ```
 
 Define a class to pass in the initial app state with the access and refresh tokens:
@@ -107,9 +260,9 @@ In the `App` component (`App.razor`), resolve the service and initialize it with
 }
 ```
 
-Add a package reference to the app for the [Microsoft.AspNet.WebApi.Client](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client) NuGet package.
+Add a package reference to the app for the [`Microsoft.AspNet.WebApi.Client`](https://www.nuget.org/packages/Microsoft.AspNet.WebApi.Client) NuGet package.
 
-In the service that makes a secure API request, inject the token provider and retrieve the token to call the API:
+In the service that makes a secure API request, inject the token provider and retrieve the token for the API request:
 
 ```csharp
 using System;
@@ -118,24 +271,23 @@ using System.Threading.Tasks;
 
 public class WeatherForecastService
 {
-    private readonly TokenProvider store;
+    private readonly HttpClient client;
+    private readonly TokenProvider tokenProvider;
 
     public WeatherForecastService(IHttpClientFactory clientFactory, 
         TokenProvider tokenProvider)
     {
-        Client = clientFactory.CreateClient();
-        store = tokenProvider;
+        client = clientFactory.CreateClient();
+        this.tokenProvider = tokenProvider;
     }
 
-    public HttpClient Client { get; }
-
-    public async Task<WeatherForecast[]> GetForecastAsync(DateTime startDate)
+    public async Task<WeatherForecast[]> GetForecastAsync()
     {
-        var token = store.AccessToken;
+        var token = tokenProvider.AccessToken;
         var request = new HttpRequestMessage(HttpMethod.Get, 
             "https://localhost:5003/WeatherForecast");
         request.Headers.Add("Authorization", $"Bearer {token}");
-        var response = await Client.SendAsync(request);
+        var response = await client.SendAsync(request);
         response.EnsureSuccessStatusCode();
 
         return await response.Content.ReadAsAsync<WeatherForecast[]>();
@@ -143,7 +295,7 @@ public class WeatherForecastService
 }
 ```
 
-## Set the authentication scheme
+<h2 id="set-the-authentication-scheme">Set the authentication scheme</h2>
 
 For an app that uses more than one Authentication Middleware and thus has more than one authentication scheme, the scheme that Blazor uses can be explicitly set in the endpoint configuration of `Startup.Configure`. The following example sets the Azure Active Directory scheme:
 
@@ -157,7 +309,7 @@ endpoints.MapBlazorHub().RequireAuthorization(
 
 ## Use OpenID Connect (OIDC) v2.0 endpoints
 
-The authentication library and Blazor templates use OpenID Connect (OIDC) v1.0 endpoints. To use a v2.0 endpoint, configure the <xref:Microsoft.AspNetCore.Builder.OpenIdConnectOptions.Authority?displayProperty=nameWithType> option in the <xref:Microsoft.AspNetCore.Builder.OpenIdConnectOptions>:
+The authentication library and Blazor templates use OpenID Connect (OIDC) v1.0 endpoints in versions of ASP.NET Core prior to 5.0. To use a v2.0 endpoint with versions of ASP.NET Core prior to 5.0, configure the <xref:Microsoft.AspNetCore.Builder.OpenIdConnectOptions.Authority?displayProperty=nameWithType> option in the <xref:Microsoft.AspNetCore.Builder.OpenIdConnectOptions>:
 
 ```csharp
 services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, 
@@ -215,3 +367,5 @@ If tacking on a segment to the authority isn't appropriate for the app's OIDC pr
 ```
 
 You can find the App ID URI to use in the OIDC provider app registration description.
+
+::: moniker-end

--- a/aspnetcore/blazor/security/server/index.md
+++ b/aspnetcore/blazor/security/server/index.md
@@ -5,7 +5,7 @@ description: Learn how to secure Blazor Server apps as ASP.NET Core applications
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/02/2020
+ms.date: 10/06/2020
 no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/security/server/index
 ---
@@ -13,7 +13,7 @@ uid: blazor/security/server/index
 
 By [Luke Latham](https://github.com/guardrex)
 
-Blazor Server apps are configured for security in the same manner as ASP.NET Core apps. For more information, see the articles under <xref:security/index>. Topics under this overview apply specifically to Blazor Server. 
+Blazor Server apps are configured for security in the same manner as ASP.NET Core apps. For more information, see the articles under <xref:security/index>. Topics under this overview apply specifically to Blazor Server.
 
 ## Blazor Server project template
 
@@ -92,7 +92,14 @@ Using the `-o|--output` option, the command uses the value provided for the `{AP
 * Create a folder for the project.
 * Name the project.
 
-For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+For more information:
+
+* See the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+* Execute the help command for the Blazor Server template (`blazorserver`) in a command shell:
+
+  ```dotnetcli
+  dotnet new blazorserver --help
+  ```
 
 ---
 
@@ -102,3 +109,8 @@ Scaffold Identity into a Blazor Server project:
 
 * [Without existing authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-without-existing-authorization).
 * [With authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-with-authorization).
+
+## Additional resources
+
+* [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app](/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp)
+* [Quickstart: Protect an ASP.NET Core web API with Microsoft identity platform](/azure/active-directory/develop/quickstart-v2-aspnet-core-web-api)


### PR DESCRIPTION
Addresses #19503

Internal Review Topics ...

* [Blazor Server security *Overview*](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/security/server/index?view=aspnetcore-3.1&branch=pr-en-us-20119)
* [Blazor Server security *Additional Resources*](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/security/server/additional-scenarios?view=aspnetcore-3.1&branch=pr-en-us-20119)

Notes ...

* Whole topic versioning ... **_BUT_** ... let's try my fancy new hardcoded `<h2>` headings with `id`s to avoid the duplicate heading build warnings and preserve our bookmark anchors in the topic doing so in an HTML5-friendly way. It's probably the best of both worlds until we get *version-by-file*, when I'll revert these back to markdown H2s.
* Let's perform full topic UE passes while we're here, and let's keep an :eye: on my naming of *things*. Do my class and member names look good? :ear:
* For the `WeatherForecastService` [that Javier provided](https://github.com/javiercn/blazor-server-aad-sample/blob/master/BlazorServerAuthWithAzureActiveDirectory/Data/WeatherForecastService.cs#L17), can't I just make a field out of the `HttpClient` as shown on this PR? Like me, Javier isn't known for doing *random things*, so I'm concerned about making the change. I'll revert back to his property approach if I'm about to break :boom: something here. :ear:
* We should be able to just drop the last three sections for the 5.0 coverage. All of that stuff goes away as a concern AFAICT.
* I place those Azure Quickstart doc cross-links in the *Overview* topic. If you think of anything else that would be good to cross-link, I'm :ear: on review.