### PR TITLE
Update httpapi.md

### DIFF
--- a/aspnetcore/grpc/httpapi.md
+++ b/aspnetcore/grpc/httpapi.md
@@ -53,7 +53,7 @@ package greet;
 service Greeter {
   rpc SayHello (HelloRequest) returns (HelloReply) {
     option (google.api.http) = {
-      get: "v1/greeter/{name}"
+      get: "/v1/greeter/{name}"
     };
   }
 }
@@ -78,11 +78,11 @@ Server logs show that the HTTP call is executed by a gRPC service. gRPC HTTP API
 info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
       Request starting HTTP/1.1 GET https://localhost:5001/v1/greeter/world
 info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
-      Executing endpoint 'gRPC - v1/greeter/{name}'
+      Executing endpoint 'gRPC - /v1/greeter/{name}'
 info: Server.GreeterService[0]
       Sending hello to world
 info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
-      Executed endpoint 'gRPC - v1/greeter/{name}'
+      Executed endpoint 'gRPC - /v1/greeter/{name}'
 info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
       Request finished in 1.996ms 200 application/json
 ```


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/1071

Sample code is incorrect. Route requires a starting slash.