### PR TITLE
Added missing step in text

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -51,7 +51,7 @@ At the end, you have an app that can manage and display movie data.
 
 * From the Visual Studio select **Create a new project**.
 
-* Select **ASP.NET Core Web Application** select **Next**.
+* Select **ASP.NET Core Web Application** > **Next**.
 
 ![new ASP.NET Core Web Application](start-mvc/_static/np_2.1.png)
 
@@ -59,7 +59,7 @@ At the end, you have an app that can manage and display movie data.
 
   ![new ASP.NET Core Web Application](start-mvc/_static/config.png)
 
-* Select **Web Application(Model-View-Controller)**. From the dropdown boxes, select .NET Core and ASP.NET Core 3.1, then select **Create**.
+* Select **Web Application(Model-View-Controller)**. From the dropdown boxes, select **.NET Core** and **ASP.NET Core 3.1**, then select **Create**.
 
 ![New project dialog, .NET Core in left pane, ASP.NET Core web ](start-mvc/_static/new_project30.png)
 

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -51,7 +51,7 @@ At the end, you have an app that can manage and display movie data.
 
 * From the Visual Studio select **Create a new project**.
 
-* Select **ASP.NET Core Web Application** and then select **Next**.
+* Select **ASP.NET Core Web Application** select **Next**.
 
 ![new ASP.NET Core Web Application](start-mvc/_static/np_2.1.png)
 
@@ -59,7 +59,7 @@ At the end, you have an app that can manage and display movie data.
 
   ![new ASP.NET Core Web Application](start-mvc/_static/config.png)
 
-* Select **Web Application(Model-View-Controller)**, and then select **Create**.
+* Select **Web Application(Model-View-Controller)**. From the dropdown boxes, select .NET Core and ASP.NET Core 3.1, then select **Create**.
 
 ![New project dialog, .NET Core in left pane, ASP.NET Core web ](start-mvc/_static/new_project30.png)
 


### PR DESCRIPTION
Added important instructional text "From the dropdown boxes, select .NET Core and ASP.NET Core 3.1". I missed this step in the tutorial because it was not instructed in the text. Later on I had to go back and recreate my project because I missed it.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->