### PR TITLE
Add QueryString to returnUrl in SelectLanguage

### DIFF
--- a/aspnetcore/fundamentals/localization/sample/3.x/Localization/Views/Shared/_SelectLanguagePartial.cshtml
+++ b/aspnetcore/fundamentals/localization/sample/3.x/Localization/Views/Shared/_SelectLanguagePartial.cshtml
@@ -13,6 +13,7 @@
         .Select(c => new SelectListItem { Value = c.Name, Text = c.DisplayName })
         .ToList();
     var returnUrl = string.IsNullOrEmpty(Context.Request.Path) ? "~/" : $"~{Context.Request.Path.Value}";
+    returnUrl += string.IsNullOrEmpty(Context.Request.QueryString.ToUriComponent()) ? "" : Context.Request.QueryString.ToUriComponent();
 }
 
 <div title="@Localizer["Request culture provider:"] @requestCulture?.Provider?.GetType().Name">


### PR DESCRIPTION
This allows users to stay on a page which needs to have a QueryString value when switching language from the dropdown menu


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->