### PR TITLE
Improve log template explanation

### DIFF
--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -328,7 +328,7 @@ _logger.LogInformation("Parameter values: {p2}, {p1}", p1, p2);
 The preceding code creates a log message with the parameter values in sequence:
 
 ```text
-Parameter values: param1, param2
+Parameter values: param2, param1
 ```
 
 This approach allows logging providers to implement [semantic or structured logging](https://github.com/NLog/NLog/wiki/How-to-use-structured-logging). The arguments themselves are passed to the logging system, not just the formatted message template. This enables logging providers to store the parameter values as fields. For example, consider the following logger method:

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -317,19 +317,20 @@ Each log API uses a message template. The message template can contain placehold
 
 [!code-csharp[](index/samples/3.x/TodoApiDTO/Controllers/TodoItemsController.cs?name=snippet_CallLogMethods&highlight=4,10)]
 
-The order of placeholders, not their names, determines which parameters are used to provide their values. In the following code, the parameter names are out of sequence in the message template:
+The *order of the parameters*, not their placeholder names, determines which parameters are used to provide placeholder values in log messages. In the following code, the parameter names are out of sequence in the placeholders of the message template:
 
 ```csharp
 string p1 = "param1";
 string p2 = "param2";
-string p3 = "param2";
-_logger.LogInformation("Parameter values: {P2}, {P3}, {P1}", p3, p1, p2);
+string p3 = "param3";
+
+_logger.LogInformation("Parameter values: {p3}, {p2}, {p1}", p1, p2, p3);
 ```
 
-The preceding code creates a log message with the parameter values in input sequence:
+However, the parameters are assigned to the placeholders in the order `p1`&mdash;`p2`&mdash;`p3` and so the log message reflects the order of the parameters:
 
 ```text
-Parameter values: param3, param1, param2
+Parameter values: param1, param2, param3
 ```
 
 This approach allows logging providers to implement [semantic or structured logging](https://github.com/NLog/NLog/wiki/How-to-use-structured-logging). The arguments themselves are passed to the logging system, not just the formatted message template. This enables logging providers to store the parameter values as fields. For example, consider the following logger method:

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -320,17 +320,17 @@ Each log API uses a message template. The message template can contain placehold
 The *order of the parameters*, not their placeholder names, determines which parameters are used to provide placeholder values in log messages. In the following code, the parameter names are out of sequence in the placeholders of the message template:
 
 ```csharp
-string p1 = "param1";
-string p2 = "param2";
-string p3 = "param3";
+string apples = 1;
+string pears = 2;
+string bananas = 3;
 
-_logger.LogInformation("Parameter values: {p3}, {p2}, {p1}", p1, p2, p3);
+_logger.LogInformation("Parameters: {pears}, {bananas}, {apples}", apples, pears, bananas);
 ```
 
-However, the parameters are assigned to the placeholders in the order: `p1`, `p2`, `p3`. The log message reflects the *order of the parameters*:
+However, the parameters are assigned to the placeholders in the order: `apples`, `pears`, `bananas`. The log message reflects the *order of the parameters*:
 
 ```text
-Parameter values: param1, param2, param3
+Parameters: 1, 2, 3
 ```
 
 This approach allows logging providers to implement [semantic or structured logging](https://github.com/NLog/NLog/wiki/How-to-use-structured-logging). The arguments themselves are passed to the logging system, not just the formatted message template. This enables logging providers to store the parameter values as fields. For example, consider the following logger method:

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -327,7 +327,7 @@ string p3 = "param3";
 _logger.LogInformation("Parameter values: {p3}, {p2}, {p1}", p1, p2, p3);
 ```
 
-However, the parameters are assigned to the placeholders in the order `p1`&mdash;`p2`&mdash;`p3`. The log message reflects the *order of the parameters*:
+However, the parameters are assigned to the placeholders in the order: `p1`, `p2`, `p3`. The log message reflects the *order of the parameters*:
 
 ```text
 Parameter values: param1, param2, param3

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -327,7 +327,7 @@ string p3 = "param3";
 _logger.LogInformation("Parameter values: {p3}, {p2}, {p1}", p1, p2, p3);
 ```
 
-However, the parameters are assigned to the placeholders in the order `p1`&mdash;`p2`&mdash;`p3` and so the log message reflects the order of the parameters:
+However, the parameters are assigned to the placeholders in the order `p1`&mdash;`p2`&mdash;`p3`. The log message reflects the *order of the parameters*:
 
 ```text
 Parameter values: param1, param2, param3

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -322,13 +322,14 @@ The order of placeholders, not their names, determines which parameters are used
 ```csharp
 string p1 = "param1";
 string p2 = "param2";
-_logger.LogInformation("Parameter values: {p2}, {p1}", p1, p2);
+string p3 = "param2";
+_logger.LogInformation("Parameter values: {P2}, {P3}, {P1}", p3, p1, p2);
 ```
 
-The preceding code creates a log message with the parameter values in sequence:
+The preceding code creates a log message with the parameter values in input sequence:
 
 ```text
-Parameter values: param2, param1
+Parameter values: param3, param1, param2
 ```
 
 This approach allows logging providers to implement [semantic or structured logging](https://github.com/NLog/NLog/wiki/How-to-use-structured-logging). The arguments themselves are passed to the logging system, not just the formatted message template. This enables logging providers to store the parameter values as fields. For example, consider the following logger method:


### PR DESCRIPTION
The docs state that "The order of placeholders, not their names, determines which parameters are used to provide their values" - and then provides an example that does the exact opposite. I have changed the example, hoping that the docs are correct. :)



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->