### PR TITLE
publishing to other web hosting providers

### DIFF
--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -265,6 +265,23 @@ To deploy the app to production, the following resources need to be provisioned:
   * There are no specific requirements for this certificate; it can be a self-signed certificate or a certificate provisioned through a CA authority.
   * It can be generated through standard tools like PowerShell or OpenSSL.
   * It can be installed into the certificate store on the target machines or deployed as a *.pfx* file with a strong password.
+### Example: Deploy to a Web Hosting
+In your web Hosting panel create or load your certificate. Then in the app's *appsettings.json* file, modify the `IdentityServer` section to include the key details:
+
+```json
+"IdentityServer": {
+  "Key": {
+    "Type": "Store",
+    "StoreName": "WebHosting",
+    "StoreLocation": "CurrentUser",
+    "Name": "CN=MyApplication"
+  }
+}
+```
+* The store name represents the name of the certificate store where the certificate is stored. In this case, it points to the web hosting store.
+* The store location represents where to load the certificate from (In this case, `CurrentUser`).
+* The name property on certificate corresponds with the distinguished subject for the certificate.
+
 
 ### Example: Deploy to Azure App Service
 

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -5,7 +5,7 @@ description: Use Identity with a Single Page App hosted inside an ASP.NET Core a
 monikerRange: '>= aspnetcore-3.0'
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 11/08/2019
+ms.date: 10/27/2020
 no-loc: ["ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/authentication/identity/spa
 ---
@@ -265,8 +265,10 @@ To deploy the app to production, the following resources need to be provisioned:
   * There are no specific requirements for this certificate; it can be a self-signed certificate or a certificate provisioned through a CA authority.
   * It can be generated through standard tools like PowerShell or OpenSSL.
   * It can be installed into the certificate store on the target machines or deployed as a *.pfx* file with a strong password.
-### Example: Deploy to a Web Hosting
-In your web Hosting panel create or load your certificate. Then in the app's *appsettings.json* file, modify the `IdentityServer` section to include the key details:
+
+### Example: Deploy to a non-Azure web hosting provider
+
+In your web hosting panel, create or load your certificate. Then in the app's *appsettings.json* file, modify the `IdentityServer` section to include the key details. For example:
 
 ```json
 "IdentityServer": {
@@ -278,10 +280,12 @@ In your web Hosting panel create or load your certificate. Then in the app's *ap
   }
 }
 ```
-* The store name represents the name of the certificate store where the certificate is stored. In this case, it points to the web hosting store.
-* The store location represents where to load the certificate from (In this case, `CurrentUser`).
-* The name property on certificate corresponds with the distinguished subject for the certificate.
 
+In the preceding example:
+
+* `StoreName` represents the name of the certificate store where the certificate is stored. In this case, it points to the web hosting store.
+* `StoreLocation` represents where to load the certificate from (`CurrentUser` in this case).
+* `Name` corresponds with the distinguished subject for the certificate.
 
 ### Example: Deploy to Azure App Service
 


### PR DESCRIPTION
It was confusing to be able to publish to other web hosting providers without using azure due to lack in documentations and enums(the StoreName enum does not contain webHosting option https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.storename?view=netcore-3.1)



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->