### PR TITLE
Remove unused using in Blazor RedirectToLogin component

### DIFF
--- a/aspnetcore/includes/blazor-security/redirecttologin-component.md
+++ b/aspnetcore/includes/blazor-security/redirecttologin-component.md
@@ -5,7 +5,7 @@ The `RedirectToLogin` component (`Shared/RedirectToLogin.razor`):
 
 ```razor
 @inject NavigationManager Navigation
-@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+
 @code {
     protected override void OnInitialized()
     {


### PR DESCRIPTION
I found this `using` to be unused when implementing this component.