### PR TITLE
Update dead link to new HTTP2 specs repo

### DIFF
--- a/aspnetcore/grpc/performance.md
+++ b/aspnetcore/grpc/performance.md
@@ -37,7 +37,7 @@ gRPC client factory offers a centralized way to configure channels. It automatic
 
 ## Connection concurrency
 
-HTTP/2 connections typically have a limit on the number of [maximum concurrent streams (active HTTP requests)](https://http2.github.io/http2-spec/#rfc.section.5.1.2) on a connection at one time. By default, most servers set this limit to 100 concurrent streams.
+HTTP/2 connections typically have a limit on the number of [maximum concurrent streams (active HTTP requests)](https://httpwg.github.io/specs/rfc7540.html#rfc.section.5.1.2) on a connection at one time. By default, most servers set this limit to 100 concurrent streams.
 
 A gRPC channel uses a single HTTP/2 connection, and concurrent calls are multiplexed on that connection. When the number of active calls reaches the connection stream limit, additional calls are queued in the client. Queued calls wait for active calls to complete before they are sent. Applications with high load, or long running streaming gRPC calls, could see performance issues caused by calls queuing because of this limit.
 


### PR DESCRIPTION
Change link to point to new http2 specs repo. Old one is 404.