### PR TITLE
Add ToC link for microservices logging and monitoring Learn module

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -177,6 +177,9 @@
             - name: Deploy with GitHub Actions >>
               display: tutorial, kubernetes, aks, acr, docker, devops
               href: /learn/modules/microservices-devops-aspnet-core/
+            - name: Log and monitor >>
+              display: tutorial, kubernetes, aks, acr, docker, serilog
+              href: /learn/modules/microservices-logging-aspnet-core/
         - name: Data access >>
           displayName: tutorial, ef, entity framework
           href: /learn/modules/persist-data-ef-core/


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/19345
Associated with https://github.com/MicrosoftDocs/learn-pr/pull/12052

Add a link to the ASP.NET Core microservices instrumentation module on Learn.