### PR TITLE
Remove warning about catch-all bug in 5.0 version

### DIFF
--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -323,8 +323,6 @@ Due to the kinds of extensibility provided by routing, it isn't possible for the
 > 
 > * Doesn't have a concept of routes.
 > * Doesn't provide ordering guarantees. All endpoints are processed at once.
->
-> If this means you're stuck using the legacy routing system, [open a GitHub issue for assistance](https://github.com/dotnet/aspnetcore/issues).
 
 <a name="rtp"></a>
 

--- a/aspnetcore/includes/catchall.md
+++ b/aspnetcore/includes/catchall.md
@@ -1,3 +1,5 @@
+::: moniker range=">= aspnetcore-3.0 < aspnetcore-5.0"
+
 > [!WARNING]
 > A **catch-all** parameter may match routes incorrectly due to a [bug](https://github.com/dotnet/aspnetcore/issues/18677) in routing. Apps impacted by this bug have the following characteristics:
 >
@@ -18,3 +20,5 @@
 >}
 >// Remaining code removed for brevity.
 >```
+
+::: moniker-end


### PR DESCRIPTION
Fixes #19817

[internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-5.0&branch=pr-en-us-20260#route-template-reference)