### PR TITLE
Clarified "Test" link in TOC

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -449,7 +449,7 @@
           uid: blazor/webassembly-lazy-load-assemblies
         - name: WebAssembly performance
           uid: blazor/webassembly-performance-best-practices
-        - name: Test
+        - name: Test components
           uid: blazor/test
         - name: Progressive Web Applications
           uid: blazor/progressive-web-app


### PR DESCRIPTION
The `Test` link in the `Blazor` section for the .NET 5 preview docs was misleading to me. At first, I wasn't sure if it was put there accidentally or what—looks like it links to the wonderful section on testing Blazor components. I think changing it to something like `Test components` is more clear.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->