### PR TITLE
Update Blazor WASM web.config

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly/_samples/web.config
+++ b/aspnetcore/blazor/host-and-deploy/webassembly/_samples/web.config
@@ -2,77 +2,68 @@
 <configuration>
   <system.webServer>
     <staticContent>
-      <remove fileExtension=".dat" />
       <remove fileExtension=".dll" />
-      <remove fileExtension=".json" />
-      <remove fileExtension=".wasm" />
-      <remove fileExtension=".woff" />
-      <remove fileExtension=".woff2" />
-      <remove fileExtension=".js.gz" />
-      <remove fileExtension=".dat.gz" />
-      <remove fileExtension=".dll.gz" />
-      <remove fileExtension=".json.gz" />
-      <remove fileExtension=".wasm.gz" />
-      <remove fileExtension=".js.br" />
-      <remove fileExtension=".dat.br" />
-      <remove fileExtension=".dll.br" />
-      <remove fileExtension=".json.br" />
-      <remove fileExtension=".wasm.br" />
       <mimeMap fileExtension=".dat" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".dll" mimeType="application/octet-stream" />
-      <mimeMap fileExtension=".json" mimeType="application/json" />
       <mimeMap fileExtension=".wasm" mimeType="application/wasm" />
-      <mimeMap fileExtension=".woff" mimeType="application/font-woff" />
-      <mimeMap fileExtension=".woff2" mimeType="application/font-woff" />
+      <mimeMap fileExtension=".blat" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".js.gz" mimeType="application/javascript" />
       <mimeMap fileExtension=".dat.gz" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".dll.gz" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".json.gz" mimeType="application/json" />
       <mimeMap fileExtension=".wasm.gz" mimeType="application/wasm" />
+      <mimeMap fileExtension=".blat.gz" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".html.gz" mimeType="text/html" />
+      <mimeMap fileExtension=".css.gz" mimeType="text/css" />
+      <mimeMap fileExtension=".ico.gz" mimeType="image/x-icon" />
+      <mimeMap fileExtension=".svg.gz" mimeType="image/svg+xml" />
       <mimeMap fileExtension=".js.br" mimeType="application/javascript" />
       <mimeMap fileExtension=".dat.br" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".dll.br" mimeType="application/octet-stream" />
       <mimeMap fileExtension=".json.br" mimeType="application/json" />
       <mimeMap fileExtension=".wasm.br" mimeType="application/wasm" />
+      <mimeMap fileExtension=".blat.br" mimeType="application/octet-stream" />
+      <mimeMap fileExtension=".html.br" mimeType="text/html" />
+      <mimeMap fileExtension=".css.br" mimeType="text/css" />
+      <mimeMap fileExtension=".ico.br" mimeType="image/x-icon" />
+      <mimeMap fileExtension=".svg.br" mimeType="image/svg+xml" />
     </staticContent>
     <httpCompression>
       <dynamicTypes>
+        <remove mimeType="text/*" />
         <remove mimeType="application/javascript" />
-        <remove mimeType="application/json" />
-        <remove mimeType="application/octet-stream" />
-        <remove mimeType="application/wasm" />
+        <remove mimeType="image/svg+xml" />
       </dynamicTypes>
       <staticTypes>
+        <remove mimeType="text/*" />
         <remove mimeType="application/javascript" />
-        <remove mimeType="application/json" />
-        <remove mimeType="application/octet-stream" />
-        <remove mimeType="application/wasm" />
+        <remove mimeType="image/svg+xml" />
       </staticTypes>
     </httpCompression>
     <rewrite>
       <outboundRules rewriteBeforeCache="true">
         <rule name="Add Vary Accept-Encoding" preCondition="PreCompressedFile" enabled="true">
-            <match serverVariable="RESPONSE_Vary" pattern=".*" />
-            <action type="Rewrite" value="Accept-Encoding" />
+          <match serverVariable="RESPONSE_Vary" pattern=".*" />
+          <action type="Rewrite" value="Accept-Encoding" />
         </rule>
         <rule name="Add Encoding Brotli" preCondition="PreCompressedBrotli" enabled="true" stopProcessing="true">
-            <match serverVariable="RESPONSE_Content_Encoding" pattern=".*" />
-            <action type="Rewrite" value="br" />
+          <match serverVariable="RESPONSE_Content_Encoding" pattern=".*" />
+          <action type="Rewrite" value="br" />
         </rule>
         <rule name="Add Encoding Gzip" preCondition="PreCompressedGzip" enabled="true" stopProcessing="true">
-            <match serverVariable="RESPONSE_Content_Encoding" pattern=".*" />
-            <action type="Rewrite" value="gzip" />
+          <match serverVariable="RESPONSE_Content_Encoding" pattern=".*" />
+          <action type="Rewrite" value="gzip" />
         </rule>
         <preConditions>
-            <preCondition name="PreCompressedFile">
-                <add input="{HTTP_URL}" pattern="\.(gz|br)$" />
-            </preCondition>
-            <preCondition name="PreCompressedGzip">
-                <add input="{HTTP_URL}" pattern="\.gz$" />
-            </preCondition>
+          <preCondition name="PreCompressedFile">
+            <add input="{HTTP_URL}" pattern="\.(gz|br)$" />
+          </preCondition>
             <preCondition name="PreCompressedBrotli">
-                <add input="{HTTP_URL}" pattern="\.br$" />
-            </preCondition>
+            <add input="{HTTP_URL}" pattern="\.br$" />
+          </preCondition>
+          <preCondition name="PreCompressedGzip">
+            <add input="{HTTP_URL}" pattern="\.gz$" />
+          </preCondition>
         </preConditions>
       </outboundRules>
       <rules>
@@ -84,6 +75,7 @@
           <match url="(.*)"/>
           <conditions>
             <add input="{HTTP_ACCEPT_ENCODING}" pattern="br" />
+            <add input="{REQUEST_FILENAME}" pattern="\.(js|dat|dll|json|wasm|blat|htm|html|css|ico|svg)$" />
             <add input="{REQUEST_FILENAME}.br" matchType="IsFile" />
           </conditions>
           <action type="Rewrite" url="{R:1}.br" />
@@ -92,6 +84,7 @@
           <match url="(.*)"/>
           <conditions>
             <add input="{HTTP_ACCEPT_ENCODING}" pattern="gzip" />
+            <add input="{REQUEST_FILENAME}" pattern="\.(js|dat|dll|json|wasm|blat|htm|html|css|ico|svg)$" />
             <add input="{REQUEST_FILENAME}.gz" matchType="IsFile" />
           </conditions>
           <action type="Rewrite" url="{R:1}.gz" />


### PR DESCRIPTION
Fixes #20205

Thanks @cornem! 🎷 and @glararan! :rocket:

* AFAICT, no need to version the updates. This should work with 3.x and 5.x.
* Decided in the DRAFT here **_NOT_** to serve double-compressed assets (in spite of the framework producing them), which I think would have unpredictable (and often not good) results. If a dev wants to change the file for things like PNG, WOFF, etc., they can do so on their own. The pattern here is easy to follow.
* For static and dynamic compression, I go off of what's in a typical (default) `applicationHost.config`. These removals look like the only ones that we need here.
* No need to remove and then add back existing MIME maps in the typical (default) scenario, so I take those out.
* Per Ben's original file, I retain the MIME change for DLLs. He goes from `application/x-msdownload` to `application/octet-stream`, so let me know if that needs to be addressed (i.e., dropped). :ear: