### PR TITLE
Azure Apps ARM template preview site extensions

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -232,9 +232,9 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
 
 **Use the preview site extension with an ARM template**
 
-If an ARM template is used to create and deploy apps, the `siteextensions` resource type can be used to add the site extension to a web app. For example:
+If an ARM template is used to create and deploy apps, the `Microsoft.Web/sites/siteextensions` resource type can be used to add the site extension to a web app. For example:
 
-[!code-json[](index/sample/arm.json?highlight=2)]
+[!code-json[](index/sample/arm.json?highlight=14)]
 
 ## Publish and deploy the app
 

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -232,7 +232,7 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
 
 **Use the preview site extension with an ARM template**
 
-If an ARM template is used to create and deploy apps, the `Microsoft.Web/sites/siteextensions` resource type can be used to add the site extension to a web app. For example:
+If an ARM template is used to create and deploy apps, the `Microsoft.Web/sites/siteextensions` resource type can be used to add the site extension to a web app. In the following example, the ASP.NET Core 5.0 (x64) Runtime site extension (`AspNetCoreRuntime.5.0.x64`) is added to the app:
 
 [!code-json[](index/sample/arm.json?highlight=14)]
 

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -234,7 +234,7 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
 
 If an ARM template is used to create and deploy apps, the `Microsoft.Web/sites/siteextensions` resource type can be used to add the site extension to a web app. In the following example, the ASP.NET Core 5.0 (x64) Runtime site extension (`AspNetCoreRuntime.5.0.x64`) is added to the app:
 
-[!code-json[](index/sample/arm.json?highlight=14)]
+[!code-json[](index/sample/arm.json)]
 
 For the placeholder `{SITE NAME}`, use the app's name in Azure App Service (for example, `contoso`).
 

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -236,6 +236,8 @@ If an ARM template is used to create and deploy apps, the `Microsoft.Web/sites/s
 
 [!code-json[](index/sample/arm.json?highlight=14)]
 
+For the placeholder `{SITE NAME}`, use the app's name in Azure App Service (for example, `contoso`).
+
 ## Publish and deploy the app
 
 ::: moniker range=">= aspnetcore-2.2"

--- a/aspnetcore/host-and-deploy/azure-apps/index/sample/arm.json
+++ b/aspnetcore/host-and-deploy/azure-apps/index/sample/arm.json
@@ -1,12 +1,24 @@
 {
-    "type": "siteextensions",
-    "name": "AspNetCoreRuntime",
-    "apiVersion": "2015-04-01",
-    "location": "[resourceGroup().location]",
-    "properties": {
-        "version": "[parameters('aspnetcoreVersion')]"
-    },
-    "dependsOn": [
-        "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
+    ...
+    "parameters": {
+        "site_name": {
+            "defaultValue": "{SITE NAME}",
+            "type": "String"
+        },
+        ...
+    },       
+    ...
+    "resources": [
+        ...
+        {
+            "type": "Microsoft.Web/sites/siteextensions",
+            "apiVersion": "2018-11-01",
+            "name": "[concat(parameters('site_name'), '/AspNetCoreRuntime.5.0.x64')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/sites', parameters('site_name'))]"
+            ]
+        }
     ]
 }
+    


### PR DESCRIPTION
Fixes #19388

[Internal Review Topic (links to section; scroll to the bottom of the section to see it)](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/azure-apps/index?view=aspnetcore-2.1&branch=pr-en-us-20298#install-the-preview-site-extension)

This is based on reverse engineering: I added the site extension to an Azure App in the portal and then exported the ARM template to see how it composed the resource (extension).

* I substituted `[resourceGroup().location]` for the string name of the datacenter, which is what my file contained ("Central US").
* I don't see a `properties` > `version` in what Azure produced; but since this is based on a live template from the portal, I assume what's on the PR is correct.