### PR TITLE
Remove token scope warning

### DIFF
--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -105,8 +105,6 @@ builder.Services.AddOidcAuthentication(options =>
 });
 ```
 
-[!INCLUDE[](~/includes/blazor-security/azure-scope-3x.md)]
-
 For more information, see the following sections of the *Additional scenarios* article:
 
 * [Request additional access tokens](xref:blazor/security/webassembly/additional-scenarios#request-additional-access-tokens)


### PR DESCRIPTION
Fixes #20310 

Thanks @yuopolev! :rocket: ... Yes, the warning INCLUDES file for access token scopes is focused on the Azure-based scenarios. The INCLUDES file is here because there was a time that thought devs could use the *Auth Lib* topic guidance with AAD. However since then, the product unit has warned devs off of using this topic at all for AAD. Although it will work, it requires additional configuration. They want everyone to use the AAD-based topics (MSAL-based approaches, as you mentioned) in this node. Additionally, it's best to pull the INCLUDES for the reason that you just mentioned. Even if we kept it, it would require me to make a third file (there will be a 3.x and 5.x version of this INCLUDES file soon), and the third file would have the correct C# code examples. Indeed ... for those two reasons ... let's get rid of the INCLUDES file for this in this topic. Thank you for catching this :eye:. :+1: