### PR TITLE
Scaffolding guidance on Blazor WASM

### DIFF
--- a/aspnetcore/security/authentication/scaffold-identity.md
+++ b/aspnetcore/security/authentication/scaffold-identity.md
@@ -355,6 +355,14 @@ In the *Pages/Shared/Layout.cshtml* file, make the following changes:
 
 Some Identity options are configured in *Areas/Identity/IdentityHostingStartup.cs*. For more information, see [IHostingStartup](xref:fundamentals/configuration/platform-specific-configuration).
 
+## Standalone or hosted Blazor WebAssembly apps
+
+Client-side Blazor WebAssembly apps use their own Identity UI approaches and can't use ASP.NET Core Identity scaffolding. Server-side ASP.NET Core apps of hosted Blazor solutions can follow the Razor Pages/MVC guidance in this article and are configured just like any other type of ASP.NET Core app that supports Identity.
+
+The Blazor framework doesn't include Razor component versions of Identity UI pages. Identity UI Razor components can be custom built or obtained from unsupported third-party sources.
+
+For more information, see the [Blazor Security and Identity articles](xref:blazor/security/index).
+
 <a name="full"></a>
 
 ## Create full Identity UI source

--- a/aspnetcore/security/authentication/scaffold-identity.md
+++ b/aspnetcore/security/authentication/scaffold-identity.md
@@ -541,7 +541,7 @@ Identity is configured in *Areas/Identity/IdentityHostingStartup.cs*. For more i
 
 ### Enable authentication
 
-In the `Configure` method of the `Startup` class, call [UseAuthentication](/dotnet/api/microsoft.aspnetcore.builder.authappbuilderextensions.useauthentication?view=aspnetcore-2.0#Microsoft_AspNetCore_Builder_AuthAppBuilderExtensions_UseAuthentication_Microsoft_AspNetCore_Builder_IApplicationBuilder_) after `UseStaticFiles`:
+In the `Configure` method of the `Startup` class, call <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthentication%2A> after `UseStaticFiles`:
 
 [!code-csharp[](scaffold-identity/sample/StartupRPnoAuth.cs?name=snippet1&highlight=29)]
 
@@ -598,7 +598,7 @@ Identity is configured in *Areas/Identity/IdentityHostingStartup.cs*. For more i
 
 [!INCLUDE[](~/includes/scaffold-identity/migrations.md)]
 
-Call [UseAuthentication](/dotnet/api/microsoft.aspnetcore.builder.authappbuilderextensions.useauthentication?view=aspnetcore-2.0#Microsoft_AspNetCore_Builder_AuthAppBuilderExtensions_UseAuthentication_Microsoft_AspNetCore_Builder_IApplicationBuilder_) after `UseStaticFiles`:
+Call <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthentication%2A> after `UseStaticFiles`:
 
 [!code-csharp[](scaffold-identity/sample/StartupMvcNoAuth.cs?name=snippet1&highlight=23)]
 


### PR DESCRIPTION
Fixes #20295

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity?view=aspnetcore-2.1&branch=pr-en-us-20361#standalone-or-hosted-blazor-webassembly-apps)

Thanks @dajma00! 🎷

IMO, this covers what we need. The 5.0 updates that have been made for Blazor WASM in the framework to correct problems with scaffolding Identity into the *Server* project of a hosted Blazor solution don't require calling out ... they're 🐞 fixes AFAICT. Since we have no coverage on this scenario (until now with this PR), there aren't existing workarounds that we need to version-out for 5.0.

The main things here to surface are ...

* One can't scaffold into a Blazor WASM project.
* Mention that **_Identity UI pages_** have no corresponding **Razor components**, but indicate that it's possible to custom-build them or find them out on the Interwebs 🕸️ (*unsupported*, of course). 
* Cross-link the general Blazor security guidance, where the reader will also get the Blazor WASM security guidance.

Also, the version-specific API doc cross-links are generating build report problems. I don't think in these contexts (middleware ordering) that we need to link to versions of the API docs. I recommend that we use the versionless link, but let me know if you want me to revert that change. :ear: