### PR TITLE
Blazor example consistency

### DIFF
--- a/aspnetcore/blazor/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/call-dotnet-from-javascript.md
@@ -108,7 +108,7 @@ When the **`Trigger .NET instance method HelloHelper.SayHello`** button is selec
 @code {
     public async Task TriggerNetInstanceMethod()
     {
-        var exampleJsInterop = new ExampleJsInterop(JSRuntime);
+        var exampleJsInterop = new ExampleJsInterop(JS);
         await exampleJsInterop.CallHelloHelperSayHello("Blazor");
     }
 }
@@ -143,19 +143,19 @@ To avoid a memory leak and allow garbage collection on a component that creates 
   ```csharp
   public class ExampleJsInterop : IDisposable
   {
-      private readonly IJSRuntime jsRuntime;
+      private readonly IJSRuntime js;
       private DotNetObjectReference<HelloHelper> objRef;
 
-      public ExampleJsInterop(IJSRuntime jsRuntime)
+      public ExampleJsInterop(IJSRuntime js)
       {
-          this.jsRuntime = jsRuntime;
+          this.js = js;
       }
 
       public ValueTask<string> CallHelloHelperSayHello(string name)
       {
           objRef = DotNetObjectReference.Create(new HelloHelper(name));
 
-          return jsRuntime.InvokeAsync<string>(
+          return js.InvokeAsync<string>(
               "exampleJsFunctions.sayHello",
               objRef);
       }
@@ -173,7 +173,7 @@ To avoid a memory leak and allow garbage collection on a component that creates 
   @page "/JSInteropComponent"
   @using {APP ASSEMBLY}.JsInteropClasses
   @implements IDisposable
-  @inject IJSRuntime JSRuntime
+  @inject IJSRuntime JS
 
   <h1>JavaScript Interop</h1>
 
@@ -188,7 +188,7 @@ To avoid a memory leak and allow garbage collection on a component that creates 
       {
           objRef = DotNetObjectReference.Create(new HelloHelper("Blazor"));
 
-          await JSRuntime.InvokeAsync<string>(
+          await JS.InvokeAsync<string>(
               "exampleJsFunctions.sayHello",
               objRef);
       }
@@ -379,7 +379,7 @@ The placeholder `{APP ASSEMBLY}` is the app's app assembly name (for example, `B
 `Shared/ListItem.razor`:
 
 ```razor
-@inject IJSRuntime JsRuntime
+@inject IJSRuntime JS
 
 <li>
     @message
@@ -398,7 +398,7 @@ The placeholder `{APP ASSEMBLY}` is the app's app assembly name (for example, `B
 
     protected async Task InteropCall()
     {
-        await JsRuntime.InvokeVoidAsync("updateMessageCallerJS",
+        await JS.InvokeVoidAsync("updateMessageCallerJS",
             DotNetObjectReference.Create(messageUpdateInvokeHelper));
     }
 

--- a/aspnetcore/blazor/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/call-javascript-from-dotnet.md
@@ -39,7 +39,7 @@ JavaScript code, such as the code shown in the preceding example, can also be lo
 
 The following component:
 
-* Invokes the `convertArray` JavaScript function using `JSRuntime` when a component button (**`Convert Array`**) is selected.
+* Invokes the `convertArray` JavaScript function using `JS` when a component button (**`Convert Array`**) is selected.
 * After the JavaScript function is called, the passed array is converted into a string. The string is returned to the component for display.
 
 [!code-razor[](call-javascript-from-dotnet/samples_snapshot/call-js-example.razor?highlight=2,34-35)]
@@ -60,7 +60,7 @@ To use the <xref:Microsoft.JSInterop.IJSRuntime> abstraction, adopt any of the f
 
   [!code-csharp[](call-javascript-from-dotnet/samples_snapshot/inject-abstraction-class.cs?highlight=5)]
 
-  Inside the `<head>` element of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server), provide a `handleTickerChanged` JavaScript function. The function is called with `JSRuntime.InvokeAsync` and returns a value:
+  Inside the `<head>` element of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server), provide a `handleTickerChanged` JavaScript function. The function is called with `JS.InvokeAsync` and returns a value:
 
   [!code-html[](call-javascript-from-dotnet/samples_snapshot/index-script-handleTickerChanged2.html)]
 
@@ -68,7 +68,7 @@ To use the <xref:Microsoft.JSInterop.IJSRuntime> abstraction, adopt any of the f
 
   ```razor
   [Inject]
-  IJSRuntime JSRuntime { get; set; }
+  IJSRuntime JS { get; set; }
   ```
 
 In the client-side sample app that accompanies this topic, two JavaScript functions are available to the app that interact with the DOM to receive user input and display a welcome message:
@@ -114,7 +114,7 @@ The sample app includes a component to demonstrate JS interop. The component:
 ```razor
 @page "/JSInterop"
 @using {APP ASSEMBLY}.JsInteropClasses
-@inject IJSRuntime JSRuntime
+@inject IJSRuntime JS
 
 <h1>JavaScript Interop</h1>
 
@@ -129,11 +129,11 @@ The sample app includes a component to demonstrate JS interop. The component:
 @code {
     public async Task TriggerJsPrompt()
     {
-        var name = await JSRuntime.InvokeAsync<string>(
+        var name = await JS.InvokeAsync<string>(
                 "exampleJsFunctions.showPrompt",
                 "What's your name?");
 
-        await JSRuntime.InvokeVoidAsync(
+        await JS.InvokeVoidAsync(
                 "exampleJsFunctions.displayWelcome",
                 $"Hello {name}! Welcome to Blazor!");
     }
@@ -219,10 +219,9 @@ To use an extension method, create a static extension method that receives the <
 
 ```csharp
 public static async Task TriggerClickEvent(this ElementReference elementRef, 
-    IJSRuntime jsRuntime)
+    IJSRuntime js)
 {
-    await jsRuntime.InvokeVoidAsync(
-        "interopFunctions.clickElement", elementRef);
+    await js.InvokeVoidAsync("interopFunctions.clickElement", elementRef);
 }
 ```
 
@@ -237,10 +236,9 @@ When working with generic types and returning a value, use <xref:System.Threadin
 
 ```csharp
 public static ValueTask<T> GenericMethod<T>(this ElementReference elementRef, 
-    IJSRuntime jsRuntime)
+    IJSRuntime js)
 {
-    return jsRuntime.InvokeAsync<T>(
-        "exampleJsFunctions.doSomethingGeneric", elementRef);
+    return js.InvokeAsync<T>("exampleJsFunctions.doSomethingGeneric", elementRef);
 }
 ```
 
@@ -471,7 +469,7 @@ JS interop may fail due to networking errors and should be treated as unreliable
 * Per-invocation in component code, a single call can specify the timeout:
 
   ```csharp
-  var result = await JSRuntime.InvokeAsync<string>("MyJSOperation", 
+  var result = await JS.InvokeAsync<string>("MyJSOperation", 
       TimeSpan.FromSeconds({SECONDS}), new[] { "Arg1" });
   ```
 
@@ -508,10 +506,10 @@ export function showPrompt(message) {
 }
 ```
 
-Add the preceding JavaScript module to a .NET library as a static web asset (`wwwroot/exampleJsInterop.js`) and then import the module into the .NET code using the <xref:Microsoft.JSInterop.IJSRuntime> service. The service is injected as `jsRuntime` (not shown) for the following example:
+Add the preceding JavaScript module to a .NET library as a static web asset (`wwwroot/exampleJsInterop.js`) and then import the module into the .NET code using the <xref:Microsoft.JSInterop.IJSRuntime> service. The service is injected as `js` (not shown) for the following example:
 
 ```csharp
-var module = await jsRuntime.InvokeAsync<IJSObjectReference>(
+var module = await js.InvokeAsync<IJSObjectReference>(
     "import", "./_content/MyComponents/exampleJsInterop.js");
 ```
 
@@ -540,13 +538,15 @@ window.unmarshalledInstance = {
 ```
 
 ```csharp
-var unmarshalledRuntime = (IJSUnmarshalledRuntime)jsRuntime;
+var unmarshalledRuntime = (IJSUnmarshalledRuntime)js;
 var jsUnmarshalledReference = unmarshalledRuntime
     .InvokeUnmarshalled<IJSUnmarshalledObjectReference>("unmarshalledInstance");
 
 string helloWorldString = jsUnmarshalledReference.InvokeUnmarshalled<string, string>(
     "helloWorld");
 ```
+
+In the preceding example, the <xref:Microsoft.JSInterop.IJSRuntime> service is injected into the class and assigned to `js` (not shown).
 
 ## Use of JavaScript libraries that render UI (DOM elements)
 

--- a/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/call-js-example.razor
+++ b/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/call-js-example.razor
@@ -1,5 +1,5 @@
 @page "/call-js-example"
-@inject IJSRuntime JSRuntime;
+@inject IJSRuntime JS;
 
 <h1>Call JavaScript Function Example</h1>
 
@@ -32,7 +32,7 @@
     private async Task ConvertArray()
     {
         var text =
-            await JSRuntime.InvokeAsync<string>("convertArray", quoteArray);
+            await JS.InvokeAsync<string>("convertArray", quoteArray);
 
         convertedText = new MarkupString(text);
     }

--- a/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/component1.razor
+++ b/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/component1.razor
@@ -1,4 +1,4 @@
-@inject IJSRuntime JSRuntime
+@inject IJSRuntime JS
 
 <button @ref="exampleButton">Example Button</button>
 
@@ -11,7 +11,7 @@
 
     public async Task TriggerClick()
     {
-        await JSRuntime.InvokeVoidAsync(
+        await JS.InvokeVoidAsync(
             "interopFunctions.clickElement", exampleButton);
     }
 }

--- a/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/component2.razor
+++ b/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/component2.razor
@@ -1,4 +1,4 @@
-@inject IJSRuntime JSRuntime
+@inject IJSRuntime JS
 @using JsInteropClasses
 
 <button @ref="exampleButton" />
@@ -12,6 +12,6 @@
 
     public async Task TriggerClick()
     {
-        await exampleButton.TriggerClickEvent(JSRuntime);
+        await exampleButton.TriggerClickEvent(JS);
     }
 }

--- a/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/component3.razor
+++ b/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/component3.razor
@@ -1,4 +1,4 @@
-@inject IJSRuntime JSRuntime
+@inject IJSRuntime JS
 @using JsInteropClasses
 
 <input @ref="username" />
@@ -14,6 +14,6 @@
 
     private async Task OnClickMethod()
     {
-        returnValue = await username.GenericMethod<string>(JSRuntime);
+        returnValue = await username.GenericMethod<string>(JS);
     }
 }

--- a/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/inject-abstraction-class.cs
+++ b/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/inject-abstraction-class.cs
@@ -1,15 +1,15 @@
 public class JsInteropClasses
 {
-    private readonly IJSRuntime jsRuntime;
+    private readonly IJSRuntime js;
 
-    public JsInteropClasses(IJSRuntime jsRuntime)
+    public JsInteropClasses(IJSRuntime js)
     {
-        this.jsRuntime = jsRuntime;
+        this.js = js;
     }
 
     public ValueTask<string> TickerChanged(string data)
     {
-        return jsRuntime.InvokeAsync<string>(
+        return js.InvokeAsync<string>(
             "handleTickerChanged",
             stockUpdate.symbol,
             stockUpdate.price);

--- a/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/inject-abstraction.razor
+++ b/aspnetcore/blazor/call-javascript-from-dotnet/samples_snapshot/inject-abstraction.razor
@@ -1,11 +1,11 @@
-@inject IJSRuntime JSRuntime
+@inject IJSRuntime JS
 
 @code {
     protected override void OnInitialized()
     {
         StocksService.OnStockTickerUpdated += stockUpdate =>
         {
-            JSRuntime.InvokeVoidAsync("handleTickerChanged",
+            JS.InvokeVoidAsync("handleTickerChanged",
                 stockUpdate.symbol, stockUpdate.price);
         };
     }

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -211,29 +211,29 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
 
-public class WeatherForecastClient
+public class WeatherForecastHttpClient
 {
-    private readonly HttpClient client;
+    private readonly HttpClient http;
 
-    public WeatherForecastClient(HttpClient client)
+    public WeatherForecastHttpClient(HttpClient http)
     {
-        this.client = client;
+        this.http = http;
     }
 
     public async Task<WeatherForecast[]> GetForecastAsync()
     {
         var forecasts = new WeatherForecast[0];
-    
+
         try
         {
-            forecasts = await client.GetFromJsonAsync<WeatherForecast[]>(
+            forecasts = await http.GetFromJsonAsync<WeatherForecast[]>(
                 "WeatherForecast");
         }
         catch
         {
             ...
         }
-    
+
         return forecasts;
     }
 }
@@ -242,7 +242,7 @@ public class WeatherForecastClient
 `Program.Main` (`Program.cs`):
 
 ```csharp
-builder.Services.AddHttpClient<WeatherForecastClient>(client => 
+builder.Services.AddHttpClient<WeatherForecastHttpClient>(client => 
     client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress));
 ```
 
@@ -251,7 +251,7 @@ Components inject the typed <xref:System.Net.Http.HttpClient> to call the web AP
 `FetchData` component (`Pages/FetchData.razor`):
 
 ```razor
-@inject WeatherForecastClient Client
+@inject WeatherForecastHttpClient Http
 
 ...
 
@@ -260,7 +260,7 @@ Components inject the typed <xref:System.Net.Http.HttpClient> to call the web AP
 
     protected override async Task OnInitializedAsync()
     {
-        forecasts = await Client.GetForecastAsync();
+        forecasts = await Http.GetForecastAsync();
     }
 }
 ```

--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -150,14 +150,14 @@ using Microsoft.Extensions.Configuration;
 
 ...
 
-var client = new HttpClient()
+var http = new HttpClient()
 {
     BaseAddress = new Uri(builder.HostEnvironment.BaseAddress)
 };
 
-builder.Services.AddScoped(sp => client);
+builder.Services.AddScoped(sp => http);
 
-using var response = await client.GetAsync("cars.json");
+using var response = await http.GetAsync("cars.json");
 using var stream = await response.Content.ReadAsStreamAsync();
 
 builder.Configuration.AddJsonStream(stream);

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -52,7 +52,7 @@ public class Program
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.Services.AddSingleton<IMyDependency, MyDependency>();
         builder.RootComponents.Add<App>("app");
-        
+
         builder.Services.AddScoped(sp => 
             new HttpClient
             {
@@ -74,7 +74,7 @@ public class Program
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.Services.AddSingleton<WeatherService>();
         builder.RootComponents.Add<App>("app");
-        
+
         builder.Services.AddScoped(sp => 
             new HttpClient
             {
@@ -101,7 +101,7 @@ public class Program
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.Services.AddSingleton<WeatherService>();
         builder.RootComponents.Add<App>("app");
-        
+
         builder.Services.AddScoped(sp => 
             new HttpClient
             {
@@ -200,7 +200,7 @@ Complex services might require additional services. In the prior example, `DataA
 ```csharp
 public class DataAccess : IDataAccess
 {
-    public DataAccess(HttpClient client)
+    public DataAccess(HttpClient http)
     {
         ...
     }

--- a/aspnetcore/blazor/security/server/additional-scenarios.md
+++ b/aspnetcore/blazor/security/server/additional-scenarios.md
@@ -119,13 +119,13 @@ using System.Threading.Tasks;
 
 public class WeatherForecastService
 {
-    private readonly HttpClient client;
+    private readonly HttpClient http;
     private readonly TokenProvider tokenProvider;
 
     public WeatherForecastService(IHttpClientFactory clientFactory, 
         TokenProvider tokenProvider)
     {
-        client = clientFactory.CreateClient();
+        http = clientFactory.CreateClient();
         this.tokenProvider = tokenProvider;
     }
 
@@ -135,7 +135,7 @@ public class WeatherForecastService
         var request = new HttpRequestMessage(HttpMethod.Get, 
             "https://localhost:5003/WeatherForecast");
         request.Headers.Add("Authorization", $"Bearer {token}");
-        var response = await client.SendAsync(request);
+        var response = await http.SendAsync(request);
         response.EnsureSuccessStatusCode();
 
         return await response.Content.ReadAsAsync<WeatherForecast[]>();
@@ -271,13 +271,13 @@ using System.Threading.Tasks;
 
 public class WeatherForecastService
 {
-    private readonly HttpClient client;
+    private readonly HttpClient http;
     private readonly TokenProvider tokenProvider;
 
     public WeatherForecastService(IHttpClientFactory clientFactory, 
         TokenProvider tokenProvider)
     {
-        client = clientFactory.CreateClient();
+        http = clientFactory.CreateClient();
         this.tokenProvider = tokenProvider;
     }
 
@@ -287,7 +287,7 @@ public class WeatherForecastService
         var request = new HttpRequestMessage(HttpMethod.Get, 
             "https://localhost:5003/WeatherForecast");
         request.Headers.Add("Authorization", $"Bearer {token}");
-        var response = await client.SendAsync(request);
+        var response = await http.SendAsync(request);
         response.EnsureSuccessStatusCode();
 
         return await response.Content.ReadAsAsync<WeatherForecast[]>();

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -48,7 +48,7 @@ The configured <xref:System.Net.Http.HttpClient> is used to make authorized requ
 
 ```razor
 @using Microsoft.AspNetCore.Components.WebAssembly.Authentication
-@inject HttpClient Client
+@inject HttpClient Http
 
 ...
 
@@ -59,7 +59,7 @@ protected override async Task OnInitializedAsync()
     try
     {
         examples = 
-            await Client.GetFromJsonAsync<ExampleType[]>("ExampleAPIMethod");
+            await Http.GetFromJsonAsync<ExampleType[]>("ExampleAPIMethod");
 
         ...
     }
@@ -174,11 +174,11 @@ using static {APP ASSEMBLY}.Data;
 
 public class WeatherForecastClient
 {
-    private readonly HttpClient client;
+    private readonly HttpClient http;
  
-    public WeatherForecastClient(HttpClient client)
+    public WeatherForecastClient(HttpClient http)
     {
-        this.client = client;
+        this.http = http;
     }
  
     public async Task<WeatherForecast[]> GetForecastAsync()
@@ -187,7 +187,7 @@ public class WeatherForecastClient
 
         try
         {
-            forecasts = await client.GetFromJsonAsync<WeatherForecast[]>(
+            forecasts = await http.GetFromJsonAsync<WeatherForecast[]>(
                 "WeatherForecast");
         }
         catch (AccessTokenNotAvailableException exception)
@@ -394,6 +394,11 @@ The following example shows how to:
 * Recover the previous state afterward authentication using the query string parameter.
 
 ```razor
+...
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+@inject IAccessTokenProvider TokenProvider
+...
+
 <EditForm Model="User" @onsubmit="OnSaveAsync">
     <label>User
         <InputText @bind-Value="User.Name" />
@@ -425,12 +430,12 @@ The following example shows how to:
 
     public async Task OnSaveAsync()
     {
-        var httpClient = new HttpClient();
-        httpClient.BaseAddress = new Uri(Navigation.BaseUri);
+        var http = new HttpClient();
+        http.BaseAddress = new Uri(Navigation.BaseUri);
 
         var resumeUri = Navigation.Uri + $"?state=resumeSavingProfile";
 
-        var tokenResult = await AuthenticationService.RequestAccessToken(
+        var tokenResult = await TokenProvider.RequestAccessToken(
             new AccessTokenRequestOptions
             {
                 ReturnUrl = resumeUri
@@ -438,9 +443,9 @@ The following example shows how to:
 
         if (tokenResult.TryGetToken(out var token))
         {
-            httpClient.DefaultRequestHeaders.Add("Authorization", 
+            http.DefaultRequestHeaders.Add("Authorization", 
                 $"Bearer {token.Value}");
-            await httpClient.PostAsJsonAsync("Save", User);
+            await http.PostAsJsonAsync("Save", User);
         }
         else
         {

--- a/aspnetcore/blazor/security/webassembly/graph-api.md
+++ b/aspnetcore/blazor/security/webassembly/graph-api.md
@@ -83,11 +83,11 @@ internal static class GraphClientExtensions
             Provider = provider;
         }
 
-        public IAccessTokenProvider Provider { get; }
+        public IAccessTokenProvider TokenProvider { get; }
 
         public async Task AuthenticateRequestAsync(HttpRequestMessage request)
         {
-            var result = await Provider.RequestAccessToken(
+            var result = await TokenProvider.RequestAccessToken(
                 new AccessTokenRequestOptions()
                 {
                     Scopes = {STRING ARRAY OF SCOPES}
@@ -103,11 +103,11 @@ internal static class GraphClientExtensions
 
     private class HttpClientHttpProvider : IHttpProvider
     {
-        private readonly HttpClient client;
+        private readonly HttpClient http;
 
-        public HttpClientHttpProvider(HttpClient client)
+        public HttpClientHttpProvider(HttpClient http)
         {
-            this.client = client;
+            this.http = http;
         }
 
         public ISerializer Serializer { get; } = new Serializer();
@@ -120,14 +120,14 @@ internal static class GraphClientExtensions
 
         public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
         {
-            return client.SendAsync(request);
+            return http.SendAsync(request);
         }
 
         public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, 
             HttpCompletionOption completionOption, 
             CancellationToken cancellationToken)
         {
-            return client.SendAsync(request, completionOption, cancellationToken);
+            return http.SendAsync(request, completionOption, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
Fixes #20335

Thanks @ericsson007! :rocket: ... This fixes the example that you highlighted and addresses some inconsistency in variable naming elsewhere. The inconsistencies are expected to a certain extent because ...

* There are several product unit developers (and myself) submitting doc code examples with different favorite-naming schemes.
* The updates and new examples come in over a long span of time ... over years.

Even the same dev might submit code examples in one year using one naming approach and then change it up in a later year and use a different naming approach.

I'll keep working on this problem as I go with topic updates. I'll also keep working on calling out namespaces in examples ... another on-going pain point. Thanks again for calling this out in that example. It led to several changes here that have improved consistency in a general away across many examples.