### PR TITLE
Heading workaround for doc build suggestion

### DIFF
--- a/aspnetcore/includes/RP/sqlite.md
+++ b/aspnetcore/includes/RP/sqlite.md
@@ -1,5 +1,3 @@
-## SQLite
-
 The [SQLite](https://www.sqlite.org/) website states:
 
 > SQLite is a self-contained, high-reliability, embedded, full-featured, public-domain, SQL database engine. SQLite is the most used database engine in the world.

--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
@@ -61,6 +61,8 @@ Note the key icon next to `ID`. By default, EF will make a property named `ID` t
 
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
+<h2 id="sqllite">SQLite database engine</h2>
+
 [!INCLUDE[](~/includes/rp/sqlite.md)]
 [!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
@@ -172,6 +174,8 @@ Note the key icon next to `ID`. By default, EF will make a property named `ID` t
   ![Movie table open showing table data](working-with-sql/_static/vd22.png)
 
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
+
+<h2 id="sqllite">SQLite database</h2>
 
 [!INCLUDE[](~/includes/rp/sqlite.md)]
 [!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]

--- a/aspnetcore/tutorials/razor-pages/sql.md
+++ b/aspnetcore/tutorials/razor-pages/sql.md
@@ -68,6 +68,8 @@ Note the key icon next to `ID`. By default, EF creates a property named `ID` for
 
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
+<h2 id="sqllite">SQLite database engine</h2>
+
 [!INCLUDE[](~/includes/rp/sqlite.md)]
 [!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
@@ -207,10 +209,14 @@ Note the key icon next to `ID`. By default, EF creates a property named `ID` for
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
+<h2 id="sqllite">SQLite database</h2>
+
 [!INCLUDE[](~/includes/rp/sqlite.md)]
 [!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
+
+<h2 id="sqllite">SQLite</h2>
 
 [!INCLUDE[](~/includes/rp/sqlite.md)]
 [!INCLUDE[](~/includes/RP-mvc-shared/sqlite-warn.md)]


### PR DESCRIPTION
This build suggestion (soon to become a warning) keeps popping up on repo builds ...

> Suggestion | User | duplicate-headings | aspnetcore/includes/RP/sqlite.md | Duplicate  heading: 'H2 'SQLite'(tutorials/razor-pages/sql.md(215,1) ->  includes/RP/sqlite.md)'. Each second level heading (H2) in an article  must be unique. NOTE: This Suggestion will become a Warning on 1/29/21.

**_One way_** to address this is to use different heading text with HTML elements and a stable `id` for bookmarking. I'll be a little surprised if you want to do this because I'm aware that you prefer the non-HTML5 way of anchoring bookmarks. However, I just wanted to show-'n-tell this as a discussion point. It should be both spec and markdown friendly&dagger;. Anyway ... I expect this to be just closed, so no worries on that point.

&dagger;I'm not too keen on their decision to suggest/warn off of HTML. I'm concerned. 😨 @scottaddie ... I think when we discussed this in ancient doc times ... *a year ago or so* 👴:smile: ... HTML elements could be added to the ignore list for markdown linting. I recommend at least adding the headings to that list (i.e., `<h1>`, `<h2>`, etc.) if not witnessing that element linting is completely ...

**_Banished to the land of wind and ghosts._** - Ryan Nowak, 2019

**UPDATE**: In spite of this working in this case, I'll go ahead and close this as a test and discussion point. This is part of a larger set of broken INCLUDE scenarios at this time that they're probably addressing internally (e.g., alt text also breaks, and dropping all INCLUDES is the only obvious way to fix that problem).