### PR TITLE
Correctly refer to MyDisplayRouteInfo location

### DIFF
--- a/aspnetcore/mvc/controllers/routing.md
+++ b/aspnetcore/mvc/controllers/routing.md
@@ -840,7 +840,7 @@ Public methods on a controller, except those with the [NonAction](xref:Microsoft
 
 ## Sample code
 
- * The [MyDisplayRouteInfo](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/mvc/controllers/routing/samples/3.x/main/Extensions/ControllerContextExtensions.cs) method is included in the [sample download](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/mvc/controllers/routing/samples/3.x) and is used to display routing information.
+* [!INCLUDE[](~/includes/MyDisplayRouteInfo.md)]
 * [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/mvc/controllers/routing/samples/3.x) ([how to download](xref:index#how-to-download-a-sample))
 
 [!INCLUDE[](~/includes/dbg-route.md)]


### PR DESCRIPTION
Commit https://github.com/dotnet/AspNetCore.Docs/commit/fa4c1e7b6e2a0c2a0dd426405d56551d49395ffe changed this at the beginning of this document, but not this instance.