### PR TITLE
Explain scoped DI in HttpClient handlers

### DIFF
--- a/aspnetcore/fundamentals/http-requests.md
+++ b/aspnetcore/fundamentals/http-requests.md
@@ -245,13 +245,19 @@ More than one handler can be added to the configuration for an `HttpClient` with
 
 [!code-csharp[](http-requests/samples/3.x/HttpClientFactorySample/Startup2.cs?name=snippet1)]
 
-In the preceding code, the `ValidateHeaderHandler` is registered with DI. The `IHttpClientFactory` creates a separate DI scope for each handler. Handlers can depend upon services of any scope. Services that handlers depend upon are disposed when the handler is disposed.
-
-Once registered, <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddHttpMessageHandler*> can be called, passing in the type for the handler.
+In the preceding code, the `ValidateHeaderHandler` is registered with DI. Once registered, <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddHttpMessageHandler*> can be called, passing in the type for the handler.
 
 Multiple handlers can be registered in the order that they should execute. Each handler wraps the next handler until the final `HttpClientHandler` executes the request:
 
 [!code-csharp[](http-requests/samples/3.x/HttpClientFactorySample/Startup.cs?name=snippet6)]
+
+### Use DI in outgoing request middleware
+
+When `IHttpClientFactory` creates a new delegating handler, it uses DI to fulfill the handler's constructor parameters. `IHttpClientFactory` creates a **separate** DI scope for each handler, which can lead to surprising behavior if a handler uses a *scoped* service.
+
+<!-- TODO: Example and supporting explanation -->
+
+Handlers can depend upon services of any scope. Services that handlers depend upon are disposed when the handler is disposed.
 
 Use one of the following approaches to share per-request state with message handlers:
 

--- a/aspnetcore/fundamentals/http-requests.md
+++ b/aspnetcore/fundamentals/http-requests.md
@@ -253,9 +253,21 @@ Multiple handlers can be registered in the order that they should execute. Each 
 
 ### Use DI in outgoing request middleware
 
-When `IHttpClientFactory` creates a new delegating handler, it uses DI to fulfill the handler's constructor parameters. `IHttpClientFactory` creates a **separate** DI scope for each handler, which can lead to surprising behavior if a handler uses a *scoped* service.
+When `IHttpClientFactory` creates a new delegating handler, it uses DI to fulfill the handler's constructor parameters. `IHttpClientFactory` creates a **separate** DI scope for each handler, which can lead to surprising behavior when a handler consumes a *scoped* service.
 
-<!-- TODO: Example and supporting explanation -->
+For example, consider the following interface and its implementation, which represents a task as an operation with an identifier, `OperationId`:
+
+[!code-csharp[](http-requests/samples/3.x/HttpRequestsSample/Models/OperationScoped.cs?name=snippet_Types)]
+
+As its name suggests, `IOperationScoped` is registered with DI using a *scoped* lifetime:
+
+[!code-csharp[](http-requests/samples/3.x/HttpRequestsSample/Startup.cs?name=snippet_IOperationScoped)]
+
+The following delegating handler consumes and uses `IOperationScoped` to set the `X-OPERATION-ID` header for the outgoing request:
+
+[!code-csharp[](http-requests/samples/3.x/HttpRequestsSample/Handlers/OperationHandler.cs?name=snippet_Class&highlight=13)]
+
+<!-- TODO: Bring it all home -->
 
 Handlers can depend upon services of any scope. Services that handlers depend upon are disposed when the handler is disposed.
 

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Handlers/OperationHandler.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Handlers/OperationHandler.cs
@@ -5,6 +5,7 @@ using HttpRequestsSample.Models;
 
 namespace HttpRequestsSample.Handlers
 {
+    #region snippet_Class
     public class OperationHandler : DelegatingHandler
     {
         private readonly IOperationScoped _operationService;
@@ -14,15 +15,13 @@ namespace HttpRequestsSample.Handlers
             _operationService = operationScoped;
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected async override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
         {
             request.Headers.Add("X-OPERATION-ID", _operationService.OperationId);
 
-            // For sample purposes, also return the OperationId as the body.
-            return Task.FromResult(new HttpResponseMessage
-            {
-                Content = new StringContent(_operationService.OperationId)
-            });
+            return await base.SendAsync(request, cancellationToken);
         }
     }
+    #endregion
 }

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Handlers/OperationHandler.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Handlers/OperationHandler.cs
@@ -1,0 +1,28 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using HttpRequestsSample.Models;
+
+namespace HttpRequestsSample.Handlers
+{
+    public class OperationHandler : DelegatingHandler
+    {
+        private readonly IOperationScoped _operationService;
+
+        public OperationHandler(IOperationScoped operationScoped)
+        {
+            _operationService = operationScoped;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.Add("X-OPERATION-ID", _operationService.OperationId);
+
+            // For sample purposes, also return the OperationId as the body.
+            return Task.FromResult(new HttpResponseMessage
+            {
+                Content = new StringContent(_operationService.OperationId)
+            });
+        }
+    }
+}

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Handlers/OperationResponseHandler.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Handlers/OperationResponseHandler.cs
@@ -1,0 +1,27 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using HttpRequestsSample.Models;
+
+namespace HttpRequestsSample.Handlers
+{
+    public class OperationResponseHandler : DelegatingHandler
+    {
+        private readonly IOperationScoped _operationService;
+
+        public OperationResponseHandler(IOperationScoped operationScoped)
+        {
+            _operationService = operationScoped;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            // For sample purposes, return the OperationId as the body.
+            return Task.FromResult(new HttpResponseMessage
+            {
+                Content = new StringContent(_operationService.OperationId)
+            });
+        }
+    }
+}

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Models/OperationScoped.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Models/OperationScoped.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace HttpRequestsSample.Models
+{
+    public interface IOperationScoped 
+    {
+        string OperationId { get; }
+    }
+
+    public class OperationScoped : IOperationScoped
+    {
+        public string OperationId { get; } = Guid.NewGuid().ToString()[^4..];
+    }
+}

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Models/OperationScoped.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Models/OperationScoped.cs
@@ -2,6 +2,7 @@ using System;
 
 namespace HttpRequestsSample.Models
 {
+    #region snippet_Types
     public interface IOperationScoped 
     {
         string OperationId { get; }
@@ -11,4 +12,5 @@ namespace HttpRequestsSample.Models
     {
         public string OperationId { get; } = Guid.NewGuid().ToString()[^4..];
     }
+    #endregion
 }

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Pages/Operation.cshtml
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Pages/Operation.cshtml
@@ -1,0 +1,9 @@
+@page
+@model OperationModel
+
+@{
+    ViewData["Title"] = "Operation";
+}
+
+<div>Request Scope: @Model.OperationIdFromRequestScope</div>
+<div>Handler Scope: @Model.OperationIdFromHandlerScope</div>

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Pages/Operation.cshtml.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Pages/Operation.cshtml.cs
@@ -1,0 +1,31 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using HttpRequestsSample.Models;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace HttpRequestsSample.Pages
+{
+    public class OperationModel : PageModel
+    {
+        private readonly IOperationScoped _operationScoped;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public OperationModel(IOperationScoped operationScoped, IHttpClientFactory httpClientFactory)
+        {
+            _operationScoped = operationScoped;
+            _httpClientFactory = httpClientFactory;
+        }
+
+        public string OperationIdFromRequestScope { get; set; }
+
+        public string OperationIdFromHandlerScope { get; set; }
+
+        public async Task OnGetAsync()
+        {
+            var httpClient = _httpClientFactory.CreateClient("Operation");
+
+            OperationIdFromRequestScope = _operationScoped.OperationId;
+            OperationIdFromHandlerScope = await httpClient.GetStringAsync("https://example.com");
+        }
+    }
+}

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Startup.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Startup.cs
@@ -29,11 +29,16 @@ namespace HttpRequestsSample
                 httpClient.Timeout = TimeSpan.FromSeconds(5);
             });
 
+            #region snippet_IOperationScoped
             services.AddScoped<IOperationScoped, OperationScoped>();
+            #endregion
+            
             services.AddTransient<OperationHandler>();
+            services.AddTransient<OperationResponseHandler>();
 
             services.AddHttpClient("Operation")
-                .AddHttpMessageHandler<OperationHandler>();
+                .AddHttpMessageHandler<OperationHandler>()
+                .AddHttpMessageHandler<OperationResponseHandler>();
 
             services.AddControllers();
             services.AddRazorPages();

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Startup.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpRequestsSample/Startup.cs
@@ -1,4 +1,5 @@
 using System;
+using HttpRequestsSample.Handlers;
 using HttpRequestsSample.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -27,6 +28,12 @@ namespace HttpRequestsSample
                 httpClient.BaseAddress = new Uri(UriHelper.BuildAbsolute(httpRequest.Scheme, httpRequest.Host, httpRequest.PathBase));
                 httpClient.Timeout = TimeSpan.FromSeconds(5);
             });
+
+            services.AddScoped<IOperationScoped, OperationScoped>();
+            services.AddTransient<OperationHandler>();
+
+            services.AddHttpClient("Operation")
+                .AddHttpMessageHandler<OperationHandler>();
 
             services.AddControllers();
             services.AddRazorPages();


### PR DESCRIPTION
Fixes #20401.

I've put together an example and added a TODO into the topic for explanation. I'll do that in the next commit, but I'm offering this up here as a draft for some feedback on the approach.

@Rick-Anderson Does the approach I've gone with look OK here? It borrows heavily from the `Operation` concept used in the DI example, but just focuses on _Scoped_, because that's where it matters for the concept being explained.