### PR TITLE
Update HttpRepl docs for 5.0 changes

### DIFF
--- a/aspnetcore/includes/http-repl/standard-options.md
+++ b/aspnetcore/includes/http-repl/standard-options.md
@@ -9,10 +9,6 @@
   * `{header}={value}`
   * `{header}:{value}`
 
-* `--response`
-
-  Specifies a file to which the entire HTTP response (including headers and body) should be written. For example, `--response "C:\response.txt"`. The file is created if it doesn't exist.
-
 * `--response:body`
 
   Specifies a file to which the HTTP response body should be written. For example, `--response:body "C:\response.json"`. The file is created if it doesn't exist.

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -604,8 +604,12 @@
       uid: web-api/advanced/conventions
     - name: Handle errors
       uid: web-api/handle-errors
-    - name: Test APIs with HTTP REPL
-      uid: web-api/http-repl
+    - name: HTTP REPL
+      items:
+      - name: Test APIs with HTTP REPL
+        uid: web-api/http-repl
+      - name: Telemetry
+        uid: web-api/http-repl-telemetry
 - name: Real-time apps
   displayName: signalr
   items:

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -606,10 +606,10 @@
       uid: web-api/handle-errors
     - name: HTTP REPL
       items:
-      - name: Test APIs with HTTP REPL
+      - name: Test APIs
         uid: web-api/http-repl
       - name: Telemetry
-        uid: web-api/http-repl-telemetry
+        uid: web-api/http-repl/telemetry
 - name: Real-time apps
   displayName: signalr
   items:

--- a/aspnetcore/web-api/http-repl-telemetry.md
+++ b/aspnetcore/web-api/http-repl-telemetry.md
@@ -1,0 +1,48 @@
+# HttpRepl telemetry
+
+HttpRepl includes a telemetry feature that collects usage data. It's important that the HttpRepl team understands how the tool is used so it can be improved.
+
+## How to opt out
+
+The HttpRepl telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_HTTPREPL_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
+
+## Disclosure
+
+HttpRepl displays text similar to the following when you first run the tool. Text may vary slightly depending on the version of the tool you're running. This "first run" experience is how Microsoft notifies you about data collection.
+
+```console
+Telemetry
+---------
+The .NET Core tools collect usage data in order to help us improve your experience. It is collected by Microsoft and shared with the community. You can opt-out of telemetry by setting the DOTNET_HTTPREPL_TELEMETRY_OPTOUT environment variable to '1' or 'true' using your favorite shell.
+```
+
+## Data points
+
+The telemetry feature doesn't collect personal data, such as usernames or email addresses or URLs. It doesn't scan your HTTP requests or responses. The data is sent securely to Microsoft servers and held under restricted access.
+
+Protecting your privacy is important to us. If you suspect the telemetry is collecting sensitive data or the data is being insecurely or inappropriately handled, file an issue in the [dotnet/httprepl](https://github.com/dotnet/httprepl/issues) repository or send an email to [dotnet@microsoft.com](mailto:dotnet@microsoft.com) for investigation.
+
+The telemetry feature collects the following data:
+
+| SDK versions | Data |
+|--------------|------|
+| >=5.0        | Timestamp of invocation. |
+| >=5.0        | Three octet IP address used to determine the geographical location. |
+| >=5.0        | Operating system and version. |
+| >=5.0        | Runtime ID (RID) the tool is running on. |
+| >=5.0        | Whether the tool is running in a container. |
+| >=5.0        | Hashed Media Access Control (MAC) address: a cryptographically (SHA256) hashed and unique ID for a machine. |
+| >=5.0        | Kernel version. |
+| >=5.0        | HttpRepl version. |
+| >=5.0        | Whether or not the tool was started with help, run or connect arguments. Actual argument values are not collected. |
+| >=5.0        | Command invoked (for example, "get") and whether or not it succeeded. |
+| >=5.0        | For the `connect` command, whether or not the root, base or openapi arguments were supplied. Actual argument values are not collected. |
+| >=5.0        | For the `pref` command, whether a `get` or `set` was issued and which preference was accessed. If not a well-known preference, the name is hashed. The value is not collected. |
+| >=5.0        | For the `set header` command, the header name being set. If not a well-known header, the name is hashed. The value is not collected. |
+| >=5.0        | For the `connect` command, whether or not a specific special-case for `dotnet new webapi` was used and, whether or not it was bypassed via preference. |
+| >=5.0        | For all HTTP commands (e.g. GET, POST, PUT, etc), whether or not each of the options was specified. The values of the options are not collected. |
+
+## See also
+
+- [.NET Core SDK telemetry](https://docs.microsoft.com/dotnet/core/tools/telemetry)
+- [.NET Core CLI Telemetry Data](https://dotnet.microsoft.com/platform/telemetry)

--- a/aspnetcore/web-api/http-repl-telemetry.md
+++ b/aspnetcore/web-api/http-repl-telemetry.md
@@ -1,10 +1,20 @@
-# HttpRepl telemetry
+---
+title: HTTP REPL telemetry
+author: scottaddie
+description: Learn about the telemetry collected by the HTTP REPL.
+monikerRange: '>= aspnetcore-2.1'
+ms.author: scaddie
+ms.date: 11/10/2020
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+uid: web-api/http-repl/telemetry
+---
+# HTTP REPL telemetry
 
-HttpRepl includes a telemetry feature that collects usage data. It's important that the HttpRepl team understands how the tool is used so it can be improved.
+The [HTTP Read-Eval-Print Loop (REPL)](xref:web-api/http-repl) includes a telemetry feature that collects usage data. It's important that the HTTP REPL team understands how the tool is used so it can be improved.
 
 ## How to opt out
 
-The HttpRepl telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_HTTPREPL_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
+The HTTP REPL telemetry feature is enabled by default. To opt out of the telemetry feature, set the `DOTNET_HTTPREPL_TELEMETRY_OPTOUT` environment variable to `1` or `true`.
 
 ## Disclosure
 
@@ -18,31 +28,39 @@ The .NET Core tools collect usage data in order to help us improve your experien
 
 ## Data points
 
-The telemetry feature doesn't collect personal data, such as usernames or email addresses or URLs. It doesn't scan your HTTP requests or responses. The data is sent securely to Microsoft servers and held under restricted access.
+The telemetry feature doesn't:
 
-Protecting your privacy is important to us. If you suspect the telemetry is collecting sensitive data or the data is being insecurely or inappropriately handled, file an issue in the [dotnet/httprepl](https://github.com/dotnet/httprepl/issues) repository or send an email to [dotnet@microsoft.com](mailto:dotnet@microsoft.com) for investigation.
+* Collect personal data, such as usernames, email addresses, or URLs.
+* Scan your HTTP requests or responses.
 
-The telemetry feature collects the following data:
+The data is sent securely to Microsoft servers and held under restricted access.
 
-| SDK versions | Data |
+Protecting your privacy is important to us. If you suspect the telemetry feature is collecting sensitive data or the data is being insecurely or inappropriately handled, take one of the following actions:
+
+* File an issue in the [dotnet/httprepl](https://github.com/dotnet/httprepl/issues) repository.
+* Send an email to [dotnet@microsoft.com](mailto:dotnet@microsoft.com) for investigation.
+
+The telemetry feature collects the following data.
+
+| .NET SDK versions | Data |
 |--------------|------|
 | >=5.0        | Timestamp of invocation. |
-| >=5.0        | Three octet IP address used to determine the geographical location. |
+| >=5.0        | Three-octet IP address used to determine the geographical location. |
 | >=5.0        | Operating system and version. |
 | >=5.0        | Runtime ID (RID) the tool is running on. |
 | >=5.0        | Whether the tool is running in a container. |
 | >=5.0        | Hashed Media Access Control (MAC) address: a cryptographically (SHA256) hashed and unique ID for a machine. |
 | >=5.0        | Kernel version. |
-| >=5.0        | HttpRepl version. |
-| >=5.0        | Whether or not the tool was started with help, run or connect arguments. Actual argument values are not collected. |
-| >=5.0        | Command invoked (for example, "get") and whether or not it succeeded. |
-| >=5.0        | For the `connect` command, whether or not the root, base or openapi arguments were supplied. Actual argument values are not collected. |
-| >=5.0        | For the `pref` command, whether a `get` or `set` was issued and which preference was accessed. If not a well-known preference, the name is hashed. The value is not collected. |
-| >=5.0        | For the `set header` command, the header name being set. If not a well-known header, the name is hashed. The value is not collected. |
-| >=5.0        | For the `connect` command, whether or not a specific special-case for `dotnet new webapi` was used and, whether or not it was bypassed via preference. |
-| >=5.0        | For all HTTP commands (e.g. GET, POST, PUT, etc), whether or not each of the options was specified. The values of the options are not collected. |
+| >=5.0        | HTTP REPL version. |
+| >=5.0        | Whether the tool was started with `help`, `run`, or `connect` arguments. Actual argument values aren't collected. |
+| >=5.0        | Command invoked (for example, `get`) and whether it succeeded. |
+| >=5.0        | For the `connect` command, whether the `root`, `base`, or `openapi` arguments were supplied. Actual argument values aren't collected. |
+| >=5.0        | For the `pref` command, whether a `get` or `set` was issued and which preference was accessed. If not a well-known preference, the name is hashed. The value isn't collected. |
+| >=5.0        | For the `set header` command, the header name being set. If not a well-known header, the name is hashed. The value isn't collected. |
+| >=5.0        | For the `connect` command, whether a special case for `dotnet new webapi` was used and, whether it was bypassed via preference. |
+| >=5.0        | For all HTTP commands (for example, GET, POST, PUT), whether each of the options was specified. The values of the options aren't collected. |
 
-## See also
+## Additional resources
 
-- [.NET Core SDK telemetry](https://docs.microsoft.com/dotnet/core/tools/telemetry)
-- [.NET Core CLI Telemetry Data](https://dotnet.microsoft.com/platform/telemetry)
+* [.NET Core SDK telemetry](/dotnet/core/tools/telemetry)
+* [.NET Core CLI telemetry data](https://dotnet.microsoft.com/platform/telemetry)

--- a/aspnetcore/web-api/http-repl.md
+++ b/aspnetcore/web-api/http-repl.md
@@ -5,7 +5,7 @@ description: Learn how to use the HTTP REPL .NET Core Global Tool to browse and 
 monikerRange: '>= aspnetcore-2.1'
 ms.author: scaddie
 ms.custom: mvc, devx-track-azurecli
-ms.date: 05/20/2020
+ms.date: 11/10/2020
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: web-api/http-repl
 ---
@@ -148,7 +148,7 @@ For example:
 
 ### Manually point to the OpenAPI description for the web API
 
-The connect command above will attempt to find the OpenAPI description automatically. If for some reason it is unable to do so, you can specify the URI of the OpenAPI description for the web API by using the `--openapi` option:
+The connect command above will attempt to find the OpenAPI description automatically. If for some reason it's unable to do so, you can specify the URI of the OpenAPI description for the web API by using the `--openapi` option:
 
 ```console
 connect <ROOT URI> --openapi <OPENAPI DESCRIPTION ADDRESS>
@@ -160,9 +160,9 @@ For example:
 (Disconnected)> connect https://localhost:5001 --openapi /swagger/v1/swagger.json
 ```
 
-### Enable verbose output for details on OpenAPI description searching, parsing and validation
+### Enable verbose output for details on OpenAPI description searching, parsing, and validation
 
-Specifying the `--verbose` option with the connect command will produce more details when the tool searches for the OpenAPI description, parses and validates it.
+Specifying the `--verbose` option with the `connect` command will produce more details when the tool searches for the OpenAPI description, parses, and validates it.
 
 ```console
 connect <ROOT URI> --verbose
@@ -649,7 +649,7 @@ To issue an HTTP PUT request:
     Server: Kestrel
     ```
 
-1. *Optional*: Issue a `get` command to see the modifications. For example, if you typed "Cherry" in the text editor, a `get` returns the following:
+1. *Optional*: Issue a `get` command to see the modifications. For example, if you typed "Cherry" in the text editor, a `get` returns the following output:
 
     ```console
     https://localhost:5001/fruits> get
@@ -740,7 +740,7 @@ To issue an HTTP DELETE request:
     Server: Kestrel
     ```
 
-1. *Optional*: Issue a `get` command to see the modifications. In this example, a `get` returns the following:
+1. *Optional*: Issue a `get` command to see the modifications. In this example, a `get` returns the following output:
 
     ```console
     https://localhost:5001/fruits> get
@@ -847,11 +847,14 @@ To set an HTTP request header, use one of the following approaches:
 
 ## Test secured endpoints
 
-The HTTP REPL supports the testing of secured endpoints in two ways: via the default credentials of the logged in user or through the use of HTTP request headers. 
+The HTTP REPL supports the testing of secured endpoints in the following ways:
+
+* Via the default credentials of the logged in user.
+* Through the use of HTTP request headers.
 
 ### Default credentials
 
-Consider a scenario in which the web API you're testing is hosted in IIS and is secured with Windows authentication. You want the credentials of the user running the tool to flow across to the HTTP endpoints being tested. To pass the default credentials of the logged in user:
+Consider a web API you're testing that's hosted in IIS and secured with Windows authentication. You want the credentials of the user running the tool to flow across to the HTTP endpoints being tested. To pass the default credentials of the logged in user:
 
 1. Set the `httpClient.useDefaultCredentials` preference to `true`:
 
@@ -863,7 +866,7 @@ Consider a scenario in which the web API you're testing is hosted in IIS and is 
  
 ### Default proxy credentials
 
-Consider a scenario in which the web API you're testing is behind a proxy that is secured with Windows authentication. You want the credentials of the user running the tool to flow to the proxy. To pass the default credentials of the logged in user:
+Consider a scenario in which the web API you're testing is behind a proxy secured with Windows authentication. You want the credentials of the user running the tool to flow to the proxy. To pass the default credentials of the logged in user:
 
 1. Set the `httpClient.proxy.useDefaultCredentials` preference to `true`:
 
@@ -875,15 +878,21 @@ Consider a scenario in which the web API you're testing is behind a proxy that i
 
 ### HTTP request headers
 
-Examples of supported authentication and authorization schemes include basic authentication, JWT bearer tokens, and digest authentication. For example, you can send a bearer token to an endpoint with the following command:
+Examples of supported authentication and authorization schemes include:
+
+* basic authentication
+* JWT bearer tokens
+* digest authentication
+
+For example, you can send a bearer token to an endpoint with the following command:
 
 ```console
 set header Authorization "bearer <TOKEN VALUE>"
 ```
 
-To access an Azure-hosted endpoint or to use the [Azure REST API](/rest/api/azure/), you need a bearer token. Use the following steps to obtain a bearer token for your Azure subscription via the [Azure CLI](/cli/azure/). The HTTP REPL sets the bearer token in an HTTP request header and retrieves a list of Azure App Service Web Apps.
+To access an Azure-hosted endpoint or to use the [Azure REST API](/rest/api/azure/), you need a bearer token. Use the following steps to obtain a bearer token for your Azure subscription via the [Azure CLI](/cli/azure/). The HTTP REPL sets the bearer token in an HTTP request header. A list of Azure App Service Web Apps is retrieved.
 
-1. Log in to Azure:
+1. Sign in to Azure:
 
     ```azurecli
     az login
@@ -1015,7 +1024,7 @@ Request echoing is off
 
 ## Run a script
 
-If you frequently execute the same set of HTTP REPL commands, consider storing them in a text file. Commands in the file take the same form as those executed manually on the command line. The commands can be executed in a batched fashion using the `run` command. For example:
+If you frequently execute the same set of HTTP REPL commands, consider storing them in a text file. Commands in the file take the same form as commands executed manually on the command line. The commands can be executed in a batched fashion using the `run` command. For example:
 
 1. Create a text file containing a set of newline-delimited commands. To illustrate, consider a *people-script.txt* file containing the following commands:
 


### PR DESCRIPTION
Updates the HttpRepl documentation for the changes we've made in 5.0.
Additionally, adds a new HTTP REPL node in the table of contents with two children - the original docs and the new telemetry doc.
The telemetry page is taken directly from https://github.com/dotnet/HttpRepl/blob/master/TELEMETRY.md

@scottaddie I didn't add any of the metadata to the top of the telemetry page since I wasn't sure if that was autogenerated or not. 