### PR TITLE
update key management

### DIFF
--- a/aspnetcore/security/data-protection/extensibility/key-management.md
+++ b/aspnetcore/security/data-protection/extensibility/key-management.md
@@ -128,17 +128,8 @@ There are four built-in concrete types which implement `IXmlRepository`:
 
 * [FileSystemXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.repositories.filesystemxmlrepository)
 * [RegistryXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.repositories.registryxmlrepository)
-* [AzureStorage.AzureBlobXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.azurestorage.azureblobxmlrepository)
+* [AzureStorage.AzureBlobXmlRepository]()
 * [RedisXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.stackexchangeredis.redisxmlrepository)
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-2.2"
-
-* [FileSystemXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.repositories.filesystemxmlrepository)
-* [RegistryXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.repositories.registryxmlrepository)
-* [AzureStorage.AzureBlobXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.azurestorage.azureblobxmlrepository)
-* [RedisXmlRepository](/dotnet/api/microsoft.aspnetcore.dataprotection.redisxmlrepository)
 
 ::: moniker-end
 


### PR DESCRIPTION
In key-management.md's code sample. 
1. There is no new API referenced to AzureBlobXmlRepository. So AzureBlobXmlRepository old API reference link was removed