### PR TITLE
Updating Program.cs examples to "#app"

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Program.cs
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/Program.cs
@@ -13,7 +13,7 @@ namespace BlazorSample
         public static async Task Main(string[] args)
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
-            builder.RootComponents.Add<App>("app");
+            builder.RootComponents.Add<App>("#app");
 
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -51,7 +51,7 @@ public class Program
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.Services.AddSingleton<IMyDependency, MyDependency>();
-        builder.RootComponents.Add<App>("app");
+        builder.RootComponents.Add<App>("#app");
 
         builder.Services.AddScoped(sp => 
             new HttpClient
@@ -73,7 +73,7 @@ public class Program
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.Services.AddSingleton<WeatherService>();
-        builder.RootComponents.Add<App>("app");
+        builder.RootComponents.Add<App>("#app");
 
         builder.Services.AddScoped(sp => 
             new HttpClient
@@ -100,7 +100,7 @@ public class Program
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.Services.AddSingleton<WeatherService>();
-        builder.RootComponents.Add<App>("app");
+        builder.RootComponents.Add<App>("#app");
 
         builder.Services.AddScoped(sp => 
             new HttpClient

--- a/aspnetcore/blazor/fundamentals/dependency-injection/samples_snapshot/3.x/transient-disposables/wasm-program.cs
+++ b/aspnetcore/blazor/fundamentals/dependency-injection/samples_snapshot/3.x/transient-disposables/wasm-program.cs
@@ -4,7 +4,7 @@ public class Program
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
         builder.DetectIncorrectUsageOfTransients();
-        builder.RootComponents.Add<App>("app");
+        builder.RootComponents.Add<App>("#app");
 
         builder.Services.AddTransient<TransientDisposable>();
         builder.Services.AddScoped(sp =>

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -817,7 +817,7 @@ public class Program
     public static async Task Main(string[] args)
     {
         var builder = WebAssemblyHostBuilder.CreateDefault(args);
-        builder.RootComponents.Add<App>("app");
+        builder.RootComponents.Add<App>("#app");
 
         builder.Services.AddScoped(sp => 
             new HttpClient

--- a/aspnetcore/blazor/templates.md
+++ b/aspnetcore/blazor/templates.md
@@ -35,7 +35,7 @@ The following files and folders make up a Blazor app generated from a Blazor pro
 
   * ASP.NET Core [host](xref:fundamentals/host/generic-host) (Blazor Server)
   * WebAssembly host (Blazor WebAssembly): The code in this file is unique to apps created from the Blazor WebAssembly template (`blazorwasm`).
-    * The `App` component is the root component of the app. The `App` component is specified as the `app` DOM element (`<app>...</app>`) to the root component collection (`builder.RootComponents.Add<App>("app")`).
+    * The `App` component is the root component of the app. The `App` component is specified as the `app` DOM element (`<app>...</app>`) to the root component collection (`builder.RootComponents.Add<App>("#app")`).
     * [Services](xref:blazor/fundamentals/dependency-injection) are added and configured (for example, `builder.Services.AddSingleton<IMyDependency, MyDependency>()`).
 
 * `Startup.cs` (Blazor Server): Contains the app's startup logic. The `Startup` class defines two methods:

--- a/aspnetcore/tutorials/signalr-blazor-webassembly/samples/3.x/BlazorSignalRApp/Client/Program.cs
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly/samples/3.x/BlazorSignalRApp/Client/Program.cs
@@ -13,7 +13,7 @@ namespace BlazorSignalRApp.Client
         public static async Task Main(string[] args)
         {
             var builder = WebAssemblyHostBuilder.CreateDefault(args);
-            builder.RootComponents.Add<App>("app");
+            builder.RootComponents.Add<App>("#app");
 
             builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 


### PR DESCRIPTION
Hello,

I noticed in latest Blazor WebAssembly sample code, the Program.cs now uses ("#app") rather than ("app"), so thought I would update to make consistent 😊

Thanks,
Carole