### PR TITLE
Adding note to also upgrade Microsoft.EntityFrameworkCore packages

### DIFF
--- a/aspnetcore/migration/31-to-50.md
+++ b/aspnetcore/migration/31-to-50.md
@@ -201,15 +201,17 @@ To resolve the error:
 
 ## Update package references
 
-In the project file, update each [Microsoft.AspNetCore.*](https://www.nuget.org/packages?q=Microsoft.AspNetCore.*), [Microsoft.Extensions.*](https://www.nuget.org/packages?q=Microsoft.Extensions.*), and [System.Net.Http.Json](https://www.nuget.org/packages/System.Net.Http.Json) package reference's `Version` attribute to 5.0.0 or later. For example:
+In the project file, update each [Microsoft.AspNetCore.*](https://www.nuget.org/packages?q=Microsoft.AspNetCore.*), [Microsoft.Extensions.*](https://www.nuget.org/packages?q=Microsoft.Extensions.*), [Microsoft.EntityFrameworkCore.*](https://www.nuget.org/packages?q=Microsoft.EntityFrameworkCore.*), and [System.Net.Http.Json](https://www.nuget.org/packages/System.Net.Http.Json) package reference's `Version` attribute to 5.0.0 or later. For example:
 
 ```diff
 <ItemGroup>
 -    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="3.1.6" />
 -    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.6" />
+-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.6">
 -    <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
 +    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.0" />
 +    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
++    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0">
 +    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
 </ItemGroup>
 ```

--- a/aspnetcore/migration/31-to-50.md
+++ b/aspnetcore/migration/31-to-50.md
@@ -201,7 +201,7 @@ To resolve the error:
 
 ## Update package references
 
-In the project file, update each [Microsoft.AspNetCore.*](https://www.nuget.org/packages?q=Microsoft.AspNetCore.*), [Microsoft.Extensions.*](https://www.nuget.org/packages?q=Microsoft.Extensions.*), [Microsoft.EntityFrameworkCore.*](https://www.nuget.org/packages?q=Microsoft.EntityFrameworkCore.*), and [System.Net.Http.Json](https://www.nuget.org/packages/System.Net.Http.Json) package reference's `Version` attribute to 5.0.0 or later. For example:
+In the project file, update each [Microsoft.AspNetCore.*](https://www.nuget.org/packages?q=Microsoft.AspNetCore.*), [Microsoft.EntityFrameworkCore.*](https://www.nuget.org/packages?q=Microsoft.EntityFrameworkCore.*), [Microsoft.Extensions.*](https://www.nuget.org/packages?q=Microsoft.Extensions.*), and [System.Net.Http.Json](https://www.nuget.org/packages/System.Net.Http.Json) package reference's `Version` attribute to 5.0.0 or later. For example:
 
 ```diff
 <ItemGroup>

--- a/aspnetcore/migration/31-to-50.md
+++ b/aspnetcore/migration/31-to-50.md
@@ -4,7 +4,7 @@ author: scottaddie
 description: Learn how to migrate an ASP.NET Core 3.1 project to ASP.NET Core 5.0.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 11/10/2020
+ms.date: 11/11/2020
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: migration/31-to-50
 ---
@@ -206,12 +206,12 @@ In the project file, update each [Microsoft.AspNetCore.*](https://www.nuget.org/
 ```diff
 <ItemGroup>
 -    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="3.1.6" />
--    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.6" />
 -    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.6">
+-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="3.1.6" />
 -    <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
 +    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.0" />
-+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
 +    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.0">
++    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
 +    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
 </ItemGroup>
 ```


### PR DESCRIPTION
This PR adds a note to inform that EF core packages should also be updated to 5.0.0.