### PR TITLE
CSS isolation support in RCLs

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -216,6 +216,7 @@ Upload the package to NuGet using the [`dotnet nuget push`](/dotnet/core/tools/d
 
 * <xref:razor-pages/ui-class>
 * [Add an XML Intermediate Language (IL) Trimmer configuration file to a library](xref:blazor/host-and-deploy/configure-trimmer)
+* [CSS isolation support with Razor class libraries](xref:blazor/components/css-isolation#razor-class-library-rcl-support)
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -166,7 +166,10 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 
 ## Razor class library (RCL) support
 
-When a [Razor class library (RCL)](xref:razor-pages/ui-class) provides isolated styles, the `<link>` tag's `href` attribute points to `_content/{ASSEMBLY NAME}/{ASSEMBLY NAME}.bundle.scp.css`, where the placeholder `{ASSEMBLY NAME}` is the class library's assembly name.
+When a [Razor class library (RCL)](xref:razor-pages/ui-class) provides isolated styles, the `<link>` tag's `href` attribute points to `{STATIC WEB ASSET BASE PATH}/{ASSEMBLY NAME}.bundle.scp.css`, where the placeholders are:
+
+* `{STATIC WEB ASSET BASE PATH}`: The static web asset base path.
+* `{ASSEMBLY NAME}`: The class library's assembly name.
 
 In the following example, the class library's assembly name is `ClassLib`:
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -163,3 +163,18 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
   <DisableScopedCssBundling>true</DisableScopedCssBundling>
 </PropertyGroup>
 ```
+
+## Razor class library (RCL) support
+
+When a [Razor class library (RCL)](xref:razor-pages/ui-class) provides isolated styles, the `<link>` tag's `href` attribute points to `_content/{ASSEMBLY NAME}/{ASSEMBLY NAME}.bundle.scp.css`, where the placeholder `{ASSEMBLY NAME}` is the class library's assembly name.
+
+In the following example, the class library's assembly name is `ClassLib`:
+
+```html
+<link href="_content/ClassLib/ClassLib.bundle.scp.css" rel="stylesheet">
+```
+
+For more information on RCLs and component libraries, see:
+
+* <xref:razor-pages/ui-class>
+* <xref:blazor/components/class-libraries>.

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -387,4 +387,15 @@ Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.csht
 
 ## Additional resources
 
+::: moniker range=">= aspnetcore-5.0"
+
 * <xref:blazor/components/class-libraries>
+* <xref:blazor/components/css-isolation#razor-class-library-rcl-support>
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+* <xref:blazor/components/class-libraries>
+
+::: moniker-end


### PR DESCRIPTION
Fixes #20480

Thanks @PoisnFang! :rocket:

Would u take a look @daveabrock? ...

* I'm a bit concerned about the 2nd `{ASSEMBLY NAME}` placeholder that I used (i.e., in the file name). See if I composed this correctly; otherwise if ur not available right now to look at this, I'll run a local test and confirm/update the behavior.
* Do I have the rest of it right (`.bundle.scp.css`) based on Javier's remark on the issue?