### PR TITLE
Error in Section "Test the PostTodoItem method 2.1"

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -1347,7 +1347,7 @@ The `CreatedAtAction` method:
 
 * Build the project.
 * In Postman, set the HTTP method to `POST`.
-* Set the URI to `https://localhost:<port>/api/TodoItem`. For example, `https://localhost:5001/api/TodoItem`.
+* Set the URI to `https://localhost:<port>/api/Todo`. For example, `https://localhost:5001/api/Todo`.
 * Select the **Body** tab.
 * Select the **raw** radio button.
 * Set the type to **JSON (application/json)**.


### PR DESCRIPTION
Fixes #20540

When following along with the .NET Core 2.1 tutorial, the part that says to `Set the URI to https://localhost:<port>/api/TodoItem...` fails. However, if you look in the screenshot for that part, the URI does not say "TodoItem" but is instead "Todo". When you use the URI `https://localhost:<port>/api/Todo`, the test passes.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->