### PR TITLE
Revert test if alt text renders file name cue

### DIFF
--- a/aspnetcore/tutorials/build-a-blazor-app.md
+++ b/aspnetcore/tutorials/build-a-blazor-app.md
@@ -86,7 +86,7 @@ At the end of this tutorial, you'll have a working todo list app.
 
 1. Add a `TodoItem.cs` file to the root of the project (the `TodoList` folder) to hold a class that represents a todo item. Use the following C# code for the `TodoItem` class:
 
-   [!code-csharp[TodoItem.cs](build-a-blazor-app/samples_snapshot/TodoItem.cs)]
+   [!code-csharp[](build-a-blazor-app/samples_snapshot/TodoItem.cs)]
 
 1. Return to the `Todo` component (`Pages/Todo.razor`):
 


### PR DESCRIPTION
Reverting the test on #20544 ...

```
[!code-csharp[TodoItem.cs](build-a-blazor-app/samples_snapshot/TodoItem.cs)]
```

It didn't work to render the file's name ...

<img width="865" alt="Capture" src="https://user-images.githubusercontent.com/1622880/98976562-20b46e00-24dd-11eb-90c1-6bc0d623c375.PNG">
