### PR TITLE
FireFox cert instructions

### DIFF
--- a/aspnetcore/includes/run-the-app.md
+++ b/aspnetcore/includes/run-the-app.md
@@ -26,3 +26,5 @@
 <!-- End of VS tabs -->
 
 ---
+
+[!INCLUDE[trust FF](~/includes/trust-ff.md)]

--- a/aspnetcore/includes/run-the-app.md
+++ b/aspnetcore/includes/run-the-app.md
@@ -26,5 +26,3 @@
 <!-- End of VS tabs -->
 
 ---
-
-[!INCLUDE[trust FF](~/includes/trust-ff.md)]

--- a/aspnetcore/includes/trust-ff.md
+++ b/aspnetcore/includes/trust-ff.md
@@ -1,0 +1,1 @@
+For information on trusting the Firefox browser, see [Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error](xref:security/enforcing-ssl#trust-ff).

--- a/aspnetcore/includes/trustCertVS.md
+++ b/aspnetcore/includes/trustCertVS.md
@@ -9,3 +9,5 @@ The following dialog is displayed:
 ![Security warning dialog](~/getting-started/_static/cert.png)
 
 Select **Yes** if you agree to trust the development certificate.
+
+[!INCLUDE[trust FF](~/includes/trust-ff.md)]

--- a/aspnetcore/includes/trustCertVSC.md
+++ b/aspnetcore/includes/trustCertVSC.md
@@ -14,3 +14,4 @@
 
   See [Trust the ASP.NET Core HTTPS development certificate](xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos) for more information.
   
+[!INCLUDE[trust FF](~/includes/trust-ff.md)]

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -438,7 +438,9 @@ To fix problems with the IIS Express certificate, select **Repair** from the Vis
 
 ### Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error
 
-In the Firefox browser, set  `security.enterprise_roots.enabled` = `true`
+The Firefox browser uses it's own certificate store, and therefore doesn't trust the [IIS Express](iis/extensions/introduction-to-iis-express/iis-express-overview) or [Kestrel](xref:fundamentals/servers/kestrel) developer certificates.
+
+To use Firefox with IIS Express or Kestrel, set  `security.enterprise_roots.enabled` = `true`
 
 1. Enter `about:config` in the FireFox browser.
 1. Select **Accept the Risk and Continue** if you accept the risk.

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -436,7 +436,7 @@ To fix problems with the IIS Express certificate, select **Repair** from the Vis
 
 ### Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error
 
-With the Firefox browser, set  `security.enterprise_roots.enabled` = `true`
+In the Firefox browser, set  `security.enterprise_roots.enabled` = `true`
 
 1. Enter `about:config` in the FireFox browser.
 1. Select **Accept the Risk and Continue** if you accept the risk.

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -434,6 +434,15 @@ See [HTTPS Error using IIS Express (dotnet/AspNetCore #16892)](https://github.co
 
 To fix problems with the IIS Express certificate, select **Repair** from the Visual Studio installer. For more information, see [this GitHub issue](https://github.com/dotnet/aspnetcore/issues/16892).
 
+### Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error
+
+With the Firefox browser, set  `security.enterprise_roots.enabled` = `true`
+
+1. Enter `about:config` in the FireFox browser.
+1. Select **Accept the Risk and Continue** if you accept the risk.
+1. Select **Show All**
+1. Set `security.enterprise_roots.enabled` = `true`
+
 ## Additional information
 
 * <xref:host-and-deploy/proxy-load-balancer>

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -442,6 +442,7 @@ In the Firefox browser, set  `security.enterprise_roots.enabled` = `true`
 1. Select **Accept the Risk and Continue** if you accept the risk.
 1. Select **Show All**
 1. Set `security.enterprise_roots.enabled` = `true`
+1. Exit and restart Firefox
 
 ## Additional information
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -434,6 +434,8 @@ See [HTTPS Error using IIS Express (dotnet/AspNetCore #16892)](https://github.co
 
 To fix problems with the IIS Express certificate, select **Repair** from the Visual Studio installer. For more information, see [this GitHub issue](https://github.com/dotnet/aspnetcore/issues/16892).
 
+<a name="trust-ff"></a>
+
 ### Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error
 
 In the Firefox browser, set  `security.enterprise_roots.enabled` = `true`

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start.md
@@ -411,7 +411,6 @@ At the end of this tutorial, you'll have a working Razor Pages web app that you'
 
   Launching the app with <kbd>Ctrl+F5</kbd> (non-debug mode) allows you to make code changes, save the file, refresh the browser, and see the code changes. Many developers prefer to use non-debug mode to quickly launch the app and view changes.
 
-
   [!INCLUDE[](~/includes/trustCertVS.md)]
 
   Visual Studio starts [IIS Express](/iis/extensions/introduction-to-iis-express/iis-express-overview) and runs the app. The address bar shows `localhost:port#` and not something like `example.com`. That's because `localhost` is the standard hostname for the local computer. Localhost only serves web requests from the local computer. When Visual Studio creates a web project, a random port is used for the web server.


### PR DESCRIPTION
Fixes #20567
* [Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-1.0&branch=pr-en-us-20570&tabs=visual-studio#firefox-sec_error_inadequate_key_usage-certificate-error) 
* [example usage](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/razor-pages-start?view=aspnetcore-5.0&branch=pr-en-us-20570&tabs=visual-studio#run-the-app)