### PR TITLE
CSS instructions were not included

### DIFF
--- a/aspnetcore/tutorials/web-api-javascript.md
+++ b/aspnetcore/tutorials/web-api-javascript.md
@@ -47,6 +47,10 @@ The simplest `fetch` call accepts a single parameter representing the route. A s
 
     [!code-html[](first-web-api/samples/3.0/TodoApi/wwwroot/index.html)]
 
+1. Add a CSS file named *site.css* to the *wwwroot/css* folder. Replace the contents of *site.css* with the following styles:
+
+    [!code-css[](first-web-api/samples/3.0/TodoApi/wwwroot/css/site.css?name=snippet_SiteCss)]
+
 1. Add a JavaScript file named *site.js* to the *wwwroot/js* folder. Replace the contents of *site.js* with the following code:
 
     [!code-javascript[](first-web-api/samples/3.0/TodoApi/wwwroot/js/site.js?name=snippet_SiteJs)]

--- a/aspnetcore/tutorials/web-api-javascript.md
+++ b/aspnetcore/tutorials/web-api-javascript.md
@@ -49,7 +49,7 @@ The simplest `fetch` call accepts a single parameter representing the route. A s
 
 1. Add a CSS file named *site.css* to the *wwwroot/css* folder. Replace the contents of *site.css* with the following styles:
 
-    [!code-css[](first-web-api/samples/3.0/TodoApi/wwwroot/css/site.css?name=snippet_SiteCss)]
+    [!code-css[](first-web-api/samples/3.0/TodoApi/wwwroot/css/site.css)]
 
 1. Add a JavaScript file named *site.js* to the *wwwroot/js* folder. Replace the contents of *site.js* with the following code:
 


### PR DESCRIPTION
The HTML file in the example references a site.css file, but the rest of the instructions did not include the CSS, which makes the finished code look weird since the edit form is not hidden at the beginning



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->