### PR TITLE
ef-rp intro: Fix code include line so it localizes

### DIFF
--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -128,6 +128,7 @@ To run the app after downloading the completed project:
 ## Set up the site style
 
 Copy and paste the following code into the *Pages/Shared/_Layout.cshtml* file:
+
 [!code-cshtml[Main](intro/samples/cu50/Pages/Shared/_Layout.cshtml?highlight=6,14,21-35,49)]
 
 The layout file sets the site header, footer, and menu. The preceding code makes the following changes:


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/data/ef-rp/intro?view=aspnetcore-5.0&branch=pr-en-us-20615&tabs=visual-studio)

Fixes: #20612 
Minor correction, adding a line space before a code sample include so it will not be dropped in localization.