### PR TITLE
Corrected error in text

### DIFF
--- a/aspnetcore/migration/31-to-50.md
+++ b/aspnetcore/migration/31-to-50.md
@@ -122,7 +122,7 @@ For a Blazor WebAssembly project, including the *`Client`* project of a hosted B
     +    { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
     ```
     
-1. In `Shared/MainLayout.razor`, surround all of the content in a `<div>` element with an `id` of `page`:
+1. In `Shared/MainLayout.razor`, surround all of the content in a `<div>` element with a `class` of `page`:
 
     ```razor
     <div class="page">


### PR DESCRIPTION
The text says `id`, while the code consistently uses a `class`. I haven't tested, but I'm guessing the code is correct?