### PR TITLE
Blazor File Uploads namespace update

### DIFF
--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -58,7 +58,7 @@ The following example demonstrates multiple image file upload in a component. `I
 }
 
 @code {
-    IList<string> imageDataUrls = new List<string>();
+    private IList<string> imageDataUrls = new List<string>();
 
     private async Task OnInputFileChange(InputFileChangeEventArgs e)
     {

--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -36,6 +36,9 @@ A component that receives an image file can call the `RequestImageFileAsync` con
 
 The following example demonstrates multiple image file upload in a component. `InputFileChangeEventArgs.GetMultipleFiles` allows reading multiple files. Specify the maximum number of files you expect to read to prevent a malicious user from uploading a larger number of files than the app expects. `InputFileChangeEventArgs.File` allows reading the first and only file if the file upload does not support multiple files.
 
+> [!NOTE]
+> <xref:Microsoft.AspNetCore.Components.Forms.InputFileChangeEventArgs> is in the <xref:Microsoft.AspNetCore.Components.Forms?displayProperty=fullName> namespace, which is typically one of the namespaces in the app's `_Imports.razor` file.
+
 ```razor
 <h3>Upload PNG images</h3>
 

--- a/aspnetcore/blazor/file-uploads/samples/5.x/Components/FileUpload.razor
+++ b/aspnetcore/blazor/file-uploads/samples/5.x/Components/FileUpload.razor
@@ -3,7 +3,6 @@
 @using System.IO
 @using System.Linq
 @using System.Threading
-@using Microsoft.AspNetCore.Components.Forms
 @implements IDisposable
 
 <h3>File Upload Component</h3>


### PR DESCRIPTION
Fixes #20618

@DataJuggler ... Turns out that that's a namespace typically placed in the `_Imports.razor` file (it's provided by default from the project template these days). Therefore, I revert the sample app patch here, avoid adding it to the in-text example, and add a NOTE to the text that calls it out. This should clear it up. I'll work on namespaces further as I make update passes on each topic heading into the holidays. Thanks again for writing in on this.