### PR TITLE
Generalize Blazor migration Identity package versions

### DIFF
--- a/aspnetcore/migration/31-to-50.md
+++ b/aspnetcore/migration/31-to-50.md
@@ -4,7 +4,7 @@ author: scottaddie
 description: Learn how to migrate an ASP.NET Core 3.1 project to ASP.NET Core 5.0.
 ms.author: scaddie
 ms.custom: mvc
-ms.date: 11/17/2020
+ms.date: 11/18/2020
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: migration/31-to-50
 ---
@@ -454,17 +454,22 @@ For AAD:
 
 ```diff
 -<PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="..." />
-+<PackageReference Include="Microsoft.Identity.Web" Version="1.2.0" />
-+<PackageReference Include="Microsoft.Identity.Web.UI" Version="1.2.0" />
++<PackageReference Include="Microsoft.Identity.Web" Version="{VERSION}" />
++<PackageReference Include="Microsoft.Identity.Web.UI" Version="{VERSION}" />
 ```
 
 For AAD B2C:
 
 ```diff
 -<PackageReference Include="Microsoft.AspNetCore.Authentication.AzureADB2C.UI" Version="..." />
-+<PackageReference Include="Microsoft.Identity.Web" Version="1.2.0" />
-+<PackageReference Include="Microsoft.Identity.Web.UI" Version="1.2.0" />
++<PackageReference Include="Microsoft.Identity.Web" Version="{VERSION}" />
++<PackageReference Include="Microsoft.Identity.Web.UI" Version="{VERSION}" />
 ```
+
+For the preceding package references, determine the package versions for the `{VERSION}` placeholders at NuGet.org:
+
+* [`Microsoft.Identity.Web`](https://www.nuget.org/packages/Microsoft.Identity.Web)
+* [`Microsoft.Identity.Web.UI`](https://www.nuget.org/packages/Microsoft.Identity.Web.UI)
 
 > [!NOTE]
 > The SDK of the *`Server`* project in a hosted Blazor WebAssembly solution remains `Microsoft.NET.Sdk.Web`:


### PR DESCRIPTION
Fixes #20654

Let's generalize the package versions for the Identity v2.0 packages because they're on a different release cadence and hardcoded versions will haunt us forever here 👻😨 if we don't. They **_just released_** new ones a few days ago, and there's no telling when they'll release again and thus break the doc again.