### PR TITLE
dotnet ef install instruction moved to beginning

### DIFF
--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -35,19 +35,12 @@ This method of keeping the database in sync with the data model works well until
 
 To work with migrations, you can use the **Package Manager Console** (PMC) or the CLI.  These tutorials show how to use CLI commands. Information about the PMC is at [the end of this tutorial](#pmc).
 
-## Install EF Core tools
-
-Install EF Core tools as a [global tool](/ef/core/miscellaneous/cli/dotnet).
-
-```dotnetcli
-dotnet tool install --global dotnet-ef
-```
-
 ## Drop the database
 
-Delete the database. Use **SQL Server Object Explorer** (SSOX) or the `database drop` CLI command:
+Install EF Core tools as a [global tool](/ef/core/miscellaneous/cli/dotnet) and elete the database. Use **SQL Server Object Explorer** (SSOX) or the `database drop` CLI command:
 
  ```dotnetcli
+ dotnet tool install --global dotnet-ef
  dotnet ef database drop
  ```
 

--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -37,7 +37,7 @@ To work with migrations, you can use the **Package Manager Console** (PMC) or th
 
 ## Drop the database
 
-Install EF Core tools as a [global tool](/ef/core/miscellaneous/cli/dotnet) and elete the database. Use **SQL Server Object Explorer** (SSOX) or the `database drop` CLI command:
+Install EF Core tools as a [global tool](/ef/core/miscellaneous/cli/dotnet) and delete the database. Use **SQL Server Object Explorer** (SSOX) or the `database drop` CLI command:
 
  ```dotnetcli
  dotnet tool install --global dotnet-ef

--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -35,6 +35,14 @@ This method of keeping the database in sync with the data model works well until
 
 To work with migrations, you can use the **Package Manager Console** (PMC) or the CLI.  These tutorials show how to use CLI commands. Information about the PMC is at [the end of this tutorial](#pmc).
 
+## Install EF Core tools
+
+Install EF Core tools as a [global tool](/ef/core/miscellaneous/cli/dotnet).
+
+```dotnetcli
+dotnet tool install --global dotnet-ef
+```
+
 ## Drop the database
 
 Delete the database. Use **SQL Server Object Explorer** (SSOX) or the `database drop` CLI command:
@@ -60,11 +68,8 @@ Save your changes and build the project. Then open a command window and navigate
 Enter the following command in the command window:
 
 ```dotnetcli
-dotnet tool install --global dotnet-ef
 dotnet ef migrations add InitialCreate
 ```
-
-`dotnet tool install --global dotnet-ef` installs `dotnet ef` as a [global tool](/ef/core/miscellaneous/cli/dotnet).
 
 In the preceding commands, output similar to the following is displayed:
 

--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -37,7 +37,7 @@ To work with migrations, you can use the **Package Manager Console** (PMC) or th
 
 ## Drop the database
 
-Install EF Core tools as a [global tool](/ef/core/miscellaneous/cli/dotnet) and delete the database. Use **SQL Server Object Explorer** (SSOX) or the `database drop` CLI command:
+Install EF Core tools as a [global tool](/ef/core/miscellaneous/cli/dotnet) and delete the database:
 
  ```dotnetcli
  dotnet tool install --global dotnet-ef


### PR DESCRIPTION
The instruction to drop the database came before the instruction to install, which leads to confusing error messages