### PR TITLE
Fix Razor Pages Model Command Names

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -305,9 +305,9 @@ The preceding commands generate the following warning: "No type was specified fo
 
 Ignore the warning, as it will be addressed in a later step.
 
-The `migrations` command generates code to create the initial database schema. The schema is based on the model specified in `DbContext`. The `InitialCreate` argument is used to name the migrations. Any name can be used, but by convention a name is selected that describes the migration.
+The `Add-Migration` command generates code to create the initial database schema. The schema is based on the model specified in `DbContext`. The `InitialCreate` argument is used to name the migrations. Any name can be used, but by convention a name is selected that describes the migration.
 
-The `update` command runs the `Up` method in migrations that have not been applied. In this case, `update` runs the `Up` method in the *Migrations/\<time-stamp>_InitialCreate.cs* file, which creates the database.
+The `Update-Database` command runs the `Up` method in migrations that have not been applied. In this case, `update` runs the `Up` method in the *Migrations/\<time-stamp>_InitialCreate.cs* file, which creates the database.
 
 # [Visual Studio](#tab/visual-studio)
 

--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -307,7 +307,7 @@ Ignore the warning, as it will be addressed in a later step.
 
 The `Add-Migration` command generates code to create the initial database schema. The schema is based on the model specified in `DbContext`. The `InitialCreate` argument is used to name the migrations. Any name can be used, but by convention a name is selected that describes the migration.
 
-The `Update-Database` command runs the `Up` method in migrations that have not been applied. In this case, `update` runs the `Up` method in the *Migrations/\<time-stamp>_InitialCreate.cs* file, which creates the database.
+The `Update-Database` command runs the `Up` method in migrations that have not been applied. In this case, `Update-Database` runs the `Up` method in the *Migrations/\<time-stamp>_InitialCreate.cs* file, which creates the database.
 
 # [Visual Studio](#tab/visual-studio)
 


### PR DESCRIPTION
Just starting out with Razor pages and I found this section of the introduction confusing because it doesn't use the actual names of the commands you enter in the previous step.