### PR TITLE
Adds change directory to SignalRChat

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -69,6 +69,7 @@ At the end, you'll have a working chat app:
    ```dotnetcli
    dotnet new webapp -o SignalRChat
    code -r SignalRChat
+   cd SignalRChat
    ```
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)

--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -68,8 +68,8 @@ At the end, you'll have a working chat app:
 
    ```dotnetcli
    dotnet new webapp -o SignalRChat
-   code -r SignalRChat
    cd SignalRChat
+   code -r SignalRChat
    ```
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)

--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -69,7 +69,7 @@ At the end, you'll have a working chat app:
    ```dotnetcli
    dotnet new webapp -o SignalRChat
    cd SignalRChat
-   code -r SignalRChat
+   code -r .
    ```
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)


### PR DESCRIPTION
Not adding "cd SignalRChat" causes the next command to copy files in wrong folder. The next command is this one: `libman install @microsoft/signalr -p unpkg -d wwwroot/lib/signalr --files dist/browser/signalr.js --files dist/browser/signalr.min.js`


