### PR TITLE
Update FileUpload.razor

### DIFF
--- a/aspnetcore/blazor/file-uploads/samples/5.x/Components/FileUpload.razor
+++ b/aspnetcore/blazor/file-uploads/samples/5.x/Components/FileUpload.razor
@@ -43,8 +43,8 @@
     protected override void OnInitialized()
     {
         cancelation = new CancellationTokenSource();
-        editContext = new EditContext(person);
         person = new Person();
+        editContext = new EditContext(person);
     }
 
     private void OnChange(InputFileChangeEventArgs eventArgs)


### PR DESCRIPTION
person needs to be initialized before constructing EditContext, or an ArgumentNullException is thrown.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->