### PR TITLE
Include ModelState in BadRequest for vcard Input Formatter sample

### DIFF
--- a/aspnetcore/web-api/advanced/custom-formatters/samples/3.x/CustomFormattersSample/Controllers/ContactsController.cs
+++ b/aspnetcore/web-api/advanced/custom-formatters/samples/3.x/CustomFormattersSample/Controllers/ContactsController.cs
@@ -19,12 +19,6 @@ namespace CustomFormattersSample.Controllers
                 Add(new Contact { FirstName = "Nancy", LastName = "Davolio" });
         }
 
-        public void Add(Contact contact)
-        {
-            contact.Id = Guid.NewGuid().ToString();
-            _contacts[contact.Id] = contact;
-        }
-
         [HttpGet]
         public IEnumerable<Contact> Get()
         {
@@ -47,7 +41,7 @@ namespace CustomFormattersSample.Controllers
         {
             if (!ModelState.IsValid)
             {
-                return BadRequest();
+                return BadRequest(ModelState);
             }
 
             Add(contact);
@@ -66,6 +60,12 @@ namespace CustomFormattersSample.Controllers
             _contacts.TryRemove(id, out _);
 
             return NoContent();
+        }
+
+        private void Add(Contact contact)
+        {
+            contact.Id = Guid.NewGuid().ToString();
+            _contacts[contact.Id] = contact;
         }
     }
 }


### PR DESCRIPTION
Addresses #20732.

Adding `ModelState` to the call to `BadRequest` ensures errors added by `VcardInputFormatter` are surfaced in the 400 response.

cc @Rick-Anderson 