### PR TITLE
Update and improve Blazor unmarshalled JS

### DIFF
--- a/aspnetcore/blazor/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/call-javascript-from-dotnet.md
@@ -709,6 +709,13 @@ window.returnJSObjectReference = () => {
 }
 ```
 
+> [!WARNING]
+> The `js_string_to_mono_string` function name, behavior, and existence is subject to change in a future release of .NET. For example:
+>
+> * The `mono` segment of the function name might be removed.
+> * The behavior of the function may change.
+> * The function itself might be removed in favor of automatic conversion of strings by the framework.
+
 `Pages/UnmarshalledJSInterop.razor` (URL: `/unmarshalled-js-interop`):
 
 ```razor
@@ -794,7 +801,7 @@ window.returnJSObjectReference = () => {
 }
 ```
 
-If an `IJSUnmarshalledRuntime` instance isn't disposed in C# code, it can be disposed in JavaScript. The following `dispose` function disposes the object reference when called from JavaScript:
+If an `IJSUnmarshalledObjectReference` instance isn't disposed in C# code, it can be disposed in JavaScript. The following `dispose` function disposes the object reference when called from JavaScript:
 
 ```javascript
 window.exampleJSObjectReferenceNotDisposedInCSharp = () => {
@@ -808,9 +815,12 @@ window.exampleJSObjectReferenceNotDisposedInCSharp = () => {
 }
 ```
 
-Array types can be converted from JavaScript objects into .NET objects using `js_typed_array_to_array`, but the JavaScript array must be a typed array. Arrays from JavaScript can be read in C# code as a .NET object array (`object[]`). For examples, search the [dotnet/aspnetcore reference source](https://github.com/dotnet/aspnetcore/search?q=js_typed_array_to_array).
+Array types can be converted from JavaScript objects into .NET objects using `js_typed_array_to_array`, but the JavaScript array must be a typed array. Arrays from JavaScript can be read in C# code as a .NET object array (`object[]`).
 
-Other data types, such as string arrays, can be converted but require creating a new Mono array object (`mono_obj_array_new`) and setting its value (`mono_obj_array_set`). For examples, search the [dotnet/aspnetcore reference source](https://github.com/dotnet/aspnetcore/search?q=mono_obj_array_set).
+Other data types, such as string arrays, can be converted but require creating a new Mono array object (`mono_obj_array_new`) and setting its value (`mono_obj_array_set`).
+
+> [!WARNING]
+> JavaScript functions provided by the Blazor framework, such as `js_typed_array_to_array`, `mono_obj_array_new`, and `mono_obj_array_set`, are subject to name changes, behavioral changes, or removal in future releases of .NET.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/call-javascript-from-dotnet.md
@@ -712,8 +712,7 @@ window.returnJSObjectReference = () => {
 > [!WARNING]
 > The `js_string_to_mono_string` function name, behavior, and existence is subject to change in a future release of .NET. For example:
 >
-> * The `mono` segment of the function name might be removed.
-> * The behavior of the function may change.
+> * The function is likely to be renamed.
 > * The function itself might be removed in favor of automatic conversion of strings by the framework.
 
 `Pages/UnmarshalledJSInterop.razor` (URL: `/unmarshalled-js-interop`):

--- a/aspnetcore/blazor/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/call-javascript-from-dotnet.md
@@ -682,6 +682,7 @@ In the following example:
 
 * A [struct](/dotnet/csharp/language-reference/builtin-types/struct) containing a string and an integer is passed unserialized to JavaScript.
 * JavaScript functions process the data and return either a boolean or string to the caller.
+* A JavaScript string isn't directly convertible into a .NET `string` object. The `unmarshalledFunctionReturnString` function calls `BINDING.js_string_to_mono_string` to manage the conversion of a Javascript string.
 
 > [!NOTE]
 > The following examples aren't typical use cases for this scenario because the [struct](/dotnet/csharp/language-reference/builtin-types/struct) passed to JavaScript doesn't result in poor component performance. The example uses a small object merely to demonstrate the concepts for passing unserialized .NET data.


### PR DESCRIPTION
Fixes #20598

Thanks @sps014! :rocket:

There are big holes in my understanding here (*not surprising* 😄), so I need help.

* The [current example in the live topic](https://docs.microsoft.com/aspnet/core/blazor/call-javascript-from-dotnet#blazor-javascript-isolation-and-object-references) is broken and throws `There is no argument given that corresponds to the required formal parameter 'arg0'`.
* The new example on the PR is based on framework test code from [here](https://github.com/dotnet/aspnetcore/blob/master/src/Components/test/testassets/BasicTestApp/InteropComponent.razor#L198-L204) and [here](https://github.com/dotnet/aspnetcore/blob/master/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsinteroptests.js#L222-L242) with [this](https://github.com/dotnet/aspnetcore/blob/master/src/Components/test/testassets/BasicTestApp/InteropTest/InteropStruct.cs).

Questions ...

1. WRT `int[]` and `string` between .NET and JS not matching ... https://github.com/dotnet/aspnetcore/issues/21492#issuecomment-637201926 ... is what I say on the PR (last line of the new section) correct? ... or how can that be made correct? Passing back a `string` did fail in my testing. Passing back an `int` or a `bool` worked fine.
1. WRT these struct field `FieldOffset` values ... any guidance to add to the PR regarding the values? I have no knowledge on this subject. I cross-link the `struct` C# topic earlier. Is that enough for advanced devs working with advanced code to grok what to do?
1. The framework example has a JS `dispose`, which I include here. Should that be included? Anything to say about it in the text?