### PR TITLE
Show how to access user secrets in a Razor Page

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -5,7 +5,7 @@ description: Learn how to use the Configuration API to configure an ASP.NET Core
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/23/2020
+ms.date: 11/24/2020
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: fundamentals/configuration/index
 ---
@@ -91,20 +91,20 @@ See [JSON configuration provider](#jcp) in this document for information on addi
 
 <a name="security"></a>
 
-## Security and secret manager
+## Security and user secrets
 
 Configuration data guidelines:
 
-* Never store passwords or other sensitive data in configuration provider code or in plain text configuration files. The [Secret manager](xref:security/app-secrets) can be used to store secrets in development.
+* Never store passwords or other sensitive data in configuration provider code or in plain text configuration files. The [Secret Manager](xref:security/app-secrets) tool can be used to store secrets in development.
 * Don't use production secrets in development or test environments.
 * Specify secrets outside of the project so that they can't be accidentally committed to a source code repository.
 
-By [default](#default), [Secret manager](xref:security/app-secrets) reads configuration settings after *appsettings.json* and *appsettings.*`Environment`*.json*.
+By [default](#default), the user secrets configuration source is registered after the JSON configuration sources. Therefore, user secrets keys take precedence over keys in *appsettings.json* and *appsettings.*`Environment`*.json*.
 
 For more information on storing passwords or other sensitive data:
 
 * <xref:fundamentals/environments>
-* <xref:security/app-secrets>:  Includes advice on using environment variables to store sensitive data. The Secret Manager uses the [File configuration provider](#fcp) to store user secrets in a JSON file on the local system.
+* <xref:security/app-secrets>: Includes advice on using environment variables to store sensitive data. The Secret Manager tool uses the [File configuration provider](#fcp) to store user secrets in a JSON file on the local system.
 
 [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) safely stores app secrets for ASP.NET Core apps. For more information, see <xref:security/key-vault-configuration>.
 
@@ -112,7 +112,7 @@ For more information on storing passwords or other sensitive data:
 
 ## Environment variables
 
-Using the [default](#default) configuration, the <xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider> loads configuration from environment variable key-value pairs after reading *appsettings.json*, *appsettings.*`Environment`*.json*, and [Secret manager](xref:security/app-secrets). Therefore, key values read from the environment override values read from *appsettings.json*, *appsettings.*`Environment`*.json*, and Secret manager.
+Using the [default](#default) configuration, the <xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider> loads configuration from environment variable key-value pairs after reading *appsettings.json*, *appsettings.*`Environment`*.json*, and [user secrets](xref:security/app-secrets). Therefore, key values read from the environment override values read from *appsettings.json*, *appsettings.*`Environment`*.json*, and user secrets.
 
 [!INCLUDE[](~/includes/environmentVarableColon.md)]
 
@@ -226,7 +226,7 @@ Environment variables set in *launchSettings.json* override those set in the sys
 Using the [default](#default) configuration, the <xref:Microsoft.Extensions.Configuration.CommandLine.CommandLineConfigurationProvider> loads configuration from command-line argument key-value pairs after the following configuration sources:
 
 * *appsettings.json* and *appsettings*.`Environment`.*json* files.
-* [App secrets (Secret Manager)](xref:security/app-secrets) in the Development environment.
+* [App secrets](xref:security/app-secrets) in the Development environment.
 * Environment variables.
 
 By [default](#default), configuration values set on the command-line override configuration values set with all the other configuration providers.
@@ -338,7 +338,7 @@ The following table shows the configuration providers available to ASP.NET Core 
 | [File configuration provider](#file-configuration-provider) | INI, JSON, and XML files |
 | [Key-per-file configuration provider](#key-per-file-configuration-provider) | Directory files |
 | [Memory configuration provider](#memory-configuration-provider) | In-memory collections |
-| [Secret Manager](xref:security/app-secrets)  | File in the user profile directory |
+| [User secrets](xref:security/app-secrets) | File in the user profile directory |
 
 Configuration sources are read in the order that their configuration providers are specified. Order configuration providers in code to suit the priorities for the underlying configuration sources that the app requires.
 
@@ -346,7 +346,7 @@ A typical sequence of configuration providers is:
 
 1. *appsettings.json*
 1. *appsettings*.`Environment`.*json*
-1. [Secret Manager](xref:security/app-secrets)
+1. [User secrets](xref:security/app-secrets)
 1. Environment variables using the [Environment Variables configuration provider](#evcp).
 1. Command-line arguments using the [Command-line configuration provider](#command-line-configuration-provider).
 
@@ -848,7 +848,7 @@ The following applies to apps using the [Web Host](xref:fundamentals/host/web-ho
 * App configuration is provided from:
   * *appsettings.json* using the [File Configuration Provider](#file-configuration-provider).
   * *appsettings.{Environment}.json* using the [File Configuration Provider](#file-configuration-provider).
-  * [Secret Manager](xref:security/app-secrets) when the app runs in the `Development` environment using the entry assembly.
+  * [User secrets](xref:security/app-secrets) when the app runs in the `Development` environment using the entry assembly.
   * Environment variables using the [Environment Variables Configuration Provider](#environment-variables-configuration-provider).
   * Command-line arguments using the [Command-line Configuration Provider](#command-line-configuration-provider).
 
@@ -863,7 +863,7 @@ Adopt the following practices to secure sensitive configuration data:
 For more information, see the following topics:
 
 * <xref:fundamentals/environments>
-* <xref:security/app-secrets>: Includes advice on using environment variables to store sensitive data. The Secret Manager uses the File Configuration Provider to store user secrets in a JSON file on the local system. The File Configuration Provider is described later in this topic.
+* <xref:security/app-secrets>: Includes advice on using environment variables to store sensitive data. The Secret Manager tool uses the File Configuration Provider to store user secrets in a JSON file on the local system. The File Configuration Provider is described later in this topic.
 
 [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) safely stores app secrets for ASP.NET Core apps. For more information, see <xref:security/key-vault-configuration>.
 
@@ -966,7 +966,7 @@ The following table shows the configuration providers available to ASP.NET Core 
 | [File Configuration Provider](#file-configuration-provider) | Files (INI, JSON, XML) |
 | [Key-per-file Configuration Provider](#key-per-file-configuration-provider) | Directory files |
 | [Memory Configuration Provider](#memory-configuration-provider) | In-memory collections |
-| [User secrets (Secret Manager)](xref:security/app-secrets) (*Security* topics) | File in the user profile directory |
+| [User secrets](xref:security/app-secrets) (*Security* topics) | File in the user profile directory |
 
 Configuration sources are read in the order that their configuration providers are specified at startup. The configuration providers described in this topic are described in alphabetical order, not in the order that the code arranges them. Order configuration providers in code to suit the priorities for the underlying configuration sources that the app requires.
 
@@ -974,7 +974,7 @@ A typical sequence of configuration providers is:
 
 1. Files (*appsettings.json*, *appsettings.{Environment}.json*, where `{Environment}` is the app's current hosting environment)
 1. [Azure Key Vault](xref:security/key-vault-configuration)
-1. [User secrets (Secret Manager)](xref:security/app-secrets) (Development environment only)
+1. [User secrets](xref:security/app-secrets) (Development environment only)
 1. Environment variables
 1. Command-line arguments
 
@@ -1050,7 +1050,7 @@ To activate command-line configuration, the <xref:Microsoft.Extensions.Configura
 `CreateDefaultBuilder` also loads:
 
 * Optional configuration from *appsettings.json* and *appsettings.{Environment}.json* files.
-* [User secrets (Secret Manager)](xref:security/app-secrets) in the Development environment.
+* [User secrets](xref:security/app-secrets) in the Development environment.
 * Environment variables.
 
 `CreateDefaultBuilder` adds the Command-line Configuration Provider last. Command-line arguments passed at runtime override configuration set by the other providers.
@@ -1165,7 +1165,7 @@ To activate environment variables configuration, call the <xref:Microsoft.Extens
 
 * App configuration from unprefixed environment variables by calling `AddEnvironmentVariables` without a prefix.
 * Optional configuration from *appsettings.json* and *appsettings.{Environment}.json* files.
-* [User secrets (Secret Manager)](xref:security/app-secrets) in the Development environment.
+* [User secrets](xref:security/app-secrets) in the Development environment.
 * Command-line arguments.
 
 The Environment Variables Configuration Provider is called after configuration is established from user secrets and *appsettings* files. Calling the provider in this position allows the environment variables read at runtime to override configuration set by user secrets and *appsettings* files.
@@ -1325,7 +1325,7 @@ For more information, see the [Default configuration](#default-configuration) se
 `CreateDefaultBuilder` also loads:
 
 * Environment variables.
-* [User secrets (Secret Manager)](xref:security/app-secrets) in the Development environment.
+* [User secrets](xref:security/app-secrets) in the Development environment.
 * Command-line arguments.
 
 The JSON Configuration Provider is established first. Therefore, user secrets, environment variables, and command-line arguments override configuration set by the *appsettings* files.

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -593,7 +593,7 @@ To load configuration by environment, we recommend:
 
 * *appsettings* files (*appsettings.{Environment}.json*). See <xref:fundamentals/configuration/index#json-configuration-provider>.
 * Environment variables (set on each system where the app is hosted). See <xref:fundamentals/host/web-host#environment> and <xref:security/app-secrets#environment-variables>.
-* Secret Manager (in the Development environment only). See <xref:security/app-secrets>.
+* User secrets (in the Development environment only). See <xref:security/app-secrets>.
 
 ## Environment-based Startup class and methods
 

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -99,7 +99,7 @@ The <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder*> method:
 * Loads app configuration from:
   * *appsettings.json*.
   * *appsettings.{Environment}.json*.
-  * [Secret Manager](xref:security/app-secrets) when the app runs in the `Development` environment.
+  * [User secrets](xref:security/app-secrets) when the app runs in the `Development` environment.
   * Environment variables.
   * Command-line arguments.
 * Adds the following [logging](xref:fundamentals/logging/index) providers:
@@ -602,7 +602,7 @@ The <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder%2A> method:
 * Loads app configuration from:
   * *appsettings.json*.
   * *appsettings.{Environment}.json*.
-  * [Secret Manager](xref:security/app-secrets) when the app runs in the `Development` environment.
+  * [User secrets](xref:security/app-secrets) when the app runs in the `Development` environment.
   * Environment variables.
   * Command-line arguments.
 * Adds the following [logging](xref:fundamentals/logging/index) providers:

--- a/aspnetcore/fundamentals/host/web-host.md
+++ b/aspnetcore/fundamentals/host/web-host.md
@@ -57,7 +57,7 @@ The code that calls `CreateDefaultBuilder` is in a method named `CreateWebHostBu
 * Loads app configuration in the following order from:
   * *appsettings.json*.
   * *appsettings.{Environment}.json*.
-  * [Secret Manager](xref:security/app-secrets) when the app runs in the `Development` environment using the entry assembly.
+  * [User secrets](xref:security/app-secrets) when the app runs in the `Development` environment using the entry assembly.
   * Environment variables.
   * Command-line arguments.
 * Configures [logging](xref:fundamentals/logging/index) for console and debug output. Logging includes [log filtering](xref:fundamentals/logging/index#log-filtering) rules specified in a Logging configuration section of an *appsettings.json* or *appsettings.{Environment}.json* file.

--- a/aspnetcore/fundamentals/index.md
+++ b/aspnetcore/fundamentals/index.md
@@ -125,7 +125,7 @@ By [default](xref:fundamentals/configuration/index#default), ASP.NET Core apps a
 
 The preferred way to read related configuration values is using the [options pattern](xref:fundamentals/configuration/options). For more information, see [Bind hierarchical configuration data using the options pattern](xref:fundamentals/configuration/index#optpat).
 
-For managing confidential configuration data such as passwords, ASP.NET Core provides the [Secret Manager](xref:security/app-secrets#secret-manager). For production secrets, we recommend [Azure Key Vault](xref:security/key-vault-configuration).
+For managing confidential configuration data such as passwords, .NET Core provides the [Secret Manager](xref:security/app-secrets#secret-manager). For production secrets, we recommend [Azure Key Vault](xref:security/key-vault-configuration).
 
 For more information, see <xref:fundamentals/configuration/index>.
 
@@ -362,7 +362,7 @@ ASP.NET Core provides a configuration framework that gets settings as name-value
 
 For example, you could specify that configuration comes from *appsettings.json* and environment variables. Then when the value of *ConnectionString* is requested, the framework looks first in the *appsettings.json* file. If the value is found there but also in an environment variable, the value from the environment variable would take precedence.
 
-For managing confidential configuration data such as passwords, ASP.NET Core provides a [Secret Manager tool](xref:security/app-secrets). For production secrets, we recommend [Azure Key Vault](xref:security/key-vault-configuration).
+For managing confidential configuration data such as passwords, .NET Core provides a [Secret Manager tool](xref:security/app-secrets). For production secrets, we recommend [Azure Key Vault](xref:security/key-vault-configuration).
 
 For more information, see <xref:fundamentals/configuration/index>.
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -1112,7 +1112,7 @@ Logging provider configuration is provided by one or more configuration provider
 * Command-line arguments.
 * Environment variables.
 * In-memory .NET objects.
-* The unencrypted [Secret Manager](xref:security/app-secrets) storage.
+* The unencrypted [user secrets](xref:security/app-secrets) storage.
 * An encrypted user store, such as [Azure Key Vault](xref:security/key-vault-configuration).
 * Custom providers (installed or created).
 

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -154,7 +154,7 @@ When `CreateDefaultBuilder` isn't called, add the user secrets configuration sou
 
 ### Read the secret via the Configuration API
 
-If the user secrets configuration source is registered, the .NET Configuration API can read the secrets. [Constructor injection](/dotnet/core/extensions/dependency-injection#constructor-injection-behavior) can be used to gain access to the .NET Configuration API. Consider the following examples:
+If the user secrets configuration source is registered, the .NET Configuration API can read the secrets. [Constructor injection](/dotnet/core/extensions/dependency-injection#constructor-injection-behavior) can be used to gain access to the .NET Configuration API. Consider the following examples of reading the `Movies:ServiceApiKey` key:
 
 **Startup class:**
 

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -164,6 +164,8 @@ If the user secrets configuration source is registered, the .NET Configuration A
 
 [!code-csharp[](app-secrets/samples/3.x/UserSecrets/Pages/Index.cshtml.cs?name=snippet_PageModel&highlight=12)]
 
+For more information, see [Access configuration in Startup](xref:fundamentals/configuration/index#access-configuration-in-startup) and [Access configuration in Razor Pages](xref:fundamentals/configuration/index#access-configuration-in-razor-pages).
+
 ## Map secrets to a POCO
 
 Mapping an entire object literal to a POCO (a simple .NET class with properties) is useful for aggregating related properties.

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -135,9 +135,16 @@ Open a command shell, and execute the following command:
 
 ## Access a secret
 
-The [Configuration API](xref:fundamentals/configuration/index) provides access to Secret Manager secrets.
+To access a secret, complete the following steps:
 
-The user secrets configuration source is automatically added in development mode when the project calls <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder%2A>. `CreateDefaultBuilder` calls <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> when the <xref:Microsoft.Extensions.Hosting.IHostEnvironment.EnvironmentName> is <xref:Microsoft.Extensions.Hosting.EnvironmentName.Development>:
+1. [Register the user secrets configuration source](#register-the-user-secrets-configuration-source)
+1. [Read the secret via the Configuration API](#read-the-secret-via-the-configuration-api)
+
+### Register the user secrets configuration source
+
+The user secrets [configuration provider](/dotnet/core/extensions/configuration-providers) registers the appropriate configuration source with the .NET [Configuration API](xref:fundamentals/configuration/index).
+
+The user secrets configuration source is automatically added in Development mode when the project calls <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder%2A>. `CreateDefaultBuilder` calls <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> when the <xref:Microsoft.Extensions.Hosting.IHostEnvironment.EnvironmentName> is <xref:Microsoft.Extensions.Hosting.EnvironmentName.Development>:
 
 [!code-csharp[](app-secrets/samples/3.x/UserSecrets/Program.cs?name=snippet_CreateHostBuilder&highlight=2)]
 
@@ -145,15 +152,17 @@ When `CreateDefaultBuilder` isn't called, add the user secrets configuration sou
 
 [!code-csharp[](app-secrets/samples/3.x/UserSecrets/Program2.cs?name=snippet_Host&highlight=6-9)]
 
-What follows are examples of accessing a secret via the .NET Configuration API. [Constructor injection](/dotnet/core/extensions/dependency-injection#constructor-injection-behavior) is used to gain access to the .NET Configuration API.
+### Read the secret via the Configuration API
 
-### Access in the Startup class
+If the user secrets configuration source is registered, the .NET Configuration API can read the secrets. [Constructor injection](/dotnet/core/extensions/dependency-injection#constructor-injection-behavior) can be used to gain access to the .NET Configuration API. Consider the following examples:
+
+**Startup class:**
 
 [!code-csharp[](app-secrets/samples/3.x/UserSecrets/Startup.cs?name=snippet_StartupClass&highlight=14)]
 
-### Access in a Razor Pages page model
+**Razor Pages page model:**
 
-[!code-csharp[](app-secrets/samples/3.x/UserSecrets/Pages/Index.cshtml.cs?name=snippet_PageModel)]
+[!code-csharp[](app-secrets/samples/3.x/UserSecrets/Pages/Index.cshtml.cs?name=snippet_PageModel&highlight=12)]
 
 ## Map secrets to a POCO
 

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -16,7 +16,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT), [Kirk Larkin](https://twitt
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/security/app-secrets/samples) ([how to download](xref:index#how-to-download-a-sample))
 
-This document explains techniques for storing and retrieving sensitive data for an ASP.NET Core app on a development machine. Never store passwords or other sensitive data in source code. Production secrets shouldn't be used for development or test. Secrets shouldn't be deployed with the app. Instead, secrets should be made available in the production environment through a controlled means like environment variables or Azure Key Vault. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+This document explains how to manage sensitive data for an ASP.NET Core app on a development machine. Never store passwords or other sensitive data in source code. Production secrets shouldn't be used for development or test. Secrets shouldn't be deployed with the app. Instead, production secrets should be accessed through a controlled means like environment variables or Azure Key Vault. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 ## Environment variables
 
@@ -38,7 +38,7 @@ The Secret Manager tool stores sensitive data during the development of an ASP.N
 
 ## How the Secret Manager tool works
 
-The Secret Manager tool abstracts away the implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON file in a user profile folder on the local machine:
+The Secret Manager tool hides implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON file in the local machine's user profile folder:
 
 # [Windows](#tab/windows)
 
@@ -137,17 +137,23 @@ Open a command shell, and execute the following command:
 
 The [Configuration API](xref:fundamentals/configuration/index) provides access to Secret Manager secrets.
 
-The user secrets configuration source is automatically added in development mode when the project calls <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder%2A> to initialize a new instance of the host with preconfigured defaults. `CreateDefaultBuilder` calls <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> when the <xref:Microsoft.Extensions.Hosting.IHostEnvironment.EnvironmentName> is <xref:Microsoft.Extensions.Hosting.EnvironmentName.Development>:
+The user secrets configuration source is automatically added in development mode when the project calls <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder%2A>. `CreateDefaultBuilder` calls <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> when the <xref:Microsoft.Extensions.Hosting.IHostEnvironment.EnvironmentName> is <xref:Microsoft.Extensions.Hosting.EnvironmentName.Development>:
 
 [!code-csharp[](app-secrets/samples/3.x/UserSecrets/Program.cs?name=snippet_CreateHostBuilder&highlight=2)]
 
-When `CreateDefaultBuilder` isn't called, add the user secrets configuration source explicitly by calling <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A>. Call `AddUserSecrets` only when the app runs in the Development environment, as shown in the following example:
+When `CreateDefaultBuilder` isn't called, add the user secrets configuration source explicitly by calling <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> in <xref:Microsoft.Extensions.Hosting.HostBuilder.ConfigureAppConfiguration%2A>. Call `AddUserSecrets` only when the app runs in the Development environment, as shown in the following example:
 
 [!code-csharp[](app-secrets/samples/3.x/UserSecrets/Program2.cs?name=snippet_Host&highlight=6-9)]
 
-User secrets can be retrieved via the `Configuration` API:
+What follows are examples of accessing a secret via the .NET Configuration API. [Constructor injection](/dotnet/core/extensions/dependency-injection#constructor-injection-behavior) is used to gain access to the .NET Configuration API.
+
+### Access in the Startup class
 
 [!code-csharp[](app-secrets/samples/3.x/UserSecrets/Startup.cs?name=snippet_StartupClass&highlight=14)]
+
+### Access in a Razor Pages page model
+
+[!code-csharp[](app-secrets/samples/3.x/UserSecrets/Pages/Index.cshtml.cs?name=snippet_PageModel)]
 
 ## Map secrets to a POCO
 
@@ -155,7 +161,7 @@ Mapping an entire object literal to a POCO (a simple .NET class with properties)
 
 [!INCLUDE[secrets.json file](~/includes/app-secrets/secrets-json-file-and-text.md)]
 
-To map the preceding secrets to a POCO, use the `Configuration` API's [object graph binding](xref:fundamentals/configuration/index#bind-to-an-object-graph) feature. The following code binds to a custom `MovieSettings` POCO and accesses the `ServiceApiKey` property value:
+To map the preceding secrets to a POCO, use the .NET Configuration API's [object graph binding](xref:fundamentals/configuration/index#bind-to-an-object-graph) feature. The following code binds to a custom `MovieSettings` POCO and accesses the `ServiceApiKey` property value:
 
 [!code-csharp[](app-secrets/samples/3.x/UserSecrets/Startup3.cs?name=snippet_BindToObjectGraph)]
 
@@ -264,7 +270,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT), [Daniel Roth](https://githu
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/security/app-secrets/samples) ([how to download](xref:index#how-to-download-a-sample))
 
-This document explains techniques for storing and retrieving sensitive data for an ASP.NET Core app on a development machine. Never store passwords or other sensitive data in source code. Production secrets shouldn't be used for development or test. Secrets shouldn't be deployed with the app. Instead, secrets should be made available in the production environment through a controlled means like environment variables or Azure Key Vault. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+This document explains how to manage sensitive data for an ASP.NET Core app on a development machine. Never store passwords or other sensitive data in source code. Production secrets shouldn't be used for development or test. Secrets shouldn't be deployed with the app. Instead, production secrets should be accessed through a controlled means like environment variables or Azure Key Vault. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 ## Environment variables
 
@@ -286,7 +292,7 @@ The Secret Manager tool stores sensitive data during the development of an ASP.N
 
 ## How the Secret Manager tool works
 
-The Secret Manager tool abstracts away the implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON file in a user profile folder on the local machine:
+The Secret Manager tool hides implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON file in the local machine's user profile folder:
 
 # [Windows](#tab/windows)
 
@@ -382,7 +388,7 @@ The [Configuration API](xref:fundamentals/configuration/index) provides access t
 
 If your project targets .NET Framework, install the [Microsoft.Extensions.Configuration.UserSecrets](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.UserSecrets) NuGet package.
 
-In ASP.NET Core 2.0 or later, the user secrets configuration source is automatically added in development mode when the project calls <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder%2A> to initialize a new instance of the host with preconfigured defaults. `CreateDefaultBuilder` calls <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> when the <xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment.EnvironmentName> is <xref:Microsoft.AspNetCore.Hosting.EnvironmentName.Development>:
+In ASP.NET Core 2.0 or later, the user secrets configuration source is automatically added in development mode when the project calls <xref:Microsoft.AspNetCore.WebHost.CreateDefaultBuilder%2A>. `CreateDefaultBuilder` calls <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> when the <xref:Microsoft.AspNetCore.Hosting.IHostingEnvironment.EnvironmentName> is <xref:Microsoft.AspNetCore.Hosting.EnvironmentName.Development>:
 
 [!code-csharp[](app-secrets/samples/2.x/UserSecrets/Program.cs?name=snippet_CreateWebHostBuilder&highlight=2)]
 
@@ -390,7 +396,7 @@ When `CreateDefaultBuilder` isn't called, add the user secrets configuration sou
 
 [!code-csharp[](app-secrets/samples/2.x/UserSecrets/Startup3.cs?name=snippet_StartupConstructor&highlight=12)]
 
-User secrets can be retrieved via the `Configuration` API:
+User secrets can be retrieved via the .NET Configuration API:
 
 [!code-csharp[](app-secrets/samples/2.x/UserSecrets/Startup.cs?name=snippet_StartupClass&highlight=14)]
 
@@ -400,7 +406,7 @@ Mapping an entire object literal to a POCO (a simple .NET class with properties)
 
 [!INCLUDE[secrets.json file](~/includes/app-secrets/secrets-json-file-and-text.md)]
 
-To map the preceding secrets to a POCO, use the `Configuration` API's [object graph binding](xref:fundamentals/configuration/index#bind-to-an-object-graph) feature. The following code binds to a custom `MovieSettings` POCO and accesses the `ServiceApiKey` property value:
+To map the preceding secrets to a POCO, use the .NET Configuration API's [object graph binding](xref:fundamentals/configuration/index#bind-to-an-object-graph) feature. The following code binds to a custom `MovieSettings` POCO and accesses the `ServiceApiKey` property value:
 
 [!code-csharp[](app-secrets/samples/2.x/UserSecrets/Startup3.cs?name=snippet_BindToObjectGraph)]
 

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -150,7 +150,7 @@ The user secrets configuration source is automatically added in Development mode
 
 When `CreateDefaultBuilder` isn't called, add the user secrets configuration source explicitly by calling <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> in <xref:Microsoft.Extensions.Hosting.HostBuilder.ConfigureAppConfiguration%2A>. Call `AddUserSecrets` only when the app runs in the Development environment, as shown in the following example:
 
-[!code-csharp[](app-secrets/samples/3.x/UserSecrets/Program2.cs?name=snippet_Host&highlight=6-9)]
+[!code-csharp[](app-secrets/samples/3.x/UserSecrets/Program2.cs?name=snippet_Program&highlight=10-13)]
 
 ### Read the secret via the Configuration API
 

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -1,10 +1,10 @@
 ---
 title: Safe storage of app secrets in development in ASP.NET Core
 author: rick-anderson
-description: Learn how to store and retrieve sensitive information as app secrets during the development of an ASP.NET Core app.
+description: Learn how to store and retrieve sensitive information during the development of an ASP.NET Core app.
 ms.author: scaddie
-ms.custom: mvc
-ms.date: 4/20/2020
+ms.custom: mvc, contperfq2
+ms.date: 11/24/2020
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/app-secrets
 ---
@@ -16,7 +16,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT), [Kirk Larkin](https://twitt
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/security/app-secrets/samples) ([how to download](xref:index#how-to-download-a-sample))
 
-This document explains techniques for storing and retrieving sensitive data during development of an ASP.NET Core app on a development machine. Never store passwords or other sensitive data in source code. Production secrets shouldn't be used for development or test. Secrets shouldn't be deployed with the app. Instead, secrets should be made available in the production environment through a controlled means like environment variables, Azure Key Vault, etc. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+This document explains techniques for storing and retrieving sensitive data for an ASP.NET Core app on a development machine. Never store passwords or other sensitive data in source code. Production secrets shouldn't be used for development or test. Secrets shouldn't be deployed with the app. Instead, secrets should be made available in the production environment through a controlled means like environment variables or Azure Key Vault. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 ## Environment variables
 
@@ -38,7 +38,7 @@ The Secret Manager tool stores sensitive data during the development of an ASP.N
 
 ## How the Secret Manager tool works
 
-The Secret Manager tool abstracts away the implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON configuration file in a system-protected user profile folder on the local machine:
+The Secret Manager tool abstracts away the implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON file in a user profile folder on the local machine:
 
 # [Windows](#tab/windows)
 
@@ -54,7 +54,7 @@ File system path:
 
 ---
 
-In the preceding file paths, replace `<user_secrets_id>` with the `UserSecretsId` value specified in the *.csproj* file.
+In the preceding file paths, replace `<user_secrets_id>` with the `UserSecretsId` value specified in the project file.
 
 Don't write code that depends on the location or format of data saved with the Secret Manager tool. These implementation details may change. For example, the secret values aren't encrypted, but could be in the future.
 
@@ -68,15 +68,15 @@ The Secret Manager tool includes an `init` command in .NET Core SDK 3.0.100 or l
 dotnet user-secrets init
 ```
 
-The preceding command adds a `UserSecretsId` element within a `PropertyGroup` of the *.csproj* file. By default, the inner text of `UserSecretsId` is a GUID. The inner text is arbitrary, but is unique to the project.
+The preceding command adds a `UserSecretsId` element within a `PropertyGroup` of the project file. By default, the inner text of `UserSecretsId` is a GUID. The inner text is arbitrary, but is unique to the project.
 
 [!code-xml[](app-secrets/samples/3.x/UserSecrets/UserSecrets.csproj?name=snippet_PropertyGroup&highlight=3)]
 
-In Visual Studio, right-click the project in Solution Explorer, and select **Manage User Secrets** from the context menu. This gesture adds a `UserSecretsId` element, populated with a GUID, to the *.csproj* file.
+In Visual Studio, right-click the project in Solution Explorer, and select **Manage User Secrets** from the context menu. This gesture adds a `UserSecretsId` element, populated with a GUID, to the project file.
 
 ## Set a secret
 
-Define an app secret consisting of a key and its value. The secret is associated with the project's `UserSecretsId` value. For example, run the following command from the directory in which the *.csproj* file exists:
+Define an app secret consisting of a key and its value. The secret is associated with the project's `UserSecretsId` value. For example, run the following command from the directory in which the project file exists:
 
 ```dotnetcli
 dotnet user-secrets set "Movies:ServiceApiKey" "12345"
@@ -84,7 +84,7 @@ dotnet user-secrets set "Movies:ServiceApiKey" "12345"
 
 In the preceding example, the colon denotes that `Movies` is an object literal with a `ServiceApiKey` property.
 
-The Secret Manager tool can be used from other directories too. Use the `--project` option to supply the file system path at which the *.csproj* file exists. For example:
+The Secret Manager tool can be used from other directories too. Use the `--project` option to supply the file system path at which the project file exists. For example:
 
 ```dotnetcli
 dotnet user-secrets set "Movies:ServiceApiKey" "12345" --project "C:\apps\WebApp1\src\WebApp1"
@@ -103,7 +103,7 @@ Visual Studio's **Manage User Secrets** gesture opens a *secrets.json* file in t
 }
 ```
 
-The JSON structure is flattened after modifications via `dotnet user-secrets remove` or `dotnet user-secrets set`. For example, running `dotnet user-secrets remove "Movies:ConnectionString"` collapses the `Movies` object literal. The modified file resembles the following:
+The JSON structure is flattened after modifications via `dotnet user-secrets remove` or `dotnet user-secrets set`. For example, running `dotnet user-secrets remove "Movies:ConnectionString"` collapses the `Movies` object literal. The modified file resembles the following JSON:
 
 ```json
 {
@@ -135,7 +135,7 @@ Open a command shell, and execute the following command:
 
 ## Access a secret
 
-The [ASP.NET Core Configuration API](xref:fundamentals/configuration/index) provides access to Secret Manager secrets.
+The [Configuration API](xref:fundamentals/configuration/index) provides access to Secret Manager secrets.
 
 The user secrets configuration source is automatically added in development mode when the project calls <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder%2A> to initialize a new instance of the host with preconfigured defaults. `CreateDefaultBuilder` calls <xref:Microsoft.Extensions.Configuration.UserSecretsConfigurationExtensions.AddUserSecrets%2A> when the <xref:Microsoft.Extensions.Hosting.IHostEnvironment.EnvironmentName> is <xref:Microsoft.Extensions.Hosting.EnvironmentName.Development>:
 
@@ -187,7 +187,7 @@ The secret's value can be set on a <xref:System.Data.SqlClient.SqlConnectionStri
 
 [!INCLUDE[secrets.json file](~/includes/app-secrets/secrets-json-file-and-text.md)]
 
-Run the following command from the directory in which the *.csproj* file exists:
+Run the following command from the directory in which the project file exists:
 
 ```dotnetcli
 dotnet user-secrets list
@@ -206,7 +206,7 @@ In the preceding example, a colon in the key names denotes the object hierarchy 
 
 [!INCLUDE[secrets.json file](~/includes/app-secrets/secrets-json-file-and-text.md)]
 
-Run the following command from the directory in which the *.csproj* file exists:
+Run the following command from the directory in which the project file exists:
 
 ```dotnetcli
 dotnet user-secrets remove "Movies:ConnectionString"
@@ -232,7 +232,7 @@ Movies:ServiceApiKey = 12345
 
 [!INCLUDE[secrets.json file](~/includes/app-secrets/secrets-json-file-and-text.md)]
 
-Run the following command from the directory in which the *.csproj* file exists:
+Run the following command from the directory in which the project file exists:
 
 ```dotnetcli
 dotnet user-secrets clear
@@ -264,7 +264,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT), [Daniel Roth](https://githu
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/security/app-secrets/samples) ([how to download](xref:index#how-to-download-a-sample))
 
-This document explains techniques for storing and retrieving sensitive data during development of an ASP.NET Core app on a development machine. Never store passwords or other sensitive data in source code. Production secrets shouldn't be used for development or test. Secrets shouldn't be deployed with the app. Instead, secrets should be made available in the production environment through a controlled means like environment variables, Azure Key Vault, etc. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+This document explains techniques for storing and retrieving sensitive data for an ASP.NET Core app on a development machine. Never store passwords or other sensitive data in source code. Production secrets shouldn't be used for development or test. Secrets shouldn't be deployed with the app. Instead, secrets should be made available in the production environment through a controlled means like environment variables or Azure Key Vault. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 ## Environment variables
 
@@ -286,7 +286,7 @@ The Secret Manager tool stores sensitive data during the development of an ASP.N
 
 ## How the Secret Manager tool works
 
-The Secret Manager tool abstracts away the implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON configuration file in a system-protected user profile folder on the local machine:
+The Secret Manager tool abstracts away the implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON file in a user profile folder on the local machine:
 
 # [Windows](#tab/windows)
 
@@ -302,7 +302,7 @@ File system path:
 
 ---
 
-In the preceding file paths, replace `<user_secrets_id>` with the `UserSecretsId` value specified in the *.csproj* file.
+In the preceding file paths, replace `<user_secrets_id>` with the `UserSecretsId` value specified in the project file.
 
 Don't write code that depends on the location or format of data saved with the Secret Manager tool. These implementation details may change. For example, the secret values aren't encrypted, but could be in the future.
 
@@ -310,16 +310,16 @@ Don't write code that depends on the location or format of data saved with the S
 
 The Secret Manager tool operates on project-specific configuration settings stored in your user profile.
 
-To use user secrets, define a `UserSecretsId` element within a `PropertyGroup` of the *.csproj* file. The inner text of `UserSecretsId` is arbitrary, but is unique to the project. Developers typically generate a GUID for the `UserSecretsId`.
+To use user secrets, define a `UserSecretsId` element within a `PropertyGroup` of the project file. The inner text of `UserSecretsId` is arbitrary, but is unique to the project. Developers typically generate a GUID for the `UserSecretsId`.
 
 [!code-xml[](app-secrets/samples/2.x/UserSecrets/UserSecrets.csproj?name=snippet_PropertyGroup&highlight=3)]
 
 > [!TIP]
-> In Visual Studio, right-click the project in Solution Explorer, and select **Manage User Secrets** from the context menu. This gesture adds a `UserSecretsId` element, populated with a GUID, to the *.csproj* file.
+> In Visual Studio, right-click the project in Solution Explorer, and select **Manage User Secrets** from the context menu. This gesture adds a `UserSecretsId` element, populated with a GUID, to the project file.
 
 ## Set a secret
 
-Define an app secret consisting of a key and its value. The secret is associated with the project's `UserSecretsId` value. For example, run the following command from the directory in which the *.csproj* file exists:
+Define an app secret consisting of a key and its value. The secret is associated with the project's `UserSecretsId` value. For example, run the following command from the directory in which the project file exists:
 
 ```dotnetcli
 dotnet user-secrets set "Movies:ServiceApiKey" "12345"
@@ -327,7 +327,7 @@ dotnet user-secrets set "Movies:ServiceApiKey" "12345"
 
 In the preceding example, the colon denotes that `Movies` is an object literal with a `ServiceApiKey` property.
 
-The Secret Manager tool can be used from other directories too. Use the `--project` option to supply the file system path at which the *.csproj* file exists. For example:
+The Secret Manager tool can be used from other directories too. Use the `--project` option to supply the file system path at which the project file exists. For example:
 
 ```dotnetcli
 dotnet user-secrets set "Movies:ServiceApiKey" "12345" --project "C:\apps\WebApp1\src\WebApp1"
@@ -346,7 +346,7 @@ Visual Studio's **Manage User Secrets** gesture opens a *secrets.json* file in t
 }
 ```
 
-The JSON structure is flattened after modifications via `dotnet user-secrets remove` or `dotnet user-secrets set`. For example, running `dotnet user-secrets remove "Movies:ConnectionString"` collapses the `Movies` object literal. The modified file resembles the following:
+The JSON structure is flattened after modifications via `dotnet user-secrets remove` or `dotnet user-secrets set`. For example, running `dotnet user-secrets remove "Movies:ConnectionString"` collapses the `Movies` object literal. The modified file resembles the following JSON:
 
 ```json
 {
@@ -378,7 +378,7 @@ Open a command shell, and execute the following command:
 
 ## Access a secret
 
-The [ASP.NET Core Configuration API](xref:fundamentals/configuration/index) provides access to Secret Manager secrets.
+The [Configuration API](xref:fundamentals/configuration/index) provides access to Secret Manager secrets.
 
 If your project targets .NET Framework, install the [Microsoft.Extensions.Configuration.UserSecrets](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.UserSecrets) NuGet package.
 
@@ -432,7 +432,7 @@ The secret's value can be set on a <xref:System.Data.SqlClient.SqlConnectionStri
 
 [!INCLUDE[secrets.json file](~/includes/app-secrets/secrets-json-file-and-text.md)]
 
-Run the following command from the directory in which the *.csproj* file exists:
+Run the following command from the directory in which the project file exists:
 
 ```dotnetcli
 dotnet user-secrets list
@@ -451,7 +451,7 @@ In the preceding example, a colon in the key names denotes the object hierarchy 
 
 [!INCLUDE[secrets.json file](~/includes/app-secrets/secrets-json-file-and-text.md)]
 
-Run the following command from the directory in which the *.csproj* file exists:
+Run the following command from the directory in which the project file exists:
 
 ```dotnetcli
 dotnet user-secrets remove "Movies:ConnectionString"
@@ -477,7 +477,7 @@ Movies:ServiceApiKey = 12345
 
 [!INCLUDE[secrets.json file](~/includes/app-secrets/secrets-json-file-and-text.md)]
 
-Run the following command from the directory in which the *.csproj* file exists:
+Run the following command from the directory in which the project file exists:
 
 ```dotnetcli
 dotnet user-secrets clear

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -269,7 +269,7 @@ No secrets configured for this application.
 
 ## Additional resources
 
-* See [this issue](https://github.com/dotnet/AspNetCore.Docs/issues/16328) for information on accessing Secret Manager from IIS.
+* See [this issue](https://github.com/dotnet/AspNetCore.Docs/issues/16328) for information on accessing user secrets from IIS.
 * <xref:fundamentals/configuration/index>
 * <xref:security/key-vault-configuration>
 
@@ -395,7 +395,7 @@ Open a command shell, and execute the following command:
 
 ## Access a secret
 
-The [Configuration API](xref:fundamentals/configuration/index) provides access to Secret Manager secrets.
+The [Configuration API](xref:fundamentals/configuration/index) provides access to user secrets.
 
 If your project targets .NET Framework, install the [Microsoft.Extensions.Configuration.UserSecrets](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.UserSecrets) NuGet package.
 
@@ -514,7 +514,7 @@ No secrets configured for this application.
 
 ## Additional resources
 
-* See [this issue](https://github.com/dotnet/AspNetCore.Docs/issues/16328) for information on accessing Secret Manager from IIS.
+* See [this issue](https://github.com/dotnet/AspNetCore.Docs/issues/16328) for information on accessing user secrets from IIS.
 * <xref:fundamentals/configuration/index>
 * <xref:security/key-vault-configuration>
 

--- a/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Pages/Index.cshtml
+++ b/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Pages/Index.cshtml
@@ -1,0 +1,5 @@
+﻿@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Home page";
+}

--- a/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Pages/Index.cshtml.cs
+++ b/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Pages/Index.cshtml.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+
+namespace UserSecrets.Pages
+{
+    #region snippet_PageModel
+    public class IndexModel : PageModel
+    {
+        private readonly IConfiguration _config;
+
+        public IndexModel(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        public void OnGet()
+        {
+            var moviesApiKey = _config["Movies:ServiceApiKey"];
+
+            // call Movies service with the API key
+        }
+    }
+    #endregion snippet_PageModel
+}

--- a/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Program2.cs
+++ b/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Program2.cs
@@ -4,11 +4,11 @@ using Microsoft.Extensions.Hosting;
 
 namespace UserSecrets
 {
+    #region snippet_Program
     public class Program
     {
         public static void Main(string[] args)
         {
-            #region snippet_Host
             var host = new HostBuilder()
                 .ConfigureAppConfiguration((hostContext, builder) =>
                 {
@@ -20,10 +20,10 @@ namespace UserSecrets
                     }
                 })
                 .Build();
-                #endregion
             
             host.Run();
         }
     }
+    #endregion snippet_Program
 }
 #endif

--- a/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Startup2.cs
+++ b/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Startup2.cs
@@ -26,6 +26,8 @@ namespace UserSecrets
                 Configuration.GetConnectionString("Movies"));
             builder.Password = Configuration["DbPassword"];
             _connection = builder.ConnectionString;
+
+            // code omitted for brevity
         }
 
         public void Configure(IApplicationBuilder app)

--- a/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Startup3.cs
+++ b/aspnetcore/security/app-secrets/samples/3.x/UserSecrets/Startup3.cs
@@ -22,8 +22,8 @@ namespace UserSecrets
         public void ConfigureServices(IServiceCollection services)
         {
 #region snippet_BindToObjectGraph
-            var moviesConfig = Configuration.GetSection("Movies")
-                                            .Get<MovieSettings>();
+            var moviesConfig = 
+                Configuration.GetSection("Movies").Get<MovieSettings>();
             _moviesApiKey = moviesConfig.ServiceApiKey;
 #endregion
         }

--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -69,7 +69,7 @@ For examples of how social logins can drive traffic and customer conversions, se
 
 ## Use SecretManager to store tokens assigned by login providers
 
-Social login providers assign **Application Id** and **Application Secret** tokens during the registration process. The exact token names vary by provider. These tokens represent the credentials your app uses to access their API. The tokens constitute the "secrets" that can be linked to your app configuration with the help of [Secret Manager](xref:security/app-secrets#secret-manager). Secret Manager is a more secure alternative to storing the tokens in a configuration file, such as *appsettings.json*.
+Social login providers assign **Application Id** and **Application Secret** tokens during the registration process. The exact token names vary by provider. These tokens represent the credentials your app uses to access their API. The tokens constitute the "user secrets" that can be linked to your app configuration with the help of [Secret Manager](xref:security/app-secrets#secret-manager). User secrets are a more secure alternative to storing the tokens in a configuration file, such as *appsettings.json*.
 
 > [!IMPORTANT]
 > Secret Manager is for development purposes only. You can store and protect Azure test and production secrets with the [Azure Key Vault configuration provider](xref:security/key-vault-configuration).

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -37,7 +37,7 @@ For more information on how to configure a sample app using preprocessor directi
 
 ## Secret storage in the Development environment
 
-Set secrets locally using the [Secret Manager tool](xref:security/app-secrets). When the sample app runs on the local machine in the Development environment, secrets are loaded from the local Secret Manager store.
+Set secrets locally using the [Secret Manager tool](xref:security/app-secrets). When the sample app runs on the local machine in the Development environment, secrets are loaded from the local user secrets store.
 
 The Secret Manager tool requires a `<UserSecretsId>` property in the app's project file. Set the property value (`{GUID}`) to any unique GUID:
 
@@ -381,7 +381,7 @@ For more information on how to configure a sample app using preprocessor directi
 
 ## Secret storage in the Development environment
 
-Set secrets locally using the [Secret Manager tool](xref:security/app-secrets). When the sample app runs on the local machine in the Development environment, secrets are loaded from the local Secret Manager store.
+Set secrets locally using the [Secret Manager tool](xref:security/app-secrets). When the sample app runs on the local machine in the Development environment, secrets are loaded from the local user secrets store.
 
 The Secret Manager tool requires a `<UserSecretsId>` property in the app's project file. Set the property value (`{GUID}`) to any unique GUID:
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/20756
Addresses https://github.com/dotnet/AspNetCore.Docs/issues/20168

**Summary of changes**
- Incorporate customer requests as part of the [Q2 content performance OKR](https://dev.azure.com/mseng/TechnicalContent/_workitems/edit/1796311)
- Incorporate Acrolinx suggestions
- Rewrite the **Access a secret** section to include distinct steps and a Razor Pages example
- Replace incorrect usage of the term "Secret Manager" with "user secrets". Secret Manager is the tool. User secrets is the term to describe the configuration source read by the tool and the Configuration API. See https://github.com/dotnet/runtime/blob/fa367a397eaa518ec4c47c51f12d5994752d7321/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/src/UserSecretsConfigurationExtensions.cs#L13.

[Internal review page](https://review.docs.microsoft.com/aspnet/core/security/app-secrets?branch=pr-en-us-20748)