### PR TITLE
Razor component insignificant whitespace

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -874,7 +874,7 @@ However, inline SVG markup isn't supported in all scenarios. If you place an `<s
 
 ::: moniker range=">= aspnetcore-5.0"
 
-Unless the [`@preservewhitespace`](xref:mvc/views/razor#preservewhitespace) directive is used with a value of `true`, whitespace is removed by default if:
+Unless the [`@preservewhitespace`](xref:mvc/views/razor#preservewhitespace) directive is used with a value of `true`, extra whitespace is removed by default if:
 
 * Leading or trailing within an element.
 * Leading or trailing within a `RenderFragment` parameter. For example, child content passed to another component.
@@ -891,7 +891,7 @@ In most cases, no action is required, as apps typically continue to behave norma
 
 ::: moniker range="< aspnetcore-5.0"
 
-Whitespace is honored in a component's source code. Whitespace-only text renders in the browser's Document Object Model (DOM) even when there's no visual effect.
+Whitespace is retained in a component's source code. Whitespace-only text renders in the browser's Document Object Model (DOM) even when there's no visual effect.
 
 Consider the following Razor component code:
 
@@ -906,21 +906,21 @@ Consider the following Razor component code:
 </ul>
 ```
 
-The preceding example renders two areas of whitespace:
+The preceding example renders the following unnecessary whitespace:
 
 * Outside of the `@foreach` code block.
 * Around the `<li>` element.
 * Around the `@item.Text` output.
 
-A list containing 100 items results in 402 areas of whitespace, and none of the whitespace visually affects the rendered output.
+A list containing 100 items results in 402 areas of whitespace, and none of the extra whitespace visually affects the rendered output.
 
-When rendering static HTML for components, whitespace inside a tag isn't preserved. For example, view the source of the following component:
+When rendering static HTML for components, whitespace inside a tag isn't preserved. For example, view the source of the following component in rendered output:
 
 ```razor
 <img     alt="My image"   src="img.png"     />
 ```
 
-Whitespace isn't preserved. The prerendered output is:
+Whitespace isn't preserved from the preceding Razor markup:
 
 ```razor
 <img alt="My image" src="img.png" />

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -5,13 +5,13 @@ description: Learn how to create and use Razor components, including how to bind
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/09/2020
+ms.date: 11/25/2020
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/components/index
 ---
 # Create and use ASP.NET Core Razor components
 
-By [Luke Latham](https://github.com/guardrex), [Daniel Roth](https://github.com/danroth27), and [Tobias Bartsch](https://www.aveo-solutions.com/)
+By [Luke Latham](https://github.com/guardrex), [Daniel Roth](https://github.com/danroth27), [Scott Addie](https://github.com/scottaddie), and [Tobias Bartsch](https://www.aveo-solutions.com/)
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/blazor/common/samples/) ([how to download](xref:index#how-to-download-a-sample))
 
@@ -869,6 +869,64 @@ Similarly, SVG images are supported in the CSS rules of a stylesheet file (`.css
 ```
 
 However, inline SVG markup isn't supported in all scenarios. If you place an `<svg>` tag directly into a component file (`.razor`), basic image rendering is supported but many advanced scenarios aren't yet supported. For example, `<use>` tags aren't currently respected, and [`@bind`][10] can't be used with some SVG tags. For more information, see [SVG support in Blazor (dotnet/aspnetcore #18271)](https://github.com/dotnet/aspnetcore/issues/18271).
+
+## Whitespace rendering behavior
+
+::: moniker range=">= aspnetcore-5.0"
+
+Unless the `@preservewhitespace` directive is used with value `true`, whitespace nodes are removed if they:
+
+* Are leading or trailing within an element.
+* Are leading or trailing within a `RenderFragment` parameter. For example, child content passed to another component.
+* Precede or follow a C# code block such as `@if` and `@foreach`.
+
+Whitespace removal might affect the rendered output when using a CSS rule, such as `white-space: pre`. To disable this performance optimization and preserve the whitespace, take one of the following actions:
+
+* Add the `@preservewhitespace true` directive at the top of the `.razor` file to apply the preference to a specific component.
+* Add the `@preservewhitespace true` directive inside an `_Imports.razor` file to apply the preference to an entire subdirectory or the entire project.
+
+In most cases, no action is required, as apps typically continue to behave normally (but faster). If stripping whitespace causes any problem for a particular component, use `@preservewhitespace true` in that component to disable this optimization.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+Whitespace is honored in a component's source code. Whitespace-only text nodes render in the browser's Document Object Model (DOM) even when there's no visual effect.
+
+Consider the following Razor component code:
+
+```razor
+<ul>
+    @foreach (var item in Items)
+    {
+        <li>
+            @item.Text
+        </li>
+    }
+</ul>
+```
+
+The preceding example renders two whitespace nodes:
+
+* Outside of the `@foreach` code block.
+* Around the `<li>` element.
+* Around the `@item.Text` output.
+
+A list containing 100 items results in 402 whitespace nodes. That's over half of all nodes rendered, even though none of the whitespace nodes visually affect the rendered output.
+
+When rendering static HTML for components, whitespace inside a tag isn't preserved. For example, view the source of the following component:
+
+```razor
+<img     alt="My image"   src="img.png"     />
+```
+
+Whitespace isn't preserved. The pre-rendered output is:
+
+```razor
+<img alt="My image" src="img.png" />
+```
+
+::: moniker-end
 
 ## Additional resources
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -874,10 +874,10 @@ However, inline SVG markup isn't supported in all scenarios. If you place an `<s
 
 ::: moniker range=">= aspnetcore-5.0"
 
-Unless the `@preservewhitespace` directive is used with value `true`, whitespace nodes are removed if they:
+Unless the [`@preservewhitespace`](xref:mvc/views/razor#preservewhitespace) directive is used with a value of `true`, whitespace is removed by default if:
 
-* Are leading or trailing within an element.
-* Are leading or trailing within a `RenderFragment` parameter. For example, child content passed to another component.
+* Leading or trailing within an element.
+* Leading or trailing within a `RenderFragment` parameter. For example, child content passed to another component.
 * Precede or follow a C# code block such as `@if` and `@foreach`.
 
 Whitespace removal might affect the rendered output when using a CSS rule, such as `white-space: pre`. To disable this performance optimization and preserve the whitespace, take one of the following actions:
@@ -891,7 +891,7 @@ In most cases, no action is required, as apps typically continue to behave norma
 
 ::: moniker range="< aspnetcore-5.0"
 
-Whitespace is honored in a component's source code. Whitespace-only text nodes render in the browser's Document Object Model (DOM) even when there's no visual effect.
+Whitespace is honored in a component's source code. Whitespace-only text renders in the browser's Document Object Model (DOM) even when there's no visual effect.
 
 Consider the following Razor component code:
 
@@ -906,13 +906,13 @@ Consider the following Razor component code:
 </ul>
 ```
 
-The preceding example renders two whitespace nodes:
+The preceding example renders two areas of whitespace:
 
 * Outside of the `@foreach` code block.
 * Around the `<li>` element.
 * Around the `@item.Text` output.
 
-A list containing 100 items results in 402 whitespace nodes. That's over half of all nodes rendered, even though none of the whitespace nodes visually affect the rendered output.
+A list containing 100 items results in 402 areas of whitespace, and none of the whitespace visually affects the rendered output.
 
 When rendering static HTML for components, whitespace inside a tag isn't preserved. For example, view the source of the following component:
 
@@ -920,7 +920,7 @@ When rendering static HTML for components, whitespace inside a tag isn't preserv
 <img     alt="My image"   src="img.png"     />
 ```
 
-Whitespace isn't preserved. The pre-rendered output is:
+Whitespace isn't preserved. The prerendered output is:
 
 ```razor
 <img alt="My image" src="img.png" />

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -878,7 +878,7 @@ Unless the [`@preservewhitespace`](xref:mvc/views/razor#preservewhitespace) dire
 
 * Leading or trailing within an element.
 * Leading or trailing within a `RenderFragment` parameter. For example, child content passed to another component.
-* Precede or follow a C# code block such as `@if` and `@foreach`.
+* It precedes or follows a C# code block, such as `@if` or `@foreach`.
 
 Whitespace removal might affect the rendered output when using a CSS rule, such as `white-space: pre`. To disable this performance optimization and preserve the whitespace, take one of the following actions:
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -692,7 +692,7 @@ When set to `false` (default), whitespace in the rendered markup from Razor comp
 
 * Leading or trailing within an element.
 * Leading or trailing within a `RenderFragment` parameter. For example, child content passed to another component.
-* Precede or follow a C# code block such as `@if` and `@foreach`.
+* It precedes or follows a C# code block, such as `@if` or `@foreach`.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -682,6 +682,20 @@ The `@page` directive on the first line of a *.cshtml* file indicates that the f
 
 ::: moniker-end
 
+::: moniker range=">= aspnetcore-5.0"
+
+### `@preservewhitespace`
+
+*This scenario only applies to Razor components (`.razor`).*
+
+When set to `false` (default), whitespace in the rendered markup from Razor components (`.razor`) is removed if:
+
+* Leading or trailing within an element.
+* Leading or trailing within a `RenderFragment` parameter. For example, child content passed to another component.
+* Precede or follow a C# code block such as `@if` and `@foreach`.
+
+::: moniker-end
+
 ### `@section`
 
 *This scenario only applies to MVC views and Razor Pages (.cshtml).*


### PR DESCRIPTION
Fixes #20758

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components/index?view=aspnetcore-3.1&branch=pr-en-us-20761#whitespace-rendering-behavior)

Scott ... Is that your text? If so, can I place your name on this topic (it's on the PR) and 👮 **_steal ur stuff_** 🚓?

I'd like to cover this quickly and move on to get as much done prior to my 🏖️ *vacation* 😁 as possible. It's quick to base the coverage on your text and perhaps make additional updates on a UE pass for this topic later ...... you know ...... *the UE pass that I was going to make a year ago*. 🙈🏃😅 

I simplified a hair ... It's certainly OK to use the word "node" to refer to a group of whitespace characters in technical content (i.e., a DOM text **_node_**); but in its plainest form for explaining the concepts here imo, "whitespace" is universally understood and valid. I don't want the word "node" to throw anyone off, nor do I want to have to cross-link something for it. See if removing it makes sense here. 🤔