### PR TITLE
Fix Typo in key-vault-configuration/samples/3.x/SampleApp/Program.cs

### DIFF
--- a/aspnetcore/security/key-vault-configuration/samples/3.x/SampleApp/Program.cs
+++ b/aspnetcore/security/key-vault-configuration/samples/3.x/SampleApp/Program.cs
@@ -75,7 +75,7 @@ namespace SampleApp
                         var builtConfig = config.Build();
                         var secretClient = new SecretClient(new Uri($"https://{builtConfig["KeyVaultName"]}.vault.azure.net/"),
                                                                  new DefaultAzureCredential());
-                        config.AddAzureKeyVault(SecretClient, new KeyVaultSecretManager());
+                        config.AddAzureKeyVault(secretClient, new KeyVaultSecretManager());
 
 
                     }


### PR DESCRIPTION
Updated: "SecretClient" should be "secretClient"
var secretClient = new SecretClient(new Uri($"https://{builtConfig["KeyVaultName"]}.vault.azure.net/"),
                                                         new DefaultAzureCredential());
config.AddAzureKeyVault(**SecretClient**, new KeyVaultSecretManager());