### PR TITLE
Strengthen the instruction and update button name

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc-issue.md
+++ b/.github/ISSUE_TEMPLATE/doc-issue.md
@@ -5,15 +5,23 @@ about: Create an issue to help us improve
 
 # Before you open an issue
 
-If the issue is with an ASP.NET Core document, open the issue with the **Content feedback** button at the bottom of that document page.
+If the issue is with an ASP.NET Core document:
+
+1. Do **not** open a new issue using this form.
+1. Open the issue with the **This page** button and form at the bottom of the document's page.
+
+Using the **This page** button and form to open an issue:
+
+* Adds article metadata for tracking, which indicates the article that you're commenting on.
+* Automatically notifies the article's author about your issue.
 
 If the issue is:
 
-- A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
-- A general support question, consider asking on a support forum site.
-- A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).
-- A problem completing a tutorial, compare your code with the completed sample.
-- A duplicate of an open or closed issue, leave a comment on that issue.
+* A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
+* A general support question, consider asking on a support forum site.
+* A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).
+* A problem completing a tutorial, compare your code with the completed sample.
+* A duplicate of an open or closed issue, leave a comment on that issue.
 
 # Issue description
 
@@ -23,9 +31,9 @@ If the issue is:
 
 Check the .NET target framework(s) being used, and include the version number(s).
 
-- [ ] .NET Core
-- [ ] .NET Framework
-- [ ] .NET Standard
+* [ ] .NET Core
+* [ ] .NET Framework
+* [ ] .NET Standard
 
 If using the .NET Core SDK, include `dotnet --info` output. If using .NET Framework without the .NET Core SDK, include info from Visual Studio's **Help** > **About Microsoft Visual Studio** dialog.
 

--- a/.github/ISSUE_TEMPLATE/doc-issue.md
+++ b/.github/ISSUE_TEMPLATE/doc-issue.md
@@ -7,8 +7,8 @@ about: Create an issue to help us improve
 
 If the issue is with an ASP.NET Core document:
 
-1. Do **not** open a new issue using this form.
-1. Open the issue with the **This page** button and form at the bottom of the document's page.
+* Do **not** open a new issue using this form.
+* Open the issue with the **This page** button and form at the bottom of the document's page.
 
 Using the **This page** button and form to open an issue:
 

--- a/.github/ISSUE_TEMPLATE/doc-issue.md
+++ b/.github/ISSUE_TEMPLATE/doc-issue.md
@@ -32,6 +32,7 @@ If the issue is:
 Check the .NET target framework(s) being used, and include the version number(s).
 
 * [ ] .NET Core
+* [ ] .NET 5.0 or later
 * [ ] .NET Framework
 * [ ] .NET Standard
 


### PR DESCRIPTION
Can we 💪 **_strengthen_** 💪 the guidance on using the **This page** feedback button and form?

Even if we don't tho, let's at least take a look at the following ...

Although "**Content feedback** button" is for the "Feedback" section and does pertain to the "content," it really isn't the "**Content feedback** button." Using "**This page** button" is clear imo.

Just for list consistency, I put asterisks in for dashes below.