### PR TITLE
Add example with set extension methods to memory cache usage

### DIFF
--- a/aspnetcore/performance/caching/memory.md
+++ b/aspnetcore/performance/caching/memory.md
@@ -67,7 +67,7 @@ The current time and the cached time are displayed:
 
 [!code-cshtml[](memory/3.0sample/WebCacheSample/Views/Home/Cache.cshtml)]
 
-The following code uses [Set](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.set#Microsoft_Extensions_Caching_Memory_CacheExtensions_Set__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object___0_System_DateTimeOffset_) and [Set](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.set#Microsoft_Extensions_Caching_Memory_CacheExtensions_Set__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object___0_System_TimeSpan_) to cache data.
+The following code uses [Set](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.set#Microsoft_Extensions_Caching_Memory_CacheExtensions_Set__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object___0_System_TimeSpan_) to cache data.
 [!code-csharp[](memory/3.0sample/WebCacheSample/Controllers/HomeController.cs?name=snippet_set)]
 
 The cached `DateTime` value remains in the cache while there are requests within the timeout period.

--- a/aspnetcore/performance/caching/memory.md
+++ b/aspnetcore/performance/caching/memory.md
@@ -67,7 +67,7 @@ The current time and the cached time are displayed:
 
 [!code-cshtml[](memory/3.0sample/WebCacheSample/Views/Home/Cache.cshtml)]
 
-The following code uses [Set](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.set#Microsoft_Extensions_Caching_Memory_CacheExtensions_Set__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object___0_System_TimeSpan_) to cache data.
+The following code uses the [Set](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.set#Microsoft_Extensions_Caching_Memory_CacheExtensions_Set__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object___0_System_TimeSpan_) extension method to cache data for a relative time without creating the `MemoryCacheEntryOptions` object.
 [!code-csharp[](memory/3.0sample/WebCacheSample/Controllers/HomeController.cs?name=snippet_set)]
 
 The cached `DateTime` value remains in the cache while there are requests within the timeout period.

--- a/aspnetcore/performance/caching/memory.md
+++ b/aspnetcore/performance/caching/memory.md
@@ -67,6 +67,9 @@ The current time and the cached time are displayed:
 
 [!code-cshtml[](memory/3.0sample/WebCacheSample/Views/Home/Cache.cshtml)]
 
+The following code uses [Set](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.set#Microsoft_Extensions_Caching_Memory_CacheExtensions_Set__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object___0_System_DateTimeOffset_) and [Set](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.set#Microsoft_Extensions_Caching_Memory_CacheExtensions_Set__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object___0_System_TimeSpan_) to cache data.
+[!code-csharp[](memory/3.0sample/WebCacheSample/Controllers/HomeController.cs?name=snippet_set)]
+
 The cached `DateTime` value remains in the cache while there are requests within the timeout period.
 
 The following code uses [GetOrCreate](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.getorcreate#Microsoft_Extensions_Caching_Memory_CacheExtensions_GetOrCreate__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object_System_Func_Microsoft_Extensions_Caching_Memory_ICacheEntry___0__) and [GetOrCreateAsync](/dotnet/api/microsoft.extensions.caching.memory.cacheextensions.getorcreateasync#Microsoft_Extensions_Caching_Memory_CacheExtensions_GetOrCreateAsync__1_Microsoft_Extensions_Caching_Memory_IMemoryCache_System_Object_System_Func_Microsoft_Extensions_Caching_Memory_ICacheEntry_System_Threading_Tasks_Task___0___) to cache data.

--- a/aspnetcore/performance/caching/memory/3.0sample/WebCacheSample/Controllers/HomeController.cs
+++ b/aspnetcore/performance/caching/memory/3.0sample/WebCacheSample/Controllers/HomeController.cs
@@ -80,24 +80,6 @@ public class HomeController : Controller
     #endregion
 
     #region snippet_set
-
-    public IActionResult SetCacheAbsoluteExpiration()
-    {
-        DateTime cacheEntry;
-
-        // Look for cache key.
-        if (!_cache.TryGetValue(CacheKeys.Entry, out cacheEntry))
-        {
-            // Key not in cache, so get data.
-            cacheEntry = DateTime.Now;
-
-            // Save data in cache and set the absolute expiration time to tomorrow
-            _cache.Set(CacheKeys.Entry, cacheEntry, DateTime.Today + TimeSpan.FromDays(1));
-        }
-
-        return View("Cache", cacheEntry);
-    }
-
     public IActionResult SetCacheRelativeExpiration()
     {
         DateTime cacheEntry;
@@ -114,7 +96,6 @@ public class HomeController : Controller
 
         return View("Cache", cacheEntry);
     }
-
     #endregion
 
     public IActionResult CacheRemove()

--- a/aspnetcore/performance/caching/memory/3.0sample/WebCacheSample/Controllers/HomeController.cs
+++ b/aspnetcore/performance/caching/memory/3.0sample/WebCacheSample/Controllers/HomeController.cs
@@ -79,6 +79,44 @@ public class HomeController : Controller
     }
     #endregion
 
+    #region snippet_set
+
+    public IActionResult SetCacheAbsoluteExpiration()
+    {
+        DateTime cacheEntry;
+
+        // Look for cache key.
+        if (!_cache.TryGetValue(CacheKeys.Entry, out cacheEntry))
+        {
+            // Key not in cache, so get data.
+            cacheEntry = DateTime.Now;
+
+            // Save data in cache and set the absolute expiration time to tomorrow
+            _cache.Set(CacheKeys.Entry, cacheEntry, DateTime.Today + TimeSpan.FromDays(1));
+        }
+
+        return View("Cache", cacheEntry);
+    }
+
+    public IActionResult SetCacheRelativeExpiration()
+    {
+        DateTime cacheEntry;
+
+        // Look for cache key.
+        if (!_cache.TryGetValue(CacheKeys.Entry, out cacheEntry))
+        {
+            // Key not in cache, so get data.
+            cacheEntry = DateTime.Now;
+
+            // Save data in cache and set the relative expiration time to one day
+            _cache.Set(CacheKeys.Entry, cacheEntry, TimeSpan.FromDays(1));
+        }
+
+        return View("Cache", cacheEntry);
+    }
+
+    #endregion
+
     public IActionResult CacheRemove()
     {
         _cache.Remove(CacheKeys.Entry);


### PR DESCRIPTION
This adds an example without creating the `MemoryCacheEntryOptions` object.
Fixes #20849 
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->