### PR TITLE
Update Blazor circular references content

### DIFF
--- a/aspnetcore/blazor/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/call-javascript-from-dotnet.md
@@ -484,10 +484,7 @@ Objects that contain circular references can't be serialized on the client for e
 * .NET method calls.
 * JavaScript method calls from C# when the return type has circular references.
 
-For more information, see the following issues:
-
-* [Circular references are not supported, take two (dotnet/aspnetcore #20525)](https://github.com/dotnet/aspnetcore/issues/20525)
-* [Proposal: Add mechanism to handle circular references when serializing (dotnet/runtime #30820)](https://github.com/dotnet/runtime/issues/30820)
+For more information, see [Circular references are not supported, take two (dotnet/aspnetcore #20525)](https://github.com/dotnet/aspnetcore/issues/20525).
 
 ::: moniker range=">= aspnetcore-5.0"
 


### PR DESCRIPTION
Fixes #17651

The [product unit issue](https://github.com/dotnet/aspnetcore/issues/20525) to work further on circular references is on the backlog. Given that it isn't clear if/when that work will take place, I think we should just remove the cross-link to the `dotnet/runtime` issue (closed as resolved) and keep the cross-link to `dotnet/aspnetcore` issue for now. We can open a new docs issue if the product unit issue is resolved or closed. I don't want to leave a lot of unactionable Blazor docs issue lying around.