### PR TITLE
Resolve 'master branch' build suggestions

### DIFF
--- a/aspnetcore/azure/devops/cicd.md
+++ b/aspnetcore/azure/devops/cicd.md
@@ -194,13 +194,11 @@ There are three distinct steps to complete. Completing the steps in the followin
     git commit -a -m "upgraded to V4"
     ```
 
-1. Push the change in the default branch (*master*) to the *origin* remote of your GitHub repository:
+1. Push the change in the default branch (*master*) to the *origin* remote of your GitHub repository. In the following command, replace the placeholder `{BRANCH}` with the default branch (use `master`):
 
     ```console
     git push origin {BRANCH}
     ```
-
-    In the preceding command, the placeholder `{BRANCH}` is the default branch (*master*).
 
     The commit appears in the GitHub repository's default branch (*master*):
 

--- a/aspnetcore/azure/devops/cicd.md
+++ b/aspnetcore/azure/devops/cicd.md
@@ -101,7 +101,7 @@ There are three distinct steps to complete. Completing the steps in the followin
 1. If two-factor authentication is enabled on your GitHub account, a personal access token is required. In that case, click the **Authorize with a GitHub personal access token** link. See the [official GitHub personal access token creation instructions](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) for help. Only the *repo* scope of permissions is needed. Otherwise, click the **Authorize using OAuth** button.
 1. When prompted, sign in to your GitHub account. Then select Authorize to grant access to your Azure DevOps organization. If successful, a new service endpoint is created.
 1. Click the ellipsis button next to the **Repository** button. Select the *<GitHub_username>/simple-feed-reader* repository from the list. Click the **Select** button.
-1. Select the *master* branch from the **Default branch for manual and scheduled builds** drop-down. Click the **Continue** button. The template selection page appears.
+1. Select the default branch (*master*) from the **Default branch for manual and scheduled builds** drop-down. Click the **Continue** button. The template selection page appears.
 
 ### Create the build definition
 
@@ -115,7 +115,7 @@ There are three distinct steps to complete. Completing the steps in the followin
 
     ![Enable continuous integration settings](media/cicd/vsts-enable-ci.png)
 
-    These settings cause a build to trigger when any change is pushed to the *master* branch of the GitHub repository. Continuous integration is tested in the [Commit changes to GitHub and automatically deploy to Azure](#commit-changes-to-github-and-automatically-deploy-to-azure) section.
+    These settings cause a build to trigger when any change is pushed to the default branch (*master*) of the GitHub repository. Continuous integration is tested in the [Commit changes to GitHub and automatically deploy to Azure](#commit-changes-to-github-and-automatically-deploy-to-azure) section.
 
 1. Click the **Save & queue** button, and select the **Save** option:
 
@@ -159,7 +159,7 @@ There are three distinct steps to complete. Completing the steps in the followin
 
     With this option enabled, a deployment occurs each time a new build is available.
 1. A **Continuous deployment trigger** panel appears to the right. Click the toggle button to enable the feature. It isn't necessary to enable the **Pull request trigger**.
-1. Click the **Add** drop-down in the **Build branch filters** section. Choose the **Build Definition's default branch** option. This filter causes the release to trigger only for a build from the GitHub repository's *master* branch.
+1. Click the **Add** drop-down in the **Build branch filters** section. Choose the **Build Definition's default branch** option. This filter causes the release to trigger only for a build from the GitHub repository's default branch (*master*).
 1. Click the **Save** button. Click the **OK** button in the resulting **Save** modal dialog.
 1. Click the **Environment 1** box. An **Environment** panel appears to the right. Change the *Environment 1* text in the **Environment name** textbox to *Production*.
 
@@ -194,15 +194,17 @@ There are three distinct steps to complete. Completing the steps in the followin
     git commit -a -m "upgraded to V4"
     ```
 
-1. Push the change in the *master* branch to the *origin* remote of your GitHub repository:
+1. Push the change in the default branch (*master*) to the *origin* remote of your GitHub repository:
 
     ```console
-    git push origin master
+    git push origin {BRANCH}
     ```
 
-    The commit appears in the GitHub repository's *master* branch:
+    In the preceding command, the placeholder `{BRANCH}` is the default branch (*master*).
 
-    ![GitHub commit in master branch](media/cicd/github-commit.png)
+    The commit appears in the GitHub repository's default branch (*master*):
+
+    ![GitHub commit in default branch (master)](media/cicd/github-commit.png)
 
     The build is triggered, since continuous integration is enabled in the build definition's **Triggers** tab:
 

--- a/aspnetcore/azure/devops/deploying-to-app-service.md
+++ b/aspnetcore/azure/devops/deploying-to-app-service.md
@@ -124,7 +124,7 @@ To deploy the app, you'll need to create an App Service [Web App](/azure/app-ser
     git remote add azure-prod GIT_DEPLOYMENT_URL
     ```
 
-    b. Push the local *master* branch to the *azure-prod* remote's *master* branch.
+    b. Push the local default branch (*master*) to the *azure-prod* remote's default branch (*master*).
 
     ```console
     git push azure-prod master
@@ -197,7 +197,7 @@ Deployment slots support the staging of changes without impacting the app runnin
     git remote add azure-staging <Git_staging_deployment_URL>
     ```
 
-    b. Push the local *master* branch to the *azure-staging* remote's *master* branch.
+    b. Push the local default branch (*master*) to the *azure-staging* remote's default branch (*master*).
 
     ```console
     git push azure-staging master

--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -1062,5 +1062,5 @@ The files can be found by searching for *aspnetcore* in the *applicationHost.con
 
 * <xref:host-and-deploy/iis/index>
 * <xref:host-and-deploy/azure-apps/index>
-* [ASP.NET Core Module reference source (master branch)](https://github.com/dotnet/aspnetcore/tree/master/src/Servers/IIS/AspNetCoreModuleV2): Use the **Branch** drop down list to select a specific release (for example, `release/3.1`).
+* [ASP.NET Core Module reference source [default branch (master)]](https://github.com/dotnet/aspnetcore/tree/master/src/Servers/IIS/AspNetCoreModuleV2): Use the **Branch** drop down list to select a specific release (for example, `release/3.1`).
 * <xref:host-and-deploy/iis/modules>


### PR DESCRIPTION
Fixes #20895

Seeking to resolve these 'master branch' build suggestions. The build new seems 😁 with the approaches on this PR.

<img width="621" alt="Capture" src="https://user-images.githubusercontent.com/1622880/101478999-1d16da00-3917-11eb-9191-e5d35113a14c.PNG">

btw - The whole `git push origin master` command is throwing, so I seek to resolve it with a placeholder that calls out using `master` for `{BRANCH}`. It's a bit funky, but it's a decent workaround unless u have another idea.

..... but it isn't too *funky* because the `master` branch might not be the default branch, so a placeholder is perhaps ok there anyway.