### PR TITLE
Fix the code sample for ShortCircuitingResourceFilter

### DIFF
--- a/aspnetcore/mvc/controllers/filters.md
+++ b/aspnetcore/mvc/controllers/filters.md
@@ -273,7 +273,7 @@ In the following code, both the `ShortCircuitingResourceFilter` and the `AddHead
 
 Therefore the `AddHeader` filter never runs for the `SomeResource` action. This behavior would be the same if both filters were applied at the action method level, provided the `ShortCircuitingResourceFilter` ran first. The `ShortCircuitingResourceFilter` runs first because of its filter type, or by explicit use of `Order` property.
 
-[!code-csharp[](./filters/3.1sample/FiltersSample/Controllers/SampleController.cs?name=snippet_AddHeader&highlight=1)]
+[!code-csharp[](./filters/3.1sample/FiltersSample/Controllers/SampleController.cs?name=snippet3&highlight=1,15)]
 
 ## Dependency injection
 


### PR DESCRIPTION
Fixes #20925
the missing code sample for ShortCircuitingResourceFilter



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #20925 

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->