### PR TITLE
Enhance Blazor transient disposable content

### DIFF
--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -223,7 +223,7 @@ The `TransientDependency` in the following example is detected (`Startup.cs`):
 
 ::: zone-end
 
-The app can register transient disposables without throwing an exception. However, constructing a transient disposable results in an <xref:System.InvalidOperationException>, as the following example shows.
+The app can register transient disposables without throwing an exception. However, attempting to resolve a transient disposable results in an <xref:System.InvalidOperationException>, as the following example shows.
 
 `Pages/TransientDisposable.razor`:
 
@@ -234,7 +234,13 @@ The app can register transient disposables without throwing an exception. Howeve
 <h1>Transient Disposable</h1>
 ```
 
-> System.InvalidOperationException: Trying to resolve transient disposable service TransientDisposable in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
+Navigate to the `TransientDisposable` component at `/transient-disposable` and the <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposable`:
+
+```
+System.InvalidOperationException: Trying to resolve transient disposable service 
+TransientDisposable in the wrong scope. Use an 'OwningComponentBase\<T>' component 
+base class for the service 'T' you are trying to resolve.
+```
 
 ## Additional resources
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -5,7 +5,7 @@ description: Learn how Blazor apps can inject services into components.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 12/11/2020
+ms.date: 12/19/2020
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/fundamentals/dependency-injection
 zone_pivot_groups: blazor-hosting-models
@@ -175,8 +175,6 @@ Two versions of the <xref:Microsoft.AspNetCore.Components.OwningComponentBase> t
 
 For more information, see <xref:blazor/blazor-server-ef-core>.
 
-::: moniker range="< aspnetcore-5.0"
-
 ## Detect transient disposables
 
 The following examples show how to detect disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. For more information, see the [Utility base component classes to manage a DI scope](#utility-base-component-classes-to-manage-a-di-scope) section.
@@ -189,17 +187,17 @@ The following examples show how to detect disposable transient services in an ap
 
 The `TransientDisposable` in the following example is detected (`Program.cs`):
 
-<!-- moniker range=">= aspnetcore-5.0"
+::: moniker range=">= aspnetcore-5.0"
 
 [!code-csharp[](dependency-injection/samples_snapshot/5.x/transient-disposables/DetectIncorrectUsagesOfTransientDisposables-wasm-program.cs?highlight=6,9,17,22-25)]
 
-moniker-end 
+::: moniker-end 
 
-moniker range="< aspnetcore-5.0" -->
+::: moniker range="< aspnetcore-5.0"
 
 [!code-csharp[](dependency-injection/samples_snapshot/3.x/transient-disposables/DetectIncorrectUsagesOfTransientDisposables-wasm-program.cs?highlight=6,9,17,22-25)]
 
-<!-- moniker-end -->
+::: moniker-end
 
 ::: zone-end
 
@@ -225,7 +223,18 @@ The `TransientDependency` in the following example is detected (`Startup.cs`):
 
 ::: zone-end
 
-::: moniker-end
+The app can register transient disposables without throwing an exception. However, constructing a transient disposable results in an <xref:System.InvalidOperationException>, as the following example shows.
+
+`Pages/TransientDisposable.razor`:
+
+```razor
+@page "/transient-disposable"
+@inject TransientDisposable
+
+<h1>Transient Disposable</h1>
+```
+
+> System.InvalidOperationException: Trying to resolve transient disposable service TransientDisposable in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -229,7 +229,7 @@ The app can register transient disposables without throwing an exception. Howeve
 
 ```razor
 @page "/transient-disposable"
-@inject TransientDisposable
+@inject TransientDisposable TransientDisposable
 
 <h1>Transient Disposable</h1>
 ```

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -231,7 +231,7 @@ The app can register transient disposables without throwing an exception. Howeve
 @page "/transient-disposable"
 @inject TransientDisposable TransientDisposable
 
-<h1>Transient Disposable</h1>
+<h1>Transient Disposable Detection</h1>
 ```
 
 Navigate to the `TransientDisposable` component at `/transient-disposable` and the <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposable`:

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -234,7 +234,7 @@ The app can register transient disposables without throwing an exception. Howeve
 <h1>Transient Disposable Detection</h1>
 ```
 
-Navigate to the `TransientDisposable` component at `/transient-disposable` and the <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposable`:
+Navigate to the `TransientDisposable` component at `/transient-disposable` and an <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposable`:
 
 ```
 System.InvalidOperationException: Trying to resolve transient disposable service 

--- a/aspnetcore/blazor/fundamentals/dependency-injection/samples_snapshot/3.x/transient-disposables/DetectIncorrectUsagesOfTransientDisposables-server.cs
+++ b/aspnetcore/blazor/fundamentals/dependency-injection/samples_snapshot/3.x/transient-disposables/DetectIncorrectUsagesOfTransientDisposables-server.cs
@@ -47,6 +47,7 @@ namespace BlazorServerTransientDisposable
             IServiceCollection containerBuilder)
         {
             var collection = new ServiceCollection();
+
             foreach (var descriptor in containerBuilder)
             {
                 if (descriptor.Lifetime == ServiceLifetime.Transient &&
@@ -123,6 +124,7 @@ namespace BlazorServerTransientDisposable
                         original.ImplementationType);
                 },
                 ServiceLifetime.Transient);
+    
             return newDescriptor;
         }
     }

--- a/aspnetcore/blazor/fundamentals/dependency-injection/samples_snapshot/3.x/transient-disposables/DetectIncorrectUsagesOfTransientDisposables-wasm.cs
+++ b/aspnetcore/blazor/fundamentals/dependency-injection/samples_snapshot/3.x/transient-disposables/DetectIncorrectUsagesOfTransientDisposables-wasm.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             webAssemblyHost.Services
                 .GetRequiredService<ThrowOnTransientDisposable>().ShouldThrow = true;
+
             return webAssemblyHost;
         }
     }
@@ -41,6 +42,7 @@ namespace BlazorWebAssemblyTransientDisposable
             IServiceCollection containerBuilder)
         {
             var collection = new ServiceCollection();
+
             foreach (var descriptor in containerBuilder)
             {
                 if (descriptor.Lifetime == ServiceLifetime.Transient &&
@@ -115,6 +117,7 @@ namespace BlazorWebAssemblyTransientDisposable
                         original.ImplementationType);
                 },
                 ServiceLifetime.Transient);
+    
             return newDescriptor;
         }
     }


### PR DESCRIPTION
Fixes #20950

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/dependency-injection?view=aspnetcore-3.1&branch=pr-en-us-21002#detect-transient-disposables)

I recalled on a second look (after the UE pass on this topic last week) that the transient disposables code doesn't "**_detect_**" them until/unless they are resolved (constructed)&dagger;. I think when I was reading the topic and working on it that I incorrectly interpreted "detect" to mean on service registration. I add a bit to the bottom of the section here with an example to call it out.

&dagger;Resolve and construct: I say "resolve" first and then "construct" later. AFAIK, these mean the same thing in this context, and we can use both here. If it should use "resolve" throughout, I'm 👂 for that feedback.

Javier, is there anything else you'd like to do with this section while we're here?

cc: @scottaddie ... I noticed that the build report provides our internal topic review links for 3.1. Will that default to 5.0 at some point? Is there any harm in manually updating the `view` to `aspnetcore-5.0` for the links today?