### PR TITLE
Clarify Virtualize component item source

### DIFF
--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -74,7 +74,7 @@ If you don't want to load all of the items into memory, you can specify an items
 
 The items provider receives an `ItemsProviderRequest`, which specifies the required number of items starting at a specific start index. The items provider then retrieves the requested items from a database or other service and returns them as an `ItemsProviderResult<TItem>` along with a count of the total items. The items provider can choose to retrieve the items with each request or cache them so that they're readily available.
 
-A `Virtualize` component can only accept one item source from its parameters, so don't attempt to simultaneously use an items provider and assign a collection to `Items`. If both are assigned, an <xref:System.InvalidOperationException> is thrown when the component's parameters are set at runtime.
+A `Virtualize` component can only accept **one item source** from its parameters, so don't attempt to simultaneously use an items provider and assign a collection to `Items`. If both are assigned, an <xref:System.InvalidOperationException> is thrown when the component's parameters are set at runtime.
 
 The following example loads employees from an `EmployeeService`:
 

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -72,7 +72,9 @@ If you don't want to load all of the items into memory, you can specify an items
 </Virtualize>
 ```
 
-The items provider receives an `ItemsProviderRequest`, which specifies the required number of items starting at a specific start index. The items provider then retrieves the requested items from a database or other service and returns them as an `ItemsProviderResult<TItem>` along with a count of the total items. The items provider can choose to retrieve the items with each request or cache them so that they're readily available. Don't attempt to use an items provider and assign a collection to `Items` for the same `Virtualize` component.
+The items provider receives an `ItemsProviderRequest`, which specifies the required number of items starting at a specific start index. The items provider then retrieves the requested items from a database or other service and returns them as an `ItemsProviderResult<TItem>` along with a count of the total items. The items provider can choose to retrieve the items with each request or cache them so that they're readily available.
+
+A `Virtualize` component can only accept one item source from its parameters, so don't attempt to simultaneously use an items provider and assign a collection to `Items`. If both are assigned, an <xref:System.InvalidOperationException> is thrown.
 
 The following example loads employees from an `EmployeeService`:
 

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -74,7 +74,7 @@ If you don't want to load all of the items into memory, you can specify an items
 
 The items provider receives an `ItemsProviderRequest`, which specifies the required number of items starting at a specific start index. The items provider then retrieves the requested items from a database or other service and returns them as an `ItemsProviderResult<TItem>` along with a count of the total items. The items provider can choose to retrieve the items with each request or cache them so that they're readily available.
 
-A `Virtualize` component can only accept one item source from its parameters, so don't attempt to simultaneously use an items provider and assign a collection to `Items`. If both are assigned, an <xref:System.InvalidOperationException> is thrown.
+A `Virtualize` component can only accept one item source from its parameters, so don't attempt to simultaneously use an items provider and assign a collection to `Items`. If both are assigned, an <xref:System.InvalidOperationException> is thrown when the component's parameters are set at runtime.
 
 The following example loads employees from an `EmployeeService`:
 


### PR DESCRIPTION
Fixes #21026

We usually use warnings for security concerns, writing unstable code or code that produces strange/unexpected results, unsupported approaches that might break, and practices that might fall victim to a future breaking change.

This one seems less severe given that there's a clear exception when the params are set, but I place the guidance into its own paragraph to highlight it a bit more than just tacking it on at the end of the current paragraph.

cc: @mkArtakMSFT 