### PR TITLE
Fix template help options

### DIFF
--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -126,6 +126,6 @@ For more information on Blazor's hosting models, see <xref:blazor/hosting-models
 Template options are available by passing the help option (`-h` or `--help`) to the [`dotnet new`](/dotnet/core/tools/dotnet-new) CLI command in a command shell:
 
 ```dotnetcli
-dotnet new blazorwasm --h
-dotnet new blazorserver --h
+dotnet new blazorwasm -h
+dotnet new blazorserver -h
 ```


### PR DESCRIPTION
On page `Tooling for ASP.NET Core Blazor` shows incorrect options