### PR TITLE
Update Readme.MD to add correct startup file for CORS

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/README.md
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorWebAssemblySample/README.md
@@ -6,7 +6,7 @@ This sample illustrates the use of Blazor scenarios described in the Blazor docu
 
 The web API example requires a running web API based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Create a web API with ASP.NET Core</a> topic, which by default uses the same HTTPS port (5001) as the Blazor sample app. To use both apps on the same machine at the same time, change the port of the web API (for example, use port 10000). The sample app makes requests to the web API at `https://localhost:10000/api/TodoItems`. If a different web API address is used, update the `ServiceEndpoint` constant value in the Razor component's `@code` block.</p>
 
-The sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from `http://localhost:5000` or `https://localhost:5001` to the web API. Credentials (authorization cookies/headers) are permitted. Add the following CORS middleware configuration to the web API's `Startup.Configure` method:</p>
+The sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from `http://localhost:5000` or `https://localhost:5001` to the web API. Credentials (authorization cookies/headers) are permitted. Add the following CORS middleware configuration to the web API's `StartupJavaScript.Configure` method:</p>
 
 ```csharp
 app.UseCors(policy => 

--- a/aspnetcore/blazor/common/samples/5.x/BlazorWebAssemblySample/README.md
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorWebAssemblySample/README.md
@@ -6,7 +6,7 @@ This sample illustrates the use of Blazor scenarios described in the Blazor docu
 
 The web API example requires a running web API based on the sample app for the <a href="https://docs.microsoft.com/aspnet/core/tutorials/first-web-api">Create a web API with ASP.NET Core</a> topic, which by default uses the same HTTPS port (5001) as the Blazor sample app. To use both apps on the same machine at the same time, change the port of the web API (for example, use port 10000). The sample app makes requests to the web API at `https://localhost:10000/api/TodoItems`. If a different web API address is used, update the `ServiceEndpoint` constant value in the Razor component's `@code` block.</p>
 
-The sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from `http://localhost:5000` or `https://localhost:5001` to the web API. Credentials (authorization cookies/headers) are permitted. Add the following CORS middleware configuration to the web API's `Startup.Configure` method:</p>
+The sample app makes a <a href="https://docs.microsoft.com/aspnet/core/security/cors">cross-origin resource sharing (CORS)</a> request from `http://localhost:5000` or `https://localhost:5001` to the web API. Credentials (authorization cookies/headers) are permitted. Add the following CORS middleware configuration to the web API's `StartupJavaScript.Configure` method:</p>
 
 ```csharp
 app.UseCors(policy => 


### PR DESCRIPTION
Helps with #18198

The sample app contains two files that contain a `Configure` method:
- `Startup.cs`
- `StartupJavaScript.cs`

Hitherto, the Readme said:
>Add the following CORS middleware configuration to the web API's `Startup.Configure` method:</p>

But that is incorrect. The configuration needs to be added to `StartupJavaScript.Configure`. It took me ages to figure it out, trusting the Readme to be correct - when it wasn't.

There's no harm in making this change. Yes, people can eventually try it out themselves, but there's no harm in adding the correct file reference.
