### PR TITLE
Blazor WASM security versioned content

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -229,9 +229,9 @@ To configure the app to receive the value from the `name` claim type:
   using Microsoft.AspNetCore.Authentication.JwtBearer;
   ```
 
-* Configure the <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType?displayProperty=nameWithType> of the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions> in `Startup.ConfigureServices`:
-
 ::: moniker range=">= aspnetcore-5.0"
+
+* Configure the <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType?displayProperty=nameWithType> of the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions> in `Startup.ConfigureServices`:
 
   ```csharp
   services.Configure<JwtBearerOptions>(
@@ -244,6 +244,8 @@ To configure the app to receive the value from the `name` claim type:
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
+
+* Configure the <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType?displayProperty=nameWithType> of the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions> in `Startup.ConfigureServices`:
 
   ```csharp
   services.Configure<JwtBearerOptions>(

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -244,9 +244,9 @@ To configure the app to receive the value from the `name` claim type:
   using Microsoft.AspNetCore.Authentication.JwtBearer;
   ```
 
-* Configure the <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType?displayProperty=nameWithType> of the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions> in `Startup.ConfigureServices`:
-
 ::: moniker range=">= aspnetcore-5.0"
+
+* Configure the <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType?displayProperty=nameWithType> of the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions> in `Startup.ConfigureServices`:
 
   ```csharp
   services.Configure<JwtBearerOptions>(
@@ -259,6 +259,8 @@ To configure the app to receive the value from the `name` claim type:
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
+
+* Configure the <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType?displayProperty=nameWithType> of the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions> in `Startup.ConfigureServices`:
 
   ```csharp
   services.Configure<JwtBearerOptions>(


### PR DESCRIPTION
Addresses #21034

Turns out that moniker ranges break indentation in sub-bullet content when the bullet item isn't included in the versioned content ...

<img width="364" alt="Capture" src="https://user-images.githubusercontent.com/1622880/103151902-f85c9800-4747-11eb-8ca8-a1406d381817.PNG">

Therefore, the versioned content must include the bulleted item ... i.e. .... the bullet item must be repeated for each version.