### PR TITLE
Update adding-model.md

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model.md
@@ -148,11 +148,11 @@ Add a connection string to the *appsettings.json* file:
 
 # [Visual Studio](#tab/visual-studio)
 
-[!code-json[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie3/appsettings.json?highlight=10-11)]
+[!code-json[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie3/appsettings.json?highlight=10-12)]
 
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
-[!code-json[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie3/appsettings_SQLite.json?highlight=10-11)]
+[!code-json[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie3/appsettings_SQLite.json?highlight=10-12)]
 
 ---
 


### PR DESCRIPTION
Fixes #20692
Fixes issue with a walkthrough user copying insufficient rows, corrupting their appsettings.json, leading to error running scaffolding
