### PR TITLE
Update IE support for Core SignalR

### DIFF
--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -188,7 +188,7 @@ The dependency on jQuery has been removed, however projects can still use jQuery
 ### Internet Explorer support
 
 ASP.NET Core SignalR doesn't support Microsoft Internet Explorer, whereas ASP.NET SignalR supports Microsoft Internet Explorer 8 or later.
-More info on browser support can be found in <xref:signalr/supported-platforms#javascript-client>.
+For more information, see <xref:signalr/supported-platforms#javascript-client>.
 
 ### JavaScript client method syntax
 

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -187,8 +187,8 @@ The dependency on jQuery has been removed, however projects can still use jQuery
 
 ### Internet Explorer support
 
-ASP.NET Core SignalR supports Microsoft Internet Explorer 11 or later, whereas ASP.NET SignalR supports Microsoft Internet Explorer 8 or later.
-More info on browser support can be found at [supported platforms](xref:signalr/supported-platforms#javascript-client).
+ASP.NET Core SignalR doesn't support Microsoft Internet Explorer, whereas ASP.NET SignalR supports Microsoft Internet Explorer 8 or later.
+More info on browser support can be found in <xref:signalr/supported-platforms#javascript-client>.
 
 ### JavaScript client method syntax
 


### PR DESCRIPTION
Fixes #21068

Thanks @chrisseed! :rocket:

Brennan ... I don't version this because we've always treated browser support as **_current only_** (unversioned in the *Supported Platforms* doc).