### PR TITLE
Fix typo in areas.md

### DIFF
--- a/aspnetcore/mvc/controllers/areas.md
+++ b/aspnetcore/mvc/controllers/areas.md
@@ -194,7 +194,7 @@ Consider the *Services* area of the sample code, which doesn't contain a *_ViewI
 
 In the preceding markup:
 
-* The fully qualified domain name must be used to specify the model (`@model RPareas.Areas.Services.Pages.Manage.AboutModel`).
+* The fully qualified class name must be used to specify the model (`@model RPareas.Areas.Services.Pages.Manage.AboutModel`).
 * [Tag Helpers](xref:mvc/views/tag-helpers/intro) are enabled by `@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers`
 
 In the sample download, the Products area contains the following *_ViewImports.cshtml* file:


### PR DESCRIPTION
I believe this sentence:

> The fully qualified domain name must be used to specify the model...

Should refer to the "class name" rather than "domain name" and thus read:

> The fully qualified class name must be used to specify the model...



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->