### PR TITLE
Update Blazor PreferExactMatches

### DIFF
--- a/aspnetcore/blazor/common/samples/5.x/BlazorServerEFCoreSample/BlazorServerDbContextExample/App.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorServerEFCoreSample/BlazorServerDbContextExample/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/common/samples/5.x/BlazorServerSample/App.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorServerSample/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/common/samples/5.x/BlazorWebAssemblySample/App.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorWebAssemblySample/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/fundamentals/routing/samples_snapshot/3.x/App1.razor
+++ b/aspnetcore/blazor/fundamentals/routing/samples_snapshot/3.x/App1.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="@typeof(Startup).Assembly">
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/fundamentals/routing/samples_snapshot/3.x/App2.razor
+++ b/aspnetcore/blazor/fundamentals/routing/samples_snapshot/3.x/App2.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="typeof(Startup).Assembly">
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/fundamentals/routing/samples_snapshot/5.x/App1.razor
+++ b/aspnetcore/blazor/fundamentals/routing/samples_snapshot/5.x/App1.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="@typeof(Startup).Assembly">
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/fundamentals/routing/samples_snapshot/5.x/App2.razor
+++ b/aspnetcore/blazor/fundamentals/routing/samples_snapshot/5.x/App2.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="typeof(Startup).Assembly">
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/includes/prefer-exact-matches.md
+++ b/aspnetcore/blazor/includes/prefer-exact-matches.md
@@ -1,6 +1,6 @@
 ::: moniker range="= aspnetcore-5.0"
 
 > [!NOTE]
-> With the release of ASP.NET Core 5.0.1 and for any additional 5.x releases, the `Router` component includes the `PreferExactMatches` parameter set to `true`. For more information, see <xref:migration/31-to-50#changes-to-blazor-app-routing-logic-in-501>.
+> With the release of ASP.NET Core 5.0.1 and for any additional 5.x releases, the `Router` component includes the `PreferExactMatches` parameter set to `@true`. For more information, see <xref:migration/31-to-50#changes-to-blazor-app-routing-logic-in-501>.
 
 ::: moniker-end

--- a/aspnetcore/blazor/layouts/sample_snapshot/3.x/App1.razor
+++ b/aspnetcore/blazor/layouts/sample_snapshot/3.x/App1.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="@typeof(Startup).Assembly">
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/layouts/sample_snapshot/3.x/App2.razor
+++ b/aspnetcore/blazor/layouts/sample_snapshot/3.x/App2.razor
@@ -1,4 +1,4 @@
-<Router AppAssembly="@typeof(Startup).Assembly">
+<Router AppAssembly="@typeof(Program).Assembly">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>

--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -481,7 +481,7 @@ It's likely that the project wasn't created using a Blazor Server template with 
 
 ```razor
 <CascadingAuthenticationState>
-    <Router AppAssembly="typeof(Startup).Assembly">
+    <Router AppAssembly="@typeof(Program).Assembly">
         ...
     </Router>
 </CascadingAuthenticationState>

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -404,7 +404,7 @@ To use the `CounterStateProvider` component, wrap an instance of the component a
 
 ```razor
 <CounterStateProvider>
-    <Router AppAssembly="typeof(Startup).Assembly">
+    <Router AppAssembly="@typeof(Program).Assembly">
         ...
     </Router>
 </CounterStateProvider>
@@ -649,7 +649,7 @@ To use the `CounterStateProvider` component, wrap an instance of the component a
 
 ```razor
 <CounterStateProvider>
-    <Router AppAssembly="typeof(Startup).Assembly">
+    <Router AppAssembly="@typeof(Program).Assembly">
         ...
     </Router>
 </CounterStateProvider>

--- a/aspnetcore/migration/31-to-50.md
+++ b/aspnetcore/migration/31-to-50.md
@@ -79,13 +79,13 @@ The original behavior is considered a bug in the implementation because our goal
 Add the `PreferExactMatches` attribute to the `Router` component in the `App.razor` file to opt into the correct behavior:
 
 ```razor
-<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
 ```
 
-When `PreferExactMatches` is set to `true`, route matching prefers exact matches over wildcards.
+When `PreferExactMatches` is set to `@true`, route matching prefers exact matches over wildcards.
 
 > [!IMPORTANT]
-> All apps should explicitly set `PreferExactMatches` to `true`.
+> All apps should explicitly set `PreferExactMatches` to `@true`.
 >
 > The ability to set the option to `false` or leave it unset, which defaults the option to `false`, *is only provided for backward compatibility*.
 >

--- a/aspnetcore/tutorials/signalr-blazor-webassembly/samples/5.x/BlazorSignalRApp/Client/App.razor
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly/samples/5.x/BlazorSignalRApp/Client/App.razor
@@ -1,4 +1,4 @@
-﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="true">
+﻿<Router AppAssembly="@typeof(Program).Assembly" PreferExactMatches="@true">
     <Found Context="routeData">
         <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
     </Found>


### PR DESCRIPTION
Fixes  #21060

Thanks @RugerSR9 :rocket: and @carthell! 🎷

cc: @mkArtakMSFT ... I'll go ahead and shoot this into the docs now. If we need to provide different/additional info, I'm :ear: for your guidance and will modify/add content as soon as I hear back from you.

btw -- Just a reminder on how `PreferExactMatches` was added: I think where we have a `Router` components in the text, the INCLUDES file is positioned nearby to surface it. An INCLUDES file is used to avoid having many temporarily versioned code blocks all over the place. It will be easy later to drop the INCLUDES from the docs at 6.0.