### PR TITLE
Fix Add URL example

### DIFF
--- a/aspnetcore/web-api/Microsoft.dotnet-openapi.md
+++ b/aspnetcore/web-api/Microsoft.dotnet-openapi.md
@@ -71,7 +71,7 @@ The preceding reference is required for the app to call the generated client cod
 |-------|------|-------------|---------|
 | -p|--updateProject | The project to operate on. |dotnet openapi add url *--updateProject .\Ref.csproj* `https://contoso.com/openapi.json` |
 | -o|--output-file | Where to place the local copy of the OpenAPI file. |dotnet openapi add url `https://contoso.com/openapi.json` *--output-file myclient.json* |
-| -c|--code-generator| The code generator to apply to the reference. Options are `NSwagCSharp` and `NSwagTypeScript`. |dotnet openapi add file .\OpenApi.json --code-generator
+| -c|--code-generator| The code generator to apply to the reference. Options are `NSwagCSharp` and `NSwagTypeScript`. |dotnet openapi add url `https://contoso.com/openapi.json` --code-generator
 | -h|--help|Show help information|dotnet openapi add url --help|
 
 #### Arguments


### PR DESCRIPTION
`Add URL` example was using `Add File` and is now correct