### PR TITLE
PreferExactMatches content update

### DIFF
--- a/aspnetcore/migration/31-to-50.md
+++ b/aspnetcore/migration/31-to-50.md
@@ -87,7 +87,7 @@ When `PreferExactMatches` is set to `@true`, route matching prefers exact matche
 > [!IMPORTANT]
 > All apps should explicitly set `PreferExactMatches` to `@true`.
 >
-> The ability to set the option to `false` or leave it unset, which defaults the option to `false`, *is only provided for backward compatibility*.
+> The ability to set `PreferExactMatches` to `@false` or leave it unset, which defaults the option to `false` in C#, *is only provided for backward compatibility*.
 >
 > When .NET 6 is released, the router will always prefer exact matches, and the `PreferExactMatches` option won't be available.
 


### PR DESCRIPTION
This is just a *nit* update to clarify that the setting would be `@false` to get a `false` value in C#. Setting to merely `false` will :boom: just like setting to `true`.