### PR TITLE
update Note part

### DIFF
--- a/aspnetcore/signalr/hubcontext.md
+++ b/aspnetcore/signalr/hubcontext.md
@@ -53,7 +53,7 @@ app.Use(async (context, next) =>
 ```
 
 > [!NOTE]
-> When hub methods are called from outside of the `Hub` class, there's no caller associated with the invocation. Therefore, there's no access to the `ConnectionId`, `Caller`, and `Others` properties.
+> When hub methods are called from outside of the `Hub` class, there's no caller associated with the invocation. Therefore, there's no access to the `ConnectionId`, `Caller` and other properties.
 
 ### Get an instance of IHubContext from IHost
 


### PR DESCRIPTION
[`HubCallerContext` class](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.signalr.hubcallercontext?view=aspnetcore-5.0) does not have a property named **Others**



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->