### PR TITLE
Improve Blazor Lifecycle remark

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -36,7 +36,9 @@ Document Object Model (DOM) event processing:
 
 The `Render` lifecycle:
 
-1. If this isn't the component's first render or [`ShouldRender`](#suppress-ui-refreshing) is evaluated as `false`, don't perform further operations on the component.
+1. Don't perform further operations on the component:
+   * After the first render.
+   * When [`ShouldRender`](#suppress-ui-refreshing) is `false`.
 1. Build the render tree diff (difference) and render the component.
 1. Await the DOM to update.
 1. Call [`OnAfterRender{Async}`](#after-component-render).

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -36,7 +36,7 @@ Document Object Model (DOM) event processing:
 
 The `Render` lifecycle:
 
-1. Don't perform further operations on the component:
+1. Stop further rendering operations on the component:
    * After the first render.
    * When [`ShouldRender`](#suppress-ui-refreshing) is `false`.
 1. Build the render tree diff (difference) and render the component.


### PR DESCRIPTION
Fixes  #21139

Thanks @TheBigBirn! :rocket:

@captainsafia ... Instead of "stop," we can use virtually anything similar to that to kick this off. Does a different word capture the technical aspect better? Here are some synonyms that we can consider ...

* Stop further rendering operations on the component: (**_currently on the PR_**)
* Cease further rendering operations on the component:
* Discontinue further rendering operations on the component:
* Halt further rendering operations on the component:
* Terminate further rendering operations on the component:
* Avoid further rendering operations on the component:

... mmmmmm 🤔 ... Not sure if anything is better than just "stop," but I'll go with whatever you think best ... or something else if you have a word that isn't listed there.