### PR TITLE
Add Blazor debug topic cross-link

### DIFF
--- a/aspnetcore/tutorials/signalr-blazor-webassembly.md
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly.md
@@ -425,3 +425,4 @@ To learn more about building Blazor apps, see the Blazor documentation:
 
 * <xref:signalr/introduction>
 * [SignalR cross-origin negotiation for authentication](xref:blazor/fundamentals/additional-scenarios#signalr-cross-origin-negotiation-for-authentication)
+* <xref:blazor/debug>


### PR DESCRIPTION
Fixes #21114

Thanks @firewater! :rocket: ... I'm merely going to add the cross-link to *Additional resources* section because we don't want to get too deep into the weeds on debugging in a tutorial. We keep these tutorial articles **_lean_** ... minimal cross-links ... minimal distractions. The topic calls out the default config, which should be working for the default browser (Chrome). If you find a bug 🐞 in the template-based app with Chrome or a scenario with Edge that is breaking unexpectedly (outside of the additional guidance that we're cross-linking with this PR), open that directly with engineering at https://github.com/dotnet/aspnetcore/issues (and note to them that you're remarking on the project template code and default debugging configuration ... that's what the topic is based on). Please add a `cc: @guardrex` to the bottom of your opening comment so that I can follow along. If we need to improve docs from there, I'll open a new docs issue to work on it. Thanks again for your comments and suggestions.