### PR TITLE
Remove debugging info for VS Code

### DIFF
--- a/aspnetcore/tutorials/signalr-blazor-webassembly.md
+++ b/aspnetcore/tutorials/signalr-blazor-webassembly.md
@@ -343,26 +343,6 @@ Follow the guidance for your tooling:
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-::: moniker range=">= aspnetcore-5.0"
-
-1. When VS Code offers to create a launch profile for the Server app (`.vscode/launch.json`), the `program` entry appears similar to the following to point to the app's assembly (`{APPLICATION NAME}.Server.dll`):
-
-   ```json
-   "program": "${workspaceFolder}/Server/bin/Debug/net5.0/{APPLICATION NAME}.Server.dll"
-   ```
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-5.0"
-
-1. When VS Code offers to create a launch profile for the Server app (`.vscode/launch.json`), the `program` entry appears similar to the following to point to the app's assembly (`{APPLICATION NAME}.Server.dll`):
-
-   ```json
-   "program": "${workspaceFolder}/Server/bin/Debug/netcoreapp3.1/{APPLICATION NAME}.Server.dll"
-   ```
-
-::: moniker-end
-
 1. Press <kbd>F5</kbd> to run the app with debugging or <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app without debugging.
 
 1. Copy the URL from the address bar, open another browser instance or tab, and paste the URL in the address bar.


### PR DESCRIPTION
Fixes #21112

Thanks again @firewater! 🎸

We'll kill this bit because it's been changing as the product unit makes improvements. It's not relevant to a successful tutorial experience, and the tutorial now cross-links to the Blazor WASM debugging topic.