### PR TITLE
Fix typo in source code comments for Startup.cs

### DIFF
--- a/aspnetcore/fundamentals/static-files/samples/3.x/StaticFileAuth/Startup.cs
+++ b/aspnetcore/fundamentals/static-files/samples/3.x/StaticFileAuth/Startup.cs
@@ -61,7 +61,7 @@ namespace StaticFileAuth
 
             app.UseHttpsRedirection();
 
-            // wwwroot css, JavaScrip, and images don't require authentication.
+            // wwwroot css, JavaScript, and images don't require authentication.
             app.UseStaticFiles();   
 
             app.UseRouting();


### PR DESCRIPTION
The following line:

>   // wwwroot css, JavaScrip, and images don't require authentication.

...is missing a "t" in the word "Javascrip" and should read:

>   // wwwroot css, JavaScript, and images don't require authentication.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->