### PR TITLE
Changing MvcMovie documentation code snippet to show correct code

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/search.md
+++ b/aspnetcore/tutorials/first-mvc-app/search.md
@@ -41,7 +41,7 @@ Navigate to `/Movies/Index`. Append a query string such as `?searchString=Ghost`
 
 If you change the signature of the `Index` method to have a parameter named `id`, the `id` parameter will match the optional `{id}` placeholder for the default routes set in *Startup.cs*.
 
-[!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie/Startup.cs?highlight=5&name=snippet_1)]
+[!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie5/Startup.cs?highlight=5&name=snippet_route)]
 
 Change the parameter to `id` and all occurrences of `searchString` change to `id`.
 

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie5/Startup.cs
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie5/Startup.cs
@@ -50,13 +50,14 @@ namespace MvcMovie
             app.UseRouting();
 
             app.UseAuthorization();
-
+            #region snippet_route
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
+            #endregion
         }
     }
 }


### PR DESCRIPTION
When reading the docs for the ASP.NET Core 5.0 MvcMovie application, I noticed a code snippet on [Part 7 - Add search](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/search?view=aspnetcore-5.0) containing code that is inconsistent with the rest of the tutorial. Specifically, it changes code in the Startup.cs file's `Configure()` method from `app.UseEndpoints()` to `app.UseMvc()`, which could be confusing to someone reading the code.

I'm not sure if this small change warrants a fix, but I thought I'd give it a go.

The snippets currently used in the documentation seem to come from an older version of the tutorial, but this is the only instance where the code blocks seem to differ compared to the 5.0 version. I changed the newer version to be the source of the snippet for the scenario where I think there should be a change to the code block.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->