### PR TITLE
Convert Blazor WASM into a PWA

### DIFF
--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -5,7 +5,7 @@ description: Learn how to build a Blazor-based Progressive Web Application (PWA)
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/10/2020
+ms.date: 01/11/2020
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/progressive-web-app
 ---
@@ -51,6 +51,57 @@ dotnet new blazorwasm -o MyNewProject --pwa
 ---
 
 Optionally, PWA can be configured for an app created from the ASP.NET Core Hosted template. The PWA scenario is independent of the hosting model.
+
+## Convert an existing Blazor WebAssembly app into a PWA
+
+Convert an existing Blazor WebAssembly app into a PWA following the guidance in this section.
+
+In the app's project file:
+
+* Add the following `ServiceWorkerAssetsManifest` property to a `PropertyGroup`:
+
+  ```xml
+    ...
+    <ServiceWorkerAssetsManifest>service-worker-assets.js</ServiceWorkerAssetsManifest>
+  </PropertyGroup>
+   ```
+
+* Add the following `ServiceWorker` item to an `ItemGroup`:
+
+  ```xml
+  <ItemGroup>
+    <ServiceWorker Include="wwwroot\service-worker.js" 
+      PublishedContent="wwwroot\service-worker.published.js" />
+  </ItemGroup>
+  ```
+
+Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 5.0 release reference source and assets. If you aren't converting an app for the 5.0 release, select the release that you're working with from the **Switch branches or tags** drop-down list that applies to your app.
+
+[dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+
+From the reference assets `wwwroot` folder, copy the following files into the app's `wwwroot` folder:
+
+* `icon-512.png`
+* `manifest.json`
+* `service-worker.js`
+* `service-worker.published.js`
+
+In the app's `wwwroot/index.html` file:
+
+* Add `<link>` elements for the manifest and app icon:
+
+  ```html
+  <link href="manifest.json" rel="manifest" />
+  <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
+  ```
+
+* Add the following `<script>` tag inside the closing `</body>` tag immediately after the `blazor.webassembly.js` script tag:
+
+  ```html
+      ...
+      <script>navigator.serviceWorker.register('service-worker.js');</script>
+  </body>
+  ```
 
 ## Installation and app manifest
 

--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -75,9 +75,26 @@ In the app's project file:
   </ItemGroup>
   ```
 
+::: moniker range=">= aspnetcore-5.0"
+
 Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 5.0 release reference source and assets. If you aren't converting an app for the 5.0 release, select the release that you're working with from the **Switch branches or tags** drop-down list that applies to your app.
 
 [dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 3.1 release reference source and assets:
+
+[dotnet/aspnetcore (release 3.1) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/3.1/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+
+> [!NOTE]
+> The URL for Blazor WebAssembly project template changed after the release of ASP.NET Core 3.1. Reference assets for 5.0 or later are available at the following URL:
+>
+> [dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+
+::: moniker-end
 
 From the reference assets `wwwroot` folder, copy the following files into the app's `wwwroot` folder:
 


### PR DESCRIPTION
Fixes  #20859

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/progressive-web-app?view=aspnetcore-3.1&branch=pr-en-us-21190#convert-an-existing-blazor-webassembly-app-into-a-pwa)

I've successfully used the reference assets cross-linking approach you see here in the past. By linking over to the `wwwroot` folder assets, we'll avoid maintaining copies of these assets in the docs repo that tend to go stale in future releases. It does require the reader to select the right branch over there (and the added little NOTE here about the Blazor folder churn between 3.1 and 5.0), but I haven't seen readers having trouble following similar guidance in the past.

**_Did I miss anything?_** This looks complete, but PWAs are one of things that I haven't had much time to play with.