### PR TITLE
Drop Blazor-Docker section

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -5,7 +5,7 @@ description: Learn how to host and deploy a Blazor app using ASP.NET Core, Conte
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/09/2020
+ms.date: 01/12/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/host-and-deploy/webassembly
 ---
@@ -602,18 +602,6 @@ http {
 Increase the value if browser developer tools or a network traffic tool indicates that requests are receiving a *503 - Service Unavailable* status code.
 
 For more information on production Nginx web server configuration, see [Creating NGINX Plus and NGINX Configuration Files](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/).
-
-### Nginx in Docker
-
-To host Blazor in Docker using Nginx, setup the Dockerfile to use the Alpine-based Nginx image. Update the Dockerfile to copy the `nginx.config` file into the container.
-
-Add one line to the Dockerfile, as shown in the following example:
-
-```dockerfile
-FROM nginx:alpine
-COPY ./bin/Release/netstandard2.0/publish /usr/share/nginx/html/
-COPY nginx.conf /etc/nginx/nginx.conf
-```
 
 ### Apache
 


### PR DESCRIPTION
Fixes #18631

cc: @mkArtakMSFT ... I'm going to leave the nibblets of info on Docker that we have in the *Hosting models* topic and the *Introduction* topic, which are the only other places we address Docker in Blazor topics. We have this one line in each of the WASM and Server sections of the *Hosting models* topic ...

> The hosted Blazor app model supports \[Docker containers](/dotnet/standard/microservices-architecture/container-docker-introduction/index). For Docker support in Visual Studio, right-click on the \`Server\` project of a hosted Blazor WebAssembly solution and select \*\*Add\*\* > \*\*Docker Support\*\*.

That link goes to :point_right: https://docs.microsoft.com/dotnet/architecture/microservices/container-docker-introduction/

We also have this one line in the *Introduction* topic ...

> \* Integrate with modern hosting platforms, such as \[Docker](/dotnet/standard/microservices-architecture/container-docker-introduction/index).

Ping me if you want me to remove or modify those instances.