### PR TITLE
Remove ASOS from the community authentication providers and update OpenIddict's description

### DIFF
--- a/aspnetcore/security/authentication/community.md
+++ b/aspnetcore/security/authentication/community.md
@@ -17,9 +17,8 @@ The list below is sorted alphabetically.
 
 | Name | Description |
 | ---- | ----------- |
-| [AspNet.Security.OpenIdConnect.Server (ASOS)](https://github.com/aspnet-contrib/AspNet.Security.OpenIdConnect.Server) | ASOS is a low-level, protocol-first OpenID Connect server framework for ASP.NET Core and OWIN/Katana. |
 | [Gluu Server](https://gluu.org/) | Enterprise ready, open source software for identity, access management (IAM), and single sign-on (SSO). For more information, see the [Gluu Product Documentation](https://gluu.org/docs/). |
 | [IdentityServer](https://identityserver.io/) | IdentityServer is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core, officially certified by the OpenID Foundation and under governance of the .NET Foundation. For more information, see [Welcome to IdentityServer4 (Documentation)](https://identityserver4.readthedocs.io/en/latest/). |
-| [OpenIddict](https://github.com/openiddict/openiddict-core) | OpenIddict is an easy-to-use OpenID Connect server for ASP.NET Core. |
+| [OpenIddict](https://github.com/openiddict/openiddict-core) | Versatile OpenID Connect stack for ASP.NET Core 2.1/3.1/5.0 and OWIN/Katana 4.1 (compatible with ASP.NET 4.6.1). |
 
 To add a provider, [edit this page](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Faspnet%2FDocs%2Fedit%2Fmaster%2Faspnetcore%2Fsecurity%2Fauthentication%2Fcommunity.md).

--- a/aspnetcore/security/authentication/community.md
+++ b/aspnetcore/security/authentication/community.md
@@ -19,6 +19,6 @@ The list below is sorted alphabetically.
 | ---- | ----------- |
 | [Gluu Server](https://gluu.org/) | Enterprise ready, open source software for identity, access management (IAM), and single sign-on (SSO). For more information, see the [Gluu Product Documentation](https://gluu.org/docs/). |
 | [IdentityServer](https://identityserver.io/) | IdentityServer is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core, officially certified by the OpenID Foundation and under governance of the .NET Foundation. For more information, see [Welcome to IdentityServer4 (Documentation)](https://identityserver4.readthedocs.io/en/latest/). |
-| [OpenIddict](https://github.com/openiddict/openiddict-core) | Versatile OpenID Connect stack for ASP.NET Core 2.1/3.1/5.0 and OWIN/Katana 4.1 (compatible with ASP.NET 4.6.1). |
+| [OpenIddict](https://github.com/openiddict/openiddict-core) | Versatile OpenID Connect stack for ASP.NET Core 2.1/3.1/5.0 and Microsoft.Owin 4.1 (compatible with ASP.NET 4.6.1). |
 
 To add a provider, [edit this page](https://github.com/login?return_to=https%3A%2F%2Fgithub.com%2Faspnet%2FDocs%2Fedit%2Fmaster%2Faspnetcore%2Fsecurity%2Fauthentication%2Fcommunity.md).


### PR DESCRIPTION
ASOS was merged into OpenIddict 3.0: https://kevinchalet.com/2020/12/23/openiddict-3-0-general-availability/

@Rick-Anderson could you PTAL? 😃 