### PR TITLE
Improve WASM security coverage for external IPs

### DIFF
--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -106,7 +106,7 @@ Google OAuth 2.0 OIDC example:
 }
 ```
 
-The redirect URI (`https://localhost:5001/authentication/login-callback`) is registered in the [Google APIs console](https://console.developers.google.com/apis/dashboard) in **Credentials** > **{NAME}** > **Authorized redirect URIs**, where `{NAME}` is the app's client name in the **OAuth 2.0 Client IDs** app list.
+The redirect URI (`https://localhost:5001/authentication/login-callback`) is registered in the [Google APIs console](https://console.developers.google.com/apis/dashboard) in **Credentials** > **`{NAME}`** > **Authorized redirect URIs**, where `{NAME}` is the app's client name in the **OAuth 2.0 Client IDs** app list of the Google APIs console.
 
 Authentication support for standalone apps is offered using OpenID Connect (OIDC). The <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication%2A> method accepts a callback to configure the parameters required to authenticate an app using OIDC. The values required for configuring the app can be obtained from the OIDC-compliant IP. Obtain the values when you register the app, which typically occurs in their online portal.
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -92,7 +92,7 @@ Configuration is supplied by the `wwwroot/appsettings.json` file:
 }
 ```
 
-Google OAuth 2.0 example:
+Google OAuth 2.0 OIDC example:
 
 ```json
 {

--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -17,6 +17,9 @@ By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https
 
 To create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) library, follow the guidance for your choice of tooling.
 
+> [!NOTE]
+> The Identity Provider (IP) must use [OpenID Connect (OIDC)](https://openid.net/connect/). For example, Facebook is **not** OIDC compliant, so the guidance in this topic doesn't apply to using the Facebook IP. For more information, see <xref:blazor/security/webassembly/index#authentication-library>.
+
 # [Visual Studio](#tab/visual-studio)
 
 To create a new Blazor WebAssembly project with an authentication mechanism:
@@ -82,12 +85,28 @@ Configuration is supplied by the `wwwroot/appsettings.json` file:
 
 ```json
 {
-    "Local": {
-        "Authority": "{AUTHORITY}",
-        "ClientId": "{CLIENT ID}"
-    }
+  "Local": {
+    "Authority": "{AUTHORITY}",
+    "ClientId": "{CLIENT ID}"
+  }
 }
 ```
+
+Google OAuth 2.0 example:
+
+```json
+{
+  "Local": {
+    "Authority": "https://accounts.google.com/",
+    "ClientId": "2.......7-e.....................q.apps.googleusercontent.com",
+    "PostLogoutRedirectUri": "https://localhost:5001/authentication/logout-callback",
+    "RedirectUri": "https://localhost:5001/authentication/login-callback",
+    "ResponseType": "id_token"
+  }
+}
+```
+
+The redirect URI (`https://localhost:5001/authentication/login-callback`) is registered in the [Google APIs console](https://console.developers.google.com/apis/dashboard) in **Credentials** > **{NAME}** > **Authorized redirect URIs**, where `{NAME}` is the app's client name in the **OAuth 2.0 Client IDs** app list.
 
 Authentication support for standalone apps is offered using OpenID Connect (OIDC). The <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication%2A> method accepts a callback to configure the parameters required to authenticate an app using OIDC. The values required for configuring the app can be obtained from the OIDC-compliant IP. Obtain the values when you register the app, which typically occurs in their online portal.
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -18,7 +18,7 @@ By [Javier Calvarro Nelson](https://github.com/javiercn) and [Luke Latham](https
 To create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) library, follow the guidance for your choice of tooling.
 
 > [!NOTE]
-> The Identity Provider (IP) must use [OpenID Connect (OIDC)](https://openid.net/connect/). For example, Facebook is **not** OIDC compliant, so the guidance in this topic doesn't apply to using the Facebook IP. For more information, see <xref:blazor/security/webassembly/index#authentication-library>.
+> The Identity Provider (IP) must use [OpenID Connect (OIDC)](https://openid.net/connect/). For example, Facebook's IP isn't an OIDC-compliant provider, so the guidance in this topic doesn't work with the Facebook IP. For more information, see <xref:blazor/security/webassembly/index#authentication-library>.
 
 # [Visual Studio](#tab/visual-studio)
 


### PR DESCRIPTION
Addresses #20175

cc: @billyjim ... This won't resolve your ask. However, the Blazor framework and existing examples (that I can find anyway) don't provide API or a recommended approach for a standalone WASM app with multiple IPs. Today, the developer can ...

* Write the code for a custom auth provider.
* Perhaps, find a third-party lib that will do it (but I didn't see one at Awesome Blazor).
* Go with a hosted solution and Identity Server, with IdS configured for the desired IPs.
* Go with Blazor Server and configure as an ASP.NET Core app for the desired IPs.

This PR tho can do a couple of quick things to improve the coverage ...

* In the *Auth Lib* topic, call out that the IP must be OIDC compliant and cross-link the *Overview* topic where that aspect is described.
* Show an example ... I use Google here, which was based on [Javier's example](https://github.com/javiercn/BlazorGoogleAuthSample/blob/master/GoogleAuth/Program.cs) and just worked for me locally.

Unless they let us know otherwise, your ask is probably a **_won't fix_** for docs at this time on the basis of:

* The framework not providing anything in-box.
* I think that the team is working hard 🚧⛏️ on 6.0 bits and too busy to knock up a sample.

Javier ... I didn't see an open Blazor issue for multiple IPs or anything on the 6.0 roadmap for it. Let me know if you think there's anything we should say about multiple IPs with a standalone WASM app.