### PR TITLE
Surface PWA conversion approach for static assets

### DIFF
--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -75,24 +75,44 @@ In the app's project file:
   </ItemGroup>
   ```
 
+To obtain static assets, use **one** of the following approaches:
+
 ::: moniker range=">= aspnetcore-5.0"
 
-Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 5.0 release reference source and assets. If you aren't converting an app for the 5.0 release, select the release that you're working with from the **Switch branches or tags** drop-down list that applies to your app.
+* Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 5.0 release reference source and assets. If you aren't converting an app for the 5.0 release, select the release that you're working with from the **Switch branches or tags** drop-down list that applies to your app.
 
-[dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+  [dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+  
+* Create a separate, new PWA project with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell:
+
+  ```dotnetcli
+  dotnet new blazorwasm -o MyNewProject --pwa
+  ```
+  
+  If you aren't converting an app for the latest release, pass the `-f|--framework` switch with the version. The following example creates the app for ASP.NET Core version 3.1:
+  
+  ```dotnetcli
+  dotnet new blazorwasm -o MyNewProject --pwa -f netstandard2.1
+  ```
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
 
-Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 3.1 release reference source and assets:
+* Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 3.1 release reference source and assets:
 
-[dotnet/aspnetcore (release 3.1) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/3.1/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+  [dotnet/aspnetcore (release 3.1) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/3.1/src/ProjectTemplates/ComponentsWebAssembly.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
 
-> [!NOTE]
-> The URL for Blazor WebAssembly project template changed after the release of ASP.NET Core 3.1. Reference assets for 5.0 or later are available at the following URL:
->
-> [dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+  > [!NOTE]
+  > The URL for Blazor WebAssembly project template changed after the release of ASP.NET Core 3.1. Reference assets for 5.0 or later are available at the following URL:
+  >
+  > [dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+  
+* Create a separate, new PWA project with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell. Pass the `-f|--framework` switch to select the version. The following example creates the app for ASP.NET Core version 3.1:
+  
+  ```dotnetcli
+  dotnet new blazorwasm -o MyNewProject --pwa -f netstandard2.1
+  ```
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -42,7 +42,7 @@ When creating a new **Blazor WebAssembly App** in the **Create a New Project** d
 
 # [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
 
-Use the following command to create a PWA project from a command shell with the `--pwa` switch:
+Use the following command to create a PWA project in a command shell with the `--pwa` switch:
 
 ```dotnetcli
 dotnet new blazorwasm -o BlazorPWA --pwa

--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -45,10 +45,10 @@ When creating a new **Blazor WebAssembly App** in the **Create a New Project** d
 Use the following command to create a PWA project in a command shell with the `--pwa` switch:
 
 ```dotnetcli
-dotnet new blazorwasm -o BlazorPWA --pwa
+dotnet new blazorwasm -o MyBlazorPwa --pwa
 ```
 
-In the preceding command, the `-o|--output` option creates a new folder for the app named `BlazorPWA`.
+In the preceding command, the `-o|--output` option creates a new folder for the app named `MyBlazorPwa`.
 
 ---
 
@@ -84,15 +84,15 @@ To obtain static assets, use **one** of the following approaches:
 * Create a separate, new PWA project with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell:
 
   ```dotnetcli
-  dotnet new blazorwasm -o BlazorPWA --pwa
+  dotnet new blazorwasm -o MyBlazorPwa --pwa
   ```
   
-  In the preceding command, the `-o|--output` option creates a new folder for the app named `BlazorPWA`.
+  In the preceding command, the `-o|--output` option creates a new folder for the app named `MyBlazorPwa`.
   
   If you aren't converting an app for the latest release, pass the `-f|--framework` option. The following example creates the app for ASP.NET Core version 3.1:
   
   ```dotnetcli
-  dotnet new blazorwasm -o MyNewProject --pwa -f netstandard2.1
+  dotnet new blazorwasm -o MyBlazorPwa --pwa -f netstandard2.1
   ```
 
 * Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 5.0 release reference source and assets. If you aren't converting an app for the 5.0 release, select the release that you're working with from the **Switch branches or tags** drop-down list that applies to your app.
@@ -106,10 +106,10 @@ To obtain static assets, use **one** of the following approaches:
 * Create a separate, new PWA project with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell. Pass the `-f|--framework` option to select the version. The following example creates the app for ASP.NET Core version 3.1:
   
   ```dotnetcli
-  dotnet new blazorwasm -o BlazorPWA --pwa -f netstandard2.1
+  dotnet new blazorwasm -o MyBlazorPwa --pwa -f netstandard2.1
   ```
   
-  In the preceding command, the `-o|--output` option creates a new folder for the app named `BlazorPWA`.
+  In the preceding command, the `-o|--output` option creates a new folder for the app named `MyBlazorPwa`.
 
 * Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 3.1 release reference source and assets:
 
@@ -122,7 +122,7 @@ To obtain static assets, use **one** of the following approaches:
 
 ::: moniker-end
 
-From the reference assets `wwwroot` folder, copy the following files into the app's `wwwroot` folder:
+From the source `wwwroot` folder either in the app that you created or from the reference assets in the `dotnet/aspnetcore` GitHub repository, copy the following files into the app's `wwwroot` folder:
 
 * `icon-512.png`
 * `manifest.json`

--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -42,11 +42,13 @@ When creating a new **Blazor WebAssembly App** in the **Create a New Project** d
 
 # [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
 
-Create a PWA project in a command shell with the `--pwa` switch:
+Use the following command to create a PWA project from a command shell with the `--pwa` switch:
 
 ```dotnetcli
-dotnet new blazorwasm -o MyNewProject --pwa
+dotnet new blazorwasm -o BlazorPWA --pwa
 ```
+
+In the preceding command, the `-o|--output` option creates a new folder for the app named `BlazorPWA`.
 
 ---
 
@@ -79,25 +81,35 @@ To obtain static assets, use **one** of the following approaches:
 
 ::: moniker range=">= aspnetcore-5.0"
 
-* Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 5.0 release reference source and assets. If you aren't converting an app for the 5.0 release, select the release that you're working with from the **Switch branches or tags** drop-down list that applies to your app.
-
-  [dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
-  
 * Create a separate, new PWA project with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell:
 
   ```dotnetcli
-  dotnet new blazorwasm -o MyNewProject --pwa
+  dotnet new blazorwasm -o BlazorPWA --pwa
   ```
   
-  If you aren't converting an app for the latest release, pass the `-f|--framework` switch with the version. The following example creates the app for ASP.NET Core version 3.1:
+  In the preceding command, the `-o|--output` option creates a new folder for the app named `BlazorPWA`.
+  
+  If you aren't converting an app for the latest release, pass the `-f|--framework` option. The following example creates the app for ASP.NET Core version 3.1:
   
   ```dotnetcli
   dotnet new blazorwasm -o MyNewProject --pwa -f netstandard2.1
   ```
 
+* Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 5.0 release reference source and assets. If you aren't converting an app for the 5.0 release, select the release that you're working with from the **Switch branches or tags** drop-down list that applies to your app.
+
+  [dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
+
+* Create a separate, new PWA project with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell. Pass the `-f|--framework` option to select the version. The following example creates the app for ASP.NET Core version 3.1:
+  
+  ```dotnetcli
+  dotnet new blazorwasm -o BlazorPWA --pwa -f netstandard2.1
+  ```
+  
+  In the preceding command, the `-o|--output` option creates a new folder for the app named `BlazorPWA`.
 
 * Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 3.1 release reference source and assets:
 
@@ -107,12 +119,6 @@ To obtain static assets, use **one** of the following approaches:
   > The URL for Blazor WebAssembly project template changed after the release of ASP.NET Core 3.1. Reference assets for 5.0 or later are available at the following URL:
   >
   > [dotnet/aspnetcore (release 5.0) Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/5.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
-  
-* Create a separate, new PWA project with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell. Pass the `-f|--framework` switch to select the version. The following example creates the app for ASP.NET Core version 3.1:
-  
-  ```dotnetcli
-  dotnet new blazorwasm -o MyNewProject --pwa -f netstandard2.1
-  ```
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -92,7 +92,7 @@ To obtain static assets, use **one** of the following approaches:
   If you aren't converting an app for the latest release, pass the `-f|--framework` option. The following example creates the app for ASP.NET Core version 3.1:
   
   ```dotnetcli
-  dotnet new blazorwasm -o MyBlazorPwa --pwa -f netstandard2.1
+  dotnet new blazorwasm -o MyBlazorPwa --pwa -f netcoreapp3.1
   ```
 
 * Navigate to the ASP.NET Core GitHub repository at the following URL, which links to 5.0 release reference source and assets. If you aren't converting an app for the 5.0 release, select the release that you're working with from the **Switch branches or tags** drop-down list that applies to your app.
@@ -106,7 +106,7 @@ To obtain static assets, use **one** of the following approaches:
 * Create a separate, new PWA project with the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in a command shell. Pass the `-f|--framework` option to select the version. The following example creates the app for ASP.NET Core version 3.1:
   
   ```dotnetcli
-  dotnet new blazorwasm -o MyBlazorPwa --pwa -f netstandard2.1
+  dotnet new blazorwasm -o MyBlazorPwa --pwa -f netcoreapp3.1
   ```
   
   In the preceding command, the `-o|--output` option creates a new folder for the app named `MyBlazorPwa`.


### PR DESCRIPTION
Addresses #20859

We can show both like this.

I agree on `dotnet new`-ing up an app to get them. This looks good. Copying the files from a local folder is nice, too. I'm making this the first option.

I think we should keep the existing bit tho. A bit of developer training for GH is ok ... the proverbial *teachable moment* because **_they want those assets_** :smile: lol ... and if I keep these links up-to-date, they probably won't even have to fiddle with the branch selector.

btw - I'm going to temporarily change the folder/app name to `MyBlazorPwa` so that it will match what's shown in the images. Later on my UE pass for this topic, images really should come out of it. Keeping up with images are a real **_pain point_** around here 😬. Later, I'll use a different name because I'm getting away from "My"-named things everywhere in this doc set.

**UPDATE**: Safia, this one seems ok as well ... given that I just caught and fixed the framework for the CLI command (`netcoreapp3.1`) ... At first, I was a **_bit too literal looking at the project file (i.e., `netstandard2.1`)!_** 🙈:smile:. I'll go ahead and you can ping me if you spot something amiss.