### PR TITLE
remove myget.org

### DIFF
--- a/aspnetcore/fundamentals/portable-object-localization.md
+++ b/aspnetcore/fundamentals/portable-object-localization.md
@@ -64,7 +64,7 @@ This example is based on an ASP.NET Core MVC application generated from a Visual
 
 ### Referencing the package
 
-Add a reference to the `OrchardCore.Localization.Core` NuGet package. It's available on [MyGet](https://www.myget.org/) at the following package source: https://www.myget.org/F/orchardcore-preview/api/v3/index.json
+Add a reference to the `OrchardCore.Localization.Core` NuGet package.
 
 The *.csproj* file now contains a line similar to the following (version number may vary):
 
@@ -280,7 +280,7 @@ This example is based on an ASP.NET Core MVC application generated from a Visual
 
 ### Referencing the package
 
-Add a reference to the `OrchardCore.Localization.Core` NuGet package. It's available on [MyGet](https://www.myget.org/) at the following package source: https://www.myget.org/F/orchardcore-preview/api/v3/index.json
+Add a reference to the `OrchardCore.Localization.Core` NuGet package.
 
 The *.csproj* file now contains a line similar to the following (version number may vary):
 

--- a/aspnetcore/razor-pages/index/sample/NuGet.config
+++ b/aspnetcore/razor-pages/index/sample/NuGet.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="aspnetcore-release" value="https://dotnet.myget.org/F/aspnetcore-release/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
Fixes #21021

@mmitche, these were the only files of "myget" in the repo.  `obj\MySharedApp.csproj.nuget.dgspec.json`, but `.gitignore` excludes the `obj` directory.