### PR TITLE
Specify the issuer explicitly App Service+IdS

### DIFF
--- a/aspnetcore/blazor/security/server/index.md
+++ b/aspnetcore/blazor/security/server/index.md
@@ -110,6 +110,10 @@ Scaffold Identity into a Blazor Server project:
 * [Without existing authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-without-existing-authorization).
 * [With authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-with-authorization).
 
+## Azure App Service on Linux with Identity Server
+
+Specify the issuer explicitly when deploying to Azure App Service on Linux with Identity Server. For more information, see <xref:security/authentication/identity/spa#azure-app-service-on-linux>.
+
 ## Additional resources
 
 * [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app](/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp)

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -113,6 +113,10 @@ The `Startup` class has the following additions.
     app.UseAuthorization();
     ```
 
+### Azure App Service on Linux
+
+Specify the issuer explicitly when deploying to Azure App Service on Linux. For more information, see <xref:security/authentication/identity/spa#azure-app-service-on-linux>.
+
 ### AddApiAuthorization
 
 The <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method configures [IdentityServer](https://identityserver.io/) for ASP.NET Core scenarios. IdentityServer is a powerful and extensible framework for handling app security concerns. IdentityServer exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided that we consider a good starting point. Once your authentication needs change, the full power of IdentityServer is available to customize authentication to suit an app's requirements.

--- a/aspnetcore/blazor/security/webassembly/index.md
+++ b/aspnetcore/blazor/security/webassembly/index.md
@@ -90,6 +90,10 @@ Apps often require claims for users based on a web API call to a server. For exa
 * [Additional scenarios: Customize the user](xref:blazor/security/webassembly/additional-scenarios#customize-the-user)
 * <xref:blazor/security/webassembly/aad-groups-roles>
 
+## Azure App Service on Linux with Identity Server
+
+Specify the issuer explicitly when deploying to Azure App Service on Linux with Identity Server. For more information, see <xref:security/authentication/identity/spa#azure-app-service-on-linux>.
+
 ## Implementation guidance
 
 Articles under this *Overview* provide information on authenticating users in Blazor WebAssembly apps against specific providers.

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -81,6 +81,27 @@ The `Startup` class has the following additions:
     app.UseIdentityServer();
     ```
 
+### Azure App Service on Linux
+
+For Azure App Service deployments on Linux, specify the issuer explicitly in `Startup.ConfigureServices`:
+
+```csharp
+services.Configure<JwtBearerOptions>(
+    IdentityServerJwtConstants.IdentityServerJwtBearerScheme, 
+    options =>
+    {
+        options.Authority = "{DOMAIN}";
+    });
+```
+
+In the preceding code, the placeholder `{DOMAIN}` is the default or custom domain.
+
+Example:
+
+```csharp
+options.Authority = "https://contoso-service.azurewebsites.net";
+```
+
 ### AddApiAuthorization
 
 This helper method configures IdentityServer to use our supported configuration. IdentityServer is a powerful and extensible framework for handling app security concerns. At the same time, that exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided to you that are considered a good starting point. Once your authentication needs change, the full power of IdentityServer is still available to customize authentication to suit your needs.

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -94,7 +94,7 @@ services.Configure<JwtBearerOptions>(
     });
 ```
 
-In the preceding code, the `{AUTHORITY}` placeholder is the Authority to use when making OpenID Connect calls.
+In the preceding code, the `{AUTHORITY}` placeholder is the <xref:Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions.Authority> to use when making OpenID Connect calls.
 
 Example:
 

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -94,7 +94,7 @@ services.Configure<JwtBearerOptions>(
     });
 ```
 
-In the preceding code, the `{AUTHORITY}` placeholder the Authority to use when making OpenID Connect calls.
+In the preceding code, the `{AUTHORITY}` placeholder is the Authority to use when making OpenID Connect calls.
 
 Example:
 

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -94,7 +94,7 @@ services.Configure<JwtBearerOptions>(
     });
 ```
 
-In the preceding code, the placeholder `{DOMAIN}` is the default or custom domain.
+In the preceding code, the `{DOMAIN}` placeholder is the default or custom domain.
 
 Example:
 

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -90,11 +90,11 @@ services.Configure<JwtBearerOptions>(
     IdentityServerJwtConstants.IdentityServerJwtBearerScheme, 
     options =>
     {
-        options.Authority = "{DOMAIN}";
+        options.Authority = "{AUTHORITY}";
     });
 ```
 
-In the preceding code, the `{DOMAIN}` placeholder is the default or custom domain.
+In the preceding code, the `{AUTHORITY}` placeholder the Authority to use when making OpenID Connect calls.
 
 Example:
 


### PR DESCRIPTION
Fixes #21228

🤔 Guessing a bit on the best way to add/organize the coverage ...

* Main section that describes what to do: `security/authentication/identity-api-authorization.md`
* Cross-links to that section:
  * `blazor/security/server/index.md`
  * `blazor/security/webassembly/index.md`
  * `blazor/security/webassembly/hosted-with-identity-server.md`
