### PR TITLE
Remove unnecessary word in comparison.md

### DIFF
--- a/aspnetcore/grpc/comparison.md
+++ b/aspnetcore/grpc/comparison.md
@@ -44,7 +44,7 @@ HTTP/2 is not exclusive to gRPC. Many request types, including HTTP APIs with JS
 
 ### Code generation
 
-All gRPC frameworks provide first-class support for code generation. A core file to gRPC development is the [.proto file](https://developers.google.com/protocol-buffers/docs/proto3), which defines the contract of gRPC services and messages. From this file gRPC frameworks will generate a service base class, messages, and a complete client.
+All gRPC frameworks provide first-class support for code generation. A core file to gRPC development is the [`.proto` file](https://developers.google.com/protocol-buffers/docs/proto3), which defines the contract of gRPC services and messages. From this file gRPC, frameworks generate a service base class, messages, and a complete client.
 
 By sharing the *.proto* file between the server and client, messages and client code can be generated from end to end. Code generation of the client eliminates duplication of messages on the client and server, and creates a strongly-typed client for you. Not having to write a client saves significant development time in applications with many services.
 

--- a/aspnetcore/grpc/comparison.md
+++ b/aspnetcore/grpc/comparison.md
@@ -44,7 +44,7 @@ HTTP/2 is not exclusive to gRPC. Many request types, including HTTP APIs with JS
 
 ### Code generation
 
-All gRPC frameworks provide first-class support for code generation. A core file to gRPC development is the [`.proto` file](https://developers.google.com/protocol-buffers/docs/proto3), which defines the contract of gRPC services and messages. From this file gRPC, frameworks generate a service base class, messages, and a complete client.
+All gRPC frameworks provide first-class support for code generation. A core file to gRPC development is the [`.proto` file](https://developers.google.com/protocol-buffers/docs/proto3), which defines the contract of gRPC services and messages. From this file, gRPC frameworks generate a service base class, messages, and a complete client.
 
 By sharing the *.proto* file between the server and client, messages and client code can be generated from end to end. Code generation of the client eliminates duplication of messages on the client and server, and creates a strongly-typed client for you. Not having to write a client saves significant development time in applications with many services.
 

--- a/aspnetcore/grpc/comparison.md
+++ b/aspnetcore/grpc/comparison.md
@@ -44,7 +44,7 @@ HTTP/2 is not exclusive to gRPC. Many request types, including HTTP APIs with JS
 
 ### Code generation
 
-All gRPC frameworks provide first-class support for code generation. A core file to gRPC development is the [.proto file](https://developers.google.com/protocol-buffers/docs/proto3), which defines the contract of gRPC services and messages. From this file gRPC frameworks will code generate a service base class, messages, and a complete client.
+All gRPC frameworks provide first-class support for code generation. A core file to gRPC development is the [.proto file](https://developers.google.com/protocol-buffers/docs/proto3), which defines the contract of gRPC services and messages. From this file gRPC frameworks will generate a service base class, messages, and a complete client.
 
 By sharing the *.proto* file between the server and client, messages and client code can be generated from end to end. Code generation of the client eliminates duplication of messages on the client and server, and creates a strongly-typed client for you. Not having to write a client saves significant development time in applications with many services.
 


### PR DESCRIPTION
The following sentence:

> From this file gRPC frameworks will code generate a service base class...

Has the word "code" which is not required and should read:

> From this file gRPC frameworks will generate a service base class...



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->