### PR TITLE
Specify Type for ProducesResponseType

### DIFF
--- a/aspnetcore/web-api/action-return-types/samples/2x/WebApiSample.Api.21/Controllers/ProductsController.cs
+++ b/aspnetcore/web-api/action-return-types/samples/2x/WebApiSample.Api.21/Controllers/ProductsController.cs
@@ -38,7 +38,7 @@ namespace WebApiSample.Controllers
 #if IActionResult
         #region snippet_GetByIdIActionResult
         [HttpGet("{id}")]
-        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(Product))]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public IActionResult GetById(int id)
         {


### PR DESCRIPTION
Later in the article, this is highlighted as one of the differences between using IActionResult and ActionResult<T>

