### PR TITLE
Flesh out SetParametersAsync example

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -72,16 +72,13 @@ In the following example, <xref:Microsoft.AspNetCore.Components.ParameterView.Tr
 
     public override async Task SetParametersAsync(ParameterView parameters)
     {
-        if (parameters.TryGetValue<string>(nameof(Param), out var value))
+        if (!parameters.TryGetValue<string>(nameof(Param), out var value))
         {
-            if (value is null)
-            {
-                message = $"The value of 'Param' is null.";
-            }
-            else
-            {
-                message = $"The value of 'Param' is {value}.";
-            }
+            message = "The value of 'Param' is null.";
+        }
+        else 
+        {
+            message = $"The value of 'Param' is {value}.";
         }
 
         await base.SetParametersAsync(parameters);

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -51,14 +51,41 @@ Developer calls to [`StateHasChanged`](#state-changes) result in a render. For m
 
 ### Before parameters are set
 
-<xref:Microsoft.AspNetCore.Components.ComponentBase.SetParametersAsync%2A> sets parameters supplied by the component's parent in the render tree:
+<xref:Microsoft.AspNetCore.Components.ComponentBase.SetParametersAsync%2A> sets parameters supplied by the component's parent in the render tree or from route parameters. By overriding the method, developer code can interact directly with the <xref:Microsoft.AspNetCore.Components.ParameterView>'s parameters.
 
-```csharp
-public override async Task SetParametersAsync(ParameterView parameters)
-{
-    await ...
+In the following example, <xref:Microsoft.AspNetCore.Components.ParameterView.TryGetValue%2A?displayProperty=nameWithType> assigns the `Param` parameter's value to `value` if parsing a route parameter for `Param` is successful. When `value` isn't `null`, the value is displayed by the `SetParametersAsyncExample` component.
 
-    await base.SetParametersAsync(parameters);
+`Pages/SetParametersAsyncExample.razor`:
+
+```razor
+@page "/setparametersasync-example/{Param?}"
+
+<h1>SetParametersAsync Example</h1>
+
+<p>@message</p>
+
+@code {
+    private string message;
+
+    [Parameter]
+    public string Param { get; set; }
+
+    public override async Task SetParametersAsync(ParameterView parameters)
+    {
+        if (parameters.TryGetValue<string>(nameof(Param), out var value))
+        {
+            if (value is null)
+            {
+                message = $"The value of 'Param' is null.";
+            }
+            else
+            {
+                message = $"The value of 'Param' is {value}.";
+            }
+        }
+
+        await base.SetParametersAsync(parameters);
+    }
 }
 ```
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -72,13 +72,13 @@ In the following example, <xref:Microsoft.AspNetCore.Components.ParameterView.Tr
 
     public override async Task SetParametersAsync(ParameterView parameters)
     {
-        if (!parameters.TryGetValue<string>(nameof(Param), out var value))
+        if (parameters.TryGetValue<string>(nameof(Param), out var value))
         {
-            message = "The value of 'Param' is null.";
+            message = $"The value of 'Param' is {value}.";
         }
         else 
         {
-            message = $"The value of 'Param' is {value}.";
+            message = "The value of 'Param' is null.";
         }
 
         await base.SetParametersAsync(parameters);


### PR DESCRIPTION
Fixes #20921

Thanks @dumaisf! :rocket:

Safia, the example thus far on the PR might be a steaming pile of **_Rex dinosaur droppings_** 💩〰️👃😵, so the example might need work or replacement with something you think would be better. Whatever we do, I hope we flesh out the example and make it a complete *cut-'n-paste* experience. As we discussed offline, it's not an example of a workaround for doing anything specific with the parameters, just *how to work with them generally*.

@dumaisf ... Following our chat on the issue, you can interact with the parameters here ... try to parse one (or several) into your custom type(s) ... if they don't parse, do something else besides load the component ... throw ... redirect. That's a *workaround*/*hack* **_idea only_**, and Safia and I didn't discuss it further. You can talk to the community further about it for other ideas ...

* [Stack Overflow (tag: `blazor`)](https://stackoverflow.com/questions/tagged/blazor)
* [ASP.NET Core Slack Team](http://tattoocoder.com/aspnet-slack-sign-up/)
* [Blazor Gitter](https://gitter.im/aspnet/Blazor)

We won't address the custom route constraint part because that's not a thing at this time. We usually only cover what the framework is capable of doing at any time. If the product unit comes up with something for that for a future release, we'll get it into the docs.