### PR TITLE
Fix redirect for First MVC index

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -21,13 +21,18 @@
             "redirect_document_id": false
         },
         {
+            "source_path": "aspnetcore/tutorials/first-mvc-app/index.md",
+            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/start-mvc",
+            "redirect_document_id": false
+        },
+        {
             "source_path": "aspnetcore/tutorials/first-mvc-app-xplat/index.md",
-            "redirect_url": "/aspnet/core/tutorials/first-mvc-app",
+            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/start-mvc",
             "redirect_document_id": false
         },
         {
             "source_path": "aspnetcore/tutorials/first-mvc-app-xplat/start-mvc.md",
-            "redirect_url": "/aspnet/core/tutorials/first-mvc-app",
+            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/start-mvc",
             "redirect_document_id": false
         },
         {
@@ -72,12 +77,12 @@
         },
         {
             "source_path": "aspnetcore/tutorials/first-mvc-app-mac/start-mvc.md",
-            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/",
+            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/start-mvc",
             "redirect_document_id": false
         },
         {
             "source_path": "aspnetcore/tutorials/first-mvc-app-mac/index.md",
-            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/",
+            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/start-mvc",
             "redirect_document_id": false
         },
         {
@@ -572,7 +577,7 @@
         },
         {
             "source_path": "aspnetcore/tutorials/your-first-aspnet-application.md",
-            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/",
+            "redirect_url": "/aspnet/core/tutorials/first-mvc-app/start-mvc",
             "redirect_document_id": false
         },
         {

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -260,8 +260,6 @@
           uid: mvc/overview
         - name: Tutorial
           items:
-            - name: Overview
-              uid: tutorials/first-mvc-app/index
             - name: Get started
               uid: tutorials/first-mvc-app/start-mvc
             - name: Add a controller


### PR DESCRIPTION
[Internal Review - Verify TOC no longer includes overview for First MVC series](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/index?view=aspnetcore-5.0&branch=pr-en-us-21286&tabs=visual-studio)

[Internal Review - Test redirect of first-mvc-app/](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/?view=aspnetcore-5.0&branch=pr-en-us-21286&tabs=visual-studio)

[Internal Review - Test redirect of first-mvc-app/index](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/index?view=aspnetcore-5.0&branch=pr-en-us-21286&tabs=visual-studio)


Fixes #21283 


* Fixed redirect for First MVC series overview that has been removed.
* Removed First MVC series overview from TOC


Related to merged PR https://github.com/dotnet/AspNetCore.Docs/pull/21233
