### PR TITLE
http-requests Cookies Sample HttpMessageHandler

### DIFF
--- a/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/Startup.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/Startup.cs
@@ -135,7 +135,7 @@ namespace HttpClientFactorySample
             services.AddHttpClient("configured-disable-automatic-cookies")
                 .ConfigurePrimaryHttpMessageHandler(() =>
                 {
-                    return new SocketsHttpHandler()
+                    return new HttpClientHandler()
                     {
                         UseCookies = false,
                     };


### PR DESCRIPTION
Switched the cookies sample to use HttpClientHandler instead of SocketsHttpHandler. HttpClientHandler (the default) handles writing diagnostic events:

https://github.com/dotnet/runtime/blob/01116d4e145d17adefc1237d55b1e3574919b1c1/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs#L31-L34

So using SocketsHttpHandler directly as the snippet suggests actually breaks some of the default behaviors (besides impacting the cookie feature being discussed). For users using something like https://github.com/open-telemetry/opentelemetry-dotnet this leads to broken traces. Instead of going into that nuance, this seemed like a more fail-safe approach.

/cc @cijothomas 