### PR TITLE
Detailed circuit errors

### DIFF
--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -72,6 +72,35 @@ The `blazor-error-ui` element is hidden by the styles included in the Blazor tem
 }
 ```
 
+## Blazor Server detailed circuit errors
+
+Client-side errors don't include the callstack and don't provide detail on the cause of the error, but server logs do contain such information. For development purposes, sensitive circuit error information can be made available to the client by enabling detailed errors.
+
+Enable Blazor Server detailed errors using the following approaches:
+
+* <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors?displayProperty=nameWithType>.
+* The `DetailedErrors` configuration key set to `true`, which can be set in the app's Development settings file (`appsettings.Development.json`). The key can also be set using the `ASPNETCORE_DETAILEDERRORS` environment variable with a value of `true`.
+* [SignalR server-side logging](xref:signalr/diagnostics#server-side-logging) (`Microsoft.AspNetCore.SignalR`) can be set to [Debug](xref:Microsoft.Extensions.Logging.LogLevel) or [Trace](xref:Microsoft.Extensions.Logging.LogLevel) for detailed SignalR logging.
+
+`appsettings.Development.json`:
+
+```json
+{
+  "DetailedErrors": true,
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Microsoft.AspNetCore.SignalR": "Debug"
+    }
+  }
+}
+```
+
+> [!WARNING]
+> Exposing error information to clients on the Internet is a security risk that should always be avoided.
+
 ## How a Blazor Server app reacts to unhandled exceptions
 
 Blazor Server is a stateful framework. While users interact with an app, they maintain a connection to the server known as a *circuit*. The circuit holds active component instances, plus many other aspects of state, such as:

--- a/aspnetcore/blazor/security/server/threat-mitigation.md
+++ b/aspnetcore/blazor/security/server/threat-mitigation.md
@@ -289,12 +289,7 @@ JS interop interactions between the client and server are recorded in the server
 
 When an error occurs on the server, the framework notifies the client and tears down the session. By default, the client receives a generic error message that can be seen in the browser's developer tools.
 
-The client-side error doesn't include the callstack and doesn't provide detail on the cause of the error, but server logs do contain such information. For development purposes, sensitive error information can be made available to the client by enabling detailed errors.
-
-Enable detailed errors in JavaScript with:
-
-* <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors?displayProperty=nameWithType>.
-* The `DetailedErrors` configuration key set to `true`, which can be set in the app settings file (`appsettings.json`). The key can also be set using the `ASPNETCORE_DETAILEDERRORS` environment variable with a value of `true`.
+The client-side error doesn't include the callstack and doesn't provide detail on the cause of the error, but server logs do contain such information. For development purposes, sensitive error information can be made available to the client by [enabling detailed errors](xref:blazor/fundamentals/handle-errors#blazor-server-detailed-circuit-errors).
 
 > [!WARNING]
 > Exposing error information to clients on the Internet is a security risk that should always be avoided.


### PR DESCRIPTION
Fixes #17071

Thanks @mrlife! 🎸 

The coverage is currently in *Size limits on JS interop calls* of the *Call .NET from JS* topic (specifically for surfacing message size limit errors) and more generally in *Threat mitigation guidance for ASP.NET Core Blazor Server*. We don't have this coverage here in the newer *Handle errors* topic. I place it and update the threat mitigation guidance to cross-link.