### PR TITLE
make Registry subkey writable

### DIFF
--- a/aspnetcore/security/data-protection/implementation/key-storage-providers.md
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers.md
@@ -122,7 +122,7 @@ Sometimes the app might not have write access to the file system. Consider a sce
 public void ConfigureServices(IServiceCollection services)
 {
     services.AddDataProtection()
-        .PersistKeysToRegistry(Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Sample\keys"));
+        .PersistKeysToRegistry(Registry.CurrentUser.OpenSubKey(@"SOFTWARE\Sample\keys", true));
 }
 ```
 


### PR DESCRIPTION
If not writable, sometimes you will suffer `UnauthorizedAccessException: Cannot write to the registry key.` I think a wide used docs should avoid that happen.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->