### PR TITLE
User claims added or updated

### DIFF
--- a/aspnetcore/blazor/security/server/index.md
+++ b/aspnetcore/blazor/security/server/index.md
@@ -110,6 +110,10 @@ Scaffold Identity into a Blazor Server project:
 * [Without existing authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-without-existing-authorization).
 * [With authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-with-authorization).
 
+## Additional claims and tokens from external providers
+
+To store additional claims from external providers, see <xref:security/authentication/social/additional-claims>.
+
 ## Azure App Service on Linux with Identity Server
 
 Specify the issuer explicitly when deploying to Azure App Service on Linux with Identity Server. For more information, see <xref:security/authentication/identity/spa#azure-app-service-on-linux>.

--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -110,7 +110,7 @@ For more information, see <xref:Microsoft.AspNetCore.Authentication.OAuth.Claims
 
 ## Add claims to users
 
-Claims are added to the user on first registration, not on sign in. If additional claims are enabled in an app after a user registers to use the app, call [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%2A) on a user to force the generation of a new authentication cookie.
+Claims are added to the user on first registration, not on sign in. If additional claims are enabled in an app after a user registers to use the app, call [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%601) on a user to force the generation of a new authentication cookie.
 
 In the Development environment working with test user accounts, you can simply delete and recreate the user account.
 
@@ -118,8 +118,8 @@ In the Development environment working with test user accounts, you can simply d
 
 Claims that change after a user signs in aren't automatically updated. If claims change while a user is signed in, call:
 
-* [UserManager.ReplaceClaimAsync](xref:Microsoft.AspNetCore.Identity.UserManager%2A) on the user for claims stored in the identity database.
-* [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%2A) on the user to force the generation of a new authentication cookie.
+* [UserManager.ReplaceClaimAsync](xref:Microsoft.AspNetCore.Identity.UserManager%601) on the user for claims stored in the identity database.
+* [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%601) on the user to force the generation of a new authentication cookie.
 
 ## Removal of claim actions and claims
 

--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -108,7 +108,7 @@ Users can define custom actions by deriving from <xref:Microsoft.AspNetCore.Auth
 
 For more information, see <xref:Microsoft.AspNetCore.Authentication.OAuth.Claims>.
 
-## Add claims to users
+## Add and update user claims
 
 Claims are copied from external providers to the user database on first registration, not on sign in. If additional claims are enabled in an app after a user registers to use the app, call [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%601) on a user to force the generation of a new authentication cookie.
 
@@ -124,7 +124,7 @@ private readonly IDictionary<string, string> _addedClaims =
     };
 ```
 
-Replace the default code of the `OnGetCallbackAsync` method with the following code. The code loops through the claims dictionary. Claims are added (backfilled) or updated for each user. When claims are added or updated, the user sign-in is refreshed using the <xref:Microsoft.AspNetCore.Identity.SignInManager%2A>, preserving the existing authentication properties (`AuthenticationProperties`).
+Replace the default code of the `OnGetCallbackAsync` method with the following code. The code loops through the claims dictionary. Claims are added (backfilled) or updated for each user. When claims are added or updated, the user sign-in is refreshed using the <xref:Microsoft.AspNetCore.Identity.SignInManager%601>, preserving the existing authentication properties (`AuthenticationProperties`).
 
 ```csharp
 public async Task<IActionResult> OnGetCallbackAsync(
@@ -219,9 +219,7 @@ public async Task<IActionResult> OnGetCallbackAsync(
 }
 ```
 
-## Update user claims
-
-Claims that change after a user signs in aren't automatically updated. If claims change while a user is signed in, call:
+A similar approach is taken when claims change while a user is signed in but a backfill step isn't required. To update a user's claims, call the following on the user:
 
 * [UserManager.ReplaceClaimAsync](xref:Microsoft.AspNetCore.Identity.UserManager%601) on the user for claims stored in the identity database.
 * [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%601) on the user to force the generation of a new authentication cookie.

--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -117,7 +117,7 @@ In the Development environment working with test user accounts, you can simply d
 Add a dictionary of added claims. Use the dictionary keys to hold the claim types, and use the values to hold a default value. Add the following line to the top of the class. The following example assumes that one claim is added for the user's Google picture with a generic headshot image as the default value:
 
 ```csharp
-private readonly IDictionary<string, string> _addedClaims = 
+private readonly IDictionary<string, string> _claimsToSync = 
     new Dictionary<string, string>()
     {
         { "urn:google:picture", "https://localhost:5001/headshot.png" },
@@ -136,7 +136,7 @@ public async Task<IActionResult> OnGetCallbackAsync(
         ErrorMessage = $"Error from external provider: {remoteError}";
         return RedirectToPage("./Login", new {ReturnUrl = returnUrl });
     }
-    var info = await _signInManager.GetExternalLoginInfoAsync();
+    var externalLogin = await _signInManager.GetExternalLoginInfoAsync();
     if (info == null)
     {
         ErrorMessage = "Error loading external login information.";
@@ -166,7 +166,7 @@ public async Task<IActionResult> OnGetCallbackAsync(
 
                 if (info.Principal.HasClaim(c => c.Type == addedClaim.Key))
                 {
-                    var principalClaim = info.Principal.FindFirst(addedClaim.Key);
+                    var externalClaim = info.Principal.FindFirst(addedClaim.Key);
 
                     if (userClaim == null)
                     {
@@ -183,6 +183,7 @@ public async Task<IActionResult> OnGetCallbackAsync(
                 }
                 else if (userClaim == null)
                 {
+                    // Fill with a default value
                     await _userManager.AddClaimAsync(user, new Claim(addedClaim.Key, 
                         addedClaim.Value));
                     refreshSignIn = true;

--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -5,7 +5,7 @@ description: Learn how to establish additional claims and tokens from external p
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/30/2020
+ms.date: 02/18/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/authentication/social/additional-claims
 ---

--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -91,6 +91,9 @@ The sample app saves the access token in `OnPostConfirmationAsync` (new user reg
 
 [!code-csharp[](additional-claims/samples/3.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs?name=snippet_OnPostConfirmationAsync&highlight=54-56)]
 
+> [!NOTE]
+> For information on passing tokens to the Razor components of a Blazor Server app, see <xref:blazor/security/server/additional-scenarios#pass-tokens-to-a-blazor-server-app>.
+
 ## How to add additional custom tokens
 
 To demonstrate how to add a custom token, which is stored as part of `SaveTokens`, the sample app adds an <xref:Microsoft.AspNetCore.Authentication.AuthenticationToken> with the current <xref:System.DateTime> for an [AuthenticationToken.Name](xref:Microsoft.AspNetCore.Authentication.AuthenticationToken.Name*) of `TicketCreated`:
@@ -104,6 +107,19 @@ The framework provides common actions and extension methods for creating and add
 Users can define custom actions by deriving from <xref:Microsoft.AspNetCore.Authentication.OAuth.Claims.ClaimAction> and implementing the abstract <xref:Microsoft.AspNetCore.Authentication.OAuth.Claims.ClaimAction.Run*> method.
 
 For more information, see <xref:Microsoft.AspNetCore.Authentication.OAuth.Claims>.
+
+## Add claims to users
+
+Claims are added to the user on first registration, not on sign in. If additional claims are enabled in an app after a user registers to use the app, call [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%2A) on a user to force the generation of a new authentication cookie.
+
+In the Development environment working with test user accounts, you can simply delete and recreate the user account.
+
+## Update user claims
+
+Claims that change after a user signs in aren't automatically updated. If claims change while a user is signed in, call:
+
+* [UserManager.ReplaceClaimAsync](xref:Microsoft.AspNetCore.Identity.UserManager%2A) on the user for claims stored in the identity database.
+* [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%2A) on the user to force the generation of a new authentication cookie.
 
 ## Removal of claim actions and claims
 

--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -110,7 +110,7 @@ For more information, see <xref:Microsoft.AspNetCore.Authentication.OAuth.Claims
 
 ## Add claims to users
 
-Claims are added to the user on first registration, not on sign in. If additional claims are enabled in an app after a user registers to use the app, call [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%601) on a user to force the generation of a new authentication cookie.
+Claims are copied from external providers to the user database on first registration, not on sign in. If additional claims are enabled in an app after a user registers to use the app, call [SignInManager.RefreshSignInAsync](xref:Microsoft.AspNetCore.Identity.SignInManager%601) on a user to force the generation of a new authentication cookie.
 
 In the Development environment working with test user accounts, you can simply delete and recreate the user account.
 

--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: This tutorial demonstrates the integration of Google account user authentication into an existing ASP.NET Core app.
 ms.author: riande
 ms.custom: "mvc, seodec18"
-ms.date: 03/19/2020
+ms.date: 02/18/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/authentication/google-logins
 ---
@@ -16,12 +16,16 @@ This tutorial shows you how to enable users to sign in with their Google account
 
 ## Create a Google API Console project and client ID
 
-* Install [Microsoft.AspNetCore.Authentication.Google](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google).
-* Navigate to [Integrating Google Sign-In into your web app](https://developers.google.com/identity/sign-in/web/sign-in) and select **Configure a project**.
-* In the **Configure your OAuth client** dialog, select **Web server**.
-* In the **Authorized redirect URIs** text entry box, set the redirect URI. For example, `https://localhost:44312/signin-google`
-* Save the **Client ID** and **Client Secret**.
-* When deploying the site, register the new public url from the **Google Console**.
+* Add the [Microsoft.AspNetCore.Authentication.Google](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Google) NuGet package to the app.
+* Follow the guidance in [Integrating Google Sign-In into your web app](https://developers.google.com/identity/sign-in/web/sign-in) (Google documentation).
+* In the **Credentials** page of the [Google console](https://console.developers.google.com/apis/credentials), select **CREATE CREDENTIALS** > **OAuth client ID**.
+* In the **Application type** dialog, select **Web application**. Provide a **Name** for the app.
+* In the **Authorized redirect URIs** section, select **ADD URI** to set the redirect URI. Example redirect URI: `https://localhost:{PORT}/signin-google`, where the `{PORT}` placeholder is the app's port.
+* Select the **CREATE** button.
+* Save the **Client ID** and **Client Secret** for use in the app's configuration.
+* When deploying the site, either:
+  * Update the app's redirect URI in the **Google Console** to the app's deployed redirect URI.
+  * Create a new Google API registration in the **Google Console** for the production app with its production redirect URI.
 
 ## Store the Google client ID and secret
 
@@ -61,7 +65,7 @@ See the <xref:Microsoft.AspNetCore.Authentication.Google.GoogleOptions> API refe
 
 ## Change the default callback URI
 
-The URI segment `/signin-google` is set as the default callback of the Google authentication provider. You can change the default callback URI while configuring the Google authentication middleware via the inherited [RemoteAuthenticationOptions.CallbackPath](/dotnet/api/microsoft.aspnetcore.authentication.remoteauthenticationoptions.callbackpath) property of the [GoogleOptions](/dotnet/api/microsoft.aspnetcore.authentication.google.googleoptions) class.
+The URI segment `/signin-google` is set as the default callback of the Google authentication provider. You can change the default callback URI while configuring the Google authentication middleware via the inherited <xref:Microsoft.AspNetCore.Authentication.RemoteAuthenticationOptions.CallbackPath?displayProperty=nameWithType>) property of the <xref:Microsoft.AspNetCore.Authentication.Google.GoogleOptions> class.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes #15445
Fixes #21560

Let's consider this again. 😄

Hao, we left this off over a year ago on the closed PR https://github.com/dotnet/AspNetCore.Docs/pull/15491.

The scenario is that there's an app in production. New external provider claims are needed. The dev updates the app according to the guidance for adding claims following the topic and on top of existing external claims that were put into the app when it was first built (i.e., just following the same pattern that they used when they built the app). The dev deploys the app to production with the new claims code in place. There are two user scenarios at this point:

* New claims aren't added to users on sign in, they're added on registration.
* New claims aren't updated for users who are currently signed into the app.

From the PR discussion and starting with language that Chris suggested, I've **_drafted_** text to **_start to cover_** the two scenarios, **_but_** ...

* On layout, should we have these two new sections here, or how should it be organized otherwise?
* On the content when I was talking to Chris about it, I merely took the low-hanging fruit and deleted my test user and recreated them. Of course, that works, but it's only useful in Development with test user accounts. On the content pertaining to the `UserManager` and `SigninManager` in a production app, are these the right calls for these two scenarios and are they in the right sections with the right (starting) text?
* WRT **_where/how to call these_**, can you be even more specific than [what you said in your last two remarks](https://github.com/dotnet/AspNetCore.Docs/pull/15491#discussion_r348664977) ... **_exactly where/how_** are these calls made?

btw - If it's best for you to take and resolve the issue with your own PR, let's close this PR and assign the issue to you. I can circle around on your PR for some **_Grammar-i-zation_**:tm: updates if needed.

It's also possible that this is a *won't fix* documentation scenario ...

* These scenarios weren't described or even mentioned in any of the *Identity and Security* topics ... *by-design*? ... are these scenarios covered somewhere that I'm not seeing (e.g., external-to-our-repo MS *Identity* docs and samples)?
* We've gone for year now, and no issues are coming in on these scenarios. No one has remarked on the existing issue or closed cross-linked issues. There are a few :+1:, but not many ... and none of them are recent.

