### PR TITLE
Fix typo in routing.md

### DIFF
--- a/aspnetcore/mvc/controllers/routing.md
+++ b/aspnetcore/mvc/controllers/routing.md
@@ -103,7 +103,7 @@ Conventional routing is used with controllers and views. The `default` route:
 
 [!code-csharp[](routing/samples/3.x/main/StartupDefaultMVC.cs?name=snippet2)]
 
-is an example of a *conventional routing*. It's called *conventional routing* because it establishes a *convention* for URL paths:
+is an example of a *conventional route*. It's called *conventional routing* because it establishes a *convention* for URL paths:
 
 * The first path segment, `{controller=Home}`, maps to the controller name.
 * The second segment, `{action=Index}`, maps to the [action](#action) name.

--- a/aspnetcore/mvc/controllers/routing.md
+++ b/aspnetcore/mvc/controllers/routing.md
@@ -103,7 +103,7 @@ Conventional routing is used with controllers and views. The `default` route:
 
 [!code-csharp[](routing/samples/3.x/main/StartupDefaultMVC.cs?name=snippet2)]
 
-is an example of a *conventional route*. It's called *conventional routing* because it establishes a *convention* for URL paths:
+The preceding is an example of a *conventional route*. It's called *conventional routing* because it establishes a *convention* for URL paths:
 
 * The first path segment, `{controller=Home}`, maps to the controller name.
 * The second segment, `{action=Index}`, maps to the [action](#action) name.


### PR DESCRIPTION
The sentence:

> ...is an example of a *conventional routing*.

Should read:

> is an example of a *conventional route*.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->