### PR TITLE
Update interprocess.md

### DIFF
--- a/aspnetcore/grpc/interprocess.md
+++ b/aspnetcore/grpc/interprocess.md
@@ -48,9 +48,6 @@ Kestrel has built-in support for UDS endpoints. UDS are supported on Linux, macO
 
 `GrpcChannel` supports making gRPC calls over custom transports. When a channel is created, it can be configured with a `SocketsHttpHandler` that has a custom `ConnectCallback`. The callback allows the client to make connections over custom transports and then send HTTP requests over that transport.
 
-> [!IMPORTANT]
-> `SocketsHttpHandler.ConnectCallback` is a new API in .NET 5.
-
 Unix domain sockets connection factory example:
 
 ```csharp

--- a/aspnetcore/grpc/interprocess.md
+++ b/aspnetcore/grpc/interprocess.md
@@ -49,7 +49,7 @@ Kestrel has built-in support for UDS endpoints. UDS are supported on Linux, macO
 `GrpcChannel` supports making gRPC calls over custom transports. When a channel is created, it can be configured with a `SocketsHttpHandler` that has a custom `ConnectCallback`. The callback allows the client to make connections over custom transports and then send HTTP requests over that transport.
 
 > [!IMPORTANT]
-> `SocketsHttpHandler.ConnectCallback` is a new API in .NET 5 release candidate 2.
+> `SocketsHttpHandler.ConnectCallback` is a new API in .NET 5.
 
 Unix domain sockets connection factory example:
 


### PR DESCRIPTION
Detail no longer needed now that .NET 5 is RTM.