### PR TITLE
Fix typo in application-model.md

### DIFF
--- a/aspnetcore/mvc/controllers/application-model.md
+++ b/aspnetcore/mvc/controllers/application-model.md
@@ -15,7 +15,7 @@ ASP.NET Core MVC defines an *application model* representing the components of a
 
 ## Models and Providers
 
-The ASP.NET Core MVC application model include both abstract interfaces and concrete implementation classes that describe an MVC application. This model is the result of MVC discovering the app's controllers, actions, action parameters, routes, and filters according to default conventions. By working with the application model, you can modify your app to follow different conventions from the default MVC behavior. The parameters, names, routes, and filters are all used as configuration data for actions and controllers.
+The ASP.NET Core MVC application model includes both abstract interfaces and concrete implementation classes that describe an MVC application. This model is the result of MVC discovering the app's controllers, actions, action parameters, routes, and filters according to default conventions. By working with the application model, you can modify your app to follow different conventions from the default MVC behavior. The parameters, names, routes, and filters are all used as configuration data for actions and controllers.
 
 The ASP.NET Core MVC Application Model has the following structure:
 


### PR DESCRIPTION
The sentence:

> ...application model INCLUDE both abstract interfaces and concrete implementation classes...

Should read:

> ...application model INCLUDES both abstract interfaces and concrete implementation classes...