### PR TITLE
Minor (I think) confliction of "authentication" & "authorization" usage

### DIFF
--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -392,8 +392,8 @@ In the default Blazor Server project template, the `App` component (`App.razor`)
                     <p>You may need to log in as a different user.</p>
                 </NotAuthorized>
                 <Authorizing>
-                    <h1>Authentication in progress</h1>
-                    <p>Only visible while authentication is in progress.</p>
+                    <h1>Authorization in progress</h1>
+                    <p>Only visible while authorization is in progress.</p>
                 </Authorizing>
             </AuthorizeRouteView>
         </Found>


### PR DESCRIPTION
There's a possible (definate?) conflict of text here - user will either see `You're not authorized` or `Authentication in progress` - one would expect both phrases to refer to "authentication" or both phrases to refer to "authorization".

I believe the latter is correct, hence this PR, but there are potentially other similar confusions of "authentication" / "authorization" in this markdown page, which aren't covered by this PR.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->