### PR TITLE
Fix WARNING box format in filters.md

### DIFF
--- a/aspnetcore/mvc/controllers/filters.md
+++ b/aspnetcore/mvc/controllers/filters.md
@@ -548,7 +548,8 @@ The ASP.NET Core runtime doesn't guarantee:
 * That a single instance of the filter will be created.
 * The filter will not be re-requested from the DI container at some later point.
 
-[!WARNING] Only configure `IFilterFactory.IsReusable` to return `true` if the source of the filters is unambiguous, the filters are stateless, and are safe to use across multiple HTTP requests. For instance, do not return filters from DI that are registered as scoped or transient if `IFilterFactory.IsReusable` returns `true`
+> [!WARNING] 
+> Only configure `IFilterFactory.IsReusable` to return `true` if the source of the filters is unambiguous, the filters are stateless, and are safe to use across multiple HTTP requests. For instance, do not return filters from DI that are registered as scoped or transient if `IFilterFactory.IsReusable` returns `true`
 
 `IFilterFactory` can be implemented using custom attribute implementations as another approach to creating filters:
 

--- a/aspnetcore/mvc/controllers/filters.md
+++ b/aspnetcore/mvc/controllers/filters.md
@@ -549,7 +549,7 @@ The ASP.NET Core runtime doesn't guarantee:
 * The filter will not be re-requested from the DI container at some later point.
 
 > [!WARNING] 
-> Only configure `IFilterFactory.IsReusable` to return `true` if the source of the filters is unambiguous, the filters are stateless, and are safe to use across multiple HTTP requests. For instance, do not return filters from DI that are registered as scoped or transient if `IFilterFactory.IsReusable` returns `true`
+> Only configure <xref:Microsoft.AspNetCore.Mvc.Filters.IFilterFactory.IsReusable?displayProperty=nameWithType> to return `true` if the source of the filters is unambiguous, the filters are stateless, and the filters are safe to use across multiple HTTP requests. For instance, don't return filters from DI that are registered as scoped or transient if `IFilterFactory.IsReusable` returns `true`.
 
 `IFilterFactory` can be implemented using custom attribute implementations as another approach to creating filters:
 


### PR DESCRIPTION
Fix format for the WARNING box with the following sentence::

> Only configure IFilterFactory.IsReusable to return true if the source of the filters...

Hopefully this will fix the broken rendering on the [live site](https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/filters?view=aspnetcore-5.0#ifilterfactory):

![image](https://user-images.githubusercontent.com/20465797/106369888-2eec8a80-6366-11eb-8364-348be1aca089.png)
