### PR TITLE
Fix typo in background-services.md

### DIFF
--- a/aspnetcore/signalr/background-services.md
+++ b/aspnetcore/signalr/background-services.md
@@ -102,7 +102,7 @@ As the `ExecuteAsync` method is called iteratively in the background service, th
 
 ## React to SignalR events with background services
 
-Like a Single Page App using the JavaScript client for SignalR or a .NET desktop app can do using the using the <xref:signalr/dotnet-client>, a `BackgroundService` or `IHostedService` implementation can also be used to connect to SignalR Hubs and respond to events.
+Like a Single Page App using the JavaScript client for SignalR, or a .NET desktop app using the <xref:signalr/dotnet-client>, a `BackgroundService` or `IHostedService` implementation can also be used to connect to SignalR Hubs and respond to events.
 
 The `ClockHubClient` class implements both the `IClock` interface and the `IHostedService` interface. This way it can be enabled during `Startup` to run continuously and respond to Hub events from the server.
 


### PR DESCRIPTION
The [sentence](https://docs.microsoft.com/en-us/aspnet/core/signalr/background-services?view=aspnetcore-5.0#react-to-signalr-events-with-background-services):

> Like a Single Page App using the JavaScript client for SignalR or a .NET desktop **app can do using the using** the ASP.NET Core SignalR .NET Client...

Should not include the text "**app can do using the using**" and should therefore read:

> Like a Single Page App using the JavaScript client for SignalR, or a .NET desktop app using the ASP.NET Core SignalR .NET Client...