### PR TITLE
Update link to configuration source code on GitHub

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -788,7 +788,7 @@ An <xref:Microsoft.AspNetCore.Hosting.IHostingStartup> implementation allows add
 
 ## Additional resources
 
-* [Configuration source code](https://github.com/dotnet/extensions/tree/master/src/Configuration)
+* [Configuration source code](https://github.com/dotnet/runtime/tree/master/src/libraries/Microsoft.Extensions.Configuration)
 * <xref:fundamentals/configuration/options>
 * <xref:blazor/fundamentals/configuration>
 


### PR DESCRIPTION
The link points to an old location. The code has since been moved to a different repo.