### PR TITLE
Configure Trimmer UE pass

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -11,13 +11,7 @@ uid: blazor/host-and-deploy/configure-trimmer
 ---
 # Configure the Trimmer for ASP.NET Core Blazor
 
-Blazor WebAssembly performs [Intermediate Language (IL)](/dotnet/standard/managed-code#intermediate-language--execution) trimming to reduce the size of the published output.
-
-By default, trimming occurs when publishing an app in Release configuration using the [`dotnet publish`](/dotnet/core/tools/dotnet-publish) command with the [-c|--configuration](/dotnet/core/tools/dotnet-publish#options) option set to `Release`:
-
-```dotnetcli
-dotnet publish -c Release
-```
+Blazor WebAssembly performs [Intermediate Language (IL)](/dotnet/standard/managed-code#intermediate-language--execution) trimming to reduce the size of the published output. By default, trimming occurs when publishing an app.
 
 Trimming may have detrimental effects. In apps that use reflection, the Trimmer often can't determine the required types for reflection at runtime. To trim apps that use reflection, the Trimmer must be informed about required types for reflection in both the app's code and in the packages or frameworks that the app depends on. The Trimmer is also unable to react to an app's dynamic behavior at runtime. To ensure the trimmed app works correctly once deployed, test published output frequently while developing.
 

--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -5,28 +5,31 @@ description: Learn how to control the Intermediate Language (IL) Linker (Trimmer
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/14/2020
+ms.date: 02/08/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/host-and-deploy/configure-trimmer
 ---
 # Configure the Trimmer for ASP.NET Core Blazor
 
-By [Pranav Krishnamoorthy](https://github.com/pranavkm)
-
 Blazor WebAssembly performs [Intermediate Language (IL)](/dotnet/standard/managed-code#intermediate-language--execution) trimming to reduce the size of the published output.
 
-Trimming an app optimizes for size but may have detrimental effects. Apps that use reflection or related dynamic features may break when trimmed because the trimmer doesn't know about dynamic behavior and can't determine in general which types are required for reflection at runtime. To trim such apps, the trimmer must be informed about any types required by reflection in the code and in packages or frameworks that the app depends on.
+By default, trimming occurs when publishing an app in Release configuration using the [`dotnet publish`](/dotnet/core/tools/dotnet-publish) command with the [-c|--configuration](/dotnet/core/tools/dotnet-publish#options) option set to `Release`:
 
-To ensure the trimmed app works correctly once deployed, it's important to test published output frequently while developing.
-
-Trimming for .NET apps can be disabled by setting the `PublishTrimmed` MSBuild property to `false` in the app's project file:
-
-```xml
-<PropertyGroup>
-  <PublishTrimmed>false</PublishTrimmed>
-</PropertyGroup>
+```dotnetcli
+dotnet publish -c Release
 ```
-Additional options to configure the trimmer can be found at [Trimming options](/dotnet/core/deploying/trimming-options).
+
+Trimming may have detrimental effects. In apps that use reflection, the Trimmer often can't determine the required types for reflection at runtime. To trim apps that use reflection, the Trimmer must be informed about required types for reflection in both the app's code and in the packages or frameworks that the app depends on. The Trimmer is also unable to react to an app's dynamic behavior at runtime. To ensure the trimmed app works correctly once deployed, test published output frequently while developing.
+
+To configure the Trimmer, see the [Trimming options](/dotnet/core/deploying/trimming-options) article in the .NET Fundamentals documentation, which includes guidance on the following subjects:
+
+* Disable trimming for the entire app with the `<PublishTrimmed>` property in the project file.
+* Control how aggressively unused IL is discarded by the Trimmer.
+* Stop the Trimmer from trimming specific assemblies.
+* "Root" assemblies for trimming.
+* Surface warnings for reflected types by setting the `<SuppressTrimAnalysisWarnings>` property to `false` in the project file.
+* Control symbol trimming and degugger support.
+* Set Trimmer features for trimming framework library features.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/webassembly-performance-best-practices.md
+++ b/aspnetcore/blazor/webassembly-performance-best-practices.md
@@ -524,9 +524,25 @@ function jsInteropCall() {
 
 ## Minimize app download size
 
+::: moniker range=">= aspnetcore-5.0"
+
 ### Intermediate Language (IL) trimming
 
 Trimming unused assemblies from a Blazor WebAssembly app reduces the app's size by removing unused code in the app's binaries. For more information, see <xref:blazor/host-and-deploy/configure-trimmer>.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+### Intermediate Language (IL) linking
+
+[Linking a Blazor WebAssembly app](xref:blazor/host-and-deploy/configure-linker) reduces the app's size by trimming unused code in the app's binaries. By default, the Intermediate Language (IL) Linker is only enabled when building in `Release` configuration. To benefit from this, publish the app for deployment using the [`dotnet publish`](/dotnet/core/tools/dotnet-publish) command with the [-c|--configuration](/dotnet/core/tools/dotnet-publish#options) option set to `Release`:
+
+```dotnetcli
+dotnet publish -c Release
+```
+
+::: moniker-end
 
 ### Use System.Text.Json
 

--- a/aspnetcore/blazor/webassembly-performance-best-practices.md
+++ b/aspnetcore/blazor/webassembly-performance-best-practices.md
@@ -524,8 +524,6 @@ function jsInteropCall() {
 
 ## Minimize app download size
 
-::: moniker range=">= aspnetcore-5.0"
-
 ### Intermediate Language (IL) trimming
 
 Trimming unused assemblies from a Blazor WebAssembly app reduces the app's size by removing unused code in the app's binaries. For more information, see <xref:blazor/host-and-deploy/configure-trimmer>.

--- a/aspnetcore/blazor/webassembly-performance-best-practices.md
+++ b/aspnetcore/blazor/webassembly-performance-best-practices.md
@@ -528,21 +528,7 @@ function jsInteropCall() {
 
 ### Intermediate Language (IL) trimming
 
-[Trimming unused assemblies from a Blazor WebAssembly app](xref:blazor/host-and-deploy/configure-trimmer) reduces the app's size by removing unused code in the app's binaries. By default, the Trimmer is executed when publishing an application. To benefit from trimming, publish the app for deployment using the [`dotnet publish`](/dotnet/core/tools/dotnet-publish) command with the [-c|--configuration](/dotnet/core/tools/dotnet-publish#options) option set to `Release`:
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-5.0"
-
-### Intermediate Language (IL) linking
-
-[Linking a Blazor WebAssembly app](xref:blazor/host-and-deploy/configure-linker) reduces the app's size by trimming unused code in the app's binaries. By default, the Intermediate Language (IL) Linker is only enabled when building in `Release` configuration. To benefit from this, publish the app for deployment using the [`dotnet publish`](/dotnet/core/tools/dotnet-publish) command with the [-c|--configuration](/dotnet/core/tools/dotnet-publish#options) option set to `Release`:
-
-::: moniker-end
-
-```dotnetcli
-dotnet publish -c Release
-```
+Trimming unused assemblies from a Blazor WebAssembly app reduces the app's size by removing unused code in the app's binaries. For more information, see <xref:blazor/host-and-deploy/configure-trimmer>.
 
 ### Use System.Text.Json
 


### PR DESCRIPTION
Addresses #19286

[Internal Review Topic](#)

* Coalesce the coverage in the Trimmer topic. Only cross-link from the WASM Performance topic.
* There's either missing coverage or a misunderstanding on what the following line means ...

  > The Trimmer is also unable to react to an app's dynamic behavior at runtime.

  Does that only refer to **_reflection_**, or is that referring to **_other dynamic behavior_** that the topic doesn't describe? If it does refer to other dynamic behavior, should the topic list the behavior and provide guidance on dealing with it? If it's just referring to reflection, we can remove that line. :ear:
* My recommendation is to let the IL Trimming topic take care of the implementation details (i.e., this draft allows the external doc cover the `<PublishTrimmed>` property). However, I propose in this draft that we briefly list what the dev will find over there.
* Is there anything else that you'd like to cover?