### PR TITLE
Clarify Blazor Server's C# execution location

### DIFF
--- a/aspnetcore/blazor/index.md
+++ b/aspnetcore/blazor/index.md
@@ -131,8 +131,9 @@ The size of the published app, its *payload size*, is a critical performance fac
 
 Blazor decouples component rendering logic from how UI updates are applied. *Blazor Server* provides support for hosting Razor components on the server in an ASP.NET Core app. UI updates are handled over a [SignalR](xref:signalr/introduction) connection.
 
-The runtime handles:
+The runtime stays on the server and handles:
 
+* Executing the app's C# code.
 * Sending UI events from the browser to the server.
 * Applying UI updates to the rendered component that are sent back by the server.
 


### PR DESCRIPTION
Fixes  #21479

Thanks @mrlife! 🎷

The WASM section earlier in the topic calls out that the runtime and code go to the client. Although we cover where the C# code executes for Blazor Server in the *Hosting Models* topic ...

> The app's .NET/C# code base, including the app's component code, isn't served to clients.

... the Introduction topic can call it out briefly with just a few nit changes drafted on this PR.