### PR TITLE
More on Kestrel vs. HTTP.sys

### DIFF
--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -45,7 +45,7 @@ HTTP.sys is useful for deployments where:
 
   ![HTTP.sys communicates directly with the Internet](httpsys/_static/httpsys-to-internet.png)
 
-* An internal deployment requires a feature not available in Kestrel. For more information, see [Kestrel vs. HTTP.sys](xref:fundamentals/servers/index).
+* An internal deployment requires a feature not available in Kestrel. For more information, see [Kestrel vs. HTTP.sys](xref:fundamentals/servers/index#kestrel-vs-httpsys)
 
   ![HTTP.sys communicates directly with the internal network](httpsys/_static/httpsys-to-internal.png)
 

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -45,7 +45,7 @@ HTTP.sys is useful for deployments where:
 
   ![HTTP.sys communicates directly with the Internet](httpsys/_static/httpsys-to-internet.png)
 
-* An internal deployment requires a feature not available in Kestrel, such as [Windows Authentication](xref:security/authentication/windowsauth).
+* An internal deployment requires a feature not available in Kestrel. For more information, see [Kestrel vs. HTTP.sys](xref:fundamentals/servers/index).
 
   ![HTTP.sys communicates directly with the internal network](httpsys/_static/httpsys-to-internal.png)
 


### PR DESCRIPTION
Fixes #21422
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/httpsys?view=aspnetcore-5.0&branch=pr-en-us-21488#when-to-use-httpsys)