### PR TITLE
Remove EF Core config provider

### DIFF
--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -87,57 +87,6 @@ using var stream = await response.Content.ReadAsStreamAsync();
 builder.Configuration.AddJsonStream(stream);
 ```
 
-## Custom configuration provider with EF Core
-
-The custom configuration provider with EF Core demonstrated in <xref:fundamentals/configuration/index#custom-configuration-provider> works with Blazor WebAssembly apps.
-
-> [!WARNING]
-> Database connection strings and databases loaded with Blazor WebAssembly apps aren't secure and shouldn't be used to store sensitive data.
-
-Add package references for [`Microsoft.EntityFrameworkCore`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore) and [`Microsoft.EntityFrameworkCore.InMemory`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.InMemory) to the app's project file.
-
-Add the EF Core configuration classes described in <xref:fundamentals/configuration/index#custom-configuration-provider>.
-
-Add namespaces for <xref:Microsoft.EntityFrameworkCore?displayProperty=fullName> and <xref:Microsoft.Extensions.Configuration.Memory?displayProperty=fullName> to `Program.cs`:
-
-```csharp
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration.Memory;
-```
-
-In `Program.Main` of `Program.cs`:
-
-```csharp
-builder.Configuration.AddEFConfiguration(
-    options => options.UseInMemoryDatabase("InMemoryDb"));
-```
-
-Inject an <xref:Microsoft.Extensions.Configuration.IConfiguration> instance into a component to access the configuration data.
-
-`Pages/EFCoreConfig.razor`:
-
-```razor
-@page "/efcore-config"
-@using Microsoft.Extensions.Configuration
-@inject IConfiguration Configuration
-
-<h1>EF Core configuration example</h1>
-
-<h2>Quotes</h2>
-
-<ul>
-    <li>@Configuration["quote1"]</li>
-    <li>@Configuration["quote2"]</li>
-    <li>@Configuration["quote3"]</li>
-</ul>
-
-<p>
-    Quotes &copy;2005 
-    <a href="https://www.uphe.com/">Universal Pictures</a>: 
-    <a href="https://www.uphe.com/movies/serenity">Serenity</a>
-</p>
-```
-
 ## Memory Configuration Source
 
 The following example uses a <xref:Microsoft.Extensions.Configuration.Memory.MemoryConfigurationSource> in `Program.Main` to supply additional configuration.


### PR DESCRIPTION
Fixes #21482

Thanks @Micteu! :rocket: ... If you want to do something like this, you should ... *in theory* ... be able to build your own based on (for Blazor Server) ... https://docs.microsoft.com/aspnet/core/fundamentals/configuration/#custom-configuration-provider. For WASM, it's not a supported scenario because EF runs into problems with client sandbox restrictions on making a direct database connection on clients. I'm not saying that it can't be done. I'm just saying that we've been made aware that there are problems that may or may not be a blocker for making it work. It might work with an in-memory dB but not with a formal database on the client. If you need support for a custom approach, discuss it with the community. We recommend the usual community support forums ...

* [Stack Overflow (tag: `blazor`)](https://stackoverflow.com/questions/tagged/blazor)
* [ASP.NET Core Slack Team](http://tattoocoder.com/aspnet-slack-sign-up/)
* [Blazor Gitter](https://gitter.im/aspnet/Blazor)

cc: @captainsafia ... I'm going to kill this section. This API is extinct AFAICT.