### PR TITLE
Add no-loc metadata to INCLUDES

### DIFF
--- a/aspnetcore/blazor/includes/prefer-exact-matches.md
+++ b/aspnetcore/blazor/includes/prefer-exact-matches.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ::: moniker range="= aspnetcore-5.0"
 
 > [!NOTE]

--- a/aspnetcore/blazor/includes/prerendering.md
+++ b/aspnetcore/blazor/includes/prerendering.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 While a Blazor Server app is prerendering, certain actions, such as calling into JavaScript, aren't possible because a connection with the browser hasn't been established. Components may need to render differently when prerendered.
 
 To delay JavaScript interop calls until after the connection with the browser is established, you can use the [OnAfterRenderAsync component lifecycle event](xref:blazor/components/lifecycle#after-component-render). This event is only called after the app is fully rendered and the client connection is established.

--- a/aspnetcore/blazor/includes/security/additional-scopes-standalone-AAD.md
+++ b/aspnetcore/blazor/includes/security/additional-scopes-standalone-AAD.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Add a <xref:Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions> for `User.Read` permission with <xref:Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.DefaultAccessTokenScopes>:
 
 ```csharp

--- a/aspnetcore/blazor/includes/security/additional-scopes-standalone-nonAAD.md
+++ b/aspnetcore/blazor/includes/security/additional-scopes-standalone-nonAAD.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Add a pair of <xref:Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions> for `openid` and `offline_access` <xref:Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions.DefaultAccessTokenScopes>:
 
 ```csharp

--- a/aspnetcore/blazor/includes/security/app-component.md
+++ b/aspnetcore/blazor/includes/security/app-component.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The `App` component (`App.razor`) is similar to the `App` component found in Blazor Server apps:
 
 * The <xref:Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationState> component manages exposing the <xref:Microsoft.AspNetCore.Components.Authorization.AuthenticationState> to the rest of the app.

--- a/aspnetcore/blazor/includes/security/authentication-component.md
+++ b/aspnetcore/blazor/includes/security/authentication-component.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The page produced by the `Authentication` component (`Pages/Authentication.razor`) defines the routes required for handling different authentication stages.
 
 The <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticatorView> component:

--- a/aspnetcore/blazor/includes/security/azure-scope-3x.md
+++ b/aspnetcore/blazor/includes/security/azure-scope-3x.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The Azure portal provides one of the following App ID URI formats based on whether or not the AAD tenant has a [verified or unverified publisher domain](/azure/active-directory/develop/howto-configure-publisher-domain):
 
 * `api://{SERVER API APP CLIENT ID OR CUSTOM VALUE}`

--- a/aspnetcore/blazor/includes/security/azure-scope-5x.md
+++ b/aspnetcore/blazor/includes/security/azure-scope-5x.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 When working with a server API registered with AAD and the app's AAD registration is in an tenant that relies on an [unverified publisher domain](/azure/active-directory/develop/howto-configure-publisher-domain), the App ID URI of your server API app isn't `api://{SERVER API APP CLIENT ID OR CUSTOM VALUE}` but instead is in the format `https://{TENANT}.onmicrosoft.com/{SERVER API APP CLIENT ID OR CUSTOM VALUE}`. If that's the case, the default access token scope in `Program.Main` (`Program.cs`) of the *`Client`* app appears similar to the following:
 
 ```csharp

--- a/aspnetcore/blazor/includes/security/blazor-shared-state.md
+++ b/aspnetcore/blazor/includes/security/blazor-shared-state.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Blazor server apps live in server memory. That means that there are multiple apps hosted within the same process. For each app session, Blazor starts a circuit with its own DI container scope. That means that scoped services are unique per Blazor session.
 
 > [!WARNING]

--- a/aspnetcore/blazor/includes/security/fetchdata-component.md
+++ b/aspnetcore/blazor/includes/security/fetchdata-component.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The `FetchData` component shows how to:
 
 * Provision an access token.

--- a/aspnetcore/blazor/includes/security/imports-file-hosted.md
+++ b/aspnetcore/blazor/includes/security/imports-file-hosted.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The <xref:Microsoft.AspNetCore.Components.Authorization?displayProperty=fullName> namespace is made available throughout the app via the `_Imports.razor` file:
 
 ::: moniker range=">= aspnetcore-5.0"

--- a/aspnetcore/blazor/includes/security/imports-file-standalone.md
+++ b/aspnetcore/blazor/includes/security/imports-file-standalone.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The <xref:Microsoft.AspNetCore.Components.Authorization?displayProperty=fullName> namespace is made available throughout the app via the `_Imports.razor` file:
 
 ::: moniker range=">= aspnetcore-5.0"

--- a/aspnetcore/blazor/includes/security/index-page-authentication.md
+++ b/aspnetcore/blazor/includes/security/index-page-authentication.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The Index page (`wwwroot/index.html`) page includes a script that defines the `AuthenticationService` in JavaScript. `AuthenticationService` handles the low-level details of the OIDC protocol. The app internally calls methods defined in the script to perform the authentication operations.
 
 ```html

--- a/aspnetcore/blazor/includes/security/index-page-msal.md
+++ b/aspnetcore/blazor/includes/security/index-page-msal.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The Index page (`wwwroot/index.html`) page includes a script that defines the `AuthenticationService` in JavaScript. `AuthenticationService` handles the low-level details of the OIDC protocol. The app internally calls methods defined in the script to perform the authentication operations.
 
 ```html

--- a/aspnetcore/blazor/includes/security/logindisplay-component.md
+++ b/aspnetcore/blazor/includes/security/logindisplay-component.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The `LoginDisplay` component (`Shared/LoginDisplay.razor`) is rendered in the `MainLayout` component (`Shared/MainLayout.razor`) and manages the following behaviors:
 
 * For authenticated users:

--- a/aspnetcore/blazor/includes/security/msal-login-mode.md
+++ b/aspnetcore/blazor/includes/security/msal-login-mode.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The framework defaults to pop-up login mode and falls back to redirect login mode if a pop-up can't be opened. Configure MSAL to use redirect login mode by setting the `LoginMode` property of <xref:Microsoft.Authentication.WebAssembly.Msal.Models.MsalProviderOptions> to `redirect`:
 
 ```csharp

--- a/aspnetcore/blazor/includes/security/redirecttologin-component.md
+++ b/aspnetcore/blazor/includes/security/redirecttologin-component.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The `RedirectToLogin` component (`Shared/RedirectToLogin.razor`):
 
 * Manages redirecting unauthorized users to the login page.

--- a/aspnetcore/blazor/includes/security/troubleshoot.md
+++ b/aspnetcore/blazor/includes/security/troubleshoot.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ## Troubleshoot
 
 ::: moniker range=">= aspnetcore-5.0"

--- a/aspnetcore/blazor/includes/security/usermanager-signinmanager.md
+++ b/aspnetcore/blazor/includes/security/usermanager-signinmanager.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ## UserManager and SignInManager
 
 Set the user identifier claim type when a Server app requires:

--- a/aspnetcore/blazor/includes/security/wasm-aad-b2c-userflows.md
+++ b/aspnetcore/blazor/includes/security/wasm-aad-b2c-userflows.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ## Custom user flows
 
 The Microsoft Authentication Library (<xref:Microsoft.Authentication.WebAssembly.Msal>, [NuGet package](https://www.nuget.org/packages/Microsoft.Authentication.WebAssembly.Msal/)) doesn't support [AAD B2C user flows](/azure/active-directory-b2c/user-flow-overview) by default. Create custom user flows in developer code.

--- a/aspnetcore/blazor/includes/share-interop-code.md
+++ b/aspnetcore/blazor/includes/share-interop-code.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ## Share interop code in a class library
 
 JS interop code can be included in a class library, which allows you to share the code in a NuGet package.

--- a/aspnetcore/blazor/includes/state-container.md
+++ b/aspnetcore/blazor/includes/state-container.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Nested components typically bind data using *chained bind* as described in <xref:blazor/components/data-binding>. Nested and un-nested components can share access to data using a registered in-memory state container. A custom state container class can use an assignable <xref:System.Action> to notify components in different parts of the app of state changes. In the following example:
 
 * A pair of components uses a state container to track a property.

--- a/aspnetcore/includes/2.1-SDK.md
+++ b/aspnetcore/includes/2.1-SDK.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [.NET Core 2.1 SDK or later](https://dotnet.microsoft.com/download/dotnet-core)

--- a/aspnetcore/includes/2.2-SDK.md
+++ b/aspnetcore/includes/2.2-SDK.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [.NET Core 2.2 SDK or later](https://dotnet.microsoft.com/download/dotnet-core)

--- a/aspnetcore/includes/3.0-SDK.md
+++ b/aspnetcore/includes/3.0-SDK.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [.NET Core 3.0 SDK or later](https://dotnet.microsoft.com/download/dotnet-core/3.0)

--- a/aspnetcore/includes/3.1-SDK.md
+++ b/aspnetcore/includes/3.1-SDK.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [.NET Core 3.1 SDK or later](https://dotnet.microsoft.com/download/dotnet-core/3.1)

--- a/aspnetcore/includes/5.0-SDK.md
+++ b/aspnetcore/includes/5.0-SDK.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [.NET 5.0 SDK or later](https://dotnet.microsoft.com/download/dotnet/5.0)

--- a/aspnetcore/includes/ForwardedHeaders.md
+++ b/aspnetcore/includes/ForwardedHeaders.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Forwarded Headers Middleware should run before other middleware. This ordering ensures that the middleware relying on forwarded headers information can consume the header values for processing. To run Forwarded Headers Middleware after diagnostics and error handling middleware, see [Forwarded Headers Middleware order](xref:host-and-deploy/proxy-load-balancer#fhmo).

--- a/aspnetcore/includes/GetTempFileName.md
+++ b/aspnetcore/includes/GetTempFileName.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 **Warning**: The following code uses `GetTempFileName`, which throws an `IOException` if more than 65535 files are created without deleting previous temporary files. A real app should either delete temporary files or use `GetTempPath` and `GetRandomFileName` to create temporary file names. The 65535 files limit is per server, so another app on the server can use up all 65535 files. 

--- a/aspnetcore/includes/IdentityServer4.md
+++ b/aspnetcore/includes/IdentityServer4.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ASP.NET Core Identity adds user interface (UI) login functionality to ASP.NET Core web apps. To secure web APIs and SPAs, use one of the following:
 
 * [Azure Active Directory](/azure/api-management/api-management-howto-protect-backend-with-aad)

--- a/aspnetcore/includes/MTcomments.md
+++ b/aspnetcore/includes/MTcomments.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 If you are reading this in a language other than English, let us know in this [GitHub discussion issue](https://github.com/aspnet/AspNetCore.Docs/issues/16455) if you'd like to see the code comments in your native language.

--- a/aspnetcore/includes/MyDisplayRouteInfo.md
+++ b/aspnetcore/includes/MyDisplayRouteInfo.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [MyDisplayRouteInfo](https://github.com/Rick-Anderson/RouteInfo/blob/master/Microsoft.Docs.Samples.RouteInfo/ControllerContextExtensions.cs) is provided by the [Rick.Docs.Samples.RouteInfo](https://www.nuget.org/packages/Rick.Docs.Samples.RouteInfo) NuGet package and displays route information.

--- a/aspnetcore/includes/MyDisplayRouteInfoBoth.md
+++ b/aspnetcore/includes/MyDisplayRouteInfoBoth.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [MyDisplayRouteInfo and ToCtxString](https://github.com/Rick-Anderson/RouteInfo/blob/master/Microsoft.Docs.Samples.RouteInfo/ControllerContextExtensions.cs) are provided by the [Rick.Docs.Samples.RouteInfo](https://www.nuget.org/packages/Rick.Docs.Samples.RouteInfo) NuGet package. The methods display `Controller` route information.

--- a/aspnetcore/includes/RP-EF/20-pdf.md
+++ b/aspnetcore/includes/RP-EF/20-pdf.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ::: moniker range="= aspnetcore-2.0"
 
 The ASP.NET Core 2.0 version of this tutorial can be found in [this PDF file](https://webpifeed.blob.core.windows.net/webpifeed/Partners/PDF-6-18-18.pdf).

--- a/aspnetcore/includes/RP-EF/intro.md
+++ b/aspnetcore/includes/RP-EF/intro.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The Contoso University web app demonstrates how to create Razor Pages web apps using EF Core and Visual Studio. For information about the tutorial series, see [the first tutorial](xref:data/ef-rp/intro).
 
 If you run into problems you can't solve, download the [completed app](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples) and compare that code to what you created by following the tutorial.

--- a/aspnetcore/includes/RP-EF/rp-over-mvc-21.md
+++ b/aspnetcore/includes/RP-EF/rp-over-mvc-21.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ::: moniker range=">= aspnetcore-2.1"
 
 This tutorial has not been upgraded to ASP.NET Core 2.1. It has been updated for ASP.NET Core 5.0.  The ASP.NET Core 2.0 version of this tutorial is available by selecting **ASP.NET Core 2.0** above the table of contents or at the top of the page:

--- a/aspnetcore/includes/RP-EF/rp-over-mvc.md
+++ b/aspnetcore/includes/RP-EF/rp-over-mvc.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 This tutorial teaches ASP.NET Core MVC and Entity Framework Core with controllers and views. [Razor Pages](xref:razor-pages/index) is an alternative programming model. For new development, we recommend Razor Pages over MVC with controllers and views. See the [Razor Pages](xref:data/ef-rp/intro) version of this tutorial. Each tutorial covers some material the other doesn't:
 
 Some things this MVC tutorial has that the Razor Pages tutorial doesn't:

--- a/aspnetcore/includes/RP-MVC/validation.md
+++ b/aspnetcore/includes/RP-MVC/validation.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <!-- USED in RP and MVC tutorial -->
 
 ## Add validation rules to the movie model

--- a/aspnetcore/includes/RP-mvc-shared/sqlite-warn.md
+++ b/aspnetcore/includes/RP-mvc-shared/sqlite-warn.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 
 > [!NOTE]
 > For this tutorial you use the Entity Framework Core *migrations* feature where possible. Migrations updates the database schema to match changes in the data model. However, migrations can only do the kinds of changes that the EF Core provider supports, and the SQLite provider's capabilities are limited. For example, adding a column is supported, but removing or changing a column is not supported. If a migration is created to remove or change a column, the `ef migrations add` command succeeds but the `ef database update` command fails. Due to these limitations, this tutorial doesn't use migrations for SQLite schema changes. Instead, when the schema changes, you drop and re-create the database.

--- a/aspnetcore/includes/RP/2.1/razor-pages-start.md
+++ b/aspnetcore/includes/RP/2.1/razor-pages-start.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The default template creates **RazorPagesMovie**, **Home**, **About** and **Contact** links and pages. Depending on the size of your browser window, you might need to click the navigation icon to show the links.
 
 ![Home or Index page](~/tutorials/razor-pages/razor-pages-start/_static/home2.png)

--- a/aspnetcore/includes/RP/2.1/recommend2.1.md
+++ b/aspnetcore/includes/RP/2.1/recommend2.1.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ::: moniker range="= aspnetcore-2.0"
 
 We recommend you follow the [ASP.NET Core 2.1 version](xref:razor-pages-start?view=aspnetcore-2.1) of this tutorial. It's easier to follow and covers more features.

--- a/aspnetcore/includes/RP/da1.md
+++ b/aspnetcore/includes/RP/da1.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Update the generated pages
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)

--- a/aspnetcore/includes/RP/da2.md
+++ b/aspnetcore/includes/RP/da2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 
 The `[Column(TypeName = "decimal(18, 2)")]` data annotation is required so Entity Framework Core can correctly map `Price` to currency in the database. For more information, see [Data Types](/ef/core/modeling/relational/data-types).
 

--- a/aspnetcore/includes/RP/download.md
+++ b/aspnetcore/includes/RP/download.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 
 ::: moniker range=">= aspnetcore-3.0"
 

--- a/aspnetcore/includes/RP/model1.md
+++ b/aspnetcore/includes/RP/model1.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 In this section, you add classes for managing movies in a database. You use these classes with [Entity Framework Core](/ef/core) (EF Core) to work with a database. EF Core is an object-relational mapping (ORM) framework that simplifies the data access code that you have to write.

--- a/aspnetcore/includes/RP/model1b.md
+++ b/aspnetcore/includes/RP/model1b.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <!-- THIS INCLUDE USED BY MVC AND RP -->
 Add the following properties to the `Movie` class:
 

--- a/aspnetcore/includes/RP/model2.md
+++ b/aspnetcore/includes/RP/model2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="dc"></a>
 
 ### Add NuGet packages and EF tools

--- a/aspnetcore/includes/RP/model3.md
+++ b/aspnetcore/includes/RP/model3.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [!INCLUDE [more information on the CLI for EF Core](~/includes/ef-cli.md)]
 
 Run the following .NET Core CLI commands:

--- a/aspnetcore/includes/RP/model4.md
+++ b/aspnetcore/includes/RP/model4.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="codegenerator"></a>
 The following table details the ASP.NET Core code generator parameters:
 

--- a/aspnetcore/includes/RP/model4Win.md
+++ b/aspnetcore/includes/RP/model4Win.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="scaffold"></a>
 
 ### Scaffold the Movie model

--- a/aspnetcore/includes/RP/model4exit.md
+++ b/aspnetcore/includes/RP/model4exit.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 If you get the error:
 
   ```

--- a/aspnetcore/includes/RP/model4tbl.md
+++ b/aspnetcore/includes/RP/model4tbl.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="codegenerator"></a>
 The following table details the ASP.NET Core code generators` parameters:
 

--- a/aspnetcore/includes/RP/model4test.md
+++ b/aspnetcore/includes/RP/model4test.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="test"></a>
 
 ### Test the app

--- a/aspnetcore/includes/RP/model4x.md
+++ b/aspnetcore/includes/RP/model4x.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="scaffold"></a>
 
 ### Scaffold the Movie model

--- a/aspnetcore/includes/RP/page1.md
+++ b/aspnetcore/includes/RP/page1.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Scaffolded Razor Pages in ASP.NET Core
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)

--- a/aspnetcore/includes/RP/page2.md
+++ b/aspnetcore/includes/RP/page2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The `<form method="post">` element is a [Form Tag Helper](xref:mvc/views/working-with-forms#the-form-tag-helper). The Form Tag Helper automatically includes an [antiforgery token](xref:security/anti-request-forgery).
 
 The scaffolding engine creates Razor markup for each field in the model (except the ID) similar to the following:

--- a/aspnetcore/includes/RP/razor-pages-start.md
+++ b/aspnetcore/includes/RP/razor-pages-start.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The default template creates **RazorPagesMovie**, **Home**, **About** and **Contact** links and pages. Depending on the size of your browser window, you might need to click the navigation icon to show the links.
 
 ![Home or Index page](../../tutorials/razor-pages/razor-pages-start/_static/home2.png)

--- a/aspnetcore/includes/RP/search.md
+++ b/aspnetcore/includes/RP/search.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Add search to an ASP.NET Core Razor Pages app
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)

--- a/aspnetcore/includes/RP/sql.md
+++ b/aspnetcore/includes/RP/sql.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Work with SQLite in an ASP.NET Core Razor Pages app
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)

--- a/aspnetcore/includes/RP/sqlite.md
+++ b/aspnetcore/includes/RP/sqlite.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ## SQLite
 
 The [SQLite](https://www.sqlite.org/) website states:

--- a/aspnetcore/includes/RP/sqlitedev.md
+++ b/aspnetcore/includes/RP/sqlitedev.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ### Use SQLite for development, SQL Server for production
 
 When SQLite is selected, the template generated code is ready for development. The following code shows how to inject <xref:Microsoft.AspNetCore.Hosting.IWebHostEnvironment> into Startup. `IWebHostEnvironment` is injected so `ConfigureServices` can use SQLite in development and SQL Server in production.

--- a/aspnetcore/includes/SameSiteIdentity.md
+++ b/aspnetcore/includes/SameSiteIdentity.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ASP.NET Core [Identity](xref:security/authentication/identity) is largely unaffected by [SameSite cookies](xref:security/samesite) except for advanced scenarios like `IFrames` or `OpenIdConnect` integration.
 
 When using `Identity`, do ***not*** add any cookie providers or call ` services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)`, `Identity` takes care of that.

--- a/aspnetcore/includes/add-EF-NuGet-SQLite-CLI-5.md
+++ b/aspnetcore/includes/add-EF-NuGet-SQLite-CLI-5.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Run the following .NET CLI commands:
 
 ```dotnetcli

--- a/aspnetcore/includes/add-EF-NuGet-SQLite-CLI.md
+++ b/aspnetcore/includes/add-EF-NuGet-SQLite-CLI.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Run the following .NET Core CLI commands:
 
 ```dotnetcli

--- a/aspnetcore/includes/advancedRP.md
+++ b/aspnetcore/includes/advancedRP.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 For a more advanced introduction aimed at developers who are familiar with controllers and views, see [Introduction to Razor Pages](xref:razor-pages/index).

--- a/aspnetcore/includes/app-secrets/secrets-json-file-and-text.md
+++ b/aspnetcore/includes/app-secrets/secrets-json-file-and-text.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Assume the app's *secrets.json* file contains the following two secrets:
 
 [!INCLUDE[secrets.json file](secrets-json-file.md)]

--- a/aspnetcore/includes/app-secrets/secrets-json-file.md
+++ b/aspnetcore/includes/app-secrets/secrets-json-file.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ```json 
 {
   "Movies:ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=Movie-1;Trusted_Connection=True;MultipleActiveResultSets=true",

--- a/aspnetcore/includes/aspnet-codegenerator-args-md.md
+++ b/aspnetcore/includes/aspnet-codegenerator-args-md.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <!-- Options common to Razor Pages and Controller -->
 | Option               | Description|
 | ----------------- | ------------ |

--- a/aspnetcore/includes/azure-apps-preview-notice.md
+++ b/aspnetcore/includes/azure-apps-preview-notice.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!IMPORTANT]
 > **ASP.NET Core preview releases with Azure App Service**
 >

--- a/aspnetcore/includes/benefits.md
+++ b/aspnetcore/includes/benefits.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ASP.NET Core provides the following benefits:
 
 * A unified story for building web UI and web APIs.

--- a/aspnetcore/includes/bind-get.md
+++ b/aspnetcore/includes/bind-get.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!WARNING]
 > For security reasons, you must opt in to binding `GET` request data to page model properties. Verify user input before mapping it to properties. Opting into `GET` binding is useful when addressing scenarios that rely on query string or route values.
 >

--- a/aspnetcore/includes/bind.md
+++ b/aspnetcore/includes/bind.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The preferred way to read related configuration values is using the [options pattern](xref:fundamentals/configuration/options). For example, to read the following configuration values:
 
 ```json

--- a/aspnetcore/includes/built-in-TH.md
+++ b/aspnetcore/includes/built-in-TH.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ## Built-in ASP.NET Core Tag Helpers
 
 **[Anchor Tag Helper](xref:mvc/views/tag-helpers/builtin-th/anchor-tag-helper)**

--- a/aspnetcore/includes/catchall.md
+++ b/aspnetcore/includes/catchall.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ::: moniker range=">= aspnetcore-3.0 < aspnetcore-5.0"
 
 > [!WARNING]

--- a/aspnetcore/includes/cdn.md
+++ b/aspnetcore/includes/cdn.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 A CDN:
 
 * Provides several [performance advantages](/office365/enterprise/content-delivery-networks#how-do-cdns-make-services-work-faster) vs hosting the asset with the web app.

--- a/aspnetcore/includes/code-comments-loc.md
+++ b/aspnetcore/includes/code-comments-loc.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 If you would like to see code comments translated to languages other than English, let us know in [this GitHub discussion issue](https://github.com/MicrosoftDocs/feedback/issues/2515).

--- a/aspnetcore/includes/combine-di.md
+++ b/aspnetcore/includes/combine-di.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="csc"></a>
 
 Consider the following `ConfigureServices` method, which registers services and configures options:

--- a/aspnetcore/includes/connectionid-signalr.md
+++ b/aspnetcore/includes/connectionid-signalr.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!WARNING]
 > Security warning: Exposing `ConnectionId` can lead to malicious impersonation if the SignalR server or client version is ASP.NET Core 2.2 or earlier.

--- a/aspnetcore/includes/csharp-8-required.md
+++ b/aspnetcore/includes/csharp-8-required.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!NOTE]
 > The following sample requires C# 8.0 or later.

--- a/aspnetcore/includes/dbg-route.md
+++ b/aspnetcore/includes/dbg-route.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ## Debug diagnostics
 
 For detailed routing diagnostic output, set `Logging:LogLevel:Microsoft` to `Debug`. In the development environment, set the log level in *appsettings.Development.json*:

--- a/aspnetcore/includes/disableVer.md
+++ b/aspnetcore/includes/disableVer.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="ddav"></a>
 ### Disable default account verification
 

--- a/aspnetcore/includes/dotnetcore-on-dotnetfx-vs.md
+++ b/aspnetcore/includes/dotnetcore-on-dotnetfx-vs.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
   > [!NOTE]
   > To use ASP.NET Core with .NET Framework, you must first select **.NET Framework** from the leftmost drop-down in the dialog, then you can select the desired ASP.NET Core version.
 

--- a/aspnetcore/includes/ef-cli.md
+++ b/aspnetcore/includes/ef-cli.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 If `dotnet ef` has not been installed, install it as a global tool:
 
 ```dotnetcli

--- a/aspnetcore/includes/ef-pmc.md
+++ b/aspnetcore/includes/ef-pmc.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 For more information on the PMC tools for EF Core, see [EF Core tools reference - PMC in Visual Studio](/ef/core/miscellaneous/cli/powershell).

--- a/aspnetcore/includes/environmentVarableColon.md
+++ b/aspnetcore/includes/environmentVarableColon.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The `:` separator doesn't work with environment variable hierarchical keys on all platforms. `__`, the double underscore, is:
 
 * Supported by all platforms. For example, the `:` separator is not supported by [Bash](https://linuxhint.com/bash-environment-variables/), but `__` is.

--- a/aspnetcore/includes/gRPCazure.md
+++ b/aspnetcore/includes/gRPCazure.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!WARNING]
 > [ASP.NET Core gRPC](xref:grpc/index) has extra requirements for being used with Azure App Service or IIS. For more information on where gRPC can be used, see <xref:grpc/supported-platforms>.

--- a/aspnetcore/includes/getting-started/next-steps.md
+++ b/aspnetcore/includes/getting-started/next-steps.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ### Next steps
 
 * An ASP.NET Core app can use the .NET Core or .NET Framework Base Class Library and runtime. For more information, see [Choosing between .NET Core and .NET Framework](/dotnet/articles/standard/choosing-core-framework-server).

--- a/aspnetcore/includes/http-repl/requires-body-options.md
+++ b/aspnetcore/includes/http-repl/requires-body-options.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * `-c|--content`
 
   Provides an inline HTTP request body. For example, `-c "{"id":2,"name":"Cherry"}"`.

--- a/aspnetcore/includes/http-repl/standard-options.md
+++ b/aspnetcore/includes/http-repl/standard-options.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * `-F|--no-formatting`
 
   A flag whose presence suppresses HTTP response formatting.

--- a/aspnetcore/includes/libman-cli/provider-names.md
+++ b/aspnetcore/includes/libman-cli/provider-names.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * `cdnjs`
 * `filesystem`
 * `jsdelivr`

--- a/aspnetcore/includes/libman-cli/standard-cli-options.md
+++ b/aspnetcore/includes/libman-cli/standard-cli-options.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * `-h|--help`
 
   Show help information.

--- a/aspnetcore/includes/localization/currency.md
+++ b/aspnetcore/includes/localization/currency.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!NOTE]
 > You may not be able to enter decimal commas in decimal fields. To support [jQuery validation](https://jqueryvalidation.org/) for non-English locales that use a comma (",") for a decimal point, and non US-English date formats, you must take steps to globalize your app. [See this GitHub issue 4076](https://github.com/dotnet/AspNetCore.Docs/issues/4076#issuecomment-326590420) for instructions on adding decimal comma.

--- a/aspnetcore/includes/localization/unsupported-culture-log-level.md
+++ b/aspnetcore/includes/localization/unsupported-culture-log-level.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!NOTE]
 > Prior to ASP.NET Core 3.0 web apps write one log of type `LogLevel.Warning` per request if the requested culture is unsupported. Logging one `LogLevel.Warning` per request is can make large log files with redundant information. This behavior has been changed in ASP.NET 3.0. The `RequestLocalizationMiddleware` writes a log of type `LogLevel.Debug`, which reduces the size of production logs.

--- a/aspnetcore/includes/mac-terminal-access.md
+++ b/aspnetcore/includes/mac-terminal-access.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ### Accessing a Command Terminal on Visual Studios for Mac
 
 Accessing a command terminal on Mac for the first time requires the following setting configurations:

--- a/aspnetcore/includes/make-x509-cert.md
+++ b/aspnetcore/includes/make-x509-cert.md
@@ -1,6 +1,6 @@
 ---
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
-On Windows, self-signed certificates can be created using the [New-SelfSignedCertificate PowerShell cmdlet](/powershell/module/pkiclient/new-selfsignedcertificate?view=win10-ps). For an unsupported example, see [UpdateIISExpressSSLForChrome.ps1](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/includes/make-x509-cert/UpdateIISExpressSSLForChrome.ps1).
+On Windows, self-signed certificates can be created using the [New-SelfSignedCertificate PowerShell cmdlet](/powershell/module/pkiclient/new-selfsignedcertificate). For an unsupported example, see [UpdateIISExpressSSLForChrome.ps1](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/includes/make-x509-cert/UpdateIISExpressSSLForChrome.ps1).
 
 On macOS, Linux, and Windows, certificates can be created using [OpenSSL](https://www.openssl.org/).

--- a/aspnetcore/includes/make-x509-cert.md
+++ b/aspnetcore/includes/make-x509-cert.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 On Windows, self-signed certificates can be created using the [New-SelfSignedCertificate PowerShell cmdlet](/powershell/module/pkiclient/new-selfsignedcertificate?view=win10-ps). For an unsupported example, see [UpdateIISExpressSSLForChrome.ps1](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/includes/make-x509-cert/UpdateIISExpressSSLForChrome.ps1).
 
 On macOS, Linux, and Windows, certificates can be created using [OpenSSL](https://www.openssl.org/).

--- a/aspnetcore/includes/mvc-intro/adding-model1.md
+++ b/aspnetcore/includes/mvc-intro/adding-model1.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Add a model to an ASP.NET Core MVC app
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Tom Dykstra](https://github.com/tdykstra)

--- a/aspnetcore/includes/mvc-intro/adding-model2.md
+++ b/aspnetcore/includes/mvc-intro/adding-model2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ## Add initial migration and update the database
 
 * Open a command prompt and navigate to the project directory. (The directory containing the *Startup.cs* file).

--- a/aspnetcore/includes/mvc-intro/adding-model2xp.md
+++ b/aspnetcore/includes/mvc-intro/adding-model2xp.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <a name="cli"></a>
 
 ## Perform initial migration

--- a/aspnetcore/includes/mvc-intro/adding-model3.md
+++ b/aspnetcore/includes/mvc-intro/adding-model3.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 
 ## Test the app
 

--- a/aspnetcore/includes/mvc-intro/adding-model4.md
+++ b/aspnetcore/includes/mvc-intro/adding-model4.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The highlighted code above shows the movie database context being added to the [Dependency Injection](xref:fundamentals/dependency-injection) container (In the *Startup.cs* file). `services.AddDbContext<MvcMovieContext>(options =>` specifies the database to use and the connection string. `=>` is a [lambda operator](/dotnet/articles/csharp/language-reference/operators/lambda-operator).
 
 Open the *Controllers/MoviesController.cs* file and examine the constructor:

--- a/aspnetcore/includes/mvc-intro/controller-methods-views.md
+++ b/aspnetcore/includes/mvc-intro/controller-methods-views.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 
 We cover [DataAnnotations](/aspnet/mvc/overview/older-versions/mvc-music-store/mvc-music-store-part-6) in the next tutorial. The [Display](/dotnet/api/microsoft.aspnetcore.mvc.modelbinding.metadata.displaymetadata) attribute specifies what to display for the name of a field (in this case "Release Date" instead of "ReleaseDate"). The [DataType](/dotnet/api/microsoft.aspnetcore.mvc.dataannotations.internal.datatypeattributeadapter) attribute specifies the type of the data (Date), so the time information stored in the field isn't displayed.
 

--- a/aspnetcore/includes/mvc-intro/download.md
+++ b/aspnetcore/includes/mvc-intro/download.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/tutorials/first-mvc-app/start-mvc/sample) ([how to download](xref:index#how-to-download-a-sample)).

--- a/aspnetcore/includes/mvc-intro/model-mig.md
+++ b/aspnetcore/includes/mvc-intro/model-mig.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The database update command generates the following warning: 
 
    "No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'."

--- a/aspnetcore/includes/mvc-intro/model1b.md
+++ b/aspnetcore/includes/mvc-intro/model1b.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Add the following properties to the `Movie` class:
 
 [!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie22/Models/Movie.cs?name=snippet1)]

--- a/aspnetcore/includes/mvc-intro/model2.md
+++ b/aspnetcore/includes/mvc-intro/model2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ::: moniker range=">= aspnetcore-3.0"
 
 <a name="dc"></a>

--- a/aspnetcore/includes/mvc-intro/model4.md
+++ b/aspnetcore/includes/mvc-intro/model4.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The following table details the ASP.NET Core code generator parameters:
 
 | Parameter               | Description|

--- a/aspnetcore/includes/mvc-intro/new-field.md
+++ b/aspnetcore/includes/mvc-intro/new-field.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Add a new field to an ASP.NET Core MVC app
 
 <!-- This include not used by windows version -->

--- a/aspnetcore/includes/mvc-intro/search1.md
+++ b/aspnetcore/includes/mvc-intro/search1.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Add search to an ASP.NET Core MVC app
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)

--- a/aspnetcore/includes/mvc-intro/search2.md
+++ b/aspnetcore/includes/mvc-intro/search2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <!--
 [!code-html[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie/Views/Shared/_Layout.cshtml?highlight=7,31)]
 

--- a/aspnetcore/includes/mvc-intro/search3.md
+++ b/aspnetcore/includes/mvc-intro/search3.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 <!--
 [!code-html[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie/Views/Shared/_Layout.cshtml?highlight=7,31)]
 

--- a/aspnetcore/includes/mvc-intro/sql.md
+++ b/aspnetcore/includes/mvc-intro/sql.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Work with SQLite in an ASP.NET Core MVC app
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)

--- a/aspnetcore/includes/mvc-intro/validation.md
+++ b/aspnetcore/includes/mvc-intro/validation.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # Add validation to an ASP.NET Core MVC app
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT)

--- a/aspnetcore/includes/net-core-prereqs-mac-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-mac-2.2.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio for Mac version 8.0 or later](https://visualstudio.microsoft.com/downloads/)
 * [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)

--- a/aspnetcore/includes/net-core-prereqs-mac-3.0.md
+++ b/aspnetcore/includes/net-core-prereqs-mac-3.0.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio for Mac version 8.0 or later](https://visualstudio.microsoft.com/vs/mac/)
 * [!INCLUDE [](~/includes/3.0-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-mac-3.1.md
+++ b/aspnetcore/includes/net-core-prereqs-mac-3.1.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio for Mac version 8.4 or later](https://visualstudio.microsoft.com/vs/mac/)
 * [!INCLUDE [.NET Core 3.1 SDK](~/includes/3.1-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-mac-5.0.md
+++ b/aspnetcore/includes/net-core-prereqs-mac-5.0.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio for Mac Preview](https://visualstudio.microsoft.com/vs/mac/)
 * [!INCLUDE [.NET 5.0 SDK](~/includes/5.0-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-macos.md
+++ b/aspnetcore/includes/net-core-prereqs-macos.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/)

--- a/aspnetcore/includes/net-core-prereqs-vs-3.0.md
+++ b/aspnetcore/includes/net-core-prereqs-vs-3.0.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
 * [!INCLUDE [](~/includes/3.0-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-vs-3.1.md
+++ b/aspnetcore/includes/net-core-prereqs-vs-3.1.md
@@ -1,2 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio 2019 16.4 or later](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
+
 * [!INCLUDE [.NET Core 3.1 SDK](~/includes/3.1-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-vs-5.0.md
+++ b/aspnetcore/includes/net-core-prereqs-vs-5.0.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio 2019 16.8 or later](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
 * [!INCLUDE [.NET 5.0 SDK](~/includes/5.0-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-vs2017-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-vs2017-2.2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio 2017 version 15.9 or later](https://visualstudio.microsoft.com/downloads/) with the **ASP.NET and web development** workload. You can use [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019), but some project creation steps differ from what's shown in the tutorial.
 * [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)
 

--- a/aspnetcore/includes/net-core-prereqs-vs2019-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-vs2019-2.2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
 * [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)
 

--- a/aspnetcore/includes/net-core-prereqs-vsc-2.2.md
+++ b/aspnetcore/includes/net-core-prereqs-vsc-2.2.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [.NET Core SDK 2.2 or later](https://dotnet.microsoft.com/download/dotnet-core)

--- a/aspnetcore/includes/net-core-prereqs-vsc-3.0.md
+++ b/aspnetcore/includes/net-core-prereqs-vsc-3.0.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [!INCLUDE [](~/includes/3.0-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-vsc-3.1.md
+++ b/aspnetcore/includes/net-core-prereqs-vsc-3.1.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [!INCLUDE [.NET Core 3.1 SDK](~/includes/3.1-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-vsc-5.0.md
+++ b/aspnetcore/includes/net-core-prereqs-vsc-5.0.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * [Visual Studio Code](https://code.visualstudio.com/download)
 * [C# for Visual Studio Code (latest version)](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
 * [!INCLUDE [.NET 5.0 SDK](~/includes/5.0-SDK.md)]

--- a/aspnetcore/includes/net-core-prereqs-windows.md
+++ b/aspnetcore/includes/net-core-prereqs-windows.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the following workloads:
 
 * **ASP.NET and web development**

--- a/aspnetcore/includes/net-core-sdk-download-link.md
+++ b/aspnetcore/includes/net-core-sdk-download-link.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 [.NET Core SDK 2.0 or later](https://dotnet.microsoft.com/download)

--- a/aspnetcore/includes/notUpdated31.md
+++ b/aspnetcore/includes/notUpdated31.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!WARNING]
 > This content has not been updated to ASP.NET Core 3.1

--- a/aspnetcore/includes/razor.md
+++ b/aspnetcore/includes/razor.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 This tutorial teaches ASP.NET Core MVC web development with controllers and views. If you're new to ASP.NET Core web development, consider the [Razor Pages](xref:tutorials/razor-pages/razor-pages-start) version of this tutorial, which provides an easier starting point.

--- a/aspnetcore/includes/regex.md
+++ b/aspnetcore/includes/regex.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!WARNING]
 > When using <xref:System.Text.RegularExpressions> to process untrusted input, pass a timeout. A malicious user can provide input to `RegularExpressions` causing a [Denial-of-Service attack](https://www.us-cert.gov/ncas/tips/ST04-015). ASP.NET Core framework APIs that use `RegularExpressions` pass a timeout.

--- a/aspnetcore/includes/requireAuth.md
+++ b/aspnetcore/includes/requireAuth.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 For information on how to globally require all users to be authenticated, see [Require authenticated users](xref:security/authorization/secure-data#rau).

--- a/aspnetcore/includes/reset.md
+++ b/aspnetcore/includes/reset.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Reset allows for the server to reset a HTTP/2 request with a specified error code. A reset request is considered aborted.
 
 ```csharp

--- a/aspnetcore/includes/run-the-app.md
+++ b/aspnetcore/includes/run-the-app.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # [Visual Studio](#tab/visual-studio)
 
 * Press Ctrl+F5 to run without the debugger.

--- a/aspnetcore/includes/scaffold-identity/hsts.md
+++ b/aspnetcore/includes/scaffold-identity/hsts.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 `UseHsts` is recommended but not required. For more information, see [HTTP Strict Transport Security Protocol](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts).

--- a/aspnetcore/includes/scaffold-identity/id-scaffold-dlg-auth.md
+++ b/aspnetcore/includes/scaffold-identity/id-scaffold-dlg-auth.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ::: moniker range=">= aspnetcore-3.0"
 
 Run the Identity scaffolder:

--- a/aspnetcore/includes/scaffold-identity/id-scaffold-dlg.md
+++ b/aspnetcore/includes/scaffold-identity/id-scaffold-dlg.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Run the Identity scaffolder:
 
 # [Visual Studio](#tab/visual-studio)

--- a/aspnetcore/includes/scaffold-identity/migrations.md
+++ b/aspnetcore/includes/scaffold-identity/migrations.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 The generated Identity database code requires [Entity Framework Core Migrations](/ef/core/managing-schemas/migrations/). Create a migration and update the database. For example, run the following commands:
 
 # [Visual Studio](#tab/visual-studio)

--- a/aspnetcore/includes/scaffoldTFM-5.md
+++ b/aspnetcore/includes/scaffoldTFM-5.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 If you get a scaffolding error, verify the Target Framework Moniker (TFM) matches the NuGet package version in the project file. For example, the following project file uses version 5.0 for .NET and the listed NuGet packages:
 
 ```xml

--- a/aspnetcore/includes/scaffoldTFM.md
+++ b/aspnetcore/includes/scaffoldTFM.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 If you get a scaffolding error, verify the Target Framework Moniker (TFM) matches the NuGet package version in the project file. For example, the following project file contains the version 3.1 for .NET Core and the listed NuGet packages:
 
 ```xml

--- a/aspnetcore/includes/signalr-typescript-webpack/npm-run-release.md
+++ b/aspnetcore/includes/signalr-typescript-webpack/npm-run-release.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ```console
 npm run release
 ```

--- a/aspnetcore/includes/signalr-version-notice.md
+++ b/aspnetcore/includes/signalr-version-notice.md
@@ -1,2 +1,5 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!NOTE]
 > This document details the latest version of ASP.NET Core SignalR. See the [SignalR 1.x documentation](/aspnet/signalr/) for the ASP.NET Framework version.

--- a/aspnetcore/includes/sqlite-warn.md
+++ b/aspnetcore/includes/sqlite-warn.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 > [!NOTE]
 > 
 > **SQLite limitations**

--- a/aspnetcore/includes/trailers.md
+++ b/aspnetcore/includes/trailers.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 HTTP Trailers are similar to HTTP Headers, except they are sent after the response body is sent. For IIS and HTTP.sys, only HTTP/2 response trailers are supported.
 
 ```csharp

--- a/aspnetcore/includes/trust-ff.md
+++ b/aspnetcore/includes/trust-ff.md
@@ -1,1 +1,4 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 For information on trusting the Firefox browser, see [Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error](xref:security/enforcing-ssl#trust-ff).

--- a/aspnetcore/includes/trustCertMac.md
+++ b/aspnetcore/includes/trustCertMac.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Visual Studio for Mac displays the following popup:
 
 ![HTTPS Development certificate not found. Do you want to install and trust the certificate?](~/getting-started/_static/trustCertMac.png)

--- a/aspnetcore/includes/trustCertVS.md
+++ b/aspnetcore/includes/trustCertVS.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Visual Studio displays the following dialog:
 
 ![This project is configured to use SSL. To avoid SSL warnings in the browser you can choose to trust the self-signed certificate that IIS Express has generated. Would you like to trust the IIS Express SSL certificate?](~/getting-started/_static/trustCert.png)

--- a/aspnetcore/includes/trustCertVSC.md
+++ b/aspnetcore/includes/trustCertVSC.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 * Trust the HTTPS development certificate by running the following command:
 
   ```dotnetcli

--- a/aspnetcore/includes/view-identity-db.md
+++ b/aspnetcore/includes/view-identity-db.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 ### View the Identity database
 
 # [Visual Studio](#tab/visual-studio) 

--- a/aspnetcore/includes/vs-vsc-vsmac-help.md
+++ b/aspnetcore/includes/vs-vsc-vsmac-help.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # [Visual Studio](#tab/visual-studio)
 
 ## Visual Studio help

--- a/aspnetcore/includes/vs-vsc-vsmac-help.md
+++ b/aspnetcore/includes/vs-vsc-vsmac-help.md
@@ -5,8 +5,8 @@ no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Bla
 
 ## Visual Studio help
 
-* [Learn to debug C# code using Visual Studio](/visualstudio/debugger/getting-started-with-the-debugger?view=vs-2017)
-* [Introduction to the Visual Studio IDE](/visualstudio/ide/visual-studio-ide?view=vs-2017)
+* [Learn to debug C# code using Visual Studio](/visualstudio/debugger/getting-started-with-the-debugger)
+* [Introduction to the Visual Studio IDE](/visualstudio/ide/visual-studio-ide)
 
 # [Visual Studio Code](#tab/visual-studio-code)
 

--- a/aspnetcore/includes/worker-template-instructions.md
+++ b/aspnetcore/includes/worker-template-instructions.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 # [Visual Studio](#tab/visual-studio)
 
 1. Create a new project.


### PR DESCRIPTION
Fixes #21501

For INCLUDES that had an existing blank line at the top, I assumed that the line is there by-design and left it alone. The other files start with content, so the metadata is added immediately above it (i.e., no blank line between the `---` and the content).

Thanks @Youssef1313! 🎸