### PR TITLE
no-loc metadata test in INCLUDES files

### DIFF
--- a/aspnetcore/blazor/includes/state-container.md
+++ b/aspnetcore/blazor/includes/state-container.md
@@ -1,3 +1,6 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
 Nested components typically bind data using *chained bind* as described in <xref:blazor/components/data-binding>. Nested and un-nested components can share access to data using a registered in-memory state container. A custom state container class can use an assignable <xref:System.Action> to notify components in different parts of the app of state changes. In the following example:
 
 * A pair of components uses a state container to track a property.
@@ -59,7 +62,7 @@ services.AddSingleton<StateContainer>();
 
     private void ChangePropertyValue()
     {
-        StateContainer.SetProperty($"New value set in Component 1 {DateTime.Now}");
+        StateContainer.SetProperty($"New value set in Component 1: {DateTime.Now}");
     }
 
     public void Dispose()
@@ -91,7 +94,7 @@ services.AddSingleton<StateContainer>();
 
     private void ChangePropertyValue()
     {
-        StateContainer.SetProperty($"New value set in Component 2 {DateTime.Now}");
+        StateContainer.SetProperty($"New value set in Component 2: {DateTime.Now}");
     }
 
     public void Dispose()


### PR DESCRIPTION
Addresses #21501

@JasonCard ...

* This will be our test to confirm that adding the metadata to an INCLUDES file **_doesn't_** work.
* When this (likely) fails, I'll revert these changes and go with the inline approach for these files. I have an algorithmic approach to make the changes in an automated way.
* Given that there's a delay on the localized version going live, I'll track on a couple of colons in the code blocks ...

  ```csharp
  StateContainer.SetProperty($"New value set in Component 1: {DateTime.Now}");
  ```

  ```csharp
  StateContainer.SetProperty($"New value set in Component 2: {DateTime.Now}");
  ```

  ... then compare the following content against "(Blazor WebAssembly)" and "(Blazor Server)" ...

  <img width="401" alt="Capture" src="https://user-images.githubusercontent.com/1622880/107510384-74306980-6b69-11eb-84bd-438a57343db4.PNG">

Cross-reference: https://docs.microsoft.com/fr-fr/aspnet/core/blazor/state-management