### PR TITLE
Hosted Blazor VSC tasks/launch guidance

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -145,7 +145,7 @@ For information on using a custom app base path for Blazor WebAssembly apps, see
 
 <h2 id="vscode">Debug standalone Blazor WebAssembly</h2>
 
-For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
+For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system guidance in <xref:blazor/tooling>.
 
 1. Open the standalone Blazor WebAssembly app in VS Code.
 
@@ -183,7 +183,7 @@ For information on configuring VS Code assets in the `.vscode` folder, see the *
 
    > Required assets to build and debug are missing from '{APPLICATION NAME}'. Add them?
 
-   For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
+   For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system guidance in <xref:blazor/tooling>.
 
 1. In the command palette at the top of the window, select the *Server* project within the hosted solution.
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -145,6 +145,8 @@ For information on using a custom app base path for Blazor WebAssembly apps, see
 
 <h2 id="vscode">Debug standalone Blazor WebAssembly</h2>
 
+For information on configuring VS Code assets in the `.vscode` folder to run and debug the app, see <xref:blazor/tooling>.
+
 1. Open the standalone Blazor WebAssembly app in VS Code.
 
    You may receive a notification that additional setup is required to enable debugging:

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -145,7 +145,7 @@ For information on using a custom app base path for Blazor WebAssembly apps, see
 
 <h2 id="vscode">Debug standalone Blazor WebAssembly</h2>
 
-For information on configuring VS Code assets in the `.vscode` folder to run and debug the app, see <xref:blazor/tooling>.
+For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
 
 1. Open the standalone Blazor WebAssembly app in VS Code.
 
@@ -182,6 +182,8 @@ For information on configuring VS Code assets in the `.vscode` folder to run and
 1. If there's no launch configuration set for the project, the following notification appears. Select **Yes**.
 
    > Required assets to build and debug are missing from '{APPLICATION NAME}'. Add them?
+
+   For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
 
 1. In the command palette at the top of the window, select the *Server* project within the hosted solution.
 

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -5,7 +5,7 @@ description: Learn about the tooling available to build Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 09/28/2020
+ms.date: 02/11/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/tooling
 zone_pivot_groups: operating-systems
@@ -32,6 +32,8 @@ zone_pivot_groups: operating-systems
 
 For more information on trusting the ASP.NET Core HTTPS development certificate, see <xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos>.
 
+When executing a hosted Blazor WebAssembly app, run the app from the solution's **`Server`** project.
+
 ::: zone-end
 
 ::: zone pivot="linux"
@@ -53,11 +55,11 @@ For more information on trusting the ASP.NET Core HTTPS development certificate,
    ```
 
    For a hosted Blazor WebAssembly experience, add the hosted option (`-ho` or `--hosted`) option to the command:
-   
+
    ```dotnetcli
    dotnet new blazorwasm -o WebApplication1 -ho
    ```
-   
+
    For a Blazor Server experience, execute the following command in a command shell:
 
    ```dotnetcli
@@ -69,6 +71,57 @@ For more information on trusting the ASP.NET Core HTTPS development certificate,
 1. Open the `WebApplication1` folder in Visual Studio Code.
 
 1. The IDE requests that you add assets to build and debug the project. Select **Yes**.
+
+   **Hosted Blazor WebAssembly launch and task configuration**
+
+   For hosted Blazor WebAssembly solutions, add (or move) the `.vscode` folder with `launch.json` and `tasks.json` files to the solution's parent folder, which is the folder that contains the typical project folder names of `Client`, `Server`, and `Shared`. Update or confirm that the configuration in the `launch.json` and `tasks.json` files execute a hosted Blazor WebAssembly app from the **`Server`** project.
+
+   **`.vscode/launch.json`** (`launch` configuration):
+
+   ```json
+   ...
+   "cwd": "${workspaceFolder}/{SERVER APP FOLDER}",
+   ...
+   ```
+
+   In the preceding configuration for the current working directory (`cwd`), the `{SERVER APP FOLDER}` placeholder is the **`Server`** project's folder, typically "`Server`".
+
+   If Microsoft Edge is used and Google Chrome isn't installed on the system, add an additional property of `"browser": "edge"` to the configuration.
+
+   Example for a project folder of `Server` and that spawns Microsoft Edge as the browser for debug runs instead of the default browser Google Chrome:
+
+   ```json
+   ...
+   "cwd": "${workspaceFolder}/Server",
+   "browser": "edge"
+   ...
+   ```
+
+   **`.vscode/tasks.json`** ([`dotnet` command](/dotnet/core/tools/dotnet) arguments):
+
+   ```json
+   ...
+   "${workspaceFolder}/{SERVER APP FOLDER}/{SERVER APP NAMESPACE}.csproj",
+   ...
+   ```
+
+   In the preceding argument:
+
+   * The `{SERVER APP FOLDER}` placeholder is the **`Server`** project's folder, typically "`Server`".
+   * The `{APP NAMESPACE}` placeholder is the app's namespace, typically based on the app's name followed by "`.Server`" in an app generated from the Blazor project template.
+
+   The following example from the [tutorial for using SignalR with a Blazor WebAssembly app](xref:tutorials/signalr-blazor) uses a project folder name of `Server` and an app namespace of `BlazorWebAssemblySignalRApp.Server`:
+
+   ```json
+   ...
+   "args": [
+     "build",
+       "${workspaceFolder}/Server/BlazorWebAssemblySignalRApp.Server.csproj",
+       "/property:GenerateFullPaths=true",
+       "/consoleloggerparameters:NoSummary"
+   ],
+   ...
+   ```
 
 1. Press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app.
 
@@ -105,6 +158,8 @@ For more information, see the guidance provided by your browser manufacturer and
 1. Select **Run** > **Start Without Debugging** to run the app *without the debugger*. Run the app with **Run** > **Start Debugging** or the Run (&#9654;) button to run the app *with the debugger*.
 
 If a prompt appears to trust the development certificate, trust the certificate and continue. The user and keychain passwords are required to trust the certificate. For more information on trusting the ASP.NET Core HTTPS development certificate, see <xref:security/enforcing-ssl#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos>.
+
+When executing a hosted Blazor WebAssembly app, run the app from the solution's **`Server`** project.
 
 ::: zone-end
 

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -101,16 +101,16 @@ When executing a hosted Blazor WebAssembly app, run the app from the solution's 
 
    ```json
    ...
-   "${workspaceFolder}/{SERVER APP FOLDER}/{SERVER APP NAMESPACE}.csproj",
+   "${workspaceFolder}/{SERVER APP FOLDER}/{PROJECT NAME}.csproj",
    ...
    ```
 
    In the preceding argument:
 
    * The `{SERVER APP FOLDER}` placeholder is the **`Server`** project's folder, typically "`Server`".
-   * The `{APP NAMESPACE}` placeholder is the app's namespace, typically based on the app's name followed by "`.Server`" in an app generated from the Blazor project template.
+   * The `{PROJECT NAME}` placeholder is the app's name, typically based on the solution's name followed by "`.Server`" in an app generated from the Blazor project template.
 
-   The following example from the [tutorial for using SignalR with a Blazor WebAssembly app](xref:tutorials/signalr-blazor) uses a project folder name of `Server` and an app namespace of `BlazorWebAssemblySignalRApp.Server`:
+   The following example from the [tutorial for using SignalR with a Blazor WebAssembly app](xref:tutorials/signalr-blazor) uses a project folder name of `Server` and a project name of `BlazorWebAssemblySignalRApp.Server`:
 
    ```json
    ...

--- a/aspnetcore/tutorials/signalr-blazor.md
+++ b/aspnetcore/tutorials/signalr-blazor.md
@@ -117,7 +117,7 @@ Follow the guidance for your choice of tooling:
    dotnet new blazorwasm -ho -o BlazorWebAssemblySignalRApp
    ```
 
-   The `-ho|--hosted` option creates a hosted Blazor WebAssembly solution.
+   The `-ho|--hosted` option creates a hosted Blazor WebAssembly solution. For information on configuring VS Code assets in the `.vscode` folder, see <xref:blazor/tooling>.
 
    The `-o|--output` option creates a folder for the solution. If you've created a folder for the solution and the command shell is open in that folder, omit the `-o|--output` option and value to create the solution.
 
@@ -361,6 +361,8 @@ Follow the guidance for your tooling:
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
+For information on configuring VS Code assets in the `.vscode` folder to run and debug the app, see <xref:blazor/tooling>.
+
 1. Press <kbd>F5</kbd> to run the app with debugging or <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app without debugging.
 
 1. Copy the URL from the address bar, open another browser instance or tab, and paste the URL in the address bar.
@@ -448,7 +450,7 @@ Follow the guidance for your choice of tooling:
 
 1. In Visual Studio Code, open the app's project folder.
 
-1. When the dialog appears to add assets to build and debug the app, select **Yes**. Visual Studio Code automatically adds the `.vscode` folder with generated `launch.json` and `tasks.json` files.
+1. When the dialog appears to add assets to build and debug the app, select **Yes**. Visual Studio Code automatically adds the `.vscode` folder with generated `launch.json` and `tasks.json` files. For information on configuring VS Code assets in the `.vscode` folder, see <xref:blazor/tooling>.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 

--- a/aspnetcore/tutorials/signalr-blazor.md
+++ b/aspnetcore/tutorials/signalr-blazor.md
@@ -117,7 +117,7 @@ Follow the guidance for your choice of tooling:
    dotnet new blazorwasm -ho -o BlazorWebAssemblySignalRApp
    ```
 
-   The `-ho|--hosted` option creates a hosted Blazor WebAssembly solution. For information on configuring VS Code assets in the `.vscode` folder, see <xref:blazor/tooling>.
+   The `-ho|--hosted` option creates a hosted Blazor WebAssembly solution. For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
 
    The `-o|--output` option creates a folder for the solution. If you've created a folder for the solution and the command shell is open in that folder, omit the `-o|--output` option and value to create the solution.
 
@@ -361,7 +361,7 @@ Follow the guidance for your tooling:
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-For information on configuring VS Code assets in the `.vscode` folder to run and debug the app, see <xref:blazor/tooling>.
+For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
 
 1. Press <kbd>F5</kbd> to run the app with debugging or <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app without debugging.
 
@@ -450,7 +450,7 @@ Follow the guidance for your choice of tooling:
 
 1. In Visual Studio Code, open the app's project folder.
 
-1. When the dialog appears to add assets to build and debug the app, select **Yes**. Visual Studio Code automatically adds the `.vscode` folder with generated `launch.json` and `tasks.json` files. For information on configuring VS Code assets in the `.vscode` folder, see <xref:blazor/tooling>.
+1. When the dialog appears to add assets to build and debug the app, select **Yes**. Visual Studio Code automatically adds the `.vscode` folder with generated `launch.json` and `tasks.json` files. For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 

--- a/aspnetcore/tutorials/signalr-blazor.md
+++ b/aspnetcore/tutorials/signalr-blazor.md
@@ -117,7 +117,7 @@ Follow the guidance for your choice of tooling:
    dotnet new blazorwasm -ho -o BlazorWebAssemblySignalRApp
    ```
 
-   The `-ho|--hosted` option creates a hosted Blazor WebAssembly solution. For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
+   The `-ho|--hosted` option creates a hosted Blazor WebAssembly solution. For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system guidance in <xref:blazor/tooling>.
 
    The `-o|--output` option creates a folder for the solution. If you've created a folder for the solution and the command shell is open in that folder, omit the `-o|--output` option and value to create the solution.
 
@@ -361,7 +361,7 @@ Follow the guidance for your tooling:
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
+For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system guidance in <xref:blazor/tooling>.
 
 1. Press <kbd>F5</kbd> to run the app with debugging or <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app without debugging.
 
@@ -450,7 +450,7 @@ Follow the guidance for your choice of tooling:
 
 1. In Visual Studio Code, open the app's project folder.
 
-1. When the dialog appears to add assets to build and debug the app, select **Yes**. Visual Studio Code automatically adds the `.vscode` folder with generated `launch.json` and `tasks.json` files. For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system tab in <xref:blazor/tooling>.
+1. When the dialog appears to add assets to build and debug the app, select **Yes**. Visual Studio Code automatically adds the `.vscode` folder with generated `launch.json` and `tasks.json` files. For information on configuring VS Code assets in the `.vscode` folder, see the **Linux** operating system guidance in <xref:blazor/tooling>.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 


### PR DESCRIPTION
Fixes #21524

Thanks @nosnetrom! :rocket:

Brennan, if you're too 🏃😅 to look, I'll ask Safia if she's free. :ear: 

[Internal Review Topic (*Tooling*)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/tooling?view=aspnetcore-3.1&branch=pr-en-us-21526)

I'm making this dead simple to follow .... **_wordy_** 📘 *yeah* ... **_but_** dead simple ...

* Let's show with placeholders because there is flexibility in the folder and app naming.
* Let's follow that with an explicit example using the SignalR-Blazor tutorial example.
* Let's call out Edge config while we're at it. I use Edge for a lot of testing, especially my WASM security testing.

Outside of the *Debug WASM* topic and *SignalR-Blazor* tutorial, I didn't look further for hosted WASM VSC tooling cross-link opportunities because we don't explicitly cover VSC in a tooling tab elsewhere. However, I will keep an :eye: out as I UE pass the entire node for cross-link opportunities. Because I'm going back to the beginning for common snippets work, I'll get to look at most of the topics that have already had a UE pass on https://github.com/dotnet/AspNetCore.Docs/issues/19286.