### PR TITLE
Component parameter assignment guidance

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -343,7 +343,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   }
   ```
   
-* To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix. To calculate a date that's one week in the past for assignment to a child's parameter, use the syntax `Title="@((DateTime.Now - TimeSpan.FromDays(7)).ToString())"`, as seen in the following child and parent component:
+* To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix. To calculate a date that's one week in the past for assignment to a child's parameter, use the syntax `{PARAMETER}="@((DateTime.Now - TimeSpan.FromDays(7)).ToString())"`, where the `{PARAMETER}` placeholder is the child component's parameter name. In the following example, the child component has a `DateTime` component parameter. The parent component assigns a date value calculated from the current local date with an explicit C# expression.
 
   `Shared/ChildComponent.razor`:
   

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -343,8 +343,10 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   }
   ```
   
-* To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix. To calculate a date that's one week in the past for assignment to a child's parameter, use the syntax `{PARAMETER (DateTime type)}="@(DateTime.Now - TimeSpan.FromDays(7))"`, where the `{PARAMETER (DateTime type)}` placeholder is the child component's parameter name. In the following example, the child component has a <xref:System.DateTime> component parameter. The parent component assigns a date value calculated from the current local date with an explicit C# expression.
+* To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix.
 
+  The following child component has a <xref:System.DateTime> component parameter, `ShowItemsSinceDate`.
+  
   `Shared/ChildComponent.razor`:
   
   ```razor
@@ -364,6 +366,8 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
       public RenderFragment ChildContent { get; set; }
   }
   ```
+  
+  The following parent component calculates a date with an explicit C# expression that's one week in the past for assignment to the child's `ShowItemsSinceDate` parameter.
   
   `Pages/ParentComponent.razor`:
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -270,36 +270,24 @@ In the following example from the sample app, the `ParentComponent` sets the val
 
 Assign C# fields, properties, and methods to component parameters as HTML attribute values using [Razor's reserved `@` symbol](xref:mvc/views/razor#razor-syntax):
 
-* To assign a parent component's field or property value to a child component's parameter, prefix the field or property name with the `@` symbol. To assign a C# field named `title` to the `Title` parameter, use the syntax `Title="@title"`, as seen in the following parent component:
+* To assign a parent component's field, property, or method to a child component's parameter, prefix the field, property, or method name with the `@` symbol. To assign the result of an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions) in the parent component to a child component's parameter, prefix the implicit expression with an `@` symbol.
+
+  The following parent component example uses the preceding `ChildComponent` component example and sets its `Title` parameter value to:
+
+  * The value of the `title` field in the first child component.
+  * The result of the `GetTitle` C# method in the second child component.
+  * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A> in the third child component.
+  * The `person` object's `Name` property in the fourth child component.
 
   ```razor
   <ChildComponent Title="@title">
       Title from field.
   </ChildComponent>
   
-  @code {
-      private string title = "Panel Title from Parent";
-  }
-  ```
-
-* To assign the result of a parent component's method to a child component's parameter, prefix the method name with the `@` symbol. To assign the result of a C# method named `GetTitle` to the `Title` parameter, use the syntax `Title="@GetTitle"`, as seen in the following parent component:
-
-  ```razor
   <ChildComponent Title="@GetTitle()">
       Title from method.
   </ChildComponent>
   
-  @code {
-      private string GetTitle()
-      {
-          return "Panel Title from Parent";
-      }
-  }
-  ```
-  
-* To assign the result of an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions) in the parent component to a child component's parameter, prefix the implicit expression with an `@` symbol. To assign the current local date in long format with <xref:System.DateTime.ToLongDateString%2A> in the parent component, assign `@DateTime.Now.ToLongDateString()` to the child's parameter. To assign a `person` object's `Name` property, assign `@person.Name`. The following example demonstrates these concepts:
-
-  ```razor
   <ChildComponent Title="@DateTime.Now.ToLongDateString()">
       Title from implicit Razor expression.
   </ChildComponent>
@@ -307,6 +295,21 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   <ChildComponent Title="@person.Name">
       Title from implicit Razor expression.
   </ChildComponent>
+  
+  @code {
+      private string title = "Panel Title from Parent";
+      private Person person = new Person();
+      
+      private string GetTitle()
+      {
+          return "Panel Title from Parent";
+      }
+      
+      private class Person
+      {
+          public string Name { get; set; } = "Dr. Who";
+      }
+  }
   ```
   
   Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After the component is rendered, the UI may be updated. The following Razor syntax is **not** supported:
@@ -338,7 +341,29 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   }
   ```
   
-* To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix. To calculate a date that's one week in the past for assignment to a child's parameter, use the syntax `Title="@((DateTime.Now - TimeSpan.FromDays(7)).ToString())"`, as seen in the following parent component:
+* To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix. To calculate a date that's one week in the past for assignment to a child's parameter, use the syntax `Title="@((DateTime.Now - TimeSpan.FromDays(7)).ToString())"`, as seen in the following child and parent component:
+
+  `Shared/ChildComponent.razor`:
+  
+  ```razor
+  <div class="panel panel-default">
+      <div class="panel-heading">Explicit DateTime Expression Example</div>
+      <div class="panel-body">
+          <p>@ChildContent</p>
+          <p>One week ago date: @ShowItemsSinceDate</p>
+      </div>
+  </div>
+
+  @code {
+      [Parameter]
+      public DateTime ShowItemsSinceDate { get; set; }
+
+      [Parameter]
+      public RenderFragment ChildContent { get; set; }
+  }
+  ```
+  
+  `Pages/ParentComponent.razor`:
 
   ```razor
   <ChildComponent ShowItemsSinceDate="@(DateTime.Now - TimeSpan.FromDays(7))">

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -343,7 +343,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   }
   ```
   
-* To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix. To calculate a date that's one week in the past for assignment to a child's parameter, use the syntax `{PARAMETER}="@((DateTime.Now - TimeSpan.FromDays(7)).ToString())"`, where the `{PARAMETER}` placeholder is the child component's parameter name. In the following example, the child component has a `DateTime` component parameter. The parent component assigns a date value calculated from the current local date with an explicit C# expression.
+* To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix. To calculate a date that's one week in the past for assignment to a child's parameter, use the syntax `{PARAMETER (DateTime type)}="@(DateTime.Now - TimeSpan.FromDays(7))"`, where the `{PARAMETER (DateTime type)}` placeholder is the child component's parameter name. In the following example, the child component has a <xref:System.DateTime> component parameter. The parent component assigns a date value calculated from the current local date with an explicit C# expression.
 
   `Shared/ChildComponent.razor`:
   

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -270,15 +270,17 @@ In the following example from the sample app, the `ParentComponent` sets the val
 
 Assign C# fields, properties, and methods to component parameters as HTML attribute values using [Razor's reserved `@` symbol](xref:mvc/views/razor#razor-syntax):
 
-* To assign a parent component's field, property, or method to a child component's parameter, prefix the field, property, or method name with the `@` symbol. To assign the result of an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions) in the parent component to a child component's parameter, prefix the implicit expression with an `@` symbol.
+* To assign a parent component's field, property, or method to a child component's parameter, prefix the field, property, or method name with the `@` symbol. To assign the result of an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions) to a parameter, prefix the implicit expression with an `@` symbol.
 
-  The following parent component example uses the preceding `ChildComponent` component example and sets its `Title` parameter value to:
+  The following parent component displays four instances of the preceding `ChildComponent` component and sets their `Title` parameter values to:
 
-  * The value of the `title` field in the first child component.
-  * The result of the `GetTitle` C# method in the second child component.
-  * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A> in the third child component.
-  * The `person` object's `Name` property in the fourth child component.
+  * The value of the `title` field.
+  * The result of the `GetTitle` C# method.
+  * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>.
+  * The `person` object's `Name` property.
 
+  `Pages/ParentComponent.razor`:
+  
   ```razor
   <ChildComponent Title="@title">
       Title from field.

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -314,7 +314,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   }
   ```
   
-  Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After the component is rendered, the UI may be updated. The following Razor syntax is **not** supported:
+  Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:
   
   ```razor
   <ChildComponent Title="@await ...">
@@ -322,7 +322,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   </ChildComponent>
   ```
   
-  The code in the preceding example generates an IntelliSense error in Visual Studio and a *compiler error* if the app is built:
+  The code in the preceding example generates a *compiler error* if the app is built:
   
   > The 'await' operator can only be used within an async method. Consider marking this method with the 'async' modifier and changing its return type to 'Task'.
 
@@ -385,7 +385,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   </ChildComponent>
   ```
   
-  The code in the preceding example generates an IntelliSense error in Visual Studio and a *compiler error* if the app is built:
+  The code in the preceding example generates a *compiler error* if the app is built:
   
   > Component attributes do not support complex content (mixed C# and markup).
   

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -385,6 +385,24 @@ For more information, see [Razor syntax reference for ASP.NET Core](xref:mvc/vie
 > [!WARNING]
 > Don't create components that write to their own *component parameters*, use a private field instead. For more information, see the [Overwritten parameters](#overwritten-parameters) section.
 
+#### Component parameters should be auto-properties
+
+Component parameters should be declared as *auto-properties*, meaning that they shouldn't contain custom logic in their getters or setters. For example, the following `StartData` property is an auto-property:
+
+```csharp
+[Parameter]
+public DateTime StartData { get; set; }
+```
+
+Don't place custom logic in the `get` or `set` accessor because component parameters are purely intended for use as a channel for a parent component to flow information to a child component. If a setter of a child component property contains logic that causes rerendering of the parent component, an *infinite rendering loop results*.
+
+If you need to transform a received parameter value:
+
+* Leave the parameter property as a pure auto-property to represent the initial raw data.
+* Create some other property or method that supplies the transformed data based on the parameter property.
+
+You can override `OnParametersSetAsync` if you want to transform a received parameter each time new data is received.
+
 ## Child content
 
 Components can set the content of another component. The assigning component provides the content between the tags that specify the receiving component.

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -309,7 +309,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   </ChildComponent>
   ```
   
-  Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. Instead, asynchronous work is performed during one of the [asynchronous component lifecycle events](xref:blazor/components/lifecycle). The following Razor syntax is **not** supported:
+  Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After the component is rendered, the UI may be updated. The following Razor syntax is **not** supported:
   
   ```razor
   <ChildComponent Title="@await ...">
@@ -333,7 +333,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
       
       protected override async Task OnInitializedAsync()
       {
-          title = await Task.FromResult<string>("Panel Title from Parent");
+          title = await ...;
       }
   }
   ```
@@ -341,7 +341,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
 * To assign the result of an [explicit C# expression](xref:mvc/views/razor#explicit-razor-expressions) in the parent component to a child component's parameter, surround the expression in parentheses with an `@` symbol prefix. To calculate a date that's one week in the past for assignment to a child's parameter, use the syntax `Title="@((DateTime.Now - TimeSpan.FromDays(7)).ToString())"`, as seen in the following parent component:
 
   ```razor
-  <ChildComponent Title="@((DateTime.Now - TimeSpan.FromDays(7)).ToString())">
+  <ChildComponent ShowItemsSinceDate="@(DateTime.Now - TimeSpan.FromDays(7))">
       Title from explicit Razor expression.
   </ChildComponent>
   ```
@@ -368,10 +368,7 @@ Assign C# fields, properties, and methods to component parameters as HTML attrib
   @code {
       private Product product = new Product();
 
-      private string GetTitle()
-      {
-          return $"SKU-{product.SKU}";
-      }
+      private string GetTitle() => $"SKU-{product.SKU}";
       
       private class Product
       {
@@ -394,11 +391,11 @@ Component parameters should be declared as *auto-properties*, meaning that they 
 public DateTime StartData { get; set; }
 ```
 
-Don't place custom logic in the `get` or `set` accessor because component parameters are purely intended for use as a channel for a parent component to flow information to a child component. If a setter of a child component property contains logic that causes rerendering of the parent component, an *infinite rendering loop results*.
+Don't place custom logic in the `get` or `set` accessor because component parameters are purely intended for use as a channel for a parent component to flow information to a child component. If a setter of a child component property contains logic that causes rerendering of the parent component, an infinite rendering loop results.
 
 If you need to transform a received parameter value:
 
-* Leave the parameter property as a pure auto-property to represent the initial raw data.
+* Leave the parameter property as a pure auto-property to represent the supplied raw data.
 * Create some other property or method that supplies the transformed data based on the parameter property.
 
 You can override `OnParametersSetAsync` if you want to transform a received parameter each time new data is received.


### PR DESCRIPTION
Fixes #21552
Fixes #21553

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components/index?view=aspnetcore-3.1&branch=pr-en-us-21555#component-parameters)

This is a little rough. If you don't get a chance to look today (Monday), I plan to give it another polish pass on Tuesday AM. It will probably improve tomorrow morning.

### General remark on UE progress

I'm addressing sour guidance on the UE passes on https://github.com/dotnet/AspNetCore.Docs/issues/19286. I haven't reached this topic yet. Given the amount of hack'in on these topics over a long period of time, all bets are off on quality until I reach and overhaul them. This one tho ... for sure ... let's immediately address ...

* The main bug of missing the `()` for a method result assignment.
* Other problems in assignment (e.g., Razor expressions).
* Flesh out examples.
* Clarify concepts (e.g., who assigns what to whom).

### Do you want to take the approach drafted here on the PR of a bullet list explaining simple assignment scenarios?

Of course, I'm all :ear: :ear: :ear: (yes, I have three :ear: ... 👽-rex) for advice on missing assignment scenarios and **_gotchas_** 😈 to call out. I'll get them in probably Tuesday morning if I hear back. If you want to cover this a different way, let me know.