### PR TITLE
Blazor Handle Errors topic UE pass

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -240,7 +240,7 @@ In the `FetchData` component of the Blazor templates, <xref:Microsoft.AspNetCore
 
 ## Handle errors
 
-For information on handling errors during lifecycle method execution, see <xref:blazor/fundamentals/handle-errors#lifecycle-methods>.
+For information on handling errors during lifecycle method execution, see <xref:blazor/fundamentals/handle-errors>.
 
 ## Stateful reconnection after prerendering
 

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -5,7 +5,7 @@ description: Discover how ASP.NET Core Blazor how Blazor manages unhandled excep
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/24/2021
+ms.date: 02/25/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/fundamentals/handle-errors
 zone_pivot_groups: blazor-hosting-models
@@ -35,28 +35,7 @@ In a Blazor WebAssembly app, customize the experience in the `wwwroot/index.html
 </div>
 ```
 
-The `blazor-error-ui` element is hidden by the styles included in the Blazor project template (`wwwroot/css/app.css`) and then shown when an error occurs:
-
-```css
-#blazor-error-ui {
-    background: lightyellow;
-    bottom: 0;
-    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
-    display: none;
-    left: 0;
-    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
-    position: fixed;
-    width: 100%;
-    z-index: 1000;
-}
-
-#blazor-error-ui .dismiss {
-    cursor: pointer;
-    position: absolute;
-    right: 0.75rem;
-    top: 0.5rem;
-}
-```
+The `blazor-error-ui` element is normally hidden due the presence of the `display: none` style of the `blazor-error-ui` CSS class in the app's stylesheet (`wwwroot/css/app.css`). When an error occurs, the framework applies `display: block` to the element.
 
 ## Manage unhandled exceptions in developer code
 
@@ -66,6 +45,10 @@ In production, don't render framework exception messages or stack traces in the 
 
 * Disclose sensitive information to end users.
 * Help a malicious user discover weaknesses in an app that can compromise the security of the app, server, or network.
+
+## Global exception handling
+
+[!INCLUDE[](~/blazor/includes/handle-errors/global-exception-handling.md)]
 
 ## Log errors with a persistent provider
 
@@ -273,28 +256,9 @@ In a Blazor Server app, customize the experience in the `Pages/_Host.cshtml` fil
 </div>
 ```
 
+The `blazor-error-ui` element is normally hidden due the presence of the `display: none` style of the `blazor-error-ui` CSS class in the site's stylesheet (`wwwroot/css/site.css`). When an error occurs, the framework applies `display: block` to the element.
+
 The `blazor-error-ui` element is hidden by the styles included in the Blazor project template (`wwwroot/css/site.css`) and then shown when an error occurs:
-
-```css
-#blazor-error-ui {
-    background: lightyellow;
-    bottom: 0;
-    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
-    display: none;
-    left: 0;
-    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
-    position: fixed;
-    width: 100%;
-    z-index: 1000;
-}
-
-#blazor-error-ui .dismiss {
-    cursor: pointer;
-    position: absolute;
-    right: 0.75rem;
-    top: 0.5rem;
-}
-```
 
 ## Blazor Server detailed circuit errors
 
@@ -350,6 +314,12 @@ In production, don't render framework exception messages or stack traces in the 
 
 * Disclose sensitive information to end users.
 * Help a malicious user discover weaknesses in an app that can compromise the security of the app, server, or network.
+
+## Global exception handling
+
+[!INCLUDE[](~/blazor/includes/handle-errors/global-exception-handling.md)]
+
+Because the approaches in this section handle errors with a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement, the SignalR connection between the client and server isn't broken when an error occurs and the circuit remains alive. Any unhandled exception is fatal to a circuit. For more information, see the preceding section on [how a Blazor Server app reacts to unhandled exceptions](#how-a-blazor-server-app-reacts-to-unhandled-exceptions).
 
 ## Log errors with a persistent provider
 

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -5,13 +5,16 @@ description: Discover how ASP.NET Core Blazor how Blazor manages unhandled excep
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/23/2020
+ms.date: 02/24/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/fundamentals/handle-errors
+zone_pivot_groups: blazor-hosting-models
 ---
 # Handle errors in ASP.NET Core Blazor apps
 
 This article describes how Blazor manages unhandled exceptions and how to develop apps that detect and handle errors.
+
+::: zone pivot="webassembly"
 
 ## Detailed errors during development
 
@@ -32,6 +35,229 @@ In a Blazor WebAssembly app, customize the experience in the `wwwroot/index.html
 </div>
 ```
 
+The `blazor-error-ui` element is hidden by the styles included in the Blazor project template (`wwwroot/css/app.css`) and then shown when an error occurs:
+
+```css
+#blazor-error-ui {
+    background: lightyellow;
+    bottom: 0;
+    box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
+    display: none;
+    left: 0;
+    padding: 0.6rem 1.25rem 0.7rem 1.25rem;
+    position: fixed;
+    width: 100%;
+    z-index: 1000;
+}
+
+#blazor-error-ui .dismiss {
+    cursor: pointer;
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+}
+```
+
+## Manage unhandled exceptions in developer code
+
+For an app to continue after an error, the app must have error handling logic. Later sections of this article describe potential sources of unhandled exceptions.
+
+In production, don't render framework exception messages or stack traces in the UI. Rendering exception messages or stack traces could:
+
+* Disclose sensitive information to end users.
+* Help a malicious user discover weaknesses in an app that can compromise the security of the app, server, or network.
+
+## Log errors with a persistent provider
+
+If an unhandled exception occurs, the exception is logged to <xref:Microsoft.Extensions.Logging.ILogger> instances configured in the service container. By default, Blazor apps log to console output with the Console Logging Provider. Consider logging to a more permanent location on the server by sending error information to a backend web API that uses a logging provider with log size management and log rotation. Alternatively, the backend web API app can use an Application Performance Management (APM) service, such as [Azure Application Insights (Azure Monitor)&dagger;](/azure/azure-monitor/app/app-insights-overview), to record error information that it receives from clients.
+
+You must decide which incidents to log and the level of severity of logged incidents. Hostile users might be able to trigger errors deliberately. For example, don't log an incident from an error where an unknown `ProductId` is supplied in the URL of a component that displays product details. Not all errors should be treated as high-severity incidents for logging.
+
+For more information, see the following articles:
+
+* <xref:blazor/fundamentals/logging>
+* <xref:fundamentals/error-handling>&Dagger;
+* <xref:web-api/index>
+
+&dagger;Native [Application Insights](/azure/azure-monitor/app/app-insights-overview) features to support Blazor WebAssembly apps and native Blazor framework support for [Google Analytics](https://analytics.google.com/analytics/web/) might become available in future releases of these technologies. For more information, see [Support App Insights in Blazor WASM Client Side (microsoft/ApplicationInsights-dotnet #2143)](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2143) and [Web analytics and diagnostics (includes links to community implementations) (dotnet/aspnetcore #5461)](https://github.com/dotnet/aspnetcore/issues/5461). In the meantime, a client-side Blazor WebAssembly app can use the [Application Insights JavaScript SDK](/azure/azure-monitor/app/javascript) with [JS interop](xref:blazor/call-javascript-from-dotnet) to log errors directly to Application Insights from a client-side app.
+&Dagger;Applies to server-side ASP.NET Core apps that are web API backend apps for client-side Blazor WebAssembly apps. Client-side apps trap and send error information to a web API, which logs the error information to a persistent logging provider.
+
+## Places where errors may occur
+
+Framework and app code may trigger unhandled exceptions in any of the following locations, which are described further in the following sections of this article:
+
+* [Component instantiation](#component-instantiation-webassembly)
+* [Lifecycle methods](#lifecycle-methods-webassembly)
+* [Rendering logic](#rendering-logic-webassembly)
+* [Event handlers](#event-handlers-webassembly)
+* [Component disposal](#component-disposal-webassembly)
+* [JavaScript interop](#javascript-interop-webassembly)
+
+<h3 id="component-instantiation-webassembly">Component instantiation</h3>
+
+When Blazor creates an instance of a component:
+
+* The component's constructor is invoked.
+* The constructors of any non-singleton DI services supplied to the component's constructor via the [`@inject`](xref:mvc/views/razor#inject) directive or the [`[Inject]` attribute](xref:blazor/fundamentals/dependency-injection#request-a-service-in-a-component) are invoked.
+
+An error in an executed constructor or a setter for any `[Inject]` property results in an unhandled exception and stops the framework from instantiating the component. If constructor logic may throw exceptions, the app should trap the exceptions using a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
+
+<h3 id="lifecycle-methods-webassembly">Lifecycle methods</h3>
+
+During the lifetime of a component, Blazor invokes [lifecycle methods](xref:blazor/components/lifecycle#lifecycle-methods). For components to deal with errors in lifecycle methods, add error handling logic.
+
+In the following example where <xref:Microsoft.AspNetCore.Components.ComponentBase.OnParametersSetAsync%2A> calls a method to obtain a product:
+
+* An exception thrown in the `ProductRepository.GetProductByIdAsync` method is handled by a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement.
+* When the `catch` block is executed:
+  * `loadFailed` is set to `true`, which is used to display an error message to the user.
+  * The error is logged.
+
+::: moniker range=">= aspnetcore-5.0"
+
+[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor?name=snippet&highlight=11,27-39)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor?name=snippet&highlight=11,27-39)]
+
+::: moniker-end
+
+<h3 id="rendering-logic-webassembly">Rendering logic</h3>
+
+The declarative markup in a Razor component file (`.razor`) is compiled into a C# method called <xref:Microsoft.AspNetCore.Components.ComponentBase.BuildRenderTree%2A>. When a component renders, <xref:Microsoft.AspNetCore.Components.ComponentBase.BuildRenderTree%2A> executes and builds up a data structure describing the elements, text, and child components of the rendered component.
+
+Rendering logic can throw an exception. An example of this scenario occurs when `@someObject.PropertyName` is evaluated but `@someObject` is `null`.
+
+To prevent a <xref:System.NullReferenceException> in rendering logic, check for a `null` object before accessing its members. In the following example, `person.Address` properties aren't accessed if `person.Address` is `null`:
+
+::: moniker range=">= aspnetcore-5.0"
+
+[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/handle-errors/PersonExample.razor?name=snippet&highlight=1)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/handle-errors/PersonExample.razor?name=snippet&highlight=1)]
+
+::: moniker-end
+
+The preceding code assumes that `person` isn't `null`. Often, the structure of the code guarantees that an object exists at the time the component is rendered. In those cases, it isn't necessary to check for `null` in rendering logic. In the prior example, `person` might be guaranteed to exist because `person` is created when the component is instantiated, as the following example shows:
+
+```razor
+@code {
+    private Person person = new Person();
+
+    ...
+}
+```
+
+<h3 id="event-handlers-webassembly">Event handlers</h3>
+
+Client-side code triggers invocations of C# code when event handlers are created using:
+
+* `@onclick`
+* `@onchange`
+* Other `@on...` attributes
+* `@bind`
+
+Event handler code might throw an unhandled exception in these scenarios.
+
+If the app calls code that could fail for external reasons, trap exceptions using a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
+
+If user code doesn't trap and handle the exception, the framework logs the exception.
+
+<h3 id="component-disposal-webassembly">Component disposal</h3>
+
+A component may be removed from the UI, for example, because the user has navigated to another page. When a component that implements <xref:System.IDisposable?displayProperty=fullName> is removed from the UI, the framework calls the component's <xref:System.IDisposable.Dispose%2A> method.
+
+If disposal logic may throw exceptions, the app should trap the exceptions using a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
+
+For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+
+<h3 id="javascript-interop-webassembly">JavaScript interop</h3>
+
+<xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A?displayProperty=nameWithType> allows .NET code to make asynchronous calls to the JavaScript runtime in the user's browser.
+
+The following conditions apply to error handling with <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A>:
+
+* If a call to <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A> fails synchronously, a .NET exception occurs. A call to <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A> may fail, for example, because the supplied arguments can't be serialized. Developer code must catch the exception.
+* If a call to <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A> fails asynchronously, the .NET <xref:System.Threading.Tasks.Task> fails. A call to <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A> may fail, for example, because the JavaScript-side code throws an exception or returns a `Promise` that completed as `rejected`. Developer code must catch the exception. If using the [`await`](/dotnet/csharp/language-reference/keywords/await) operator, consider wrapping the method call in a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
+* By default, calls to <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A> must complete within a certain period or else the call times out. The default timeout period is one minute. The timeout protects the code against a loss in network connectivity or JavaScript code that never sends back a completion message. If the call times out, the resulting <xref:System.Threading.Tasks> fails with an <xref:System.OperationCanceledException>. Trap and process the exception with logging.
+
+Similarly, JavaScript code may initiate calls to .NET methods indicated by the [`[JSInvokable]` attribute](xref:blazor/call-dotnet-from-javascript). If these .NET methods throw an unhandled exception, the JavaScript-side `Promise` is rejected.
+
+You have the option of using error handling code on either the .NET side or the JavaScript side of the method call.
+
+For more information, see the following articles:
+
+* <xref:blazor/call-javascript-from-dotnet>
+* <xref:blazor/call-dotnet-from-javascript>
+
+## Advanced scenarios
+
+### Recursive rendering
+
+Components can be nested recursively. This is useful for representing recursive data structures. For example, a `TreeNode` component can render more `TreeNode` components for each of the node's children.
+
+When rendering recursively, avoid coding patterns that result in infinite recursion:
+
+* Don't recursively render a data structure that contains a cycle. For example, don't render a tree node whose children includes itself.
+* Don't create a chain of layouts that contain a cycle. For example, don't create a layout whose layout is itself.
+* Don't allow an end user to violate recursion invariants (rules) through malicious data entry or JavaScript interop calls.
+
+Infinite loops during rendering:
+
+* Causes the rendering process to continue forever.
+* Is equivalent to creating an unterminated loop.
+
+In these scenarios, the thread usually attempts to:
+
+* Consume as much CPU time as permitted by the operating system, indefinitely.
+* Consume an unlimited amount of client memory. Consuming unlimited memory is equivalent to the scenario where an unterminated loop adds entries to a collection on every iteration.
+
+To avoid infinite recursion patterns, ensure that recursive rendering code contains suitable stopping conditions.
+
+### Custom render tree logic
+
+Most Blazor components are implemented as Razor component files (`.razor`) and are compiled to produce logic that operates on a <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> to render their output. A developer may manually implement <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> logic using procedural C# code. For more information, see <xref:blazor/advanced-scenarios#manual-rendertreebuilder-logic>.
+
+> [!WARNING]
+> Use of manual render tree builder logic is considered an advanced and unsafe scenario, not recommended for general component development.
+
+If <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> code is written, the developer must guarantee the correctness of the code. For example, the developer must ensure that:
+
+* Calls to <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.OpenElement%2A> and <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder.CloseElement%2A> are correctly balanced.
+* Attributes are only added in the correct places.
+
+Incorrect manual render tree builder logic can cause arbitrary undefined behavior, including crashes, app hangs, and security vulnerabilities.
+
+Consider manual render tree builder logic on the same level of complexity and with the same level of *danger* as writing assembly code or [Microsoft Intermediate Language (MSIL)](/dotnet/standard/managed-code) instructions by hand.
+
+## Additional resources
+
+* <xref:blazor/fundamentals/logging>
+* <xref:fundamentals/error-handling>&dagger;
+* <xref:web-api/index>
+
+&dagger;Applies to backend ASP.NET Core web API apps that client-side Blazor WebAssembly apps use for logging.
+
+::: zone-end
+
+::: zone pivot="server"
+
+## Detailed errors during development
+
+When a Blazor app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor apps display a gold bar at the bottom of the screen:
+
+* During development, the gold bar directs you to the browser console, where you can see the exception.
+* In production, the gold bar notifies the user that an error has occurred and recommends refreshing the browser.
+
+The UI for this error handling experience is part of the Blazor project templates.
+
 In a Blazor Server app, customize the experience in the `Pages/_Host.cshtml` file:
 
 ```cshtml
@@ -47,7 +273,7 @@ In a Blazor Server app, customize the experience in the `Pages/_Host.cshtml` fil
 </div>
 ```
 
-The `blazor-error-ui` element is hidden by the styles included in the Blazor templates (`wwwroot/css/app.css` or `wwwroot/css/site.css`) and then shown when an error occurs:
+The `blazor-error-ui` element is hidden by the styles included in the Blazor project template (`wwwroot/css/site.css`) and then shown when an error occurs:
 
 ```css
 #blazor-error-ui {
@@ -72,13 +298,11 @@ The `blazor-error-ui` element is hidden by the styles included in the Blazor tem
 
 ## Blazor Server detailed circuit errors
 
-Client-side errors don't include the callstack and don't provide detail on the cause of the error, but server logs do contain such information. For development purposes, sensitive circuit error information can be made available to the client by enabling detailed errors.
+Client-side errors don't include the call stack and don't provide detail on the cause of the error, but server logs do contain such information. For development purposes, sensitive circuit error information can be made available to the client by enabling detailed errors.
 
-Enable Blazor Server detailed errors using the following approaches:
+Set <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors?displayProperty=nameWithType> to `true`. For more information and an example, see <xref:blazor/fundamentals/signalr#circuit-handler-options>.
 
-* <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors?displayProperty=nameWithType>.
-* The `DetailedErrors` configuration key set to `true`, which can be set in the app's Development settings file (`appsettings.Development.json`). The key can also be set using the `ASPNETCORE_DETAILEDERRORS` environment variable with a value of `true`.
-* [SignalR server-side logging](xref:signalr/diagnostics#server-side-logging) (`Microsoft.AspNetCore.SignalR`) can be set to [Debug](xref:Microsoft.Extensions.Logging.LogLevel) or [Trace](xref:Microsoft.Extensions.Logging.LogLevel) for detailed SignalR logging.
+An alternative to setting <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors> is to set the `DetailedErrors` configuration key to `true` in the app's Development environment settings file (`appsettings.Development.json`).  Additionally, set [SignalR server-side logging](xref:signalr/diagnostics#server-side-logging) (`Microsoft.AspNetCore.SignalR`) to [Debug](xref:Microsoft.Extensions.Logging.LogLevel) or [Trace](xref:Microsoft.Extensions.Logging.LogLevel) for detailed SignalR logging.
 
 `appsettings.Development.json`:
 
@@ -96,8 +320,10 @@ Enable Blazor Server detailed errors using the following approaches:
 }
 ```
 
+The <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors> configuration key can also be set to `true` using the `ASPNETCORE_DETAILEDERRORS` environment variable with a value of `true` on Development/Staging environment servers or on your local system.
+
 > [!WARNING]
-> Exposing error information to clients on the Internet is a security risk that should always be avoided.
+> **Always avoid exposing error information to clients on the Internet, which is a security risk.**
 
 ## How a Blazor Server app reacts to unhandled exceptions
 
@@ -110,7 +336,7 @@ If a user opens the app in multiple browser tabs, they have multiple independent
 
 Blazor treats most unhandled exceptions as fatal to the circuit where they occur. If a circuit is terminated due to an unhandled exception, the user can only continue to interact with the app by reloading the page to create a new circuit. Circuits outside of the one that's terminated, which are circuits for other users or other browser tabs, aren't affected. This scenario is similar to a desktop app that crashes. The crashed app must be restarted, but other apps aren't affected.
 
-A circuit is terminated when an unhandled exception occurs for the following reasons:
+The framework terminates a circuit when an unhandled exception occurs for the following reasons:
 
 * An unhandled exception often leaves the circuit in an undefined state.
 * The app's normal operation can't be guaranteed after an unhandled exception.
@@ -127,29 +353,30 @@ In production, don't render framework exception messages or stack traces in the 
 
 ## Log errors with a persistent provider
 
-If an unhandled exception occurs, the exception is logged to <xref:Microsoft.Extensions.Logging.ILogger> instances configured in the service container. By default, Blazor apps log to console output with the Console Logging Provider. Consider logging to a more permanent location with a provider that manages log size and log rotation. For more information, see <xref:fundamentals/logging/index>.
+If an unhandled exception occurs, the exception is logged to <xref:Microsoft.Extensions.Logging.ILogger> instances configured in the service container. By default, Blazor apps log to console output with the Console Logging Provider. Consider logging to a more permanent location on the server with a provider that manages log size and log rotation. Alternatively, the app can use an Application Performance Management (APM) service, such as [Azure Application Insights (Azure Monitor)](/azure/azure-monitor/app/app-insights-overview).
 
-During development, Blazor usually sends the full details of exceptions to the browser's console to aid in debugging. In production, detailed errors in the browser's console are disabled by default, which means that errors aren't sent to clients but the exception's full details are still logged server-side. For more information, see <xref:fundamentals/error-handling>.
+During development, a Blazor Server app usually sends the full details of exceptions to the browser's console to aid in debugging. In production, detailed errors aren't sent to clients, but an exception's full details are logged on the server.
 
 You must decide which incidents to log and the level of severity of logged incidents. Hostile users might be able to trigger errors deliberately. For example, don't log an incident from an error where an unknown `ProductId` is supplied in the URL of a component that displays product details. Not all errors should be treated as high-severity incidents for logging.
 
-For more information, see <xref:blazor/fundamentals/logging>.
+For more information, see the following articles:
+
+* <xref:blazor/fundamentals/logging>
+* <xref:fundamentals/error-handling>
 
 ## Places where errors may occur
 
-Framework and app code may trigger unhandled exceptions in any of the following locations:
+Framework and app code may trigger unhandled exceptions in any of the following locations, which are described further in the following sections of this article:
 
-* [Component instantiation](#component-instantiation)
-* [Lifecycle methods](#lifecycle-methods)
-* [Rendering logic](#rendering-logic)
-* [Event handlers](#event-handlers)
-* [Component disposal](#component-disposal)
-* [JavaScript interop](#javascript-interop)
-* [Blazor Server rerendering](#blazor-server-prerendering)
+* [Component instantiation](#component-instantiation-server)
+* [Lifecycle methods](#lifecycle-methods-server)
+* [Rendering logic](#rendering-logic-server)
+* [Event handlers](#event-handlers-server)
+* [Component disposal](#component-disposal-server)
+* [JavaScript interop](#javascript-interop-server)
+* [Blazor Server rerendering](#blazor-server-prerendering-server)
 
-The preceding unhandled exceptions are described in the following sections of this article.
-
-### Component instantiation
+<h3 id="component-instantiation-server">Component instantiation</h3>
 
 When Blazor creates an instance of a component:
 
@@ -158,16 +385,9 @@ When Blazor creates an instance of a component:
 
 A Blazor Server circuit fails when any executed constructor or a setter for any `[Inject]` property throws an unhandled exception. The exception is fatal because the framework can't instantiate the component. If constructor logic may throw exceptions, the app should trap the exceptions using a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
 
-### Lifecycle methods
+<h3 id="lifecycle-methods-server">Lifecycle methods</h3>
 
-During the lifetime of a component, Blazor invokes the following [lifecycle methods](xref:blazor/components/lifecycle):
-
-* <xref:Microsoft.AspNetCore.Components.ComponentBase.OnInitialized%2A> / <xref:Microsoft.AspNetCore.Components.ComponentBase.OnInitializedAsync%2A>
-* <xref:Microsoft.AspNetCore.Components.ComponentBase.OnParametersSet%2A> / <xref:Microsoft.AspNetCore.Components.ComponentBase.OnParametersSetAsync%2A>
-* <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>
-* <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRender%2A> / <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync%2A>
-
-If any lifecycle method throws an exception, synchronously or asynchronously, the exception is fatal to a Blazor Server circuit. For components to deal with errors in lifecycle methods, add error handling logic.
+During the lifetime of a component, Blazor invokes [lifecycle methods](xref:blazor/components/lifecycle#lifecycle-methods). If any lifecycle method throws an exception, synchronously or asynchronously, the exception is fatal to a Blazor Server circuit. For components to deal with errors in lifecycle methods, add error handling logic.
 
 In the following example where <xref:Microsoft.AspNetCore.Components.ComponentBase.OnParametersSetAsync%2A> calls a method to obtain a product:
 
@@ -178,39 +398,47 @@ In the following example where <xref:Microsoft.AspNetCore.Components.ComponentBa
 
 ::: moniker range=">= aspnetcore-5.0"
 
-[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor?name=snippet&highlight=11,27-39)]
+[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor?name=snippet&highlight=11,27-39)]
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
 
-[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/handle-errors/ProductDetails.razor?name=snippet&highlight=11,27-39)]
+[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_Server/Pages/handle-errors/ProductDetails.razor?name=snippet&highlight=11,27-39)]
 
 ::: moniker-end
 
-### Rendering logic
+<h3 id="rendering-logic-server">Rendering logic</h3>
 
-The declarative markup in a `.razor` component file is compiled into a C# method called <xref:Microsoft.AspNetCore.Components.ComponentBase.BuildRenderTree%2A>. When a component renders, <xref:Microsoft.AspNetCore.Components.ComponentBase.BuildRenderTree%2A> executes and builds up a data structure describing the elements, text, and child components of the rendered component.
+The declarative markup in a Razor component file (`.razor`) is compiled into a C# method called <xref:Microsoft.AspNetCore.Components.ComponentBase.BuildRenderTree%2A>. When a component renders, <xref:Microsoft.AspNetCore.Components.ComponentBase.BuildRenderTree%2A> executes and builds up a data structure describing the elements, text, and child components of the rendered component.
 
 Rendering logic can throw an exception. An example of this scenario occurs when `@someObject.PropertyName` is evaluated but `@someObject` is `null`. An unhandled exception thrown by rendering logic is fatal to a Blazor Server circuit.
 
-To prevent a null reference exception in rendering logic, check for a `null` object before accessing its members. In the following example, `person.Address` properties aren't accessed if `person.Address` is `null`:
+To prevent a <xref:System.NullReferenceException> in rendering logic, check for a `null` object before accessing its members. In the following example, `person.Address` properties aren't accessed if `person.Address` is `null`:
 
 ::: moniker range=">= aspnetcore-5.0"
 
-[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/handle-errors/PersonExample.razor?name=snippet&highlight=1)]
+[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_Server/Pages/handle-errors/PersonExample.razor?name=snippet&highlight=1)]
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
 
-[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/handle-errors/PersonExample.razor?name=snippet&highlight=1)]
+[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_Server/Pages/handle-errors/PersonExample.razor?name=snippet&highlight=1)]
 
 ::: moniker-end
 
-The preceding code assumes that `person` isn't `null`. Often, the structure of the code guarantees that an object exists at the time the component is rendered. In those cases, it isn't necessary to check for `null` in rendering logic. In the prior example, `person` might be guaranteed to exist because `person` is created when the component is instantiated.
+The preceding code assumes that `person` isn't `null`. Often, the structure of the code guarantees that an object exists at the time the component is rendered. In those cases, it isn't necessary to check for `null` in rendering logic. In the prior example, `person` might be guaranteed to exist because `person` is created when the component is instantiated, as the following example shows:
 
-### Event handlers
+```razor
+@code {
+    private Person person = new Person();
+
+    ...
+}
+```
+
+<h3 id="event-handlers-server">Event handlers</h3>
 
 Client-side code triggers invocations of C# code when event handlers are created using:
 
@@ -225,7 +453,7 @@ If an event handler throws an unhandled exception (for example, a database query
 
 If user code doesn't trap and handle the exception, the framework logs the exception and terminates the circuit.
 
-### Component disposal
+<h3 id="component-disposal-server">Component disposal</h3>
 
 A component may be removed from the UI, for example, because the user has navigated to another page. When a component that implements <xref:System.IDisposable?displayProperty=fullName> is removed from the UI, the framework calls the component's <xref:System.IDisposable.Dispose%2A> method.
 
@@ -233,7 +461,7 @@ If the component's `Dispose` method throws an unhandled exception, the exception
 
 For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
 
-### JavaScript interop
+<h3 id="javascript-interop-server">JavaScript interop</h3>
 
 <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A?displayProperty=nameWithType> allows .NET code to make asynchronous calls to the JavaScript runtime in the user's browser.
 
@@ -255,7 +483,7 @@ For more information, see the following articles:
 * <xref:blazor/call-javascript-from-dotnet>
 * <xref:blazor/call-dotnet-from-javascript>
 
-### Blazor Server prerendering
+<h3 id="blazor-server-prerendering-server">Blazor Server prerendering</h3>
 
 Blazor components can be prerendered using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) so that their rendered HTML markup is returned as part of the user's initial HTTP request. This works by:
 
@@ -298,7 +526,7 @@ To avoid infinite recursion patterns, ensure that recursive rendering code conta
 
 ### Custom render tree logic
 
-Most Blazor components are implemented as `.razor` files and are compiled to produce logic that operates on a <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> to render their output. A developer may manually implement <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> logic using procedural C# code. For more information, see <xref:blazor/advanced-scenarios#manual-rendertreebuilder-logic>.
+Most Blazor components are implemented as Razor component files (`.razor`) and are compiled to produce logic that operates on a <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> to render their output. A developer may manually implement <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> logic using procedural C# code. For more information, see <xref:blazor/advanced-scenarios#manual-rendertreebuilder-logic>.
 
 > [!WARNING]
 > Use of manual render tree builder logic is considered an advanced and unsafe scenario, not recommended for general component development.
@@ -310,4 +538,11 @@ If <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> code is wr
 
 Incorrect manual render tree builder logic can cause arbitrary undefined behavior, including crashes, server hangs, and security vulnerabilities.
 
-Consider manual render tree builder logic on the same level of complexity and with the same level of *danger* as writing assembly code or MSIL instructions by hand.
+Consider manual render tree builder logic on the same level of complexity and with the same level of *danger* as writing assembly code or [Microsoft Intermediate Language (MSIL)](/dotnet/standard/managed-code) instructions by hand.
+
+## Additional resources
+
+* <xref:blazor/fundamentals/logging>
+* <xref:fundamentals/error-handling>
+
+::: zone-end

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -18,10 +18,10 @@ This article describes how Blazor manages unhandled exceptions and how to develo
 
 ## Detailed errors during development
 
-When a Blazor app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor apps display a gold bar at the bottom of the screen:
+When a Blazor app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor apps display a light yellow bar at the bottom of the screen:
 
-* During development, the gold bar directs you to the browser console, where you can see the exception.
-* In production, the gold bar notifies the user that an error has occurred and recommends refreshing the browser.
+* During development, the bar directs you to the browser console, where you can see the exception.
+* In production, the bar notifies the user that an error has occurred and recommends refreshing the browser.
 
 The UI for this error handling experience is part of the Blazor project templates.
 
@@ -54,7 +54,7 @@ In production, don't render framework exception messages or stack traces in the 
 
 If an unhandled exception occurs, the exception is logged to <xref:Microsoft.Extensions.Logging.ILogger> instances configured in the service container. By default, Blazor apps log to console output with the Console Logging Provider. Consider logging to a more permanent location on the server by sending error information to a backend web API that uses a logging provider with log size management and log rotation. Alternatively, the backend web API app can use an Application Performance Management (APM) service, such as [Azure Application Insights (Azure Monitor)&dagger;](/azure/azure-monitor/app/app-insights-overview), to record error information that it receives from clients.
 
-You must decide which incidents to log and the level of severity of logged incidents. Hostile users might be able to trigger errors deliberately. For example, don't log an incident from an error where an unknown `ProductId` is supplied in the URL of a component that displays product details. Not all errors should be treated as high-severity incidents for logging.
+You must decide which incidents to log and the level of severity of logged incidents. Hostile users might be able to trigger errors deliberately. For example, don't log an incident from an error where an unknown `ProductId` is supplied in the URL of a component that displays product details. Not all errors should be treated as incidents for logging.
 
 For more information, see the following articles:
 
@@ -63,7 +63,8 @@ For more information, see the following articles:
 * <xref:web-api/index>
 
 &dagger;Native [Application Insights](/azure/azure-monitor/app/app-insights-overview) features to support Blazor WebAssembly apps and native Blazor framework support for [Google Analytics](https://analytics.google.com/analytics/web/) might become available in future releases of these technologies. For more information, see [Support App Insights in Blazor WASM Client Side (microsoft/ApplicationInsights-dotnet #2143)](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2143) and [Web analytics and diagnostics (includes links to community implementations) (dotnet/aspnetcore #5461)](https://github.com/dotnet/aspnetcore/issues/5461). In the meantime, a client-side Blazor WebAssembly app can use the [Application Insights JavaScript SDK](/azure/azure-monitor/app/javascript) with [JS interop](xref:blazor/call-javascript-from-dotnet) to log errors directly to Application Insights from a client-side app.
-&Dagger;Applies to server-side ASP.NET Core apps that are web API backend apps for client-side Blazor WebAssembly apps. Client-side apps trap and send error information to a web API, which logs the error information to a persistent logging provider.
+
+&Dagger;Applies to server-side ASP.NET Core apps that are web API backend apps for Blazor apps. Client-side apps trap and send error information to a web API, which logs the error information to a persistent logging provider.
 
 ## Places where errors may occur
 
@@ -206,7 +207,7 @@ To avoid infinite recursion patterns, ensure that recursive rendering code conta
 
 ### Custom render tree logic
 
-Most Blazor components are implemented as Razor component files (`.razor`) and are compiled to produce logic that operates on a <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> to render their output. A developer may manually implement <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> logic using procedural C# code. For more information, see <xref:blazor/advanced-scenarios#manual-rendertreebuilder-logic>.
+Most Blazor components are implemented as Razor component files (`.razor`) and are compiled by the framework to produce logic that operates on a <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> to render their output. However, a developer may manually implement <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> logic using procedural C# code. For more information, see <xref:blazor/advanced-scenarios#manual-rendertreebuilder-logic>.
 
 > [!WARNING]
 > Use of manual render tree builder logic is considered an advanced and unsafe scenario, not recommended for general component development.
@@ -234,10 +235,10 @@ Consider manual render tree builder logic on the same level of complexity and wi
 
 ## Detailed errors during development
 
-When a Blazor app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor apps display a gold bar at the bottom of the screen:
+When a Blazor app isn't functioning properly during development, receiving detailed error information from the app assists in troubleshooting and fixing the issue. When an error occurs, Blazor apps display a light yellow bar at the bottom of the screen:
 
-* During development, the gold bar directs you to the browser console, where you can see the exception.
-* In production, the gold bar notifies the user that an error has occurred and recommends refreshing the browser.
+* During development, the bar directs you to the browser console, where you can see the exception.
+* In production, the bar notifies the user that an error has occurred and recommends refreshing the browser.
 
 The UI for this error handling experience is part of the Blazor project templates.
 
@@ -258,15 +259,13 @@ In a Blazor Server app, customize the experience in the `Pages/_Host.cshtml` fil
 
 The `blazor-error-ui` element is normally hidden due the presence of the `display: none` style of the `blazor-error-ui` CSS class in the site's stylesheet (`wwwroot/css/site.css`). When an error occurs, the framework applies `display: block` to the element.
 
-The `blazor-error-ui` element is hidden by the styles included in the Blazor project template (`wwwroot/css/site.css`) and then shown when an error occurs:
-
 ## Blazor Server detailed circuit errors
 
 Client-side errors don't include the call stack and don't provide detail on the cause of the error, but server logs do contain such information. For development purposes, sensitive circuit error information can be made available to the client by enabling detailed errors.
 
 Set <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors?displayProperty=nameWithType> to `true`. For more information and an example, see <xref:blazor/fundamentals/signalr#circuit-handler-options>.
 
-An alternative to setting <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors> is to set the `DetailedErrors` configuration key to `true` in the app's Development environment settings file (`appsettings.Development.json`).  Additionally, set [SignalR server-side logging](xref:signalr/diagnostics#server-side-logging) (`Microsoft.AspNetCore.SignalR`) to [Debug](xref:Microsoft.Extensions.Logging.LogLevel) or [Trace](xref:Microsoft.Extensions.Logging.LogLevel) for detailed SignalR logging.
+An alternative to setting <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors?displayProperty=nameWithType> is to set the `DetailedErrors` configuration key to `true` in the app's Development environment settings file (`appsettings.Development.json`).  Additionally, set [SignalR server-side logging](xref:signalr/diagnostics#server-side-logging) (`Microsoft.AspNetCore.SignalR`) to [Debug](xref:Microsoft.Extensions.Logging.LogLevel) or [Trace](xref:Microsoft.Extensions.Logging.LogLevel) for detailed SignalR logging.
 
 `appsettings.Development.json`:
 
@@ -287,7 +286,7 @@ An alternative to setting <xref:Microsoft.AspNetCore.Components.Server.CircuitOp
 The <xref:Microsoft.AspNetCore.Components.Server.CircuitOptions.DetailedErrors> configuration key can also be set to `true` using the `ASPNETCORE_DETAILEDERRORS` environment variable with a value of `true` on Development/Staging environment servers or on your local system.
 
 > [!WARNING]
-> **Always avoid exposing error information to clients on the Internet, which is a security risk.**
+> Always avoid exposing error information to clients on the Internet, which is a security risk.
 
 ## How a Blazor Server app reacts to unhandled exceptions
 
@@ -296,7 +295,7 @@ Blazor Server is a stateful framework. While users interact with an app, they ma
 * The most recent rendered output of components.
 * The current set of event-handling delegates that could be triggered by client-side events.
 
-If a user opens the app in multiple browser tabs, they have multiple independent circuits.
+If a user opens the app in multiple browser tabs, the user creates multiple independent circuits.
 
 Blazor treats most unhandled exceptions as fatal to the circuit where they occur. If a circuit is terminated due to an unhandled exception, the user can only continue to interact with the app by reloading the page to create a new circuit. Circuits outside of the one that's terminated, which are circuits for other users or other browser tabs, aren't affected. This scenario is similar to a desktop app that crashes. The crashed app must be restarted, but other apps aren't affected.
 
@@ -304,7 +303,7 @@ The framework terminates a circuit when an unhandled exception occurs for the fo
 
 * An unhandled exception often leaves the circuit in an undefined state.
 * The app's normal operation can't be guaranteed after an unhandled exception.
-* Security vulnerabilities may appear in the app if the circuit continues.
+* Security vulnerabilities may appear in the app if the circuit continues in an undefined state.
 
 ## Manage unhandled exceptions in developer code
 
@@ -327,12 +326,14 @@ If an unhandled exception occurs, the exception is logged to <xref:Microsoft.Ext
 
 During development, a Blazor Server app usually sends the full details of exceptions to the browser's console to aid in debugging. In production, detailed errors aren't sent to clients, but an exception's full details are logged on the server.
 
-You must decide which incidents to log and the level of severity of logged incidents. Hostile users might be able to trigger errors deliberately. For example, don't log an incident from an error where an unknown `ProductId` is supplied in the URL of a component that displays product details. Not all errors should be treated as high-severity incidents for logging.
+You must decide which incidents to log and the level of severity of logged incidents. Hostile users might be able to trigger errors deliberately. For example, don't log an incident from an error where an unknown `ProductId` is supplied in the URL of a component that displays product details. Not all errors should be treated as incidents for logging.
 
 For more information, see the following articles:
 
 * <xref:blazor/fundamentals/logging>
-* <xref:fundamentals/error-handling>
+* <xref:fundamentals/error-handling>&dagger;
+
+&dagger;Applies to server-side ASP.NET Core apps that are web API backend apps for Blazor apps.
 
 ## Places where errors may occur
 
@@ -496,7 +497,7 @@ To avoid infinite recursion patterns, ensure that recursive rendering code conta
 
 ### Custom render tree logic
 
-Most Blazor components are implemented as Razor component files (`.razor`) and are compiled to produce logic that operates on a <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> to render their output. A developer may manually implement <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> logic using procedural C# code. For more information, see <xref:blazor/advanced-scenarios#manual-rendertreebuilder-logic>.
+Most Blazor components are implemented as Razor component files (`.razor`) and are compiled by the framework to produce logic that operates on a <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> to render their output. However, a developer may manually implement <xref:Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder> logic using procedural C# code. For more information, see <xref:blazor/advanced-scenarios#manual-rendertreebuilder-logic>.
 
 > [!WARNING]
 > Use of manual render tree builder logic is considered an advanced and unsafe scenario, not recommended for general component development.
@@ -513,6 +514,8 @@ Consider manual render tree builder logic on the same level of complexity and wi
 ## Additional resources
 
 * <xref:blazor/fundamentals/logging>
-* <xref:fundamentals/error-handling>
+* <xref:fundamentals/error-handling>&dagger;
+
+&dagger;Applies to server-side ASP.NET Core apps that are web API backend apps for Blazor apps.
 
 ::: zone-end

--- a/aspnetcore/blazor/includes/handle-errors/global-exception-handling.md
+++ b/aspnetcore/blazor/includes/handle-errors/global-exception-handling.md
@@ -1,9 +1,9 @@
 ---
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
-Blazor is a single-page application (SPA) client-side framework. The browser serves as the app's host and thus acts as the processing pipeline for individual Razor components based on URI requests for navigation and static assets. Unlike ASP.NET Core apps that run on the server with a middleware processing pipeline, there is no middleware pipeline processing requests for Razor components that can be leveraged for global error handling. However, an app can use an error processing component as a cascading value to the components of an app to process errors in a centralized way.
+Blazor is a single-page application (SPA) client-side framework. The browser serves as the app's host and thus acts as the processing pipeline for individual Razor components based on URI requests for navigation and static assets. Unlike ASP.NET Core apps that run on the server with a middleware processing pipeline, there is no middleware pipeline that processes requests for Razor components that can be leveraged for global error handling. However, an app can use an error processing component as a cascading value to process errors in a centralized way.
 
-The following `Error` component passes itself as a [`CascadingValue`](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component) to child components. The component processes a string of error information by merely logging the string. However, any degree of error processing desired can occur in the `ProcessError` method. An advantage of using a component over using an [injected service](xref:blazor/fundamentals/dependency-injection) throughout the app is that the component can render content and apply CSS styles when an error occurs.
+The following `Error` component passes itself as a [`CascadingValue`](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component) to child components. The following example merely logs the error, but methods of the component can process errors in any way required by the app, including through the use of multiple error processing methods. An advantage of using a component over using an [injected service](xref:blazor/fundamentals/dependency-injection) or a custom logger implementation is that a cascaded component can render content and apply CSS styles when an error occurs.
 
 `Shared/Error.razor`:
 
@@ -27,7 +27,7 @@ The following `Error` component passes itself as a [`CascadingValue`](xref:blazo
 }
 ```
 
-In the app's `App` component, wrap the `Router` component with the `Error` component. This permits the `Error` component to cascade down to any component of the app where the `Error` component is received as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute).
+In the `App` component, wrap the `Router` component with the `Error` component. This permits the `Error` component to cascade down to any component of the app where the `Error` component is received as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute).
 
 `App.razor`:
 
@@ -39,7 +39,7 @@ In the app's `App` component, wrap the `Router` component with the `Error` compo
 </Error>
 ```
 
-To process errors in any app component:
+To process errors in a component:
 
 * Designate the `Error` component as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute) in the [`@code`](xref:mvc/views/razor#code) block:
 
@@ -48,7 +48,7 @@ To process errors in any app component:
   public Error Error { get; set; }
   ```
 
-* Call the `ProcessError` method in any `catch` block with an appropriate exception type:
+* Call an error processing method in any `catch` block with an appropriate exception type. The example `Error` component only offers a single `ProcessError` method, but the error processing component can provide any number of error processing methods to address alternative error processing requirements throughout the app.
 
   ```csharp
   try
@@ -61,7 +61,7 @@ To process errors in any app component:
   }
   ```
 
-The browser's developer tools console shows a trapped error:
+Using the preceding example `Error` component and `ProcessError` method, the browser's developer tools console indicates the trapped, logged error:
 
 > fail: BlazorSample.Shared.Error[0]
 > Error:ProcessError - Type: System.NullReferenceException Message: Object reference not set to an instance of an object.

--- a/aspnetcore/blazor/includes/handle-errors/global-exception-handling.md
+++ b/aspnetcore/blazor/includes/handle-errors/global-exception-handling.md
@@ -40,16 +40,12 @@ In the app's `App` component, wrap the `Router` component with the `Error` compo
 
 To process errors in a component, designate the `Error` component as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute) and call its `ProcessError` method in any `catch` block. The following example adds a button to trigger a mock error for processing. Any `try-catch` block in any of the app's components can similarly process any trapped error where the `Error` component cascading parameter is present.
 
-`Pages/Counter.razor`:
+`Pages/Example.razor`:
 
 ```razor
-@page "/counter"
+@page "/example"
 
-<h1>Counter</h1>
-
-<p>Current count: @currentCount</p>
-
-<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+<h1>Example</h1>
 
 <button class="btn btn-primary" @onclick="ProcessExampleError">
     Process an example error
@@ -59,13 +55,6 @@ To process errors in a component, designate the `Error` component as a [`Cascadi
     [CascadingParameter]
     public Error Error { get; set; }
 
-    private int currentCount = 0;
-
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-
     private void ProcessExampleError()
     {
         try
@@ -74,7 +63,7 @@ To process errors in a component, designate the `Error` component as a [`Cascadi
         }
         catch (NullReferenceException ex)
         {
-            Error.ProcessError($"{nameof(Counter)} component error = {ex.Message}");
+            Error.ProcessError($"{nameof(Example)} component error = {ex.Message}");
         }
     }
 }
@@ -83,7 +72,7 @@ To process errors in a component, designate the `Error` component as a [`Cascadi
 The browser's developer tools console shows the logged error when the **Process an example error** button is selected:
 
 > fail: BlazorSample.Shared.Error[0]
-> Error:ProcessError - Counter component error = Object reference not set to an instance of an object.
+> Error:ProcessError - Example component error = Object reference not set to an instance of an object.
 
 To show the Blazor error UI, add a JavaScript function that triggers display of the error UI and use JS interop to call the function.
 

--- a/aspnetcore/blazor/includes/handle-errors/global-exception-handling.md
+++ b/aspnetcore/blazor/includes/handle-errors/global-exception-handling.md
@@ -19,9 +19,10 @@ The following `Error` component passes itself as a [`CascadingValue`](xref:blazo
     [Parameter]
     public RenderFragment ChildContent { get; set; }
 
-    public void ProcessError(string errorInformation)
+    public void ProcessError(Exception ex)
     {
-        Logger.LogError("Error information: {ErrorInformation}", errorInformation);
+        Logger.LogError("Error:ProcessError - Type: {Type} Message: {Message}", 
+            ex.GetType(), ex.Message);
     }
 }
 ```
@@ -38,105 +39,31 @@ In the app's `App` component, wrap the `Router` component with the `Error` compo
 </Error>
 ```
 
-To process errors in a component, designate the `Error` component as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute) and call its `ProcessError` method in any `catch` block. The following example adds a button to trigger a mock error for processing. Any `try-catch` block in any of the app's components can similarly process any trapped error where the `Error` component cascading parameter is present.
+To process errors in any app component:
 
-`Pages/Example.razor`:
+* Designate the `Error` component as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute) in the [`@code`](xref:mvc/views/razor#code) block:
 
-```razor
-@page "/example"
+  ```razor
+  [CascadingParameter]
+  public Error Error { get; set; }
+  ```
 
-<h1>Example</h1>
+* Call the `ProcessError` method in any `catch` block with an appropriate exception type:
 
-<button class="btn btn-primary" @onclick="ProcessExampleError">
-    Process an example error
-</button>
+  ```csharp
+  try
+  {
+      ...
+  }
+  catch (Exception ex)
+  {
+      Error.ProcessError(ex);
+  }
+  ```
 
-@code {
-    [CascadingParameter]
-    public Error Error { get; set; }
-
-    private void ProcessExampleError()
-    {
-        try
-        {
-            throw new NullReferenceException();
-        }
-        catch (NullReferenceException ex)
-        {
-            Error.ProcessError($"{nameof(Example)} component error = {ex.Message}");
-        }
-    }
-}
-```
-
-The browser's developer tools console shows the logged error when the **Process an example error** button is selected:
+The browser's developer tools console shows a trapped error:
 
 > fail: BlazorSample.Shared.Error[0]
-> Error:ProcessError - Example component error = Object reference not set to an instance of an object.
+> Error:ProcessError - Type: System.NullReferenceException Message: Object reference not set to an instance of an object.
 
-To show the Blazor error UI, add a JavaScript function that triggers display of the error UI and use JS interop to call the function.
-
-`wwwroot/index.html`:
-
-```html
-    ...
-
-    <script>
-        window.displayErrorUI = () => 
-            document.getElementById("blazor-error-ui").style.display = "block";
-    </script>
-</head>
-```
-
-In the `ProcessError` method of the `Error` component, trigger the JavaScript function with JS interop.
-
-`Shared/Error.razor`:
-
-```razor
-...
-@using Microsoft.JSInterop
-@inject IJSRuntime JSRuntime
-
-...
-
-@code {
-    ...
-
-    public void ProcessError(string errorInformation)
-    {
-        ...
-
-        JSRuntime.InvokeVoidAsync("displayErrorUI");
-    }
-}
-```
-
-The preceding example doesn't attempt to change the text of the `blazor-error-ui` element, so the default text of "`An unhandled error has occurred.`" is displayed unless additional code is added to set the content of the element.
-
-The app can apply CSS styles directly to the rendered child content of the `Error` component. In the following example, a style string is set for a `<div>` element wrapping the child content. When `ProcessError` executes, the style string applies a red background color to the content. When a style is applied through the cascaded `Error` component, a call to [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes) is required to rerender the UI.
-
-`Shared/Error.razor`:
-
-```razor
-...
-
-<CascadingValue Value=this>
-    <div style="@cssStyle">
-        @ChildContent
-    </div>
-</CascadingValue>
-
-@code {
-    private string cssStyle;
-
-    ...
-
-    public void ProcessError(string errorInformation)
-    {
-        ...
-
-        cssStyle = "background-color: red";
-        StateHasChanged();
-    }
-}
-```
+If the `ProcessError` method directly participates in rendering, such as showing a custom error message bar or changing the CSS styles of the rendered elements, call [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes) at the end of the `ProcessErrors` method to rerender the UI.

--- a/aspnetcore/blazor/includes/handle-errors/global-exception-handling.md
+++ b/aspnetcore/blazor/includes/handle-errors/global-exception-handling.md
@@ -1,0 +1,153 @@
+---
+no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
+Blazor is a single-page application (SPA) client-side framework. The browser serves as the app's host and thus acts as the processing pipeline for individual Razor components based on URI requests for navigation and static assets. Unlike ASP.NET Core apps that run on the server with a middleware processing pipeline, there is no middleware pipeline processing requests for Razor components that can be leveraged for global error handling. However, an app can use an error processing component as a cascading value to the components of an app to process errors in a centralized way.
+
+The following `Error` component passes itself as a [`CascadingValue`](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component) to child components. The component processes a string of error information by merely logging the string. However, any degree of error processing desired can occur in the `ProcessError` method. An advantage of using a component over using an [injected service](xref:blazor/fundamentals/dependency-injection) throughout the app is that the component can render content and apply CSS styles when an error occurs.
+
+`Shared/Error.razor`:
+
+```razor
+@using Microsoft.Extensions.Logging
+@inject ILogger<Error> Logger
+
+<CascadingValue Value=this>
+    @ChildContent
+</CascadingValue>
+
+@code {
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+
+    public void ProcessError(string errorInformation)
+    {
+        Logger.LogError("Error information: {ErrorInformation}", errorInformation);
+    }
+}
+```
+
+In the app's `App` component, wrap the `Router` component with the `Error` component. This permits the `Error` component to cascade down to any component of the app where the `Error` component is received as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute).
+
+`App.razor`:
+
+```razor
+<Error>
+    <Router ...>
+        ...
+    </Router>
+</Error>
+```
+
+To process errors in a component, designate the `Error` component as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute) and call its `ProcessError` method in any `catch` block. The following example adds a button to trigger a mock error for processing. Any `try-catch` block in any of the app's components can similarly process any trapped error where the `Error` component cascading parameter is present.
+
+`Pages/Counter.razor`:
+
+```razor
+@page "/counter"
+
+<h1>Counter</h1>
+
+<p>Current count: @currentCount</p>
+
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+<button class="btn btn-primary" @onclick="ProcessExampleError">
+    Process an example error
+</button>
+
+@code {
+    [CascadingParameter]
+    public Error Error { get; set; }
+
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+
+    private void ProcessExampleError()
+    {
+        try
+        {
+            throw new NullReferenceException();
+        }
+        catch (NullReferenceException ex)
+        {
+            Error.ProcessError($"{nameof(Counter)} component error = {ex.Message}");
+        }
+    }
+}
+```
+
+The browser's developer tools console shows the logged error when the **Process an example error** button is selected:
+
+> fail: BlazorSample.Shared.Error[0]
+> Error:ProcessError - Counter component error = Object reference not set to an instance of an object.
+
+To show the Blazor error UI, add a JavaScript function that triggers display of the error UI and use JS interop to call the function.
+
+`wwwroot/index.html`:
+
+```html
+    ...
+
+    <script>
+        window.displayErrorUI = () => 
+            document.getElementById("blazor-error-ui").style.display = "block";
+    </script>
+</head>
+```
+
+In the `ProcessError` method of the `Error` component, trigger the JavaScript function with JS interop.
+
+`Shared/Error.razor`:
+
+```razor
+...
+@using Microsoft.JSInterop
+@inject IJSRuntime JSRuntime
+
+...
+
+@code {
+    ...
+
+    public void ProcessError(string errorInformation)
+    {
+        ...
+
+        JSRuntime.InvokeVoidAsync("displayErrorUI");
+    }
+}
+```
+
+The preceding example doesn't attempt to change the text of the `blazor-error-ui` element, so the default text of "`An unhandled error has occurred.`" is displayed unless additional code is added to set the content of the element.
+
+The app can apply CSS styles directly to the rendered child content of the `Error` component. In the following example, a style string is set for a `<div>` element wrapping the child content. When `ProcessError` executes, the style string applies a red background color to the content. When a style is applied through the cascaded `Error` component, a call to [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes) is required to rerender the UI.
+
+`Shared/Error.razor`:
+
+```razor
+...
+
+<CascadingValue Value=this>
+    <div style="@cssStyle">
+        @ChildContent
+    </div>
+</CascadingValue>
+
+@code {
+    private string cssStyle;
+
+    ...
+
+    public void ProcessError(string errorInformation)
+    {
+        ...
+
+        cssStyle = "background-color: red";
+        StateHasChanged();
+    }
+}
+```

--- a/aspnetcore/blazor/security/server/threat-mitigation.md
+++ b/aspnetcore/blazor/security/server/threat-mitigation.md
@@ -122,7 +122,7 @@ For calls from .NET methods to JavaScript:
 
 Take the following precautions to guard against the preceding scenarios:
 
-* Wrap JS interop calls within [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statements to account for errors that might occur during the invocations. For more information, see <xref:blazor/fundamentals/handle-errors#javascript-interop>.
+* Wrap JS interop calls within [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statements to account for errors that might occur during the invocations. For more information, see <xref:blazor/fundamentals/handle-errors?pivots=server#javascript-interop-server>.
 * Validate data returned from JS interop invocations, including error messages, before taking any action.
 
 ### .NET methods invoked from the browser

--- a/aspnetcore/blazor/security/server/threat-mitigation.md
+++ b/aspnetcore/blazor/security/server/threat-mitigation.md
@@ -285,7 +285,7 @@ JS interop interactions between the client and server are recorded in the server
 
 When an error occurs on the server, the framework notifies the client and tears down the session. By default, the client receives a generic error message that can be seen in the browser's developer tools.
 
-The client-side error doesn't include the callstack and doesn't provide detail on the cause of the error, but server logs do contain such information. For development purposes, sensitive error information can be made available to the client by [enabling detailed errors](xref:blazor/fundamentals/handle-errors#blazor-server-detailed-circuit-errors).
+The client-side error doesn't include the call stack and doesn't provide detail on the cause of the error, but server logs do contain such information. For development purposes, sensitive error information can be made available to the client by [enabling detailed errors](xref:blazor/fundamentals/handle-errors#blazor-server-detailed-circuit-errors).
 
 > [!WARNING]
 > Exposing error information to clients on the Internet is a security risk that should always be avoided.


### PR DESCRIPTION
Addresses #19286

\[Internal Review Topic]()

Notes ...

* I slept on the problem with MIA global exception handling. I still think that we should do something about it. Going all the way to November seems like a looooong wait.

  I did scale back the section+example here. What I like about what I'm pitching here relative how devs have worked around this (e.g., logger implementations and other complicated approaches) is that the cascading component approach ...
  * Is simple to reason about and can be shown/used quickly because it's based on a garden variety component with cascading values and parameters. Besides the approach's value for this use case, it cross-teaches the cascading concept, which is a powerful approach for component coordination anyway.
  * Is easy to customize, including for ...
    * When one wants to do something with the UI ... render something, such as a custom error UI piece, or affect CSS styles in other ways. [Both require a call to `StateHasChanged`, which the section calls out.]
    * When one wants to have multiple methods to call in `catch` blocks that do different things, such as manage different types of errors or log different things.

  ... and then (whatever we show) we can revise to something else for <6.0 when we work up the content for the new 6.0 features later. Of course, we're going to have quite a bit to update for 6.0+ because almost all of this says 'use try-catch and trap.' Tea leaves indicate to me that your new features will avoid so much boilerplate code in apps.

* Confirm my understanding on this: Setting `CircuitOptions.DetailedErrors` **_is the same thing_** as setting the `DetailedErrors` configuration key in a config file (**_and_** setting the `ASPNETCORE_DETAILEDERRORS` env var has the same effect).