### PR TITLE
Contact.cs: include using in region

### DIFF
--- a/aspnetcore/security/authorization/secure-data/samples/starter2.1/Models/Contact.cs
+++ b/aspnetcore/security/authorization/secure-data/samples/starter2.1/Models/Contact.cs
@@ -11,6 +11,7 @@ namespace ContactManager.Models
         public string City { get; set; }
         public string State { get; set; }
         public string Zip { get; set; }
+        // using System.ComponentModel.DataAnnotations;
         [DataType(DataType.EmailAddress)]
         public string Email { get; set; }
     }

--- a/aspnetcore/security/authorization/secure-data/samples/starter2.1/Models/Contact.cs
+++ b/aspnetcore/security/authorization/secure-data/samples/starter2.1/Models/Contact.cs
@@ -1,8 +1,8 @@
-﻿using System.ComponentModel.DataAnnotations;
+#region snippet1
+using System.ComponentModel.DataAnnotations;
 
 namespace ContactManager.Models
 {
-    #region snippet1
     public class Contact
     {
         public int ContactId { get; set; }
@@ -14,5 +14,5 @@ namespace ContactManager.Models
         [DataType(DataType.EmailAddress)]
         public string Email { get; set; }
     }
-    #endregion
 }
+#endregion


### PR DESCRIPTION
The following section:

https://docs.microsoft.com/en-us/aspnet/core/security/authorization/secure-data?view=aspnetcore-5.0#create-the-starter-app

shows the following:

![image](https://user-images.githubusercontent.com/20816/109870609-2adeb180-7c1f-11eb-910e-b0257430e90f.png)

This will not build without the line:

    using System.ComponentModel.DataAnnotations;

which the user may not know to add. VS and vscode will not add the line for them.

This patch updates the snippet so as to include the using line.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->