### PR TITLE
Add information about the location of app.UseWebsockets()

### DIFF
--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -46,7 +46,7 @@ Add the WebSockets middleware in the `Configure` method of the `Startup` class:
 [!code-csharp[](websockets/samples/2.x/WebSocketsSample/Startup.cs?name=UseWebSockets)]
 
 > [!NOTE]
-> If you would like to accept WebSocket requests in a controller, the call to `app.UseWebSockets()` must occur before `app.UseEndpoints()`.
+> If you would like to accept WebSocket requests in a controller, the call to `app.UseWebSockets` must occur before `app.UseEndpoints`.
 
 ::: moniker range="< aspnetcore-2.2"
 

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -45,6 +45,9 @@ Add the WebSockets middleware in the `Configure` method of the `Startup` class:
 
 [!code-csharp[](websockets/samples/2.x/WebSocketsSample/Startup.cs?name=UseWebSockets)]
 
+> [!NOTE]
+> If you would like to accept WebSocket requests in a controller, the call to `app.UseWebSockets()` must occur before `app.UseEndpoints()`.
+
 ::: moniker range="< aspnetcore-2.2"
 
 The following settings can be configured:


### PR DESCRIPTION
See https://github.com/dotnet/aspnetcore/issues/30646 - you won't be able to accept WebSocket connections in a controller if the UseWebSockets() middleware is below the UseEndpoints() middleware. In my opinion, whether or not the root issue is a bug is irrelevant (and I don't know if it is or not yet). This little note would benefit documentation readers. :)