### PR TITLE
Remove dotnet watch GitHub repo link

### DIFF
--- a/aspnetcore/tutorials/dotnet-watch.md
+++ b/aspnetcore/tutorials/dotnet-watch.md
@@ -202,7 +202,3 @@ Some configuration options can be passed to `dotnet watch` through environment v
 | `DOTNET_WATCH_SUPPRESS_MSBUILD_INCREMENTALISM`   | By default, `dotnet watch` optimizes the build by avoiding certain operations such as running restore or re-evaluating the set of watched files on every file change. If set to "1" or "true",  these optimizations are disabled. |
 | `DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER`   | `dotnet watch run` attempts to launch browsers for web apps with `launchBrowser` configured in *launchSettings.json*. If set to "1" or "true", this behavior is suppressed. |
 | `DOTNET_WATCH_SUPPRESS_BROWSER_REFRESH`   | `dotnet watch run` attempts to refresh browsers when it detects file changes. If set to "1" or "true", this behavior is suppressed. This behavior is also suppressed if `DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER` is set. |
-
-## `dotnet-watch` in GitHub
-
-`dotnet-watch` is part of the GitHub [dotnet/AspNetCore repository](https://github.com/dotnet/AspNetCore/tree/master/src/Tools/dotnet-watch).


### PR DESCRIPTION
The code for dotnet watch no longer lives in the dotnet/aspnetcore github repo. It was moved to the dotnet/sdk repo: https://github.com/dotnet/sdk/tree/master/src/BuiltInTools/dotnet-watch. Having this link in the docs seems unnecessary.