### PR TITLE
Use correct endpoint to avoid 401

### DIFF
--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Startup.cs
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Startup.cs
@@ -52,7 +52,7 @@ namespace SignalRChat
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
-                endpoints.MapHub<ChatHub>("/chathub");
+                endpoints.MapHub<ChatHub>("/chatHub");
             });
         }
     }


### PR DESCRIPTION
The `chat.js` file uses the URL "/chatHub" when connecting to the hub rather than lowercase "/chathub". I was receiving a 404 until changing it to align with the endpoint set in Startup.js.