### PR TITLE
Update name used in cookie handling snippet

### DIFF
--- a/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/Startup.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Polly;
 using System;
 using System.Net.Http;
@@ -132,7 +133,7 @@ namespace HttpClientFactorySample
             #endregion
 
             #region snippet13
-            services.AddHttpClient("configured-disable-automatic-cookies")
+            services.AddHttpClient(Options.DefaultName)
                 .ConfigurePrimaryHttpMessageHandler(() =>
                 {
                     return new HttpClientHandler()


### PR DESCRIPTION
`UseCookies = false` should be the default from a security/privacy perspective, but due to backwards compatibility probably can't be changed now. Thus, it's important that the example here show how to change this for the default instance since that is the most common use case and it was difficult/took some time to find how to configure this for the default instance (since you can't call 'ConfigurePrimaryHttpMessageHandler' on `services.AddHttpClient()`. By updating this example, it helps show you need to use `Options.DefaultName` to make this change for the unnamed/default instance. Related to #15848.
