### PR TITLE
Update the aspnet/AspNetCore.Docs repo references

### DIFF
--- a/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/GitHub/GitHubService.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/GitHub/GitHubService.cs
@@ -29,7 +29,7 @@ namespace HttpClientFactorySample.GitHub
         public async Task<IEnumerable<GitHubIssue>> GetAspNetDocsIssues()
         {
             var response = await Client.GetAsync(
-                "/repos/aspnet/AspNetCore.Docs/issues?state=open&sort=created&direction=desc");
+                "/repos/dotnet/AspNetCore.Docs/issues?state=open&sort=created&direction=desc");
 
             response.EnsureSuccessStatusCode();
 

--- a/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/Pages/BasicUsage.cshtml.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/Pages/BasicUsage.cshtml.cs
@@ -24,7 +24,7 @@ namespace HttpClientFactorySample.Pages
         public async Task OnGet()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, 
-                "https://api.github.com/repos/aspnet/AspNetCore.Docs/branches");
+                "https://api.github.com/repos/dotnet/AspNetCore.Docs/branches");
             request.Headers.Add("Accept", "application/vnd.github.v3+json");
             request.Headers.Add("User-Agent", "HttpClientFactory-Sample");
 

--- a/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/Pages/NamedClient.cshtml.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/2.x/HttpClientFactorySample/Pages/NamedClient.cshtml.cs
@@ -27,7 +27,7 @@ namespace HttpClientFactorySample.Pages
         public async Task OnGet()
         {
             var request = new HttpRequestMessage(HttpMethod.Get, 
-                "repos/aspnet/AspNetCore.Docs/pulls");
+                "repos/dotnet/AspNetCore.Docs/pulls");
 
             var client = _clientFactory.CreateClient("github");
 

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpClientFactorySample/GitHub/GitHubService.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpClientFactorySample/GitHub/GitHubService.cs
@@ -30,7 +30,7 @@ namespace HttpClientFactorySample.GitHub
         public async Task<IEnumerable<GitHubIssue>> GetAspNetDocsIssues()
         {
             var response = await Client.GetAsync(
-                "/repos/aspnet/AspNetCore.Docs/issues?state=open&sort=created&direction=desc");
+                "/repos/dotnet/AspNetCore.Docs/issues?state=open&sort=created&direction=desc");
 
             response.EnsureSuccessStatusCode();
 

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpClientFactorySample/Pages/BasicUsage.cshtml.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpClientFactorySample/Pages/BasicUsage.cshtml.cs
@@ -25,7 +25,7 @@ namespace HttpClientFactorySample.Pages
         public async Task OnGet()
         {
             var request = new HttpRequestMessage(HttpMethod.Get,
-                "https://api.github.com/repos/aspnet/AspNetCore.Docs/branches");
+                "https://api.github.com/repos/dotnet/AspNetCore.Docs/branches");
             request.Headers.Add("Accept", "application/vnd.github.v3+json");
             request.Headers.Add("User-Agent", "HttpClientFactory-Sample");
 

--- a/aspnetcore/fundamentals/http-requests/samples/3.x/HttpClientFactorySample/Pages/NamedClient.cshtml.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/3.x/HttpClientFactorySample/Pages/NamedClient.cshtml.cs
@@ -28,7 +28,7 @@ namespace HttpClientFactorySample.Pages
         public async Task OnGet()
         {
             var request = new HttpRequestMessage(HttpMethod.Get,
-                "repos/aspnet/AspNetCore.Docs/pulls");
+                "repos/dotnet/AspNetCore.Docs/pulls");
 
             var client = _clientFactory.CreateClient("github");
 

--- a/aspnetcore/includes/MTcomments.md
+++ b/aspnetcore/includes/MTcomments.md
@@ -1,4 +1,4 @@
 ---
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
-If you are reading this in a language other than English, let us know in this [GitHub discussion issue](https://github.com/aspnet/AspNetCore.Docs/issues/16455) if you'd like to see the code comments in your native language.
+If you are reading this in a language other than English, let us know in this [GitHub discussion issue](https://github.com/dotnet/AspNetCore.Docs/issues/16455) if you'd like to see the code comments in your native language.

--- a/aspnetcore/release-notes/aspnetcore-3.0.md
+++ b/aspnetcore/release-notes/aspnetcore-3.0.md
@@ -390,7 +390,7 @@ For more information, see <xref:security/authentication/windowsauth>.
 The web UI templates (Razor Pages, MVC with controller and views) have the following removed:
 
 * The cookie consent UI is no longer included. To enable the cookie consent feature in an ASP.NET Core 3.0 template-generated app, see <xref:security/gdpr>.
-* Scripts and related static assets are now referenced as local files instead of using CDNs. For more information, see [Scripts and related static assets are now referenced as local files instead of using CDNs based on the current environment (aspnet/AspNetCore.Docs #14350)](https://github.com/dotnet/AspNetCore.Docs/issues/14350).
+* Scripts and related static assets are now referenced as local files instead of using CDNs. For more information, see [Scripts and related static assets are now referenced as local files instead of using CDNs based on the current environment (dotnet/AspNetCore.Docs #14350)](https://github.com/dotnet/AspNetCore.Docs/issues/14350).
 
 The Angular template updated to use Angular 8.
 


### PR DESCRIPTION
The repo was migrated from the _aspnet_ org. to the _dotnet_ org. Updating the repo references accordingly.