### PR TITLE
Update ASP.NET Core 5.0-to-6.0 migration guide for Preview 2

### DIFF
--- a/aspnetcore/includes/net-prereqs-vs-6.0.md
+++ b/aspnetcore/includes/net-prereqs-vs-6.0.md
@@ -1,5 +1,5 @@
 ---
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
-* [Visual Studio 2019 16.9 or later](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
+* [Visual Studio 2019 16.10 or later](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **ASP.NET and web development** workload
 * [!INCLUDE [.NET 6.0 SDK](~/includes/6.0-SDK.md)]

--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -3,7 +3,7 @@ title: Migrate from ASP.NET Core 5.0 to 6.0
 author: scottaddie
 description: Learn how to migrate an ASP.NET Core 5.0 project to ASP.NET Core 6.0.
 ms.author: scaddie
-ms.date: 02/18/2021
+ms.date: 03/15/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: migration/50-to-60
 ---
@@ -35,7 +35,7 @@ If you rely upon a [global.json](/dotnet/core/tools/global-json) file to target 
 {
   "sdk": {
 -    "version": "5.0.100"
-+    "version": "6.0.100-preview.1.21103.13"
++    "version": "6.0.100-preview.2.21155.3"
   }
 }
 ```
@@ -63,8 +63,8 @@ In the project file, update each [Microsoft.AspNetCore.*](https://www.nuget.org/
 <ItemGroup>
 -    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="5.0.3" />
 -    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
-+    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.0-preview.1.*" />
-+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0-preview.1.*" />
++    <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="6.0.0-preview.2.*" />
++    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0-preview.2.*" />
 </ItemGroup>
 ```
 


### PR DESCRIPTION
Incorporates details from https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-preview-2/

[Internal review page](https://review.docs.microsoft.com/en-us/aspnet/core/migration/50-to-60?view=aspnetcore-1.0&branch=pr-en-us-21804&tabs=visual-studio)