### PR TITLE
Configure gRPC client factory on .NET Standard 2.0

### DIFF
--- a/aspnetcore/grpc/browser.md
+++ b/aspnetcore/grpc/browser.md
@@ -135,7 +135,7 @@ builder.Services
         options.Address = new Uri("https://localhost:5001");
     })
     .ConfigurePrimaryHttpMessageHandler(
-        () => new GrpcWebHandler(GrpcWebMode.GrpcWebText, new HttpClientHandler()));
+        () => new GrpcWebHandler(new HttpClientHandler()));
 ```
 
 For more information, see <xref:grpc/clientfactory>.

--- a/aspnetcore/grpc/browser.md
+++ b/aspnetcore/grpc/browser.md
@@ -118,7 +118,7 @@ The preceding code:
 
 ### Use gRPC client factory with gRPC-Web
 
-A gRPC-Web compatible .NET client can be created using gRPC's integration with [HttpClientFactory](xref:System.Net.Http.IHttpClientFactory).
+A gRPC-Web compatible .NET client can be created using the [gRPC client factory](xref:grpc/clientfactory).
 
 To use gRPC-Web with client factory:
 
@@ -130,7 +130,7 @@ To use gRPC-Web with client factory:
 
 ```csharp
 builder.Services
-    .AddGrpcClient<Greet.GreeterClient>((services, options) =>
+    .AddGrpcClient<Greet.GreeterClient>(options =>
     {
         options.Address = new Uri("https://localhost:5001");
     })

--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -46,6 +46,18 @@ var client = new Greeter.GreeterClient(channel);
 var response = await client.SayHelloAsync(new HelloRequest { Name = ".NET" });
 ```
 
+Clients can also be created using the [gRPC client factory](xref:grpc/clientfactory). An HTTP provider is configured using the <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.ConfigurePrimaryHttpMessageHandler%2A> extension method.
+
+```csharp
+builder.Services
+    .AddGrpcClient<Greet.GreeterClient>(options =>
+    {
+        options.Address = new Uri("https://localhost:5001");
+    })
+    .ConfigurePrimaryHttpMessageHandler(
+        () => new GrpcWebHandler(new HttpClientHandler()));
+```
+
 For more information, see [Configure gRPC-Web with the .NET gRPC client](xref:grpc/browser#configure-grpc-web-with-the-net-grpc-client).
 
 ## .NET Framework


### PR DESCRIPTION
How to use gRPC client factory on .NET Standard 2.0 implementations.