### PR TITLE
Update API ref page link for 5.0 default selection

### DIFF
--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -261,7 +261,7 @@ additionalContent:
       # Card
       - title: API reference for ASP.NET Core
         links:
-          - url: /dotnet/api/?view=aspnetcore-3.1
+          - url: /dotnet/api/?view=aspnetcore-5.0
             text: ".NET API browser"
       # Card
       - title: Host and deploy


### PR DESCRIPTION
Changing the querystring value to default select ASP.NET Core 5.0