### PR TITLE
Fixed typo and added deep link

### DIFF
--- a/aspnetcore/data/ef-mvc/intro.md
+++ b/aspnetcore/data/ef-mvc/intro.md
@@ -327,7 +327,7 @@ Because `EnsureCreated` is called in the initializer method that runs on app sta
 * Delete the database.
 * Stop, then start the app. The database is automatically re-created to match the change.
 
-For example, if an `EmailAddress` property is added to the `Student` class, a new `EmailAddress` column in the re-created table. The view partials won't display the new `EmailAddress` property.
+For example, if an `EmailAddress` property is added to the `Student` class, a new `EmailAddress` column in the re-created table. The view won't display the new `EmailAddress` property.
 
 ## Conventions
 

--- a/aspnetcore/data/ef-mvc/intro.md
+++ b/aspnetcore/data/ef-mvc/intro.md
@@ -327,7 +327,7 @@ Because `EnsureCreated` is called in the initializer method that runs on app sta
 * Delete the database.
 * Stop, then start the app. The database is automatically re-created to match the change.
 
-For example, if an `EmailAddress` property is added to the `Student` class, a new `EmailAddress` column in the re-created table. The view classed won't display the new `EmailAddress` property.
+For example, if an `EmailAddress` property is added to the `Student` class, a new `EmailAddress` column in the re-created table. The view partials won't display the new `EmailAddress` property.
 
 ## Conventions
 
@@ -367,7 +367,7 @@ For more information about asynchronous programming in .NET, see [Async Overview
 
 ## Limit entities fetched
 
-See [Performance considerations](xref:data/ef-rp/intro) for information on limiting the number or entities returned from a query.
+See [Performance considerations](xref:data/ef-rp/intro#performance-considerations) for information on limiting the number or entities returned from a query.
 
 Advance to the next tutorial to learn how to perform basic CRUD (create, read, update, delete) operations.
 


### PR DESCRIPTION
Hi,

I have corrected a typo in the `Getting Started ` for EF MVC. I also think it can be helpful if there can be a deep link to the performance considerations from the MVC page. I have done both in a single PR as they are on the same page. 

Poornima