### PR TITLE
Blazor generic type cascading feature

### DIFF
--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -100,7 +100,7 @@ When using generic-typed components, the type parameter is inferred if possible.
 
 An ancestor component can cascade a type parameter by name to descendants using the `CascadingTypeParameter` attribute. This attribute allows a generic type inference to use the specified type parameter automatically with descendants that have a type parameter with the same name.
 
-For example, the following `Chart` component receives stock price data and cascades a generic type parameter named `TLineData` to its descendent components:
+For example, the following `Chart` component receives stock price data and cascades a generic type parameter named `TLineData` to its descendent components.
 
 `Shared/Chart.razor`:
 
@@ -143,7 +143,7 @@ When the `Chart` component is used, `TLineData` isn't specified for each `Line` 
 `Pages/StockPriceHistory.razor`:
 
 ```razor
-...
+@page "/stock-price-history"
 
 <Chart Data="stockPriceHistory.GroupBy(x => x.Date)">
     <Line Title="Open" Value="day => day.Values.First()" />
@@ -151,8 +151,6 @@ When the `Chart` component is used, `TLineData` isn't specified for each `Line` 
     <Line Title="Low" Value="day => day.Values.Min()" />
     <Line Title="Close" Value="day => day.Values.Last()" />
 </Chart>
-
-...
 ```
 
 > [!NOTE]
@@ -164,7 +162,7 @@ By adding `@attribute [CascadingTypeParameter(...)]` to a component, the specifi
 * Also declare a [`@typeparam`](xref:mvc/views/razor#typeparam) with the exact same name.
 * Don't have another value supplied or inferred for the type parameter. If another value is supplied or inferred, it takes precedence over the cascaded generic type.
 
-When receiving a cascaded type parameter, components obtain it from the closest ancestor that has a `CascadingTypeParameter` with a matching name. The cascaded generic types parameters are overridden within a particular subtree.
+When receiving a cascaded type parameter, components obtain the parameter value from the closest ancestor that has a `CascadingTypeParameter` with a matching name. Cascaded generic type parameters are overridden within a particular subtree.
 
 Matching is only performed by name. Therefore, we recommend avoiding a cascaded generic type parameter with a generic name, for example `T` or `TItem`. If a developer opts into cascading a type parameter, they're implicitly promising that its name is unique enough not to clash with other cascaded type parameters from unrelated components.
 

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -170,7 +170,7 @@ Matching is only performed by name. Therefore, we recommend avoiding a cascaded 
 ::: moniker range="< aspnetcore-6.0"
 
 > [!NOTE]
-> Generic type constraints are supported in ASP.NET Core 6.0. For more information, see [the 6.0 version of this article](?view=aspnetcore-6.0).
+> Generic type constraints are supported in ASP.NET Core 6.0. For more information, see [the 6.0 version of this article](?preserve-view=true&view=aspnetcore-6.0).
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -132,6 +132,9 @@ For example, the following `Chart` component receives stock price data and casca
 
     [Parameter]
     public decimal Value { get; set; }
+
+    [Parameter]
+    public IEnumerable<TLineData> Data { get; set; }
 }
 ```
 

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -94,10 +94,101 @@ When using generic-typed components, the type parameter is inferred if possible.
 
 ::: moniker-end
 
-## Generic type constraints
+## Infer generic types based on ancestor components
+
+::: moniker range=">= aspnetcore-5.0"
+
+Ancestor components must opt in to this behavior. An ancestor component can cascade a type parameter by name to descendants using the `CascadingTypeParameter` attribute. This attribute allows a generic type inference to use the specified type parameter automatically with descendants that have a type parameter with the same name.
+
+For example, define `Grid` and `Column` components.
+
+`Shared/Grid.razor`:
+
+```razor
+@typeparam TItem
+@attribute [CascadingTypeParameter(nameof(TItem))]
+
+<table class="table">
+    <thead>
+        <tr>
+            @ChildContent
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Items)
+        {
+            <tr>
+                <td>@item.Name</td>
+                <td>@item.Quantity</td>
+            </tr>
+        }
+    </tbody>
+</table>
+
+@code {
+    [Parameter]
+    public IEnumerable<TItem> Items { get; set; }
+
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+}
+```
+
+`Shared/Column.razor`:
+
+```razor
+@typeparam TItem
+
+<th>@Title</th>
+
+@code {
+    [Parameter]
+    public string Title { get; set; }
+}
+```
+
+Use the `Grid` and `Column` components.
+
+`Pages/GenericCascadedType.razor`:
+
+```razor
+@page "/generic-cascaded-type"
+
+<Grid Items="@GetSaleRecords()">
+    <Column Title="Product name" />
+    <Column Title="Number of sales" />
+</Grid>
+
+@code {
+    private IEnumerable<SaleRecord> GetSaleRecords()
+    {
+        return new List<SaleRecord>()
+            {
+                new SaleRecord() { Name = "Product 1", Quantity = 100 },
+                new SaleRecord() { Name = "Product 2", Quantity = 200 },
+                new SaleRecord() { Name = "Product 3", Quantity = 50 },
+            };
+    }
+
+    private class SaleRecord
+    {
+        public string Name { get; set; }
+        public int Quantity { get; set; }
+    }
+}
+```
 
 > [!NOTE]
-> Generic type constraints will be supported in a future release. For more information, see [Allow generic type constraints (dotnet/aspnetcore #8433)](https://github.com/dotnet/aspnetcore/issues/8433).
+> The Razor support in Visual Studio Code has not yet been updated to support this feature, so you may get incorrect errors even though the project correctly builds. This will be addressed in an upcoming tooling release.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+> [!NOTE]
+> Generic type constraints are supported in ASP.NET Core 6.0. For more information, see [the 6.0 version of this article](?view=aspnetcore-6.0).
+
+::: moniker-end
 
 ## Additional resources
 

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -96,7 +96,7 @@ When using generic-typed components, the type parameter is inferred if possible.
 
 ## Infer generic types based on ancestor components
 
-::: moniker range=">= aspnetcore-5.0"
+::: moniker range=">= aspnetcore-6.0"
 
 An ancestor component can cascade a type parameter by name to descendants using the `CascadingTypeParameter` attribute. This attribute allows a generic type inference to use the specified type parameter automatically with descendants that have a type parameter with the same name.
 
@@ -167,7 +167,7 @@ Matching is only performed by name. Therefore, we recommend avoiding a cascaded 
 
 ::: moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+::: moniker range="< aspnetcore-6.0"
 
 > [!NOTE]
 > Generic type constraints are supported in ASP.NET Core 6.0. For more information, see [the 6.0 version of this article](?view=aspnetcore-6.0).

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -171,7 +171,7 @@ Matching is only performed by name. Therefore, we recommend avoiding a cascaded 
 ::: moniker range="< aspnetcore-6.0"
 
 > [!NOTE]
-> Generic type constraints are supported in ASP.NET Core 6.0. For more information, see [the 6.0 version of this article](?preserve-view=true&view=aspnetcore-6.0).
+> Inferred generic types are supported in ASP.NET Core 6.0 or later. For more information, see a version of this article later than ASP.NET Core 5.0.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -98,31 +98,72 @@ When using generic-typed components, the type parameter is inferred if possible.
 
 ::: moniker range=">= aspnetcore-5.0"
 
-Ancestor components must opt in to this behavior. An ancestor component can cascade a type parameter by name to descendants using the `CascadingTypeParameter` attribute. This attribute allows a generic type inference to use the specified type parameter automatically with descendants that have a type parameter with the same name. The following example cascades a generic type parameter named `TItem`.
+An ancestor component can cascade a type parameter by name to descendants using the `CascadingTypeParameter` attribute. This attribute allows a generic type inference to use the specified type parameter automatically with descendants that have a type parameter with the same name.
 
-For example, the following 
+For example, the following `Chart` component receives stock price data and cascades a generic type parameter named `TLineData` to its descendent components:
+
+`Shared/Chart.razor`:
 
 ```razor
+@typeparam TLineData
+@attribute [CascadingTypeParameter(nameof(TLineData))]
+
+...
+
+@code {
+    [Parameter]
+    public IEnumerable<TLineData> Data { get; set; }
+
+    [Parameter]
+    public RenderFragment ChildContent { get; set; }
+}
+```
+
+`Shared/Line.razor`:
+
+```razor
+@typeparam TLineData
+
+...
+
+@code {
+    [Parameter]
+    public string Title { get; set; }
+
+    [Parameter]
+    public decimal Value { get; set; }
+}
+```
+
+When the `Chart` component is used, `TLineData` isn't specified for each `Line` component of the chart.
+
+`Pages/StockPriceHistory.razor`:
+
+```razor
+...
+
 <Chart Data="stockPriceHistory.GroupBy(x => x.Date)">
     <Line Title="Open" Value="day => day.Values.First()" />
     <Line Title="High" Value="day => day.Values.Max()" />
     <Line Title="Low" Value="day => day.Values.Min()" />
     <Line Title="Close" Value="day => day.Values.Last()" />
 </Chart>
+
+...
 ```
 
 > [!NOTE]
-> The Razor support in Visual Studio Code has not yet been updated to support this feature, so you may get incorrect errors even though the project correctly builds. This will be addressed in an upcoming tooling release.
+> The Razor support in Visual Studio Code hasn't been updated to support this feature, so you may receive incorrect errors even though the project correctly builds. This will be addressed in an upcoming tooling release.
 
 By adding `@attribute [CascadingTypeParameter(...)]` to a component, the specified generic type argument is automatically used by descendants that:
 
 * Are nested as child content for the component in the same `.razor` document.
-* Also declare a `@typeparam` with the exact same name.
-* Don't have another value supplied or inferred for the type parameter. If they do, the other value takes precedence over the cascaded generic type.
+* Also declare a [`@typeparam`](xref:mvc/views/razor#typeparam) with the exact same name.
+* Don't have another value supplied or inferred for the type parameter. If another value is supplied or inferred, it takes precedence over the cascaded generic type.
 
 When receiving a cascaded type parameter, components obtain it from the closest ancestor that has a `CascadingTypeParameter` with a matching name. The cascaded generic types parameters are overridden within a particular subtree.
 
-Matching is only performed by name. Therefore, we recommend avoiding a cascaded generic type parameter with a generic name, for example `T`. If a developer opts into cascading a type parameter, they are implicitly promising that its name is unique enough not to clash with other cascaded type parameters from unrelated components.
+Matching is only performed by name. Therefore, we recommend avoiding a cascaded generic type parameter with a generic name, for example `T` or `TItem`. If a developer opts into cascading a type parameter, they're implicitly promising that its name is unique enough not to clash with other cascaded type parameters from unrelated components.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -98,53 +98,20 @@ When using generic-typed components, the type parameter is inferred if possible.
 
 ::: moniker range=">= aspnetcore-5.0"
 
-Ancestor components must opt in to this behavior. An ancestor component can cascade a type parameter by name to descendants using the `CascadingTypeParameter` attribute. This attribute allows a generic type inference to use the specified type parameter automatically with descendants that have a type parameter with the same name.
+Ancestor components must opt in to this behavior. An ancestor component can cascade a type parameter by name to descendants using the `CascadingTypeParameter` attribute. This attribute allows a generic type inference to use the specified type parameter automatically with descendants that have a type parameter with the same name. The following example cascades a generic type parameter named `TItem`.
 
 For example, define `Grid` and `Column` components.
 
 `Shared/Grid.razor`:
 
 ```razor
-@typeparam TItem
-@attribute [CascadingTypeParameter(nameof(TItem))]
 
-<table class="table">
-    <thead>
-        <tr>
-            @ChildContent
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var item in Items)
-        {
-            <tr>
-                <td>@item.Name</td>
-                <td>@item.Quantity</td>
-            </tr>
-        }
-    </tbody>
-</table>
-
-@code {
-    [Parameter]
-    public IEnumerable<TItem> Items { get; set; }
-
-    [Parameter]
-    public RenderFragment ChildContent { get; set; }
-}
 ```
 
 `Shared/Column.razor`:
 
 ```razor
-@typeparam TItem
 
-<th>@Title</th>
-
-@code {
-    [Parameter]
-    public string Title { get; set; }
-}
 ```
 
 Use the `Grid` and `Column` components.
@@ -152,34 +119,21 @@ Use the `Grid` and `Column` components.
 `Pages/GenericCascadedType.razor`:
 
 ```razor
-@page "/generic-cascaded-type"
 
-<Grid Items="@GetSaleRecords()">
-    <Column Title="Product name" />
-    <Column Title="Number of sales" />
-</Grid>
-
-@code {
-    private IEnumerable<SaleRecord> GetSaleRecords()
-    {
-        return new List<SaleRecord>()
-            {
-                new SaleRecord() { Name = "Product 1", Quantity = 100 },
-                new SaleRecord() { Name = "Product 2", Quantity = 200 },
-                new SaleRecord() { Name = "Product 3", Quantity = 50 },
-            };
-    }
-
-    private class SaleRecord
-    {
-        public string Name { get; set; }
-        public int Quantity { get; set; }
-    }
-}
 ```
 
 > [!NOTE]
 > The Razor support in Visual Studio Code has not yet been updated to support this feature, so you may get incorrect errors even though the project correctly builds. This will be addressed in an upcoming tooling release.
+
+By adding `@attribute [CascadingTypeParameter(...)]` to a component, the specified generic type argument is automatically used by descendants that:
+
+* Are nested as child content for the component in the same `.razor` document.
+* Also declare a `@typeparam` with the exact same name.
+* Don't have another value supplied or inferred for the type parameter. If they do, the other value takes precedence over the cascaded generic type.
+
+When receiving a cascaded type parameter, components obtain it from the closest ancestor that has a `CascadingTypeParameter` with a matching name. The cascaded generic types parameters are overridden within a particular subtree.
+
+Matching is only performed by name. Therefore, we recommend avoiding a cascaded generic type parameter with a generic name, for example `T`. If a developer opts into cascading a type parameter, they are implicitly promising that its name is unique enough not to clash with other cascaded type parameters from unrelated components.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -100,26 +100,15 @@ When using generic-typed components, the type parameter is inferred if possible.
 
 Ancestor components must opt in to this behavior. An ancestor component can cascade a type parameter by name to descendants using the `CascadingTypeParameter` attribute. This attribute allows a generic type inference to use the specified type parameter automatically with descendants that have a type parameter with the same name. The following example cascades a generic type parameter named `TItem`.
 
-For example, define `Grid` and `Column` components.
-
-`Shared/Grid.razor`:
+For example, the following 
 
 ```razor
-
-```
-
-`Shared/Column.razor`:
-
-```razor
-
-```
-
-Use the `Grid` and `Column` components.
-
-`Pages/GenericCascadedType.razor`:
-
-```razor
-
+<Chart Data="stockPriceHistory.GroupBy(x => x.Date)">
+    <Line Title="Open" Value="day => day.Values.First()" />
+    <Line Title="High" Value="day => day.Values.Max()" />
+    <Line Title="Low" Value="day => day.Values.Min()" />
+    <Line Title="Close" Value="day => day.Values.Last()" />
+</Chart>
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Fixes #21769

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components/templated-components?view=aspnetcore-3.1&branch=pr-en-us-21846#infer-generic-types-based-on-ancestor-components)

Steve ... If it's easier/quicker to just fix it, please feel free to edit the PR directly. It starts at Line 97.