### PR TITLE
Corrected documentation for migrations

### DIFF
--- a/aspnetcore/data/ef-mvc/migrations.md
+++ b/aspnetcore/data/ef-mvc/migrations.md
@@ -84,7 +84,7 @@ Migrations calls the `Up` method to implement the data model changes for a migra
 
 This code is for the initial migration that was created when you entered the `migrations add InitialCreate` command. The migration name parameter ("InitialCreate" in the example) is used for the file name and can be whatever you want. It's best to choose a word or phrase that summarizes what is being done in the migration. For example, you might name a later migration "AddDepartmentTable".
 
-If you created the initial migration when the database already exists, the database creation code is generated but it doesn't have to run because the database already matches the data model. When you deploy the app to another environment where the database doesn't exist yet, this code will run to create your database, so it's a good idea to test it first. That's why you changed the name of the database in the connection string earlier -- so that migrations can create a new one from scratch.
+If you created the initial migration when the database already exists, the database creation code is generated but it doesn't have to run because the database already matches the data model. When you deploy the app to another environment where the database doesn't exist yet, this code will run to create your database, so it's a good idea to test it first. That's why you dropped the database earlier -- so that migrations can create a new one from scratch.
 
 ## The data model snapshot
 


### PR DESCRIPTION
Hi,

I have made a small correction to the migrations tutorial. The tutorial says to drop the database where as the tutorial said you changed the connection string earlier.

Regards,
Poornima