### PR TITLE
Fix Blazor Data Binding code snippet

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -218,13 +218,13 @@ In a more sophisticated and real-world example, the following `Password` compone
 
 ::: moniker range=">= aspnetcore-5.0"
 
-[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Shared/data-binding/PasswordEntry.razor?highlight=7-10,23-24,26-27,13,36-39)]
+[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Shared/data-binding/PasswordEntry.razor?highlight=7-10,13,23-24,26-27,36-39)]
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
 
-[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Shared/data-binding/PasswordEntry.razor?highlight=7-10,23-24,26-27,13,36-39)]
+[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Shared/data-binding/PasswordEntry.razor?highlight=7-10,13,23-24,26-27,36-39)]
 
 ::: moniker-end
 


### PR DESCRIPTION
cc: @scottaddie (in your final days pinging u probably one last time :smile:) @Rick-Anderson @wadepickett 

I detect a rendering problem that might be due to an out-of-sequence highlight list. The original line is ...

```
[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Shared/data-binding/PasswordEntry.razor?highlight=7-10,23-24,26-27,13,36-39)]
```

... with a highlight of `7-10,23-24,26-27,13,36-39` (the "13" is out of sequence) producing ...

<img width="541" alt="Capture" src="https://user-images.githubusercontent.com/1622880/112390194-e72e1380-8cc3-11eb-92d4-ed96f6939ad2.PNG">

I'm updating the line here to ...

```
[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Shared/data-binding/PasswordEntry.razor?highlight=7-10,13,23-24,26-27,36-39)]
```

... with a highlight of `7-10,13,23-24,26-27,36-39` ("13" in sequence).

This PR is an attempt to see if the sequence is producing the rendering problem because the snippet file is fine.