### PR TITLE
Add access token scope cross-links

### DIFF
--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
@@ -102,7 +102,9 @@ After creating the app, you should be able to:
 * Log into the app using an AAD user account.
 * Request access tokens for Microsoft APIs. For more information, see:
   * [Access token scopes](#access-token-scopes)
-  * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis).
+  * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
+  * [Hosted with AAD: Access token scopes (includes guidance on AAD `App ID URI` scope formats)](xref:blazor/security/webassembly/hosted-with-azure-active-directory#access-token-scopes)
+  * [Access token scopes for Microsoft Graph API](xref:blazor/security/webassembly/graph-api)
 
 ## Authentication package
 


### PR DESCRIPTION
Fixes #21877

Thanks @dkboon01! :rocket: ... Let's start with cross-links to more info for Microsoft APIs. This is the most general and generic of the AAD-based Blazor auth topics, so the section on access token scopes will be a bit more vague than the other topics in this node. However, these enhanced cross-links should help. If you need general advice and product support, try the community on the usual public support places ...

* [Stack Overflow (tag: `blazor`)](https://stackoverflow.com/questions/tagged/blazor)
* [ASP.NET Core Slack Team](http://tattoocoder.com/aspnet-slack-sign-up/)
* [Blazor Gitter](https://gitter.im/aspnet/Blazor)

If you have topic feedback, such as for the issue that you opened, you did the right thing to open an issue using the **This page** feedback button+form at the bottom of the topic.

I'll just note in passing that I, too, had to **_fight with Azure_** a bit 🥊🤜😵 on the scope URIs. It took me a long time to finally find out why the App ID URI would have either an `api://` scheme or an `https://` scheme. It finally turned out to be trusted versus untrusted publisher domain for the AAD directory in use. That's all covered now, but it was a pain point for a while. The rest of the Microsoft APIs, such as Graph, work out fairly cleanly per Azure docs and the portal UI ... the scopes are usually readily and accurately reported. There haven't been too many issues (*yet* 🤞🍀 lol). Anyway ... open a new issue if you run into another doc problem, and I'll see if I can help. For general help, we recommend those community support forums :point_up:. 