### PR TITLE
Patch line breaks problem

### DIFF
--- a/aspnetcore/fundamentals/host/web-host.md
+++ b/aspnetcore/fundamentals/host/web-host.md
@@ -261,10 +261,10 @@ WebHost.CreateDefaultBuilder(args)
 
 Set the HTTPS redirect port. Used in [enforcing HTTPS](xref:security/enforcing-ssl).
 
-**Key**: https_port
-**Type**: *string*
-**Default**: A default value isn't set.
-**Set using**: `UseSetting`
+**Key**: https_port  
+**Type**: *string*  
+**Default**: A default value isn't set.  
+**Set using**: `UseSetting`  
 **Environment variable**: `ASPNETCORE_HTTPS_PORT`
 
 ```csharp


### PR DESCRIPTION
Fixes #21931

Thanks @oreze! :rocket:

@Rick-Anderson ... Chatted with ... er ... I think it was Scott ... at some point about this. We have double-spaces here and there to get `<br>`s in for this scenario. We spoke about just having true `<br>`s in these spots, which are instantly visible over markdown double-spaces. If we did switch over to `<br>`, it should be fine for inline markup ...

https://github.com/dotnet/AspNetCore.Docs/blob/main/.markdownlint.json#L35

Let me know if you prefer the switch, and I'll start go forward with `<br>` and revise as docs come up in the normal course of work. Otherwise, I'll keep going with markdown double-spaces. :ear: 