### PR TITLE
Blazor-SignalR tutorial updates

### DIFF
--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/BlazorServerSignalRApp.csproj
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/BlazorServerSignalRApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.11" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.13" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Hubs/ChatHub.cs
@@ -5,7 +5,7 @@ namespace BlazorServerSignalRApp.Server.Hubs
 {
     public class ChatHub : Hub
     {
-        public async Task SendMessageAsync(string user, string message)
+        public async Task SendMessage(string user, string message)
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Hubs/ChatHub.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 
 namespace BlazorServerSignalRApp.Server.Hubs
 {
     public class ChatHub : Hub
     {
-        public async Task SendMessage(string user, string message)
+        public async Task SendMessageAsync(string user, string message)
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -49,7 +49,7 @@
     }
 
     async Task Send() =>
-        await hubConnection.SendAsync("SendMessageAsync", userInput, messageInput);
+        await hubConnection.SendAsync("SendMessage", userInput, messageInput);
 
     public bool IsConnected =>
         hubConnection.State == HubConnectionState.Connected;

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -48,8 +48,8 @@
         await hubConnection.StartAsync();
     }
 
-    Task Send() =>
-        hubConnection.SendAsync("SendMessage", userInput, messageInput);
+    async Task Send() =>
+        await hubConnection.SendAsync("SendMessageAsync", userInput, messageInput);
 
     public bool IsConnected =>
         hubConnection.State == HubConnectionState.Connected;

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Client/BlazorWebAssemblySignalRApp.Client.csproj
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Client/BlazorWebAssemblySignalRApp.Client.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.2.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="3.2.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Build" Version="3.2.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="3.2.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.13" />
+    <PackageReference Include="System.Net.Http.Json" Version="3.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Shared\BlazorWebAssemblySignalRApp.Shared.csproj" />

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -48,12 +48,12 @@
         await hubConnection.StartAsync();
     }
 
-    Task Send() =>
-        hubConnection.SendAsync("SendMessage", userInput, messageInput);
+    async Task Send() =>
+        await hubConnection.SendAsync("SendMessageAsync", userInput, messageInput);
 
     public bool IsConnected =>
         hubConnection.State == HubConnectionState.Connected;
-        
+
     public void Dispose()
     {
         _ = hubConnection.DisposeAsync();

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -49,7 +49,7 @@
     }
 
     async Task Send() =>
-        await hubConnection.SendAsync("SendMessageAsync", userInput, messageInput);
+        await hubConnection.SendAsync("SendMessage", userInput, messageInput);
 
     public bool IsConnected =>
         hubConnection.State == HubConnectionState.Connected;

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Server/BlazorWebAssemblySignalRApp.Server.csproj
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Server/BlazorWebAssemblySignalRApp.Server.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="3.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Server/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Server/Hubs/ChatHub.cs
@@ -5,7 +5,7 @@ namespace BlazorWebAssemblySignalRApp.Server.Hubs
 {
     public class ChatHub : Hub
     {
-        public async Task SendMessageAsync(string user, string message)
+        public async Task SendMessage(string user, string message)
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Server/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Server/Hubs/ChatHub.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 
 namespace BlazorWebAssemblySignalRApp.Server.Hubs
 {
     public class ChatHub : Hub
     {
-        public async Task SendMessage(string user, string message)
+        public async Task SendMessageAsync(string user, string message)
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/BlazorServerSignalRApp.csproj
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/BlazorServerSignalRApp.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.4" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Hubs/ChatHub.cs
@@ -5,7 +5,7 @@ namespace BlazorServerSignalRApp.Server.Hubs
 {
     public class ChatHub : Hub
     {
-        public async Task SendMessageAsync(string user, string message)
+        public async Task SendMessage(string user, string message)
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Hubs/ChatHub.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 
 namespace BlazorServerSignalRApp.Server.Hubs
 {
     public class ChatHub : Hub
     {
-        public async Task SendMessage(string user, string message)
+        public async Task SendMessageAsync(string user, string message)
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -49,7 +49,7 @@
     }
 
     async Task Send() =>
-        await hubConnection.SendAsync("SendMessageAsync", userInput, messageInput);
+        await hubConnection.SendAsync("SendMessage", userInput, messageInput);
 
     public bool IsConnected =>
         hubConnection.State == HubConnectionState.Connected;

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -48,8 +48,8 @@
         await hubConnection.StartAsync();
     }
 
-    Task Send() =>
-        hubConnection.SendAsync("SendMessage", userInput, messageInput);
+    async Task Send() =>
+        await hubConnection.SendAsync("SendMessageAsync", userInput, messageInput);
 
     public bool IsConnected =>
         hubConnection.State == HubConnectionState.Connected;

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/BlazorWebAssemblySignalRApp.Client.csproj
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/BlazorWebAssemblySignalRApp.Client.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="5.0.4" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -49,7 +49,7 @@
     }
 
     async Task Send() =>
-        await hubConnection.SendAsync("SendMessageAsync", userInput, messageInput);
+        await hubConnection.SendAsync("SendMessage", userInput, messageInput);
 
     public bool IsConnected =>
         hubConnection.State == HubConnectionState.Connected;

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -48,12 +48,12 @@
         await hubConnection.StartAsync();
     }
 
-    Task Send() =>
-        hubConnection.SendAsync("SendMessage", userInput, messageInput);
+    async Task Send() =>
+        await hubConnection.SendAsync("SendMessageAsync", userInput, messageInput);
 
     public bool IsConnected =>
         hubConnection.State == HubConnectionState.Connected;
-        
+
     public async ValueTask DisposeAsync()
     {
         await hubConnection.DisposeAsync();

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Server/BlazorWebAssemblySignalRApp.Server.csproj
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Server/BlazorWebAssemblySignalRApp.Server.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="5.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Server/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Server/Hubs/ChatHub.cs
@@ -5,7 +5,7 @@ namespace BlazorWebAssemblySignalRApp.Server.Hubs
 {
     public class ChatHub : Hub
     {
-        public async Task SendMessageAsync(string user, string message)
+        public async Task SendMessage(string user, string message)
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Server/Hubs/ChatHub.cs
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Server/Hubs/ChatHub.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 
 namespace BlazorWebAssemblySignalRApp.Server.Hubs
 {
     public class ChatHub : Hub
     {
-        public async Task SendMessage(string user, string message)
+        public async Task SendMessageAsync(string user, string message)
         {
             await Clients.All.SendAsync("ReceiveMessage", user, message);
         }


### PR DESCRIPTION
Fixes #21938

Thanks @mrlife! 🎷

Brennan ...

* I found one totally *wrong* 🙈 sample package version. I don't think anyone pulled that sample down because I think I would've received the usual 💀 **_death threat_** 💀 from the community when I screw something up. :smile:
* I changed the name of `SendMessage` to `SendMessageAsync` for consistency, but I'll revert if that's a bad idea. :ear:
* In spite of roll-forward patch package version behavior, one of these apps was flaking out for no obvious reason on the presence of `PreferExactMatches` (a 5.0.1 thing) until I made package references point to the latest patch versions. It might have just been that I didn't clean the app. Anyway ... I went ahead and made all packages in all samples latest. *All apps work normally now.* :+1:
* There's no doc text to change for these updates.