### PR TITLE
Use ??= operator instead of "If"  for null check

### DIFF
--- a/aspnetcore/mvc/controllers/application-model/sample/src/AppModelSample/Conventions/MustBeInRouteParameterModelConvention.cs
+++ b/aspnetcore/mvc/controllers/application-model/sample/src/AppModelSample/Conventions/MustBeInRouteParameterModelConvention.cs
@@ -8,10 +8,7 @@ namespace AppModelSample.Conventions
     {
         public void Apply(ParameterModel model)
         {
-            if (model.BindingInfo == null)
-            {
-                model.BindingInfo = new BindingInfo();
-            }
+            model.BindingInfo ??= new BindingInfo();
             model.BindingInfo.BindingSource = BindingSource.Path;
         }
     }


### PR DESCRIPTION
Currently using **if**  for null checking and creating **BindingInfo** object, but we have a operator in C# i.e. ??= which does the same thing with less amount of code.
Reference article   https://docs.microsoft.com/en-us/aspnet/core/mvc/controllers/application-model?view=aspnetcore-5.0#conventions



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->