### PR TITLE
Removing extra '-' when calling aspnet-generator

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -128,13 +128,13 @@ The *appsettings.json* file is updated with the connection string used to connec
 * **For Windows**: Run the following command:
 
   ```dotnetcli
-  dotnet-aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages\Movies --referenceScriptLibraries
+  dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages\Movies --referenceScriptLibraries
   ```
 
 * **For macOS and Linux**: Run the following command:
 
   ```dotnetcli
-  dotnet-aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
+  dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries
   ```
 
 <a name="codegenerator"></a>
@@ -151,7 +151,7 @@ The following table details the ASP.NET Core code generator options.
 Use the `-h` option to get help on the `aspnet-codegenerator razorpage` command:
 
 ```dotnetcli
-dotnet-aspnet-codegenerator razorpage -h
+dotnet aspnet-codegenerator razorpage -h
 ```
 
 For more information, see [dotnet-aspnet-codegenerator](xref:fundamentals/tools/dotnet-aspnet-codegenerator).


### PR DESCRIPTION
Removing an extra '-' when explaining how to call aspnet-generator. The correct way of calling it doesn't need the '-' between the dotnet and the aspnet-generator option. You can also see this as a way of unify how the asp-generator is being used in other tutorials like the first-mvc-app adding-model page here: https://github.com/iamnicoj/AspNetCore.Docs/blob/main/aspnetcore/tutorials/first-mvc-app/adding-model.md

Other related open issue caused by this extra hyphen: dotnet/Scaffolding#1404