### PR TITLE
Updated documentation to include PersistKeysToDbContext

### DIFF
--- a/aspnetcore/security/data-protection/configuration/overview.md
+++ b/aspnetcore/security/data-protection/configuration/overview.md
@@ -108,7 +108,7 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-This will store the keys used in the configured database. The database context being used must adhere to `IDataProtectionKeyContext` which exposes the property `DataProtectionKeys` 
+The preceding code stores the keys in the configured database. The database context being used must implement `IDataProtectionKeyContext`.  `IDataProtectionKeyContext` exposes the property `DataProtectionKeys` 
 
 ```csharp
 public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }

--- a/aspnetcore/security/data-protection/configuration/overview.md
+++ b/aspnetcore/security/data-protection/configuration/overview.md
@@ -106,6 +106,7 @@ public void ConfigureServices(IServiceCollection services)
     services.AddDataProtection()
         .PersistKeysToDbContext<DbContext>()
 }
+```
 
 This will store the keys used in the configured database. The database context being used must adhere to `IDataProtectionKeyContext` which exposes the property `DataProtectionKeys` 
 

--- a/aspnetcore/security/data-protection/configuration/overview.md
+++ b/aspnetcore/security/data-protection/configuration/overview.md
@@ -96,6 +96,25 @@ public void ConfigureServices(IServiceCollection services)
 > [!WARNING]
 > If you change the key persistence location, the system no longer automatically encrypts keys at rest, since it doesn't know whether DPAPI is an appropriate encryption mechanism.
 
+## PersistKeysToDbContext
+
+To store keys in a database using EntityFramework, configure the system with the [Microsoft.AspNetCore.DataProtection.EntityFrameworkCore](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.EntityFrameworkCore/) package:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddDataProtection()
+        .PersistKeysToDbContext<DbContext>()
+}
+
+This will store the keys used in the configured database. The database context being used must adhere to `IDataProtectionKeyContext` which exposes the property `DataProtectionKeys` 
+
+```csharp
+public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
+```
+
+This property represents the table in which the keys will be stored. The definition of this type [can be found here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.dataprotection.entityframeworkcore.dataprotectionkey?view=aspnetcore-5.0). This table will need to be created either manually or via your DbContext Migrations.
+
 ## ProtectKeysWith\*
 
 You can configure the system to protect keys at rest by calling any of the [ProtectKeysWith\*](/dotnet/api/microsoft.aspnetcore.dataprotection.dataprotectionbuilderextensions) configuration APIs. Consider the example below, which stores keys on a UNC share and encrypts those keys at rest with a specific X.509 certificate:

--- a/aspnetcore/security/data-protection/configuration/overview.md
+++ b/aspnetcore/security/data-protection/configuration/overview.md
@@ -114,7 +114,7 @@ The preceding code stores the keys in the configured database. The database cont
 public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
 ```
 
-This property represents the table in which the keys will be stored. The definition of this type [can be found here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.dataprotection.entityframeworkcore.dataprotectionkey?view=aspnetcore-5.0). This table will need to be created either manually or via your DbContext Migrations.
+This property represents the table in which the keys are stored. Create the table manually or with `DbContext` Migrations. See <xref:Microsoft.AspNetCore.DataProtection.EntityFrameworkCore.DataProtectionKey> for more information.
 
 ## ProtectKeysWith\*
 


### PR DESCRIPTION
Fixes #21996

Updated documentation to cover for PersistKeysToDbContext functionality in aspnetcore > security > data-protection > configuration > overview