### PR TITLE
Add build warning status check

### DIFF
--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -1,0 +1,14 @@
+name: 'Status checker'
+
+on: 
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  status_checker_job:
+    name: Look for build warnings
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dotnet/samples/.github/actions/status-checker@main
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a status check that fails if there are build warnings. This status check is not required to pass before the PR can be merged.