### PR TITLE
Add the Blazor first tutorial to the ToC

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -79,7 +79,13 @@
               uid: tutorials/first-mvc-app/details
         - name: Blazor
           displayName: tutorial
-          uid: tutorials/build-a-blazor-app
+          items:
+            - name: Build your first Blazor app
+              href: /learn/aspnet/blazor-tutorial/intro
+            - name: Build a Blazor todo list app
+              uid: tutorials/build-a-blazor-app
+            - name: SignalR with Blazor
+              uid: tutorials/signalr-blazor
     - name: Web API apps
       items:
         - name: Create a web API
@@ -306,6 +312,8 @@
           uid: blazor/hosting-models
         - name: Tutorials
           items:
+            - name: Build your first Blazor app
+              href: /learn/aspnet/blazor-tutorial/intro
             - name: Build a Blazor todo list app
               uid: tutorials/build-a-blazor-app
             - name: SignalR with Blazor


### PR DESCRIPTION
The link at the end of the 'build your first' tutorial brings the reader back to the doc set at the 'build a todo list' tutorial, so they'll go away for it to `/learn/aspnet/blazor-tutorial/intro` but come back here and pick up where they left off.

Also, I add the Blazor-SignalR tutorial to the main *Tutorials* list.