### PR TITLE
FF trust cert

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -411,6 +411,8 @@ Establishing trust is browser specific. The following sections provide instructi
 
 ### Trust HTTPS certificate on Linux using Edge or Chrome
 
+For chromium browsers on Linux:
+
   * Install the `libnss3-tools` for your distribution.
   * Create or verify the `$HOME/.pki/nssdb` folder exists on the machine.
   * Export the certificate with the following command:

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -345,12 +345,18 @@ dotnet dev-certs https --help
 
 <a name="trust-ff"></a>
 
-### Trust the HTTPS certificate on Firefox
+### Trust the HTTPS certificate with Firefox to prevent SEC_ERROR_INADEQUATE_KEY_USAGE error
+
+The Firefox browser uses it's own certificate store, and therefore doesn't trust the [IIS Express](/iis/extensions/introduction-to-iis-express/iis-express-overview) or [Kestrel](xref:fundamentals/servers/kestrel) developer certificates.
+
+There are two approaches to trusting the HTTPS certificate with Firefox, create a policy file or configure with the FireFox browser. Configuring with the browser creates the policy file.
+
+#### Create a policy file to trust HTTPS certificate with Firefox
 
 Create a policy file at:
 
-* On windows: `%PROGRAMFILES%\Mozilla Firefox\distribution\policies.json`
-* On MacOS: `Firefox.app/Contents/Resources/distribution`
+* Windows: `%PROGRAMFILES%\Mozilla Firefox\distribution\policies.json`
+* MacOS: `Firefox.app/Contents/Resources/distribution`
 
 Add the following JSON to the Firefox policy file:
 
@@ -366,9 +372,7 @@ Add the following JSON to the Firefox policy file:
 
 The preceding policy file makes Firefox trust certificates from the trusted certificates in the Windows certificate store. The next section provides an alternative approach for the Firefox browser.
 
-### Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error
-
-The Firefox browser uses it's own certificate store, and therefore doesn't trust the [IIS Express](/iis/extensions/introduction-to-iis-express/iis-express-overview) or [Kestrel](xref:fundamentals/servers/kestrel) developer certificates.
+### Configure trust of HTTPS certificate using Firefox browser
 
 To use Firefox with IIS Express or Kestrel, set  `security.enterprise_roots.enabled` = `true`
 
@@ -390,6 +394,18 @@ See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/6199).
 
 Establishing trust is browser specific. The following sections provide instructions for the Chromium browsers Edge and Chrome and for Firefox.
 
+## Ubuntu trust the certificate for service-to-service communication
+
+1. Install [OpenSSL](https://www.openssl.org/) 1.1.1h or later. See your distribution for instructions on how to update OpenSSL.
+1. Run the following commands:
+
+  ```cli
+  sudo dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+  sudo update-ca-certificates
+  ```
+
+The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
+
 ### Trust HTTPS certificate on Linux using Edge or Chrome
 
   * Install the `libnss3-tools` for your distribution.
@@ -399,7 +415,9 @@ Establishing trust is browser specific. The following sections provide instructi
     ```cli
     dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
     ```
-  
+
+    Note, the path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
+
   * Run the following commands:
   
     ```cli
@@ -431,21 +449,11 @@ Establishing trust is browser specific. The following sections provide instructi
   }
   ```
 
-## Ubuntu trust the certificate for service-to-service communication
-
-1. Install [OpenSSL](https://www.openssl.org/) 1.1.1h or later. See your distribution for instructions on how to update OpenSSL.
-1. Run the following commands:
-
-  ```cli
-  sudo dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
-  sudo update-ca-certificates
-  ```
-
 <a name="wsl"></a>
 
 ## Trust HTTPS certificate from Windows Subsystem for Linux
 
-The [Windows Subsystem for Linux (WSL)](/windows/wsl/about) generates an HTTPS self-signed cert. To configure the Windows certificate store to trust the WSL certificate:
+The [Windows Subsystem for Linux (WSL)](/windows/wsl/about) generates an HTTPS self-signed development certificate. To configure the Windows certificate store to trust the WSL certificate:
 
 * Export the developer certificate to a file on ***Windows***:
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -322,7 +322,7 @@ For the Firefox browser, see the next section.
 
 The .NET Core SDK includes an HTTPS development certificate. The certificate is installed as part of the first-run experience. For example, `dotnet --info` produces a variation of the following output:
 
-```
+```cli
 ASP.NET Core
 ------------
 Successfully installed the ASP.NET Core HTTPS Development Certificate.
@@ -364,7 +364,7 @@ Add the following JSON to the Firefox policy file:
 }
 ```
 
-The preceding policy file makes Firefox trust certificates from the trusted certificates in the Windows certificate store. The next section provides an alternative approach to for the Firefox browser.
+The preceding policy file makes Firefox trust certificates from the trusted certificates in the Windows certificate store. The next section provides an alternative approach for the Firefox browser.
 
 ### Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error
 
@@ -388,28 +388,28 @@ See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/6199).
 
 ## Trust HTTPS certificate on Linux
 
-Establishing trust is browser specific.
+Establishing trust is browser specific. The following sections provide instructions for the Chromium browsers Edge and Chrome and for Firefox.
 
-### Trust HTTPS certificate on Linux with Chromium browsers Edge and Chrome
+### Trust HTTPS certificate on Linux using Edge or Chrome
 
-* Install the `libnss3-tools` for your distribution.
-* Create or verify the `$HOME/.pki/nssdb` folder exists on the machine.
-* Export the certificate with the following command:
+  * Install the `libnss3-tools` for your distribution.
+  * Create or verify the `$HOME/.pki/nssdb` folder exists on the machine.
+  * Export the certificate with the following command:
+  
+    ```cli
+    dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+    ```
+  
+  * Run the following commands:
+  
+    ```cli
+    certutil -d sql:$HOME/.pki/nssdb -A -t "P,," -n localhost -i /usr/local/share/ca-certificates/  aspnet/https.crt
+    certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n localhost -i /usr/local/share/ca-certificates/  aspnet/https.crt
+    ```
+  
+  * Exit and restart the browser.
 
-  ```cli
-  dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
-  ```
-
-* Run the following commands:
-
-  ```cli
-  certutil -d sql:$HOME/.pki/nssdb -A -t "P,," -n localhost -i /usr/local/share/ca-certificates/aspnet/https.crt
-  certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n localhost -i /usr/local/share/ca-certificates/aspnet/https.crt
-  ```
-
-* Exit and restart the browser.
-
-### Trust the certificate in Firefox
+### Trust the certificate with Firefox
 
 * Export the certificate with the following command:
 
@@ -433,9 +433,8 @@ Establishing trust is browser specific.
 
 ## Ubuntu trust the certificate for service-to-service communication
 
-Install [OpenSSL ](https://www.openssl.org/) 1.1.1h or later. See your distribution for instructions on how to update OpenSSL.
-
-* Run the following commands:
+1. Install [OpenSSL](https://www.openssl.org/) 1.1.1h or later. See your distribution for instructions on how to update OpenSSL.
+1. Run the following commands:
 
   ```cli
   sudo dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
@@ -458,7 +457,7 @@ The [Windows Subsystem for Linux (WSL)](/windows/wsl/about) generates an HTTPS s
 * In a WSL window, import the exported certificate on the WSL instance:
 
   ```
-  dotnet dev-certs https --clean --import /mnt/c/<<path-to-folder>>/aspnetcore.pfx -p <<password>>
+  dotnet dev-certs https --clean --import /mnt/c/<<path-to-folder>>/aspnetcore.pfx -p $CREDENTIAL_PLACEHOLDER$
   ```
 
 The preceding approach is a one time operation per certificate and per WSL distribution. It's easier than exporting the certificate over and over. If you update or regenerate the certificate on windows, you might need to run the preceding commands again.

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -386,11 +386,59 @@ See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/6199).
 
 <a name="ssl-linux"></a>
 
-## ~Trust HTTPS certificate on Linux~
+## Trust HTTPS certificate on Linux
 
-<!-- Instructions to be updated by engineering team after 5.0 RTM. -->
+Establishing trust is browser specific.
 
-~For instructions on Linux, refer to the distribution documentation.~
+### Trust HTTPS certificate on Linux with Chromium browsers Edge and Chrome
+
+* Install the `libnss3-tools` for your distribution.
+* Create or verify the `$HOME/.pki/nssdb` folder exists on the machine.
+* Export the certificate with the following command:
+
+  ```cli
+  dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+  ```
+
+* Run the following commands:
+
+  ```cli
+  certutil -d sql:$HOME/.pki/nssdb -A -t "P,," -n localhost -i /usr/local/share/ca-certificates/aspnet/https.crt
+  certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n localhost -i /usr/local/share/ca-certificates/aspnet/https.crt
+  ```
+
+* Exit and restart the browser.
+
+### Trust the certificate in Firefox
+
+* Export the certificate with the following command:
+
+  ```vstscli
+  dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+  ```
+
+* Create a JSON file at `/usr/lib/firefox/distribution/policies.json` with the following contents:
+
+  ```json
+  {
+      "policies": {
+          "Certificates": {
+              "Install": [
+                  "/usr/local/share/ca-certificates/aspnet/https.crt"
+              ]
+          }
+      }
+  }
+  ```
+
+## Ubuntu to make dotnet trust the certificate (for service-to-service communication)
+
+* **Requires openssl 1.1.1h and higher**. For instructions on how to update openssl find a guide for your OS.
+* Run the following two commands:
+  ```
+  sudo dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+  sudo update-ca-certificates
+  ```
 
 <a name="wsl"></a>
 
@@ -398,7 +446,7 @@ See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/6199).
 
 The [Windows Subsystem for Linux (WSL)](/windows/wsl/about) generates an HTTPS self-signed cert. To configure the Windows certificate store to trust the WSL certificate:
 
-* Export the developer certificate to a file on ***Windows***
+* Export the developer certificate to a file on ***Windows***:
 
   ```
   dotnet dev-certs https --ep C:\<<path-to-folder>>\aspnetcore.pfx -p $CREDENTIAL_PLACEHOLDER$
@@ -411,7 +459,7 @@ The [Windows Subsystem for Linux (WSL)](/windows/wsl/about) generates an HTTPS s
   dotnet dev-certs https --clean --import /mnt/c/<<path-to-folder>>/aspnetcore.pfx -p <<password>>
   ```
 
-  The preceding approach is a one time operation per certificate and per WSL distribution. It's easier than exporting the certificate over and over. If you update or regenerate the certificate on windows, you might need to run the preceding commands again.
+The preceding approach is a one time operation per certificate and per WSL distribution. It's easier than exporting the certificate over and over. If you update or regenerate the certificate on windows, you might need to run the preceding commands again.
 
 ## Troubleshoot certificate problems
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -320,6 +320,8 @@ dotnet new webapp --no-https
 
 ## Trust the ASP.NET Core HTTPS development certificate on Windows and macOS
 
+To trust the Firefox browser, see the next section.
+
 The .NET Core SDK includes an HTTPS development certificate. The certificate is installed as part of the first-run experience. For example, `dotnet --info` produces a variation of the following output:
 
 ```
@@ -342,6 +344,43 @@ The following command provides help on the `dev-certs` tool:
 ```dotnetcli
 dotnet dev-certs https --help
 ```
+
+<a name="trust-ff"></a>
+
+### Trust the HTTPS certificate on Firefox
+
+Create a policy file at:
+
+* On windows: `%PROGRAMFILES%\`Mozilla Firefox\distribution\policies.json`
+* On MacOS: `Firefox.app/Contents/Resources/distribution`
+
+Add the following JSON to the Firefox policy file:
+
+```json
+{
+  "policies": {
+    "Certificates": {
+      "ImportEnterpriseRoots": true
+    }
+  }
+}
+```
+
+The preceding policy file makes Firefox trust certificates from the trusted certificates in the Windows certificate store. The next section provides an alternative approach to for the Firefox browser.
+
+### Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error
+
+The Firefox browser uses it's own certificate store, and therefore doesn't trust the [IIS Express](/iis/extensions/introduction-to-iis-express/iis-express-overview) or [Kestrel](xref:fundamentals/servers/kestrel) developer certificates.
+
+To use Firefox with IIS Express or Kestrel, set  `security.enterprise_roots.enabled` = `true`
+
+1. Enter `about:config` in the FireFox browser.
+1. Select **Accept the Risk and Continue** if you accept the risk.
+1. Select **Show All**
+1. Set `security.enterprise_roots.enabled` = `true`
+1. Exit and restart Firefox
+
+For more information, see [Setting Up Certificate Authorities (CAs) in Firefox](https://support.mozilla.org/kb/setting-certificate-authorities-firefox) and the [`mozilla/policy-templates/README file](https://github.com/mozilla/policy-templates/blob/master/README.md).
 
 ## How to set up a developer certificate for Docker
 
@@ -435,22 +474,6 @@ See [HTTPS Error using IIS Express (dotnet/AspNetCore #16892)](https://github.co
 ### IIS Express SSL certificate used with Visual Studio
 
 To fix problems with the IIS Express certificate, select **Repair** from the Visual Studio installer. For more information, see [this GitHub issue](https://github.com/dotnet/aspnetcore/issues/16892).
-
-<a name="trust-ff"></a>
-
-### Firefox SEC_ERROR_INADEQUATE_KEY_USAGE certificate error
-
-The Firefox browser uses it's own certificate store, and therefore doesn't trust the [IIS Express](/iis/extensions/introduction-to-iis-express/iis-express-overview) or [Kestrel](xref:fundamentals/servers/kestrel) developer certificates.
-
-To use Firefox with IIS Express or Kestrel, set  `security.enterprise_roots.enabled` = `true`
-
-1. Enter `about:config` in the FireFox browser.
-1. Select **Accept the Risk and Continue** if you accept the risk.
-1. Select **Show All**
-1. Set `security.enterprise_roots.enabled` = `true`
-1. Exit and restart Firefox
-
-For more information, see [Setting Up Certificate Authorities (CAs) in Firefox](https://support.mozilla.org/kb/setting-certificate-authorities-firefox).
 
 ## Additional information
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -386,11 +386,11 @@ See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/6199).
 
 <a name="ssl-linux"></a>
 
-## Trust HTTPS certificate on Linux
+## ~Trust HTTPS certificate on Linux~
 
 <!-- Instructions to be updated by engineering team after 5.0 RTM. -->
 
-For instructions on Linux, refer to the distribution documentation.
+~For instructions on Linux, refer to the distribution documentation.~
 
 <a name="wsl"></a>
 
@@ -401,7 +401,7 @@ The [Windows Subsystem for Linux (WSL)](/windows/wsl/about) generates an HTTPS s
 * Export the developer certificate to a file on ***Windows***
 
   ```
-dotnet dev-certs https --ep C:\<<path-to-folder>>\aspnetcore.pfx -p $CREDENTIAL_PLACEHOLDER$
+  dotnet dev-certs https --ep C:\<<path-to-folder>>\aspnetcore.pfx -p $CREDENTIAL_PLACEHOLDER$
   ```
   Where `$CREDENTIAL_PLACEHOLDER$` is a password.
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -431,11 +431,13 @@ Establishing trust is browser specific.
   }
   ```
 
-## Ubuntu to make dotnet trust the certificate (for service-to-service communication)
+## Ubuntu trust the certificate for service-to-service communication
 
-* **Requires openssl 1.1.1h and higher**. For instructions on how to update openssl find a guide for your OS.
-* Run the following two commands:
-  ```
+Install [OpenSSL ](https://www.openssl.org/) 1.1.1h or later. See your distribution for instructions on how to update OpenSSL.
+
+* Run the following commands:
+
+  ```cli
   sudo dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
   sudo update-ca-certificates
   ```

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -93,7 +93,7 @@ Specify the HTTPS port using any of the following approaches:
 
 ::: moniker range=">= aspnetcore-3.0"
 
-* Set the `https_port` [host setting](../fundamentals/host/generic-host.md?view=aspnetcore-3.0#https_port):
+* Set the `https_port` [host setting](xref:fundamentals/host/generic-host#https_port):
 
   * In host configuration.
   * By setting the `ASPNETCORE_HTTPS_PORT` environment variable.
@@ -101,7 +101,7 @@ Specify the HTTPS port using any of the following approaches:
 
     [!code-json[](enforcing-ssl/sample-snapshot/3.x/appsettings.json?highlight=2)]
 
-* Indicate a port with the secure scheme using the [ASPNETCORE_URLS environment variable](../fundamentals/host/generic-host.md?view=aspnetcore-3.0#urls). The environment variable configures the server. The middleware indirectly discovers the HTTPS port via <xref:Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>. This approach doesn't work in reverse proxy deployments.
+* Indicate a port with the secure scheme using the [ASPNETCORE_URLS environment variable](xref:fundamentals/host/generic-host#urls). The environment variable configures the server. The middleware indirectly discovers the HTTPS port via <xref:Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>. This approach doesn't work in reverse proxy deployments.
 
 ::: moniker-end
 
@@ -148,7 +148,6 @@ When deploying to Azure App Service, follow the guidance in [Tutorial: Bind an e
 ### Options
 
 The following highlighted code calls [AddHttpsRedirection](/dotnet/api/microsoft.aspnetcore.builder.httpsredirectionservicesextensions.addhttpsredirection) to configure middleware options:
-
 
 ::: moniker range=">= aspnetcore-3.0"
 
@@ -258,7 +257,6 @@ For production environments that are implementing HTTPS for the first time, set 
 
 The following code:
 
-
 ::: moniker range=">= aspnetcore-3.0"
 
 [!code-csharp[](enforcing-ssl/sample-snapshot/3.x/Startup.cs?name=snippet2&highlight=5-12)]
@@ -320,7 +318,7 @@ dotnet new webapp --no-https
 
 ## Trust the ASP.NET Core HTTPS development certificate on Windows and macOS
 
-To trust the Firefox browser, see the next section.
+For the Firefox browser, see the next section.
 
 The .NET Core SDK includes an HTTPS development certificate. The certificate is installed as part of the first-run experience. For example, `dotnet --info` produces a variation of the following output:
 
@@ -351,7 +349,7 @@ dotnet dev-certs https --help
 
 Create a policy file at:
 
-* On windows: `%PROGRAMFILES%\`Mozilla Firefox\distribution\policies.json`
+* On windows: `%PROGRAMFILES%\Mozilla Firefox\distribution\policies.json`
 * On MacOS: `Firefox.app/Contents/Resources/distribution`
 
 Add the following JSON to the Firefox policy file:
@@ -398,22 +396,22 @@ For instructions on Linux, refer to the distribution documentation.
 
 ## Trust HTTPS certificate from Windows Subsystem for Linux
 
-The Windows Subsystem for Linux (WSL) generates an HTTPS self-signed cert. To configure the Windows certificate store to trust the WSL certificate:
+The [Windows Subsystem for Linux (WSL)](/windows/wsl/about) generates an HTTPS self-signed cert. To configure the Windows certificate store to trust the WSL certificate:
 
-* Run the following command to export the WSL-generated certificate:
-
-  ```
-  dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p <cryptic-password>
-  ```
-* In a WSL window, run the following command:
+* Export the developer certificate to a file on ***Windows***
 
   ```
-    ASPNETCORE_Kestrel__Certificates__Default__Password="<cryptic-password>" 
-    ASPNETCORE_Kestrel__Certificates__Default__Path=/mnt/c/Users/user-name/.aspnet/https/aspnetapp.pfx
-    dotnet watch run
+dotnet dev-certs https --ep C:\<<path-to-folder>>\aspnetcore.pfx -p $CREDENTIAL_PLACEHOLDER$
+  ```
+  Where `$CREDENTIAL_PLACEHOLDER$` is a password.
+
+* In a WSL window, import the exported certificate on the WSL instance:
+
+  ```
+  dotnet dev-certs https --clean --import /mnt/c/<<path-to-folder>>/aspnetcore.pfx -p <<password>>
   ```
 
-  The preceding command sets the environment variables so Linux uses the Windows trusted certificate.
+  The preceding approach is a one time operation per certificate and per WSL distribution. It's easier than exporting the certificate over and over. If you update or regenerate the certificate on windows, you might need to run the preceding commands again.
 
 ## Troubleshoot certificate problems
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -349,7 +349,7 @@ dotnet dev-certs https --help
 
 The Firefox browser uses it's own certificate store, and therefore doesn't trust the [IIS Express](/iis/extensions/introduction-to-iis-express/iis-express-overview) or [Kestrel](xref:fundamentals/servers/kestrel) developer certificates.
 
-There are two approaches to trusting the HTTPS certificate with Firefox, create a policy file or configure with the FireFox browser. Configuring with the browser creates the policy file.
+There are two approaches to trusting the HTTPS certificate with Firefox, create a policy file or configure with the FireFox browser. Configuring with the browser creates the policy file, so the two approaches are equivalent.
 
 #### Create a policy file to trust HTTPS certificate with Firefox
 
@@ -370,11 +370,13 @@ Add the following JSON to the Firefox policy file:
 }
 ```
 
-The preceding policy file makes Firefox trust certificates from the trusted certificates in the Windows certificate store. The next section provides an alternative approach for the Firefox browser.
+The preceding policy file makes Firefox trust certificates from the trusted certificates in the Windows certificate store. The next section provides an alternative approach to create the preceding policy file buy using the Firefox browser.
+
+<a name="trust-ff-ba"></a>
 
 ### Configure trust of HTTPS certificate using Firefox browser
 
-To use Firefox with IIS Express or Kestrel, set  `security.enterprise_roots.enabled` = `true`
+Set  `security.enterprise_roots.enabled` = `true` using the following instructions:
 
 1. Enter `about:config` in the FireFox browser.
 1. Select **Accept the Risk and Continue** if you accept the risk.
@@ -382,29 +384,29 @@ To use Firefox with IIS Express or Kestrel, set  `security.enterprise_roots.enab
 1. Set `security.enterprise_roots.enabled` = `true`
 1. Exit and restart Firefox
 
-For more information, see [Setting Up Certificate Authorities (CAs) in Firefox](https://support.mozilla.org/kb/setting-certificate-authorities-firefox) and the [`mozilla/policy-templates/README file](https://github.com/mozilla/policy-templates/blob/master/README.md).
+For more information, see [Setting Up Certificate Authorities (CAs) in Firefox](https://support.mozilla.org/kb/setting-certificate-authorities-firefox) and the [mozilla/policy-templates/README file](https://github.com/mozilla/policy-templates/blob/master/README.md).
 
 ## How to set up a developer certificate for Docker
 
 See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/6199).
-
-<a name="ssl-linux"></a>
-
-## Trust HTTPS certificate on Linux
-
-Establishing trust is browser specific. The following sections provide instructions for the Chromium browsers Edge and Chrome and for Firefox.
 
 ## Ubuntu trust the certificate for service-to-service communication
 
 1. Install [OpenSSL](https://www.openssl.org/) 1.1.1h or later. See your distribution for instructions on how to update OpenSSL.
 1. Run the following commands:
 
-  ```cli
-  sudo dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
-  sudo update-ca-certificates
-  ```
+    ```cli
+    sudo dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+    sudo update-ca-certificates
+    ```
 
 The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
+
+<a name="ssl-linux"></a>
+
+## Trust HTTPS certificate on Linux
+
+Establishing trust is browser specific. The following sections provide instructions for the Chromium browsers Edge and Chrome and for Firefox.
 
 ### Trust HTTPS certificate on Linux using Edge or Chrome
 
@@ -416,7 +418,7 @@ The path in the preceding command is specific for Ubuntu. For other distribution
     dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
     ```
 
-    Note, the path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
+    The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
 
   * Run the following commands:
   
@@ -435,6 +437,8 @@ The path in the preceding command is specific for Ubuntu. For other distribution
   dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
   ```
 
+  The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
+
 * Create a JSON file at `/usr/lib/firefox/distribution/policies.json` with the following contents:
 
   ```json
@@ -448,6 +452,8 @@ The path in the preceding command is specific for Ubuntu. For other distribution
       }
   }
   ```
+  
+See [Configure trust of HTTPS certificate using Firefox browser](#trust-ff-ba) in this document for an alternative way to configure the policy file using the browser.
 
 <a name="wsl"></a>
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -357,6 +357,7 @@ Create a policy file at:
 
 * Windows: `%PROGRAMFILES%\Mozilla Firefox\distribution\policies.json`
 * MacOS: `Firefox.app/Contents/Resources/distribution`
+* Linux: See [Trust the certificate with Firefox on Linux](#trust-ff-linux) in this document.
 
 Add the following JSON to the Firefox policy file:
 
@@ -429,7 +430,9 @@ Establishing trust is browser specific. The following sections provide instructi
   
   * Exit and restart the browser.
 
-### Trust the certificate with Firefox
+<a name="trust-ff-linux"></a>
+
+### Trust the certificate with Firefox on Linux
 
 * Export the certificate with the following command:
 


### PR DESCRIPTION
Fixes #22020
Fixes #22021
Fixes #22019

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-5.0&branch=pr-en-us-22064&tabs=visual-studio#trust-the-aspnet-core-https-development-certificate-on-windows-and-macos)