### PR TITLE
Update API description

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -87,7 +87,7 @@ JSON helper methods send requests to a URI (a web API in the following examples)
   }
   ```
 
-* <xref:System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync%2A>: Sends an HTTP POST request, including JSON-encoded content, and parses the JSON response body to create an object.
+* <xref:System.Net.Http.Json.HttpClientJsonExtensions.PostAsJsonAsync%2A>: Sends a POST request to the specified URI containing the value serialized as JSON in the request body.
 
   In the following code, `newItemName` is provided by a bound element of the component. The `AddItem` method is triggered by selecting a `<button>` element. See the sample app for a complete example.
 


### PR DESCRIPTION
Fixes #22063

Thanks @ToiWright! :rocket: ... The `HttpResponseMessage` is called out immediately under the example. This topic is due for an overhaul soon on https://github.com/dotnet/AspNetCore.Docs/issues/19286, and I'll take another look and make further updates when I reach it on that issue. Thanks again.