### PR TITLE
duplicate instruction for --dataContext removed and added command instruction for --useSqlite

### DIFF
--- a/aspnetcore/includes/aspnet-codegenerator-args-md.md
+++ b/aspnetcore/includes/aspnet-codegenerator-args-md.md
@@ -11,4 +11,4 @@ no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Bla
 | --layout or -l | Custom Layout page to use. |
 | --useDefaultLayout or -udl | Use the default layout for the views. |
 | --force or -f | Overwrite existing files. |
-| --dataContext or -dc  | The `DbContext` class to use or the name of the class to generate. |
+| --useSqlite or -sqlite | Flag to specify if `DbContext` should use SQLite instead of SQL Server. |


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/21475
