### PR TITLE
Windows version updates

### DIFF
--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -74,7 +74,7 @@ gRPC services can be hosted by all built-in ASP.NET Core servers.
 &dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later.  
 &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.
 
-The preceding Windows 10 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.
+The preceding Windows 10 Build versions may require the use of a [Windows Insider build](https://insider.windows.com).
 
 For more information about choosing the right server for an ASP.NET Core app, see <xref:fundamentals/servers/index>.
 
@@ -120,13 +120,13 @@ For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpo
 
 ## IIS
 
-[Internet Information Services (IIS)](xref:host-and-deploy/iis/index) is a flexible, secure and manageable Web Server for hosting web apps, including ASP.NET Core. .NET 5 and Windows 10 Build 20300.1000 or later are required to host gRPC services with IIS, which may require the use of a [Windows Insider](https://insider.windows.com) build.
+[Internet Information Services (IIS)](xref:host-and-deploy/iis/index) is a flexible, secure and manageable Web Server for hosting web apps, including ASP.NET Core. .NET 5 and Windows 10 Build 20300.1000 or later are required to host gRPC services with IIS, which may require the use of a [Windows Insider build](https://insider.windows.com).
 
 IIS must be configured to use TLS and HTTP/2. For more information, see <xref:host-and-deploy/iis/protocols>.
 
 ## HTTP.sys
 
-[HTTP.sys](xref:fundamentals/servers/httpsys) is a web server for ASP.NET Core that only runs on Windows. .NET 5 and Windows 10 Build 19529 or later are required to host gRPC services with HTTP.sys, which may require the use of a [Windows Insider](https://insider.windows.com) build.
+[HTTP.sys](xref:fundamentals/servers/httpsys) is a web server for ASP.NET Core that only runs on Windows. .NET 5 and Windows 10 Build 19529 or later are required to host gRPC services with HTTP.sys, which may require the use of a [Windows Insider build](https://insider.windows.com).
 
 HTTP.sys must be configured to use TLS and HTTP/2. For more information, see  [HTTP.sys web server HTTP/2 support](xref:fundamentals/servers/httpsys#http2-support).
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -74,7 +74,7 @@ gRPC services can be hosted by all built-in ASP.NET Core servers.
 &dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later.  
 &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.
 
-The preceding Windows 10 Build versions may require the use of a [Windows Insider build](https://insider.windows.com).
+The preceding Windows 10 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 For more information about choosing the right server for an ASP.NET Core app, see <xref:fundamentals/servers/index>.
 
@@ -120,13 +120,13 @@ For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpo
 
 ## IIS
 
-[Internet Information Services (IIS)](xref:host-and-deploy/iis/index) is a flexible, secure and manageable Web Server for hosting web apps, including ASP.NET Core. .NET 5 and Windows 10 Build 20300.1000 or later are required to host gRPC services with IIS, which may require the use of a [Windows Insider build](https://insider.windows.com).
+[Internet Information Services (IIS)](xref:host-and-deploy/iis/index) is a flexible, secure and manageable Web Server for hosting web apps, including ASP.NET Core. .NET 5 and Windows 10 Build 20300.1000 or later are required to host gRPC services with IIS, which may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 IIS must be configured to use TLS and HTTP/2. For more information, see <xref:host-and-deploy/iis/protocols>.
 
 ## HTTP.sys
 
-[HTTP.sys](xref:fundamentals/servers/httpsys) is a web server for ASP.NET Core that only runs on Windows. .NET 5 and Windows 10 Build 19529 or later are required to host gRPC services with HTTP.sys, which may require the use of a [Windows Insider build](https://insider.windows.com).
+[HTTP.sys](xref:fundamentals/servers/httpsys) is a web server for ASP.NET Core that only runs on Windows. .NET 5 and Windows 10 Build 19529 or later are required to host gRPC services with HTTP.sys, which may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 HTTP.sys must be configured to use TLS and HTTP/2. For more information, see  [HTTP.sys web server HTTP/2 support](xref:fundamentals/servers/httpsys#http2-support).
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -71,9 +71,10 @@ gRPC services can be hosted by all built-in ASP.NET Core servers.
 > * IIS&dagger;
 > * HTTP.sys&Dagger;
 
-&dagger;IIS requires .NET 5 and Windows 10 Build 20241 or later.
-
+&dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later.  
 &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.
+
+The preceding Windows 10 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 For more information about choosing the right server for an ASP.NET Core app, see <xref:fundamentals/servers/index>.
 
@@ -119,13 +120,13 @@ For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpo
 
 ## IIS
 
-[Internet Information Services (IIS)](xref:host-and-deploy/iis/index) is a flexible, secure and manageable Web Server for hosting web apps, including ASP.NET Core. .NET 5 and Windows 10 Build 20241 or later are required to host gRPC services with IIS.
+[Internet Information Services (IIS)](xref:host-and-deploy/iis/index) is a flexible, secure and manageable Web Server for hosting web apps, including ASP.NET Core. .NET 5 and Windows 10 Build 20300.1000 or later are required to host gRPC services with IIS, which may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 IIS must be configured to use TLS and HTTP/2. For more information, see <xref:host-and-deploy/iis/protocols>.
 
 ## HTTP.sys
 
-[HTTP.sys](xref:fundamentals/servers/httpsys) is a web server for ASP.NET Core that only runs on Windows. .NET 5 and Windows 10 Build 19529 or later are required to host gRPC services with HTTP.sys.
+[HTTP.sys](xref:fundamentals/servers/httpsys) is a web server for ASP.NET Core that only runs on Windows. .NET 5 and Windows 10 Build 19529 or later are required to host gRPC services with HTTP.sys, which may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 HTTP.sys must be configured to use TLS and HTTP/2. For more information, see  [HTTP.sys web server HTTP/2 support](xref:fundamentals/servers/httpsys#http2-support).
 

--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -66,7 +66,7 @@ For more information, see [Configure gRPC-Web with the .NET gRPC client](xref:gr
 
 Requirements and restrictions to using `WinHttpHandler`:
 
-* Windows 10 Build 19622 or later. May require the use of a [Windows Insider](https://insider.windows.com) build).
+* Windows 10 Build 19622 or later. May require the use of a [Windows Insider build](https://insider.windows.com)).
 * A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.0-preview.3.21201.4 or later.
 * Only unary and server streaming gRPC calls are supported.
 * Only gRPC calls over TLS are supported.

--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -66,7 +66,7 @@ For more information, see [Configure gRPC-Web with the .NET gRPC client](xref:gr
 
 Requirements and restrictions to using `WinHttpHandler`:
 
-* Windows 10 Build 19622 or later. May require the use of a [Windows Insider](https://insider.windows.com) build).
+* Windows 10 Build 19622 or later. May require the use of a [Windows Insider](https://insider.windows.com) build.
 * A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.0-preview.3.21201.4 or later.
 * Only unary and server streaming gRPC calls are supported.
 * Only gRPC calls over TLS are supported.
@@ -84,7 +84,7 @@ var response = await client.SayHelloAsync(new HelloRequest { Name = ".NET" });
 > [!NOTE]
 > .NET Framework support is in its early stages and requires using pre-release software:
 >
-> * Windows 10 Build 19622 or later is available as a [Windows Insiders Build](https://insider.windows.com).
+> * Windows 10 Build 19622 or later is available as a [Windows Insider](https://insider.windows.com) build.
 > * [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.0-preview.3.21201.4 or later.
 
 ## gRPC C# core-library

--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -66,8 +66,8 @@ For more information, see [Configure gRPC-Web with the .NET gRPC client](xref:gr
 
 Requirements and restrictions to using `WinHttpHandler`:
 
-* Windows 10 Build 19622 or later.
-* A reference to [System.Net.Http.WinHttpHandler](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.0-preview.3.21201.4 or later.
+* Windows 10 Build 19622 or later. May require the use of a [Windows Insider](https://insider.windows.com) build).
+* A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.0-preview.3.21201.4 or later.
 * Only unary and server streaming gRPC calls are supported.
 * Only gRPC calls over TLS are supported.
 
@@ -82,9 +82,10 @@ var response = await client.SayHelloAsync(new HelloRequest { Name = ".NET" });
 ```
 
 > [!NOTE]
-> .NET Framework support is in its early stages and requires using pre-release software.
-> * Windows 10 Build 19622 or later is available as a [Windows Insiders](https://insider.windows.com/) build.
-> * [System.Net.Http.WinHttpHandler](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.0-preview.3.21201.4 or later.
+> .NET Framework support is in its early stages and requires using pre-release software:
+>
+> * Windows 10 Build 19622 or later is available as a [Windows Insiders Build](https://insider.windows.com).
+> * [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.0-preview.3.21201.4 or later.
 
 ## gRPC C# core-library
 

--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -66,7 +66,7 @@ For more information, see [Configure gRPC-Web with the .NET gRPC client](xref:gr
 
 Requirements and restrictions to using `WinHttpHandler`:
 
-* Windows 10 Build 19622 or later. May require the use of a [Windows Insider build](https://insider.windows.com)).
+* Windows 10 Build 19622 or later. May require the use of a [Windows Insider](https://insider.windows.com) build).
 * A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.0-preview.3.21201.4 or later.
 * Only unary and server streaming gRPC calls are supported.
 * Only gRPC calls over TLS are supported.

--- a/aspnetcore/grpc/supported-platforms.md
+++ b/aspnetcore/grpc/supported-platforms.md
@@ -56,9 +56,10 @@ All built-in ASP.NET Core servers are supported.
 > * IIS&dagger;
 > * HTTP.sys&Dagger;
 
-&dagger;IIS requires .NET 5 and Windows 10 Build 20241 or later.
-
+&dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later.  
 &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.
+
+The preceding Windows 10 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 For information about configuring ASP.NET Core servers to run gRPC, see <xref:grpc/aspnetcore#server-options>.
 
@@ -94,7 +95,7 @@ The following table lists .NET implementations and their gRPC client support:
 | Universal Windows Platform 10.0.16299        | ❌                | ✔️         |
 | Unity 2018.1                                 | ❌                | ✔️         |
 
-&dagger;.NET Framework requires <xref:System.Net.Http.WinHttpHandler> to be configured and Windows 10 Build 19622 or later.
+&dagger;.NET Framework requires <xref:System.Net.Http.WinHttpHandler> to be configured and Windows 10 Build 19622 or later, which may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 Using `Grpc.Net.Client` on .NET Framework or with gRPC-Web requires additional configuration. For more information, see <xref:grpc/netstandard>.
 

--- a/aspnetcore/grpc/supported-platforms.md
+++ b/aspnetcore/grpc/supported-platforms.md
@@ -59,7 +59,7 @@ All built-in ASP.NET Core servers are supported.
 &dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later.  
 &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.
 
-The preceding Windows 10 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.
+The preceding Windows 10 Build versions may require the use of a [Windows Insider build](https://insider.windows.com).
 
 For information about configuring ASP.NET Core servers to run gRPC, see <xref:grpc/aspnetcore#server-options>.
 
@@ -95,7 +95,7 @@ The following table lists .NET implementations and their gRPC client support:
 | Universal Windows Platform 10.0.16299        | ❌                | ✔️         |
 | Unity 2018.1                                 | ❌                | ✔️         |
 
-&dagger;.NET Framework requires <xref:System.Net.Http.WinHttpHandler> to be configured and Windows 10 Build 19622 or later, which may require the use of a [Windows Insider](https://insider.windows.com) build.
+&dagger;.NET Framework requires <xref:System.Net.Http.WinHttpHandler> to be configured and Windows 10 Build 19622 or later, which may require the use of a [Windows Insider build](https://insider.windows.com).
 
 Using `Grpc.Net.Client` on .NET Framework or with gRPC-Web requires additional configuration. For more information, see <xref:grpc/netstandard>.
 

--- a/aspnetcore/grpc/supported-platforms.md
+++ b/aspnetcore/grpc/supported-platforms.md
@@ -59,7 +59,7 @@ All built-in ASP.NET Core servers are supported.
 &dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later.  
 &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.
 
-The preceding Windows 10 Build versions may require the use of a [Windows Insider build](https://insider.windows.com).
+The preceding Windows 10 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 For information about configuring ASP.NET Core servers to run gRPC, see <xref:grpc/aspnetcore#server-options>.
 
@@ -95,7 +95,7 @@ The following table lists .NET implementations and their gRPC client support:
 | Universal Windows Platform 10.0.16299        | ❌                | ✔️         |
 | Unity 2018.1                                 | ❌                | ✔️         |
 
-&dagger;.NET Framework requires <xref:System.Net.Http.WinHttpHandler> to be configured and Windows 10 Build 19622 or later, which may require the use of a [Windows Insider build](https://insider.windows.com).
+&dagger;.NET Framework requires <xref:System.Net.Http.WinHttpHandler> to be configured and Windows 10 Build 19622 or later, which may require the use of a [Windows Insider](https://insider.windows.com) build.
 
 Using `Grpc.Net.Client` on .NET Framework or with gRPC-Web requires additional configuration. For more information, see <xref:grpc/netstandard>.
 

--- a/aspnetcore/host-and-deploy/iis/protocols.md
+++ b/aspnetcore/host-and-deploy/iis/protocols.md
@@ -34,7 +34,7 @@ Additional HTTP/2 features in IIS support gRPC, including support for response t
 Requirements to run gRPC on IIS:
 
 * In-process hosting.
-* Windows 10, OS Build 20300.1000 or later. May require use of Windows Insider Builds.
+* Windows 10, OS Build 20300.1000 or later. May require use of a [Windows Insider](https://insider.windows.com) build.
 * TLS 1.2 or later connection
 
 ### Trailers

--- a/aspnetcore/host-and-deploy/iis/protocols.md
+++ b/aspnetcore/host-and-deploy/iis/protocols.md
@@ -34,7 +34,7 @@ Additional HTTP/2 features in IIS support gRPC, including support for response t
 Requirements to run gRPC on IIS:
 
 * In-process hosting.
-* Windows 10, OS Build 20300.1000 or later. May require use of a [Windows Insider build](https://insider.windows.com).
+* Windows 10, OS Build 20300.1000 or later. May require use of a [Windows Insider](https://insider.windows.com) build.
 * TLS 1.2 or later connection
 
 ### Trailers

--- a/aspnetcore/host-and-deploy/iis/protocols.md
+++ b/aspnetcore/host-and-deploy/iis/protocols.md
@@ -34,7 +34,7 @@ Additional HTTP/2 features in IIS support gRPC, including support for response t
 Requirements to run gRPC on IIS:
 
 * In-process hosting.
-* Windows 10, OS Build 20300.1000 or later. May require use of a [Windows Insider](https://insider.windows.com) build.
+* Windows 10, OS Build 20300.1000 or later. May require use of a [Windows Insider build](https://insider.windows.com).
 * TLS 1.2 or later connection
 
 ### Trailers


### PR DESCRIPTION
Fixes #22107

Thanks @richardbartley! :rocket:

Where the &dagger; and &Dagger; are stacked, I remove the intervening line and place two spaces at the end of the first line. This markdown creates a `<br>` there so that they'll be on separate lines. This is better than paragraphs imo.

From ...

> * Kestrel
> * TestServer
> * IIS&dagger;
> * HTTP.sys&Dagger;
>
> &dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later.
>
> &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.
>
> The preceding Windows 10 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.



To ....

> * Kestrel
> * TestServer
> * IIS&dagger;
> * HTTP.sys&Dagger;
>
> &dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later.
> &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.
>
> The preceding Windows 10 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.

Alternatively, we can collapse those into a single paragraph, so let me know if you prefer that ...

> &dagger;IIS requires .NET 5 and Windows 10 Build 20300.1000 or later. &Dagger;HTTP.sys requires .NET 5 and Windows 10 Build 19529 or later.