### PR TITLE
Replace status code with status code enum

### DIFF
--- a/aspnetcore/fundamentals/error-handling/samples/2.x/ErrorHandlingSample/Startup.cs
+++ b/aspnetcore/fundamentals/error-handling/samples/2.x/ErrorHandlingSample/Startup.cs
@@ -90,7 +90,7 @@ namespace ErrorHandlingSample
                {
                     errorApp.Run(async context =>
                     {
-                        context.Response.StatusCode = 500;
+                        context.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
                         context.Response.ContentType = "text/html";
 
                         await context.Response.WriteAsync("<html lang=\"en\"><body>\r\n");

--- a/aspnetcore/fundamentals/error-handling/samples/5.x/ErrorHandlingSample/StartupLambda.cs
+++ b/aspnetcore/fundamentals/error-handling/samples/5.x/ErrorHandlingSample/StartupLambda.cs
@@ -41,7 +41,7 @@ namespace ErrorHandlingSample
                 {
                     errorApp.Run(async context =>
                     {
-                        context.Response.StatusCode = 500;
+                        context.Response.StatusCode = (int) HttpStatusCode.InternalServerError;;
                         context.Response.ContentType = "text/html";
 
                         await context.Response.WriteAsync("<html lang=\"en\"><body>\r\n");

--- a/aspnetcore/fundamentals/url-rewriting/samples/2.x/SampleApp/RewriteRules.cs
+++ b/aspnetcore/fundamentals/url-rewriting/samples/2.x/SampleApp/RewriteRules.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Rewrite;
@@ -23,7 +24,7 @@ namespace RewriteRules
             if (request.Path.Value.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
             {
                 var response = context.HttpContext.Response;
-                response.StatusCode = StatusCodes.Status301MovedPermanently;
+                response.StatusCode = (int) HttpStatusCode.MovedPermanently;
                 context.Result = RuleResult.EndResponse;
                 response.Headers[HeaderNames.Location] = 
                     "/xmlfiles" + request.Path + request.QueryString;
@@ -86,7 +87,7 @@ namespace RewriteRules
             if (request.Path.Value.EndsWith(_extension, StringComparison.OrdinalIgnoreCase))
             {
                 var response = context.HttpContext.Response;
-                response.StatusCode = StatusCodes.Status301MovedPermanently;
+                response.StatusCode = (int) HttpStatusCode.MovedPermanently;
                 context.Result = RuleResult.EndResponse;
                 response.Headers[HeaderNames.Location] = 
                     _newPath + request.Path + request.QueryString;

--- a/aspnetcore/fundamentals/url-rewriting/samples/3.x/SampleApp/RewriteRules.cs
+++ b/aspnetcore/fundamentals/url-rewriting/samples/3.x/SampleApp/RewriteRules.cs
@@ -1,4 +1,5 @@
 using System;
+using Sytem.Net;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Rewrite;
@@ -23,7 +24,7 @@ namespace RewriteRules
             if (request.Path.Value.EndsWith(".xml", StringComparison.OrdinalIgnoreCase))
             {
                 var response = context.HttpContext.Response;
-                response.StatusCode = StatusCodes.Status301MovedPermanently;
+                response.StatusCode = (int) HttpStatusCode.MovedPermanently;
                 context.Result = RuleResult.EndResponse;
                 response.Headers[HeaderNames.Location] = 
                     "/xmlfiles" + request.Path + request.QueryString;
@@ -86,7 +87,7 @@ namespace RewriteRules
             if (request.Path.Value.EndsWith(_extension, StringComparison.OrdinalIgnoreCase))
             {
                 var response = context.HttpContext.Response;
-                response.StatusCode = StatusCodes.Status301MovedPermanently;
+                response.StatusCode = (int) HttpStatusCode.MovedPermanently;
                 context.Result = RuleResult.EndResponse;
                 response.Headers[HeaderNames.Location] = 
                     _newPath + request.Path + request.QueryString;

--- a/aspnetcore/fundamentals/websockets/samples/1.x/WebSocketsSample/Startup.cs
+++ b/aspnetcore/fundamentals/websockets/samples/1.x/WebSocketsSample/Startup.cs
@@ -60,7 +60,7 @@ namespace EchoApp
                     }
                     else
                     {
-                        context.Response.StatusCode = 400;
+                        context.Response.StatusCode = (int) HttpStatusCode.BadRequest;
                     }
                 }
                 else

--- a/aspnetcore/fundamentals/websockets/samples/2.x/WebSocketsSample/Startup.cs
+++ b/aspnetcore/fundamentals/websockets/samples/2.x/WebSocketsSample/Startup.cs
@@ -82,7 +82,7 @@ namespace EchoApp
                     }
                     else
                     {
-                        context.Response.StatusCode = 400;
+                        context.Response.StatusCode = (int) HttpStatusCode.BadRequest;
                     }
                 }
                 else

--- a/aspnetcore/mvc/controllers/filters/3.1sample/FiltersSample/Filters/UnprocessableResultFilter.cs
+++ b/aspnetcore/mvc/controllers/filters/3.1sample/FiltersSample/Filters/UnprocessableResultFilter.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
+using System.Net;
 
 namespace FiltersSample.Filters
 {
@@ -10,11 +11,11 @@ namespace FiltersSample.Filters
         public void OnResultExecuting(ResultExecutingContext context)
         {
             if (context.Result is StatusCodeResult statusCodeResult &&
-                statusCodeResult.StatusCode == 415)
+                statusCodeResult.StatusCode == (int) HttpStatusCode.UnsupportedMediaType)
             {
                 context.Result = new ObjectResult("Can't process this!")
                 {
-                    StatusCode = 422,
+                    StatusCode = (int) HttpStatusCode.UnsupportedMediaType,
                 };
             }
         }

--- a/aspnetcore/mvc/controllers/filters/sample/FiltersSample/Filters/UnprocessableResultFilter.cs
+++ b/aspnetcore/mvc/controllers/filters/sample/FiltersSample/Filters/UnprocessableResultFilter.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
+using System.Net;
 
 namespace FiltersSample.Filters
 {
@@ -10,11 +11,11 @@ namespace FiltersSample.Filters
         public void OnResultExecuting(ResultExecutingContext context)
         {
             if (context.Result is StatusCodeResult statusCodeResult &&
-                statusCodeResult.StatusCode == 415)
+                statusCodeResult.StatusCode == (int) HttpStatusCode.UnsupportedMediaType)
             {
                 context.Result = new ObjectResult("Can't process this!")
                 {
-                    StatusCode = 422,
+                    StatusCode = (int) HttpStatusCode.UnsupportedMediaType,
                 };
             }
         }

--- a/aspnetcore/security/anti-request-forgery/sample/AngularSample/Startup.cs
+++ b/aspnetcore/security/anti-request-forgery/sample/AngularSample/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -61,7 +62,7 @@ public void Configure(IApplicationBuilder app,
                         repository.Add(item);
                     }
 
-                    context.Response.StatusCode = 204;
+                    context.Response.StatusCode = (int) HttpStatusCode.NoContent;
                 }
             }));
         }

--- a/aspnetcore/security/anti-request-forgery/sample/Javascript/Startup.cs
+++ b/aspnetcore/security/anti-request-forgery/sample/Javascript/Startup.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -63,7 +64,7 @@ namespace Javascript
                     var item = JsonSerializer.Deserialize<TodoItem>(json);
                     repository.Add(item);
 
-                    context.Response.StatusCode = 204;
+                    context.Response.StatusCode = (int) HttpStatusCode.NoContent;
                 });
             });
         }

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -185,7 +185,7 @@ public void ConfigureServices(IServiceCollection services)
     {
         services.AddHttpsRedirection(options =>
         {
-            options.RedirectStatusCode = StatusCodes.Status308PermanentRedirect;
+            options.RedirectStatusCode = (int) HttpStatusCode.PermanentRedirect;
             options.HttpsPort = 443;
         });
     }
@@ -206,7 +206,7 @@ public void ConfigureServices(IServiceCollection services)
     {
         services.AddHttpsRedirection(options =>
         {
-            options.RedirectStatusCode = StatusCodes.Status308PermanentRedirect;
+            options.RedirectStatusCode = (int) HttpStatusCode.MovedPermanently;
             options.HttpsPort = 443;
         });
     }

--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/2.x/Startup.cs
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/2.x/Startup.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Net;
 
 namespace WebHTTPS
 {
@@ -32,7 +33,7 @@ namespace WebHTTPS
 
             services.AddHttpsRedirection(options =>
             {
-                options.RedirectStatusCode = StatusCodes.Status307TemporaryRedirect;
+                options.RedirectStatusCode = (int) HttpStatusCode.TemporaryRedirect;
                 options.HttpsPort = 5001;
             });
         }

--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/3.x/Startup.cs
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/3.x/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -38,7 +39,7 @@ namespace WebHTTPS
 
             services.AddHttpsRedirection(options =>
             {
-                options.RedirectStatusCode = StatusCodes.Status307TemporaryRedirect;
+                options.RedirectStatusCode = (int) HttpStatusCode.TemporaryRedirect;
                 options.HttpsPort = 5001;
             });
         }

--- a/aspnetcore/security/ip-safelist/samples/Shared/ClientIpSafelistComponents/Middlewares/AdminSafeListMiddleware.cs
+++ b/aspnetcore/security/ip-safelist/samples/Shared/ClientIpSafelistComponents/Middlewares/AdminSafeListMiddleware.cs
@@ -52,7 +52,7 @@ namespace ClientIpSafelistComponents.Middlewares
                 {
                     _logger.LogWarning(
                         "Forbidden Request from Remote IP address: {RemoteIp}", remoteIp);
-                    context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                    context.Response.StatusCode = (int) HttpStatusCode.Forbidden;
                     return;
                 }
             }

--- a/aspnetcore/signalr/security/sample/Startup.cs
+++ b/aspnetcore/signalr/security/sample/Startup.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace SignalR_CORS
@@ -73,7 +74,7 @@ namespace SignalR_CORS
                     if (!string.IsNullOrEmpty(origin) && !_allowedOrigins.Contains(origin))
                     {
                         // The origin is not allowed, reject the request
-                        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                        context.Response.StatusCode = (int) HttpStatusCode.Forbidden;
                         return Task.CompletedTask;
                     }
                 }

--- a/aspnetcore/web-api/route-to-code/sample/Startup2.cs
+++ b/aspnetcore/web-api/route-to-code/sample/Startup2.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace WebR2C
@@ -41,14 +42,14 @@ namespace WebR2C
                 {
                     if (!context.Request.HasJsonContentType())
                     {
-                        context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
+                        context.Response.StatusCode = (int) HttpStatusCode.UnsupportedMediaType;
                         return;
                     }
 
                     var weather = await context.Request.ReadFromJsonAsync<WeatherForecast>();
                     await UpdateDatabaseAsync(weather);
 
-                    context.Response.StatusCode = StatusCodes.Status202Accepted;
+                    context.Response.StatusCode = (int) HttpStatusCode.Accepted;
                 });
             });
             #endregion


### PR DESCRIPTION
Fixes #22115.

Created on @Rick-Anderson suggestion in #22114.

I have also replaced all `StatusCodes` references to `HttpStatusCode` so the code is consistent in the documentation. If this is not right just comment and I will revert the last commit and remove only hardcoded status codes.