### PR TITLE
Remove EF warning on cache

### DIFF
--- a/aspnetcore/performance/caching/memory.md
+++ b/aspnetcore/performance/caching/memory.md
@@ -51,7 +51,7 @@ Use `System.Runtime.Caching`/`MemoryCache` as a compatibility bridge when portin
 > [!WARNING]
 > Using a *shared* memory cache from [Dependency Injection](xref:fundamentals/dependency-injection) and calling `SetSize`, `Size`, or `SizeLimit` to limit cache size can cause the app to fail. When a size limit is set on a cache, all entries must specify a size when being added. This can lead to issues since developers may not have full control on what uses the shared cache.
 > When using `SetSize`, `Size`, or `SizeLimit` to limit cache, create a cache singleton for caching. For more information and an example, see [Use SetSize, Size, and SizeLimit to limit cache size](#use-setsize-size-and-sizelimit-to-limit-cache-size).
-> A shared cache is one shared by other frameworks or libraries. For example, EF Core uses the shared cache and does not specify a size.
+> A shared cache is one shared by other frameworks or libraries. For example, EF Core uses the shared cache and specifies a size.
 
 In-memory caching is a *service* that's referenced from an app using [Dependency Injection](xref:fundamentals/dependency-injection). Request the `IMemoryCache` instance in the constructor:
 

--- a/aspnetcore/performance/caching/memory.md
+++ b/aspnetcore/performance/caching/memory.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to cache data in memory in ASP.NET Core.
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/02/2020
+ms.date: 4/27/2021
 no-loc: [appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: performance/caching/memory
 ---
@@ -49,9 +49,9 @@ Use `System.Runtime.Caching`/`MemoryCache` as a compatibility bridge when portin
 ## Use IMemoryCache
 
 > [!WARNING]
-> Using a *shared* memory cache from [Dependency Injection](xref:fundamentals/dependency-injection) and calling `SetSize`, `Size`, or `SizeLimit` to limit cache size can cause the app to fail. When a size limit is set on a cache, all entries must specify a size when being added. This can lead to issues since developers may not have full control on what uses the shared cache. For example, Entity Framework Core uses the shared cache and does not specify a size. If an app sets a cache size limit and uses EF Core, the app throws an `InvalidOperationException`.
+> Using a *shared* memory cache from [Dependency Injection](xref:fundamentals/dependency-injection) and calling `SetSize`, `Size`, or `SizeLimit` to limit cache size can cause the app to fail. When a size limit is set on a cache, all entries must specify a size when being added. This can lead to issues since developers may not have full control on what uses the shared cache.
 > When using `SetSize`, `Size`, or `SizeLimit` to limit cache, create a cache singleton for caching. For more information and an example, see [Use SetSize, Size, and SizeLimit to limit cache size](#use-setsize-size-and-sizelimit-to-limit-cache-size).
-> A shared cache is one shared by other frameworks or libraries. For example, EF Core uses the shared cache and does not specify a size. 
+> A shared cache is one shared by other frameworks or libraries. For example, EF Core uses the shared cache and does not specify a size.
 
 In-memory caching is a *service* that's referenced from an app using [Dependency Injection](xref:fundamentals/dependency-injection). Request the `IMemoryCache` instance in the constructor:
 


### PR DESCRIPTION
Fixes #22142
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/performance/caching/memory?view=aspnetcore-5.0&branch=pr-en-us-22145#use-imemorycache)