### PR TITLE
Use relative path in NavigateTo

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -231,7 +231,7 @@ The following component shows an example of how to perform the initial redirecti
         var query = $"?culture={Uri.EscapeDataString(culture)}&" +
             $"redirectUri={Uri.EscapeDataString(uri)}";
 
-        NavigationManager.NavigateTo("/Culture/SetCulture" + query, forceLoad: true);
+        NavigationManager.NavigateTo("Culture/SetCulture" + query, forceLoad: true);
     }
 }
 ```

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -231,11 +231,12 @@ The following component shows an example of how to perform the initial redirecti
         var query = $"?culture={Uri.EscapeDataString(culture)}&" +
             $"redirectUri={Uri.EscapeDataString(uri)}";
 
-        NavigationManager.NavigateTo("Culture/SetCulture" + query, forceLoad: true);
+        NavigationManager.NavigateTo("/Culture/SetCulture" + query, forceLoad: true);
     }
 }
 ```
 
 ## Additional resources
 
+* [Set the app base path](xref:blazor/host-and-deploy/index#app-base-path)
 * <xref:fundamentals/localization>


### PR DESCRIPTION
In the code snippet provided as example of doing redirection for user selected culture, there was a NavigateTo with absolute path. This doesn't work if the app is behind a reverse proxy in some virtual subfolder.
