### PR TITLE
Blazor CSS isolation stylesheet link clarification

### DIFF
--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -59,7 +59,7 @@ Within the bundled file, each component is associated with a scope identifier. F
 <h1 b-3xxtam6d07>
 ```
 
-The `ProjectName.styles.css` file uses the scope identifier to group a style declaration with its component. The following example provides the style for the preceding `<h1>` element:
+The `AssemblyName.styles.css` file uses the scope identifier to group a style declaration with its component. The following example provides the style for the preceding `<h1>` element:
 
 ```css
 /* /Pages/Counter.razor.rz.scp.css */

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -43,17 +43,15 @@ h1 {
 > [!NOTE]
 > In order to guarantee style isolation when bundling occurs, importing CSS in Razor code blocks isn't supported.
 
-These styles are made available at build time in a bundled static CSS file. Add this reference inside the `<head>` tag of the HTML in your root page (usually index.html): 
+## CSS isolation bundling
+
+CSS isolation occurs at build time. During this process, Blazor rewrites CSS selectors to match markup rendered by the component. These rewritten CSS styles are bundled and produced as a static asset at `{ASSEMBLY NAME}.styles.css`, where the placeholder `{ASSEMBLY NAME}` is the referenced name of the package or project's assembly. Note that `{ASSEMBLY NAME}` may include ".Client" and not just the solution's name.
+
+These static files are referenced from the root path of the app by default. In the app, reference the bundled file by including the reference inside the `<head>` tag of the root page HTML (usually index.html; this is done for you when using the default Visual Studio templates for a Blazor project):
 
 ```html
 <link href="AssemblyName.styles.css" rel="stylesheet">
 ```
-
-## CSS isolation bundling
-
-CSS isolation occurs at build time. During this process, Blazor rewrites CSS selectors to match markup rendered by the component. These rewritten CSS styles are bundled and produced as a static asset at `{ASSEMBLY NAME}.styles.css`, where the placeholder `{ASSEMBLY NAME}` is the referenced name of the package or project's assembly.
-
-These static files should be referenced from the root path of the app by default, as noted above in "Enable CSS Isolation".
 
 Within the bundled file, each component is associated with a scope identifier. For each styled component, an HTML attribute is appended with the format `b-<10-character-string>`. The identifier is unique and different for each app. In the rendered `Counter` component, Blazor appends a scope identifier to the `h1` element:
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -43,15 +43,17 @@ h1 {
 > [!NOTE]
 > In order to guarantee style isolation when bundling occurs, importing CSS in Razor code blocks isn't supported.
 
-## CSS isolation bundling
-
-CSS isolation occurs at build time. During this process, Blazor rewrites CSS selectors to match markup rendered by the component. These rewritten CSS styles are bundled and produced as a static asset at `{ASSEMBLY NAME}.styles.css`, where the placeholder `{ASSEMBLY NAME}` is the referenced name of the package or project's assembly.
-
-These static files are referenced from the root path of the app by default. In the app, reference the bundled file by inspecting the reference inside the `<head>` tag of the generated HTML:
+These styles are made available at build time in a static CSS file which should be referenced from the root static page of the app. In the app, reference the bundled file by adding this reference inside the `<head>` tag of the HTML in your root static page (usually index.html): 
 
 ```html
 <link href="AssemblyName.styles.css" rel="stylesheet">
 ```
+
+## CSS isolation bundling
+
+CSS isolation occurs at build time. During this process, Blazor rewrites CSS selectors to match markup rendered by the component. These rewritten CSS styles are bundled and produced as a static asset at `{ASSEMBLY NAME}.styles.css`, where the placeholder `{ASSEMBLY NAME}` is the referenced name of the package or project's assembly.
+
+These static files should be referenced from the root path of the app by default, as noted above, in "Enable CSS Isolation".
 
 Within the bundled file, each component is associated with a scope identifier. For each styled component, an HTML attribute is appended with the format `b-<10-character-string>`. The identifier is unique and different for each app. In the rendered `Counter` component, Blazor appends a scope identifier to the `h1` element:
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -43,7 +43,7 @@ h1 {
 > [!NOTE]
 > In order to guarantee style isolation when bundling occurs, importing CSS in Razor code blocks isn't supported.
 
-These styles are made available at build time in a static CSS file which should be referenced from the root static page of the app. In the app, reference the bundled file by adding this reference inside the `<head>` tag of the HTML in your root static page (usually index.html): 
+These styles at build time are made available in a bundled static CSS file which must be referenced from the root page of the app. Reference the bundled file by adding this reference inside the `<head>` tag of the HTML in your root page (usually index.html): 
 
 ```html
 <link href="AssemblyName.styles.css" rel="stylesheet">
@@ -53,7 +53,7 @@ These styles are made available at build time in a static CSS file which should 
 
 CSS isolation occurs at build time. During this process, Blazor rewrites CSS selectors to match markup rendered by the component. These rewritten CSS styles are bundled and produced as a static asset at `{ASSEMBLY NAME}.styles.css`, where the placeholder `{ASSEMBLY NAME}` is the referenced name of the package or project's assembly.
 
-These static files should be referenced from the root path of the app by default, as noted above, in "Enable CSS Isolation".
+These static files should be referenced from the root path of the app by default, as noted above in "Enable CSS Isolation".
 
 Within the bundled file, each component is associated with a scope identifier. For each styled component, an HTML attribute is appended with the format `b-<10-character-string>`. The identifier is unique and different for each app. In the rendered `Counter` component, Blazor appends a scope identifier to the `h1` element:
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -63,7 +63,7 @@ Within the bundled file, each component is associated with a scope identifier. F
 <h1 b-3xxtam6d07>
 ```
 
-The `AssemblyName.styles.css` file uses the scope identifier to group a style declaration with its component. The following example provides the style for the preceding `<h1>` element:
+The `{ASSEMBLY NAME}.styles.css` file uses the scope identifier to group a style declaration with its component. The following example provides the style for the preceding `<h1>` element:
 
 ```css
 /* /Pages/Counter.razor.rz.scp.css */
@@ -157,7 +157,7 @@ By default, scope identifiers use the format `b-<10-character-string>`. To custo
 </ItemGroup>
 ```
 
-In the preceding example, the CSS generated for `Example.Razor.css` changes its scope identifier from `b-<10-character-string>` to `my-custom-scope-identifier`.
+In the preceding example, the CSS generated for `Example.razor.css` changes its scope identifier from `b-<10-character-string>` to `my-custom-scope-identifier`.
 
 Use scope identifiers to achieve inheritance with scoped CSS files. In the following project file example, a `BaseComponent.razor.css` file contains common styles across components. A `DerivedComponent.razor.css` file inherits these styles.
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -51,7 +51,7 @@ CSS isolation occurs at build time. Blazor rewrites CSS selectors to match marku
 <link href="{ASSEMBLY NAME}.styles.css" rel="stylesheet">
 ```
 
-The following example is from a hosted Blazor WebAssembly **`Client`** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor WebAssembly project template when the project is created with the Hosted option (`-ho|--hosted` option using the .NET CLI or **ASP.NET Core hosted** check box using Visual Studio):
+The following example is from a hosted Blazor WebAssembly **`Client`** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor WebAssembly project template when the project is created with the Hosted option (`-ho|--hosted` option using the .NET CLI or **ASP.NET Core hosted** checkbox using Visual Studio):
 
 ```html
 <link href="BlazorSample.Client.styles.css" rel="stylesheet">

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -45,12 +45,16 @@ h1 {
 
 ## CSS isolation bundling
 
-CSS isolation occurs at build time. During this process, Blazor rewrites CSS selectors to match markup rendered by the component. These rewritten CSS styles are bundled and produced as a static asset at `{ASSEMBLY NAME}.styles.css`, where the placeholder `{ASSEMBLY NAME}` is the referenced name of the package or project's assembly. Note that `{ASSEMBLY NAME}` may include ".Client" and not just the solution's name.
-
-These static files are referenced from the root path of the app by default. In the app, reference the bundled file by including the reference inside the `<head>` tag of the root page HTML (usually index.html; this is done for you when using the default Visual Studio templates for a Blazor project):
+CSS isolation occurs at build time. Blazor rewrites CSS selectors to match markup rendered by the component. The rewritten CSS styles are bundled and produced as a static asset. The stylesheet is referenced inside the `<head>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server). The following `<link>` element is added by default to an app created from the Blazor project templates, where the placeholder `{ASSEMBLY NAME}` is the project's assembly name:
 
 ```html
-<link href="AssemblyName.styles.css" rel="stylesheet">
+<link href="{ASSEMBLY NAME}.styles.css" rel="stylesheet">
+```
+
+The following example is from a hosted Blazor WebAssembly **`Client`** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor hosted WebAssembly project template when the project is created:
+
+```html
+<link href="BlazorSample.Client.styles.css" rel="stylesheet">
 ```
 
 Within the bundled file, each component is associated with a scope identifier. For each styled component, an HTML attribute is appended with the format `b-<10-character-string>`. The identifier is unique and different for each app. In the rendered `Counter` component, Blazor appends a scope identifier to the `h1` element:

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -51,7 +51,7 @@ CSS isolation occurs at build time. Blazor rewrites CSS selectors to match marku
 <link href="{ASSEMBLY NAME}.styles.css" rel="stylesheet">
 ```
 
-The following example is from a hosted Blazor WebAssembly **`Client`** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor hosted WebAssembly project template when the project is created:
+The following example is from a hosted Blazor WebAssembly **`Client`** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor WebAssembly project template when the project is created with the Hosted option (`-ho|--hosted` option using the .NET CLI or **ASP.NET Core hosted** check box using Visual Studio):
 
 ```html
 <link href="BlazorSample.Client.styles.css" rel="stylesheet">

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -43,7 +43,7 @@ h1 {
 > [!NOTE]
 > In order to guarantee style isolation when bundling occurs, importing CSS in Razor code blocks isn't supported.
 
-These styles at build time are made available in a bundled static CSS file which must be referenced from the root page of the app. Reference the bundled file by adding this reference inside the `<head>` tag of the HTML in your root page (usually index.html): 
+These styles are made available at build time in a bundled static CSS file. Add this reference inside the `<head>` tag of the HTML in your root page (usually index.html): 
 
 ```html
 <link href="AssemblyName.styles.css" rel="stylesheet">


### PR DESCRIPTION
Fixed missing instruction that rose to issue #22177 and this SO post: https://stackoverflow.com/questions/65057537/why-blazor-css-isolation-not-adding-the-link-tag-to-load-the-bundled-css-file



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->