### PR TITLE
modified documentation for customize identity model

### DIFF
--- a/aspnetcore/performance/caching/response.md
+++ b/aspnetcore/performance/caching/response.md
@@ -49,7 +49,7 @@ The [HTTP 1.1 Caching specification for the Cache-Control header](https://tools.
 
 Always honoring client `Cache-Control` request headers makes sense if you consider the goal of HTTP caching. Under the official specification, caching is meant to reduce the latency and network overhead of satisfying requests across a network of clients, proxies, and servers. It isn't necessarily a way to control the load on an origin server.
 
-There's no developer control over this caching behavior when using the [Response Caching Middleware](xref:performance/caching/middleware) because the middleware adheres to the official caching specification. [Planned enhancements to the middleware](https://github.com/dotnet/AspNetCore/issues/2612) are an opportunity to configure the middleware to ignore a request's `Cache-Control` header when deciding to serve a cached response. Planned enhancements provide an opportunity to better control server load.
+There's no developer control over this caching behavior when using the [Response Caching Middleware](xref:performance/caching/middleware) because the middleware adheres to the official caching specification. Support for *output caching* to better control server load is a design proposal for a future release of ASP.NET Core. For more information, see [Add support for Output Caching (dotnet/aspnetcore #27387)](https://github.com/dotnet/aspnetcore/issues/27387).
 
 ## Other caching technology in ASP.NET Core
 

--- a/aspnetcore/security/authentication/customize-identity-model.md
+++ b/aspnetcore/security/authentication/customize-identity-model.md
@@ -349,7 +349,7 @@ services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireCo
         .AddEntityFrameworkStores<ApplicationDbContext>();                                    
 ```
 
-Calling <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionUIExtensions.AddDefaultIdentity%2A> is equivalent to the following,
+Calling <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionUIExtensions.AddDefaultIdentity%2A> is equivalent to the following code:
 
 ```csharp
 services.AddAuthentication(o =>

--- a/aspnetcore/security/authentication/customize-identity-model.md
+++ b/aspnetcore/security/authentication/customize-identity-model.md
@@ -351,7 +351,7 @@ services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireCo
         .AddEntityFrameworkStores<ApplicationDbContext>();                                    
 ```
 
-`AddDefaultIdentity<TUser>` is equivalent to the following,
+Calling `AddDefaultIdentity<TUser>()` is equivalent to the following,
 
 ```csharp
 services.AddAuthentication(o =>
@@ -372,7 +372,7 @@ services.AddIdentityCore<TUser>(o =>
 
 ::: moniker-end
 
-In ASP.NET Core 2.1 or later, Identity is provided as a Razor Class Library. For more information, see <xref:security/authentication/scaffold-identity>. Consequently, the preceding code requires a call to <xref:Microsoft.AspNetCore.Identity.IdentityBuilderUIExtensions.AddDefaultUI\*>. If the Identity scaffolder was used to add Identity files to the project, remove the call to `AddDefaultUI`. For more information, see:
+Identity is provided as a Razor Class Library. For more information, see <xref:security/authentication/scaffold-identity>. Consequently, the preceding code requires a call to <xref:Microsoft.AspNetCore.Identity.IdentityBuilderUIExtensions.AddDefaultUI\*>. If the Identity scaffolder was used to add Identity files to the project, remove the call to `AddDefaultUI`. For more information, see:
 
 * [Scaffold Identity](xref:security/authentication/scaffold-identity)
 * [Add, download, and delete custom user data to Identity](xref:security/authentication/add-user-data)
@@ -386,7 +386,7 @@ Follow these steps to change the PK type:
 1. If the database was created before the PK change, run `Drop-Database` (PMC) or `dotnet ef database drop` (.NET Core CLI) to delete it.
 2. After confirming deletion of the database, remove the initial migration with `Remove-Migration` (PMC) or `dotnet ef migrations remove` (.NET Core CLI).
 3. Update the `ApplicationDbContext` class to derive from <xref:Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityDbContext%603>. Specify the new key type for `TKey`. For example, to use a `Guid` key type:
-
+ 
    ```csharp
    public class ApplicationDbContext
        : IdentityDbContext<IdentityUser<Guid>, IdentityRole<Guid>, Guid>
@@ -398,30 +398,18 @@ Follow these steps to change the PK type:
    }
    ```
 
-   ::: moniker range=">= aspnetcore-2.0 <= aspnetcore-5.0"
-
    In the preceding code, the generic classes <xref:Microsoft.AspNetCore.Identity.IdentityUser%601> and <xref:Microsoft.AspNetCore.Identity.IdentityRole%601> must be specified to use the new key type.
 
-   ::: moniker-end
-
    `Startup.ConfigureServices` must be updated to use the generic user:
-
-   ::: moniker range=">= aspnetcore-2.1 <= aspnetcore-5.0"
 
    ```csharp
    services.AddDefaultIdentity<IdentityUser<Guid>>(options => options.SignIn.RequireConfirmedAccount = true)
            .AddEntityFrameworkStores<ApplicationDbContext>();
    ```
 
-   ::: moniker-end
-
 4. If a custom `ApplicationUser` class is being used, update the class to inherit from `IdentityUser`. For example:
 
-   ::: moniker range=">= aspnetcore-2.1 <= aspnetcore-5.0"
-
    [!code-csharp[](customize-identity-model/samples/2.1/RazorPagesSampleApp/Data/ApplicationUser.cs?name=snippet_ApplicationUser&highlight=4)]
-
-   ::: moniker-end
 
    Update `ApplicationDbContext` to reference the custom `ApplicationUser` class:
 
@@ -438,8 +426,6 @@ Follow these steps to change the PK type:
 
    Register the custom database context class when adding the Identity service in `Startup.ConfigureServices`:
 
-   ::: moniker range=">= aspnetcore-2.1 <= aspnetcore-5.0"
-
    ```csharp
    services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
            .AddEntityFrameworkStores<ApplicationDbContext>();
@@ -447,17 +433,13 @@ Follow these steps to change the PK type:
 
    The primary key's data type is inferred by analyzing the [DbContext](/dotnet/api/microsoft.entityframeworkcore.dbcontext) object.
 
-   In ASP.NET Core 2.1 or later, Identity is provided as a Razor Class Library. For more information, see <xref:security/authentication/scaffold-identity>. Consequently, the preceding code requires a call to <xref:Microsoft.AspNetCore.Identity.IdentityBuilderUIExtensions.AddDefaultUI\*>. If the Identity scaffolder was used to add Identity files to the project, remove the call to `AddDefaultUI`.
-
-   ::: moniker-end
+   Identity is provided as a Razor Class Library. For more information, see <xref:security/authentication/scaffold-identity>. Consequently, the preceding code requires a call to <xref:Microsoft.AspNetCore.Identity.IdentityBuilderUIExtensions.AddDefaultUI\*>. If the Identity scaffolder was used to add Identity files to the project, remove the call to `AddDefaultUI`.
 
 5. If a custom `ApplicationRole` class is being used, update the class to inherit from `IdentityRole<TKey>`. For example:
 
    [!code-csharp[](customize-identity-model/samples/2.1/RazorPagesSampleApp/Data/ApplicationRole.cs?name=snippet_ApplicationRole&highlight=4)]
 
    Update `ApplicationDbContext` to reference the custom `ApplicationRole` class. For example, the following class references a custom `ApplicationUser` and a custom `ApplicationRole`:
-
-   ::: moniker range=">= aspnetcore-2.1 <= aspnetcore-5.0"
 
    [!code-csharp[](customize-identity-model/samples/2.1/RazorPagesSampleApp/Data/ApplicationDbContext.cs?name=snippet_ApplicationDbContext&highlight=5-6)]
 
@@ -468,8 +450,6 @@ Follow these steps to change the PK type:
    The primary key's data type is inferred by analyzing the [DbContext](/dotnet/api/microsoft.entityframeworkcore.dbcontext) object.
 
    In ASP.NET Core 2.1 or later, Identity is provided as a Razor Class Library. For more information, see <xref:security/authentication/scaffold-identity>. Consequently, the preceding code requires a call to <xref:Microsoft.AspNetCore.Identity.IdentityBuilderUIExtensions.AddDefaultUI\*>. If the Identity scaffolder was used to add Identity files to the project, remove the call to `AddDefaultUI`.
-
-   ::: moniker-end
 
 ### Add navigation properties
 
@@ -887,8 +867,6 @@ protected override void OnModelCreating(ModelBuilder modelBuilder)
 }
 ```
 
-::: moniker range=">= aspnetcore-2.1"
-
 ### Lazy loading
 
 In this section, support for lazy-loading proxies in the Identity model is added. Lazy-loading is useful since it allows navigation properties to be used without first ensuring they're loaded.
@@ -915,5 +893,3 @@ Refer to the preceding examples for guidance on adding navigation properties to 
 ## Additional resources
 
 * <xref:security/authentication/scaffold-identity>
-
-::: moniker-end

--- a/aspnetcore/security/authentication/customize-identity-model.md
+++ b/aspnetcore/security/authentication/customize-identity-model.md
@@ -344,14 +344,12 @@ Update *Pages/Shared/_LoginPartial.cshtml* and replace `IdentityUser` with `Appl
 
 Update *Areas/Identity/IdentityHostingStartup.cs* or `Startup.ConfigureServices` and replace `IdentityUser` with `ApplicationUser`.
 
-::: moniker range=">= aspnetcore-2.1 <= aspnetcore-5.0"
-
 ```csharp
 services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
         .AddEntityFrameworkStores<ApplicationDbContext>();                                    
 ```
 
-Calling `AddDefaultIdentity<TUser>()` is equivalent to the following,
+Calling <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionUIExtensions.AddDefaultIdentity%2A> is equivalent to the following,
 
 ```csharp
 services.AddAuthentication(o =>
@@ -368,9 +366,7 @@ services.AddIdentityCore<TUser>(o =>
 })
 .AddDefaultUI()
 .AddDefaultTokenProviders();
-```                
-
-::: moniker-end
+```
 
 Identity is provided as a Razor Class Library. For more information, see <xref:security/authentication/scaffold-identity>. Consequently, the preceding code requires a call to <xref:Microsoft.AspNetCore.Identity.IdentityBuilderUIExtensions.AddDefaultUI\*>. If the Identity scaffolder was used to add Identity files to the project, remove the call to `AddDefaultUI`. For more information, see:
 
@@ -449,7 +445,7 @@ Follow these steps to change the PK type:
 
    The primary key's data type is inferred by analyzing the [DbContext](/dotnet/api/microsoft.entityframeworkcore.dbcontext) object.
 
-   In ASP.NET Core 2.1 or later, Identity is provided as a Razor Class Library. For more information, see <xref:security/authentication/scaffold-identity>. Consequently, the preceding code requires a call to <xref:Microsoft.AspNetCore.Identity.IdentityBuilderUIExtensions.AddDefaultUI\*>. If the Identity scaffolder was used to add Identity files to the project, remove the call to `AddDefaultUI`.
+   Identity is provided as a Razor Class Library. For more information, see <xref:security/authentication/scaffold-identity>. Consequently, the preceding code requires a call to <xref:Microsoft.AspNetCore.Identity.IdentityBuilderUIExtensions.AddDefaultUI%2A>. If the Identity scaffolder was used to add Identity files to the project, remove the call to `AddDefaultUI`.
 
 ### Add navigation properties
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/22179

@Rick-Anderson I did a lot of modifications. I do think that at this point we don't even need the `moniker range=">= aspnetcore-2.1 <= aspnetcore-5.0"` since I removed everything for `1.1` and `2.0`. And from 2.1 to 5.0 the snippets are all same. 

Please review.