### PR TITLE
#22206 Reference Client ID and Secret detail from Azure Dashboard

### DIFF
--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -44,7 +44,7 @@ The URI segment `/signin-microsoft` is set as the default callback of the Micros
 
 ## Store the Microsoft client ID and secret
 
-Store sensitive settings such as the Microsoft client ID and secret values with [Secret Manager](xref:security/app-secrets). For this sample, use the following steps:
+Store sensitive settings such as the Microsoft **Application (client) ID** found on the **Overview** page of the App Registration and **Client Secret** you created on the **Certificates & secrets page** with [Secret Manager](xref:security/app-secrets). For this sample, use the following steps:
 
 1. Initialize the project for secret storage per the instructions at [Enable secret storage](xref:security/app-secrets#enable-secret-storage).
 1. Store the sensitive settings in the local secret store with the secret keys `Authentication:Microsoft:ClientId` and `Authentication:Microsoft:ClientSecret`:


### PR DESCRIPTION
Fixes #22206

App Registration in Azure Dashboard displays multiple values that could be understood as "Client ID": in particular the "ID" field of the "Client Secret" which is actually the Secret ID. This change edits the text to make the description more detailed (although this is somewhat at the expense of becoming outdated quicker when Azure Dashboard UX changes).

The "perfect" fix would have been to make both "Client ID" and "Client Secret" into hyperlinks that go to Azure documentation for the App Registration (with corresponding anchors) and explain what those values are, where they are on the dashboard, and show screenshots. This kind of documentation doesn't exist as far as I know, so it can't be linked to.

I bolded field names and tab names as is common in most product documentation, if that's not OK I can revert back to plain formatting.

Also note that I used "you" to refer to the user, but there are multiple instances of that on this same page, so I assume that's still OK as well.