### PR TITLE
Link to Kestrel endpoints HTTPS from gRPC docs

### DIFF
--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -107,7 +107,7 @@ Alternatively, Kestrel endpoints can be configured in *Program.cs*:
 
 [!code-csharp[](~/grpc/aspnetcore/sample/Program.cs?highlight=7&name=snippet)]
 
-For more information about TLS options in Kestrel, see [configure Kestrel endpoints with HTTPS](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps).
+For more information on enabling TLS with Kestrel, see [Kestrel HTTPS endpoint configuration](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps).
 
 ### Protocol negotiation
 
@@ -162,6 +162,8 @@ In production, TLS must be explicitly configured. In the following *appsettings.
 Alternatively, Kestrel endpoints can be configured in *Program.cs*:
 
 [!code-csharp[](~/grpc/aspnetcore/sample/Program.cs?highlight=7&name=snippet)]
+
+For more information on enabling TLS with Kestrel, see [Kestrel HTTPS endpoint configuration](xref:fundamentals/servers/kestrel#listenoptionsusehttps).
 
 ### Protocol negotiation
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -107,6 +107,8 @@ Alternatively, Kestrel endpoints can be configured in *Program.cs*:
 
 [!code-csharp[](~/grpc/aspnetcore/sample/Program.cs?highlight=7&name=snippet)]
 
+For more information about TLS options in Kestrel, see [configure Kestrel endpoints with HTTPS](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps).
+
 ### Protocol negotiation
 
 TLS is used for more than securing communication. The TLS [Application-Layer Protocol Negotiation (ALPN)](https://tools.ietf.org/html/rfc7301#section-3) handshake is used to negotiate the connection protocol between the client and the server when an endpoint supports multiple protocols. This negotiation determines whether the connection uses HTTP/1.1 or HTTP/2.


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/16959

(I think some conditional sections might be needed here because the Kestrel page was restructured in .NET 5)