### PR TITLE
refactor: remove always true condition

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -301,9 +301,9 @@ public class CustomUserFactory
         if (user.Identity.IsAuthenticated)
         {
             var identity = (ClaimsIdentity)user.Identity;
-            var roleClaims = identity.FindAll(identity.RoleClaimType).ToArray();
+            var roleClaims = identity.FindAll(identity.RoleClaimType);
 
-            if (roleClaims.Any())
+            if (roleClaims != null && roleClaims.Any())
             {
                 foreach (var existingClaim in roleClaims)
                 {

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -303,7 +303,7 @@ public class CustomUserFactory
             var identity = (ClaimsIdentity)user.Identity;
             var roleClaims = identity.FindAll(identity.RoleClaimType).ToArray();
 
-            if (roleClaims != null && roleClaims.Any())
+            if (roleClaims.Any())
             {
                 foreach (var existingClaim in roleClaims)
                 {


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/22368203/118486234-0b392e80-b722-11eb-8131-48c13ac8ae13.png)

Result of .ToArray() is always not null.