### PR TITLE
Remove outdated instructions

### DIFF
--- a/aspnetcore/data/ef-rp/complex-data-model.md
+++ b/aspnetcore/data/ef-rp/complex-data-model.md
@@ -218,24 +218,6 @@ SqliteException: SQLite Error 1: 'no such column: s.FirstName'.
   dotnet ef database update
   ```
 
-  The database update command displays an error like the following example:
-
-  ```text
-  SQLite does not support this migration operation ('AlterColumnOperation'). For more information, see http://go.microsoft.com/fwlink/?LinkId=723262.
-  ```
-
-For this tutorial, the way to get past this error is to delete and re-create the initial migration. For more information, see the SQLite warning note at the top of the [migrations tutorial](xref:data/ef-rp/migrations).
-
-* Delete the *Migrations* folder.
-* Run the following commands to drop the database, create a new initial migration, and apply the migration:
-
-  ```dotnetcli
-  dotnet ef database drop --force
-  dotnet ef migrations add InitialCreate
-  dotnet ef database update
-   
-  ```
-
 * Examine the Student table with a SQLite tool. The column that was `FirstMidName` is now `FirstName`.
 
 ---

--- a/aspnetcore/data/ef-rp/complex-data-model.md
+++ b/aspnetcore/data/ef-rp/complex-data-model.md
@@ -217,7 +217,25 @@ SqliteException: SQLite Error 1: 'no such column: s.FirstName'.
   dotnet ef migrations add ColumnFirstName
   dotnet ef database update
   ```
+<!--
+  The database update command displays an error like the following example:
 
+  ```text
+  SQLite does not support this migration operation ('AlterColumnOperation'). For more information, see http://go.microsoft.com/fwlink/?LinkId=723262.
+  ```
+
+For this tutorial, the way to get past this error is to delete and re-create the initial migration. For more information, see the SQLite warning note at the top of the [migrations tutorial](xref:data/ef-rp/migrations).
+
+* Delete the *Migrations* folder.
+* Run the following commands to drop the database, create a new initial migration, and apply the migration:
+
+  ```dotnetcli
+  dotnet ef database drop --force
+  dotnet ef migrations add InitialCreate
+  dotnet ef database update
+   
+  ```
+-->
 * Examine the Student table with a SQLite tool. The column that was `FirstMidName` is now `FirstName`.
 
 ---


### PR DESCRIPTION
This section:

https://docs.microsoft.com/en-us/aspnet/core/data/ef-rp/complex-data-model?view=aspnetcore-5.0&tabs=visual-studio-code#create-a-migration

contains the following

![image](https://user-images.githubusercontent.com/20816/119201951-b6105c00-ba44-11eb-943c-09a01b0a7e69.png)

After running the commands shown, I did not get the SQLite error message shown.

The docs mention `AlterColumnOperation`. Note that the migration file in my case uses `AlterColumn`:

![image](https://user-images.githubusercontent.com/20816/119202072-f243bc80-ba44-11eb-8965-132517cbf81c.png)

Note that column is now called `FirstName`:

![image](https://user-images.githubusercontent.com/20816/119202187-1dc6a700-ba45-11eb-8a49-4e7d99a5f72f.png)

So the instructions now seem to work without issue on SQLite.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->