### PR TITLE
Build report bug fixes

### DIFF
--- a/aspnetcore/data/entity-framework-6.md
+++ b/aspnetcore/data/entity-framework-6.md
@@ -54,7 +54,7 @@ The EF6 command-line tools that you'll use in the EF6 class library project requ
 
 [!code-csharp[](entity-framework-6/sample/EF6/SchoolContext.cs?name=snippet_Constructor)]
 
-Since your EF6 context doesn't have a parameterless constructor, your EF6 project has to provide an implementation of <xref:System.Data.Entity.Infrastructure.IDbContextFactory%601?view=entity-framework-6.2.0>. The EF6 command-line tools will find and use that implementation so they can instantiate the context. Here's an example.
+Since your EF6 context doesn't have a parameterless constructor, your EF6 project has to provide an implementation of <xref:System.Data.Entity.Infrastructure.IDbContextFactory%601>. The EF6 command-line tools will find and use that implementation so they can instantiate the context. Here's an example.
 
 [!code-csharp[](entity-framework-6/sample/EF6/SchoolContextFactory.cs?name=snippet_IDbContextFactory)]
 

--- a/aspnetcore/data/entity-framework-6.md
+++ b/aspnetcore/data/entity-framework-6.md
@@ -9,6 +9,7 @@ no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cook
 uid: data/entity-framework-6
 ---
 # ASP.NET Core and Entity Framework 6
+
 ::: moniker range=">= aspnetcore-3.0"
 
 By [Patrick Goode](https://github.com/attrib75)
@@ -25,74 +26,74 @@ By [Patrick Goode](https://github.com/attrib75)
 
 ::: moniker range="< aspnetcore-3.0"
 
-By [Paweł Grudzień](https://github.com/pgrudzien12), [Damien Pontifex](https://github.com/DamienPontifex), and [Tom Dykstra](https://github.com/tdykstra)
+By [Paweł Grudzień](https://github.com/pgrudzien12) and [Damien Pontifex](https://github.com/DamienPontifex)
 
-This article shows how to use Entity Framework 6 in an ASP.NET Core application.	
+This article shows how to use Entity Framework 6 in an ASP.NET Core application.
 
-## Overview	
+## Overview
 
-To use Entity Framework 6, your project has to compile against .NET Framework, as Entity Framework 6 doesn't support .NET Core. If you need cross-platform features you will need to upgrade to [Entity Framework Core](/ef/).	
+To use Entity Framework 6, your project has to compile against .NET Framework, as Entity Framework 6 doesn't support .NET Core. If you need cross-platform features you will need to upgrade to [Entity Framework Core](/ef/).
 
-The recommended way to use Entity Framework 6 in an ASP.NET Core application is to put the EF6 context and model classes in a class library project that targets .NET Framework. Add a reference to the class library from the ASP.NET Core project. See the sample [Visual Studio solution with EF6 and ASP.NET Core projects](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/entity-framework-6/sample/).	
+The recommended way to use Entity Framework 6 in an ASP.NET Core application is to put the EF6 context and model classes in a class library project that targets .NET Framework. Add a reference to the class library from the ASP.NET Core project. See the sample [Visual Studio solution with EF6 and ASP.NET Core projects](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/entity-framework-6/sample/).
 
-You can't put an EF6 context in an ASP.NET Core project because .NET Core projects don't support all of the functionality that EF6 commands such as *Enable-Migrations* require.	
+You can't put an EF6 context in an ASP.NET Core project because .NET Core projects don't support all of the functionality that EF6 commands such as *Enable-Migrations* require.
 
-Regardless of project type in which you locate your EF6 context, only EF6 command-line tools work with an EF6 context. For example, `Scaffold-DbContext` is only available in Entity Framework Core. If you need to do reverse engineering of a database into an EF6 model, see <https://docs.microsoft.com/ef/ef6/modeling/code-first/workflows/existing-database>.	
+Regardless of project type in which you locate your EF6 context, only EF6 command-line tools work with an EF6 context. For example, `Scaffold-DbContext` is only available in Entity Framework Core. If you need to do reverse engineering of a database into an EF6 model, see [Code First to an Existing Database](/ef/ef6/modeling/code-first/workflows/existing-database).
 
-## Reference full framework and EF6 in the ASP.NET Core project	
+## Reference full framework and EF6 in the ASP.NET Core project
 
-Your ASP.NET Core project needs to target .NET Framework and reference EF6. For example, the *.csproj* file of your ASP.NET Core project will look similar to the following example (only relevant parts of the file are shown).	
+Your ASP.NET Core project needs to target .NET Framework and reference EF6. For example, the *.csproj* file of your ASP.NET Core project will look similar to the following example (only relevant parts of the file are shown).
 
-[!code-xml[](entity-framework-6/sample/MVCCore/MVCCore.csproj?range=3-9&highlight=2)]	
+[!code-xml[](entity-framework-6/sample/MVCCore/MVCCore.csproj?range=3-9&highlight=2)]
 
-When creating a new project, use the **ASP.NET Core Web Application (.NET Framework)** template.	
+When creating a new project, use the **ASP.NET Core Web Application (.NET Framework)** template.
 
-## Handle connection strings	
+## Handle connection strings
 
-The EF6 command-line tools that you'll use in the EF6 class library project require a default constructor so they can instantiate the context. But you'll probably want to specify the connection string to use in the ASP.NET Core project, in which case your context constructor must have a parameter that lets you pass in the connection string. Here's an example.	
+The EF6 command-line tools that you'll use in the EF6 class library project require a default constructor so they can instantiate the context. But you'll probably want to specify the connection string to use in the ASP.NET Core project, in which case your context constructor must have a parameter that lets you pass in the connection string. Here's an example.
 
-[!code-csharp[](entity-framework-6/sample/EF6/SchoolContext.cs?name=snippet_Constructor)]	
+[!code-csharp[](entity-framework-6/sample/EF6/SchoolContext.cs?name=snippet_Constructor)]
 
-Since your EF6 context doesn't have a parameterless constructor, your EF6 project has to provide an implementation of <https://docs.microsoft.com/dotnet/api/system.data.entity.infrastructure.idbcontextfactory-1?view=entity-framework-6.2.0>. The EF6 command-line tools will find and use that implementation so they can instantiate the context. Here's an example.	
+Since your EF6 context doesn't have a parameterless constructor, your EF6 project has to provide an implementation of <xref:System.Data.Entity.Infrastructure.IDbContextFactory%601?view=entity-framework-6.2.0>. The EF6 command-line tools will find and use that implementation so they can instantiate the context. Here's an example.
 
-[!code-csharp[](entity-framework-6/sample/EF6/SchoolContextFactory.cs?name=snippet_IDbContextFactory)]	
+[!code-csharp[](entity-framework-6/sample/EF6/SchoolContextFactory.cs?name=snippet_IDbContextFactory)]
 
-In this sample code, the `IDbContextFactory` implementation passes in a hard-coded connection string. This is the connection string that the command-line tools will use. You'll want to implement a strategy to ensure that the class library uses the same connection string that the calling application uses. For example, you could get the value from an environment variable in both projects.	
+In this sample code, the `IDbContextFactory` implementation passes in a hard-coded connection string. This is the connection string that the command-line tools will use. You'll want to implement a strategy to ensure that the class library uses the same connection string that the calling application uses. For example, you could get the value from an environment variable in both projects.
 
-## Set up dependency injection in the ASP.NET Core project	
+## Set up dependency injection in the ASP.NET Core project
 
-In the Core project's *Startup.cs* file, set up the EF6 context for dependency injection (DI) in `ConfigureServices`. EF context objects should be scoped for a per-request lifetime.	
+In the Core project's *Startup.cs* file, set up the EF6 context for dependency injection (DI) in `ConfigureServices`. EF context objects should be scoped for a per-request lifetime.
 
-[!code-csharp[](entity-framework-6/sample/MVCCore/Startup.cs?name=snippet_ConfigureServices&highlight=5)]	
+[!code-csharp[](entity-framework-6/sample/MVCCore/Startup.cs?name=snippet_ConfigureServices&highlight=5)]
 
-You can then get an instance of the context in your controllers by using DI. The code is similar to what you'd write for an EF Core context:	
+You can then get an instance of the context in your controllers by using DI. The code is similar to what you'd write for an EF Core context:
 
-[!code-csharp[](entity-framework-6/sample/MVCCore/Controllers/StudentsController.cs?name=snippet_ContextInController)]	
+[!code-csharp[](entity-framework-6/sample/MVCCore/Controllers/StudentsController.cs?name=snippet_ContextInController)]
 
-## Sample application	
+## Sample application
 
-For a working sample application, see the [sample Visual Studio solution](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/entity-framework-6/sample/) that accompanies this article.	
+For a working sample application, see the [sample Visual Studio solution](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/entity-framework-6/sample/) that accompanies this article.
 
-This sample can be created from scratch by the following steps in Visual Studio:	
+This sample can be created from scratch by the following steps in Visual Studio:
 
-* Create a solution.	
+* Create a solution.
 
-* **Add** > **New Project** > **Web** > **ASP.NET Core Web Application**	
-  * In project template selection dialog, select API and .NET Framework in dropdown	
+* **Add** > **New Project** > **Web** > **ASP.NET Core Web Application**
+  * In project template selection dialog, select API and .NET Framework in dropdown
 
-* **Add** > **New Project** > **Windows Desktop** > **Class Library (.NET Framework)**	
+* **Add** > **New Project** > **Windows Desktop** > **Class Library (.NET Framework)**
 
-* In **Package Manager Console** (PMC) for both projects, run the command `Install-Package Entityframework`.	
+* In **Package Manager Console** (PMC) for both projects, run the command `Install-Package Entityframework`.
 
-* In the class library project, create data model classes and a context class, and an implementation of `IDbContextFactory`.	
+* In the class library project, create data model classes and a context class, and an implementation of `IDbContextFactory`.
 
-* In PMC for the class library project, run the commands `Enable-Migrations` and `Add-Migration Initial`. If you have set the ASP.NET Core project as the startup project, add `-StartupProjectName EF6` to these commands.	
+* In PMC for the class library project, run the commands `Enable-Migrations` and `Add-Migration Initial`. If you have set the ASP.NET Core project as the startup project, add `-StartupProjectName EF6` to these commands.
 
-* In the Core project, add a project reference to the class library project.	
+* In the Core project, add a project reference to the class library project.
 
-* In the Core project, in *Startup.cs*, register the context for DI.	
+* In the Core project, in *Startup.cs*, register the context for DI.
 
-* In the Core project, in *appsettings.json*, add the connection string.	
+* In the Core project, in *appsettings.json*, add the connection string.
 
 * In the Core project, add a controller and view(s) to verify that you can read and write data. (Note that ASP.NET Core MVC scaffolding won't work with the EF6 context referenced from the class library.)
 

--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -234,7 +234,7 @@ The default list goes from most specific to least specific. Later in the article
 
 ### QueryStringRequestCultureProvider
 
-Some apps will use a query string to set the <https://docs.microsoft.com/dotnet/api/system.globalization.cultureinfo?view=netcore-3.1>. For apps that use the cookie or Accept-Language header approach, adding a query string to the URL is useful for debugging and testing code. By default, the `QueryStringRequestCultureProvider` is registered as the first localization provider in the `RequestCultureProvider` list. You pass the query string parameters `culture` and `ui-culture`. The following example sets the specific culture (language and region) to Spanish/Mexico:
+Some apps will use a query string to set the <xref:System.Globalization.CultureInfo>. For apps that use the cookie or Accept-Language header approach, adding a query string to the URL is useful for debugging and testing code. By default, the `QueryStringRequestCultureProvider` is registered as the first localization provider in the `RequestCultureProvider` list. You pass the query string parameters `culture` and `ui-culture`. The following example sets the specific culture (language and region) to Spanish/Mexico:
 
    `http://localhost:5000/?culture=es-MX&ui-culture=es-MX`
 
@@ -333,7 +333,7 @@ The process of localizing your app also requires a basic understanding of releva
 
 [Localizability](/dotnet/standard/globalization-localization/localizability-review) is an intermediate process for verifying that a globalized app is ready for localization.
 
-The [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) format for the culture name is `<languagecode2>-<country/regioncode2>`, where `<languagecode2>` is the language code and `<country/regioncode2>` is the subculture code. For example, `es-CL` for Spanish (Chile), `en-US` for English (United States), and `en-AU` for English (Australia). [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) is a combination of an ISO 639 two-letter lowercase culture code associated with a language and an ISO 3166 two-letter uppercase subculture code associated with a country or region. See <https://docs.microsoft.com/previous-versions/commerce-server/ee825488(v=cs.20)>.
+The [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) format for the culture name is `<languagecode2>-<country/regioncode2>`, where `<languagecode2>` is the language code and `<country/regioncode2>` is the subculture code. For example, `es-CL` for Spanish (Chile), `en-US` for English (United States), and `en-AU` for English (Australia). [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) is a combination of an ISO 639 two-letter lowercase culture code associated with a language and an ISO 3166 two-letter uppercase subculture code associated with a country or region. For more information, see <xref:System.Globalization.CultureInfo?displayProperty=fullName>.
 
 Internationalization is often abbreviated to "I18N". The abbreviation takes the first and last letters and the number of letters between them, so 18 stands for the number of letters between the first "I" and the last "N". The same applies to Globalization (G11N), and Localization (L10N).
 
@@ -588,7 +588,7 @@ The default list goes from most specific to least specific. Later in the article
 
 ### QueryStringRequestCultureProvider
 
-Some apps will use a query string to set the <https://docs.microsoft.com/dotnet/api/system.globalization.cultureinfo?view=netcore-3.1>. For apps that use the cookie or Accept-Language header approach, adding a query string to the URL is useful for debugging and testing code. By default, the `QueryStringRequestCultureProvider` is registered as the first localization provider in the `RequestCultureProvider` list. You pass the query string parameters `culture` and `ui-culture`. The following example sets the specific culture (language and region) to Spanish/Mexico:
+Some apps will use a query string to set the <xref:System.Globalization.CultureInfo>. For apps that use the cookie or Accept-Language header approach, adding a query string to the URL is useful for debugging and testing code. By default, the `QueryStringRequestCultureProvider` is registered as the first localization provider in the `RequestCultureProvider` list. You pass the query string parameters `culture` and `ui-culture`. The following example sets the specific culture (language and region) to Spanish/Mexico:
 
 ```
 http://localhost:5000/?culture=es-MX&ui-culture=es-MX
@@ -689,7 +689,7 @@ The process of localizing your app also requires a basic understanding of releva
 
 [Localizability](/dotnet/standard/globalization-localization/localizability-review) is an intermediate process for verifying that a globalized app is ready for localization.
 
-The [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) format for the culture name is `<languagecode2>-<country/regioncode2>`, where `<languagecode2>` is the language code and `<country/regioncode2>` is the subculture code. For example, `es-CL` for Spanish (Chile), `en-US` for English (United States), and `en-AU` for English (Australia). [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) is a combination of an ISO 639 two-letter lowercase culture code associated with a language and an ISO 3166 two-letter uppercase subculture code associated with a country or region. See <https://docs.microsoft.com/previous-versions/commerce-server/ee825488(v=cs.20)>.
+The [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) format for the culture name is `<languagecode2>-<country/regioncode2>`, where `<languagecode2>` is the language code and `<country/regioncode2>` is the subculture code. For example, `es-CL` for Spanish (Chile), `en-US` for English (United States), and `en-AU` for English (Australia). [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) is a combination of an ISO 639 two-letter lowercase culture code associated with a language and an ISO 3166 two-letter uppercase subculture code associated with a country or region. For more information, see <xref:System.Globalization.CultureInfo?displayProperty=fullName>.
 
 Internationalization is often abbreviated to "I18N". The abbreviation takes the first and last letters and the number of letters between them, so 18 stands for the number of letters between the first "I" and the last "N". The same applies to Globalization (G11N), and Localization (L10N).
 
@@ -1067,7 +1067,7 @@ The process of localizing your app also requires a basic understanding of releva
 
 [Localizability](/dotnet/standard/globalization-localization/localizability-review) is an intermediate process for verifying that a globalized app is ready for localization.
 
-The [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) format for the culture name is `<languagecode2>-<country/regioncode2>`, where `<languagecode2>` is the language code and `<country/regioncode2>` is the subculture code. For example, `es-CL` for Spanish (Chile), `en-US` for English (United States), and `en-AU` for English (Australia). [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) is a combination of an ISO 639 two-letter lowercase culture code associated with a language and an ISO 3166 two-letter uppercase subculture code associated with a country or region. See <https://docs.microsoft.com/previous-versions/commerce-server/ee825488(v=cs.20)>.
+The [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) format for the culture name is `<languagecode2>-<country/regioncode2>`, where `<languagecode2>` is the language code and `<country/regioncode2>` is the subculture code. For example, `es-CL` for Spanish (Chile), `en-US` for English (United States), and `en-AU` for English (Australia). [RFC 4646](https://www.ietf.org/rfc/rfc4646.txt) is a combination of an ISO 639 two-letter lowercase culture code associated with a language and an ISO 3166 two-letter uppercase subculture code associated with a country or region. For more information, see <xref:System.Globalization.CultureInfo?displayProperty=fullName>.
 
 Internationalization is often abbreviated to "I18N". The abbreviation takes the first and last letters and the number of letters between them, so 18 stands for the number of letters between the first "I" and the last "N". The same applies to Globalization (G11N), and Localization (L10N).
 

--- a/aspnetcore/migration/http-modules.md
+++ b/aspnetcore/migration/http-modules.md
@@ -82,7 +82,7 @@ In addition to modules, you can add handlers for the life cycle events to your *
 
 * See [Create a middleware pipeline with IApplicationBuilder](xref:fundamentals/middleware/index#create-a-middleware-pipeline-with-iapplicationbuilder)
 
-![Middleware](http-modules/_static/middleware.png)
+![Authorization Middleware short-circuits a request for a user who isn't authorized. A request for the Index page is permitted and processed by MVC Middleware. A request for a sales report is permitted and processed by a custom report Middleware.](http-modules/_static/middleware.png)
 
 Note how in the image above, the authentication middleware short-circuited the request.
 

--- a/aspnetcore/migration/http-modules.md
+++ b/aspnetcore/migration/http-modules.md
@@ -39,7 +39,7 @@ Before proceeding to ASP.NET Core middleware, let's first recap how HTTP modules
 
 **The order in which modules process incoming requests is determined by:**
 
-1. The <https://docs.microsoft.com/previous-versions/ms227673(v=vs.140)>, which is a series events fired by ASP.NET: [BeginRequest](/dotnet/api/system.web.httpapplication.beginrequest), [AuthenticateRequest](/dotnet/api/system.web.httpapplication.authenticaterequest), etc. Each module can create a handler for one or more events.
+1. A series events fired by ASP.NET, such as <xref:System.Web.HttpApplication.BeginRequest> and <xref:System.Web.HttpApplication.AuthenticateRequest>. For a complete list, see <xref:System.Web.HttpApplication?displayProperty=fullName>. Each module can create a handler for one or more events.
 
 2. For the same event, the order in which they're configured in *Web.config*.
 
@@ -76,7 +76,7 @@ In addition to modules, you can add handlers for the life cycle events to your *
 
 **Middleware and modules are processed in a different order:**
 
-* Order of middleware is based on the order in which they're inserted into the request pipeline, while order of modules is mainly based on <https://docs.microsoft.com/previous-versions/ms227673(v=vs.140)> events
+* Order of middleware is based on the order in which they're inserted into the request pipeline, while order of modules is mainly based on <xref:System.Web.HttpApplication?displayProperty=fullName> events.
 
 * Order of middleware for responses is the reverse from that for requests, while order of modules is the same for requests and responses
 

--- a/aspnetcore/migration/mvc.md
+++ b/aspnetcore/migration/mvc.md
@@ -81,7 +81,7 @@ In the ASP.NET Core project, a new empty controller class and view class would b
 
 The ASP.NET Core *WebApp1* project already includes a minimal example controller and view by the same name as the ASP.NET MVC project. So those will serve as placeholders for the ASP.NET MVC controller and views to be migrated from the ASP.NET MVC *WebApp1* project.
 
-1. Copy the methods from the ASP.NET MVC `HomeController` to replace the new ASP.NET Core `HomeController` methods. There's no need to change the return type of the action methods. The ASP.NET MVC built-in template's controller action method return type is <https://docs.microsoft.com/dotnet/api/system.web.mvc.actionresult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`.
+1. Copy the methods from the ASP.NET MVC `HomeController` to replace the new ASP.NET Core `HomeController` methods. There's no need to change the return type of the action methods. The ASP.NET MVC built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`.
 1. In the ASP.NET Core project, right-click the *Views/Home* directory, select **Add** > **Existing Item**.
 1. In the **Add Existing Item** dialog, navigate to the ASP.NET MVC *WebApp1* project's *Views/Home* directory.
 1. Select the *About.cshtml*, *Contact.cshtml*, and *Index.cshtml* Razor view files, then select **Add**, replacing the existing files.
@@ -275,7 +275,7 @@ The following functionality requires migration from the example ASP.NET MVC proj
 
 ## Controllers and views
 
-* Copy each of the methods from the ASP.NET MVC `HomeController` to the new `HomeController`. In ASP.NET MVC, the built-in template's controller action method return type is <https://docs.microsoft.com/dotnet/api/system.web.mvc.actionresult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`, so there's no need to change the return type of the action methods.
+* Copy each of the methods from the ASP.NET MVC `HomeController` to the new `HomeController`. In ASP.NET MVC, the built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`, so there's no need to change the return type of the action methods.
 
 * Copy the *About.cshtml*, *Contact.cshtml*, and *Index.cshtml* Razor view files from the ASP.NET MVC project to the ASP.NET Core project.
 
@@ -461,7 +461,7 @@ The following functionality requires migration from the example ASP.NET MVC proj
 
 ## Controllers and views
 
-* Copy each of the methods from the ASP.NET MVC `HomeController` to the new `HomeController`. In ASP.NET MVC, the built-in template's controller action method return type is <https://docs.microsoft.com/dotnet/api/system.web.mvc.actionresult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`, so there's no need to change the return type of the action methods.
+* Copy each of the methods from the ASP.NET MVC `HomeController` to the new `HomeController`. In ASP.NET MVC, the built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`, so there's no need to change the return type of the action methods.
 
 * Copy the *About.cshtml*, *Contact.cshtml*, and *Index.cshtml* Razor view files from the ASP.NET MVC project to the ASP.NET Core project.
 

--- a/aspnetcore/migration/mvc.md
+++ b/aspnetcore/migration/mvc.md
@@ -81,7 +81,7 @@ In the ASP.NET Core project, a new empty controller class and view class would b
 
 The ASP.NET Core *WebApp1* project already includes a minimal example controller and view by the same name as the ASP.NET MVC project. So those will serve as placeholders for the ASP.NET MVC controller and views to be migrated from the ASP.NET MVC *WebApp1* project.
 
-1. Copy the methods from the ASP.NET MVC `HomeController` to replace the new ASP.NET Core `HomeController` methods. There's no need to change the return type of the action methods. The ASP.NET MVC built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`.
+1. Copy the methods from the ASP.NET MVC `HomeController` to replace the new ASP.NET Core `HomeController` methods. There's no need to change the return type of the action methods. The ASP.NET MVC built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`.
 1. In the ASP.NET Core project, right-click the *Views/Home* directory, select **Add** > **Existing Item**.
 1. In the **Add Existing Item** dialog, navigate to the ASP.NET MVC *WebApp1* project's *Views/Home* directory.
 1. Select the *About.cshtml*, *Contact.cshtml*, and *Index.cshtml* Razor view files, then select **Add**, replacing the existing files.
@@ -231,7 +231,7 @@ In this section, a minimal controller and view are added to serve as placeholder
 
 * Add a **Controller Class** named *HomeController.cs* to the *Controllers* directory.
 
-![Add New Item dialog](mvc/_static/add_mvc_ctl.png)
+![Add New Item dialog with MVC Controller Class selected](mvc/_static/add_mvc_ctl.png)
 
 * Add a *Views* directory.
 
@@ -239,7 +239,7 @@ In this section, a minimal controller and view are added to serve as placeholder
 
 * Add a **Razor View** named *Index.cshtml* to the *Views/Home* directory.
 
-![Add New Item dialog](mvc/_static/view.png)
+![Add New Item dialog with MVC View Page selected](mvc/_static/view.png)
 
 The project structure is shown below:
 
@@ -275,7 +275,7 @@ The following functionality requires migration from the example ASP.NET MVC proj
 
 ## Controllers and views
 
-* Copy each of the methods from the ASP.NET MVC `HomeController` to the new `HomeController`. In ASP.NET MVC, the built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`, so there's no need to change the return type of the action methods.
+* Copy each of the methods from the ASP.NET MVC `HomeController` to the new `HomeController`. In ASP.NET MVC, the built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`, so there's no need to change the return type of the action methods.
 
 * Copy the *About.cshtml*, *Contact.cshtml*, and *Index.cshtml* Razor view files from the ASP.NET MVC project to the ASP.NET Core project.
 
@@ -391,7 +391,7 @@ To demonstrate the upgrade, we'll start by creating a ASP.NET MVC app. Create it
 
 Create a new *empty* ASP.NET Core web app with the same name as the previous project (*WebApp1*) so the namespaces in the two projects match. Having the same namespace makes it easier to copy code between the two projects. Create this project in a different directory than the previous project to use the same name.
 
-![New Project dialog](mvc/_static/new_core.png)
+![New Project dialog wtih ](mvc/_static/new_core.png)
 
 ![New ASP.NET Web Application dialog: Empty project template selected in ASP.NET Core Templates panel](mvc/_static/new-project-select-empty-aspnet5-template.png)
 
@@ -417,7 +417,7 @@ In this section, a minimal controller and view are added to serve as placeholder
 
 * Add a **Controller Class** named *HomeController.cs* to the *Controllers* directory.
 
-![Add New Item dialog](mvc/_static/add_mvc_ctl.png)
+![Add New Item dialog with MVC Controller Class selected (prior to the release of ASP.NET Core 2.1)](mvc/_static/add_mvc_ctl.png)
 
 * Add a *Views* directory.
 
@@ -425,7 +425,7 @@ In this section, a minimal controller and view are added to serve as placeholder
 
 * Add a **Razor View** named *Index.cshtml* to the *Views/Home* directory.
 
-![Add New Item dialog](mvc/_static/view.png)
+![Add New Item dialog with MVC View Page selected (prior to the release of ASP.NET Core 2.1)](mvc/_static/view.png)
 
 The project structure is shown below:
 
@@ -461,7 +461,7 @@ The following functionality requires migration from the example ASP.NET MVC proj
 
 ## Controllers and views
 
-* Copy each of the methods from the ASP.NET MVC `HomeController` to the new `HomeController`. In ASP.NET MVC, the built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult?view=aspnet-mvc-5.2>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`, so there's no need to change the return type of the action methods.
+* Copy each of the methods from the ASP.NET MVC `HomeController` to the new `HomeController`. In ASP.NET MVC, the built-in template's controller action method return type is <xref:System.Web.Mvc.ActionResult>; in ASP.NET Core MVC, the action methods return `IActionResult` instead. `ActionResult` implements `IActionResult`, so there's no need to change the return type of the action methods.
 
 * Copy the *About.cshtml*, *Contact.cshtml*, and *Index.cshtml* Razor view files from the ASP.NET MVC project to the ASP.NET Core project.
 

--- a/aspnetcore/migration/proper-to-2x/membership-to-core-identity.md
+++ b/aspnetcore/migration/proper-to-2x/membership-to-core-identity.md
@@ -19,9 +19,9 @@ This article demonstrates migrating the database schema for ASP.NET apps using M
 
 ## Review of Membership schema
 
-Prior to ASP.NET 2.0, developers were tasked with creating the entire authentication and authorization process for their apps. With ASP.NET 2.0, Membership was introduced, providing a boilerplate solution to handling security within ASP.NET apps. Developers were now able to bootstrap a schema into a SQL Server database with the <https://docs.microsoft.com/previous-versions/ms229862(v=vs.140)> command. After running this command, the following tables were created in the database.
+Prior to ASP.NET 2.0, developers were tasked with creating the entire authentication and authorization process for their apps. With ASP.NET 2.0, Membership was introduced, providing a boilerplate solution to handling security within ASP.NET apps. Developers were now able to bootstrap a schema into a SQL Server database with the ASP.NET SQL Server Registration Tool (`Aspnet_regsql.exe`) (no longer supported). After running this command, the following tables were created in the database.
 
-  ![Membership Tables](identity/_static/membership-tables.png)
+![Membership Tables](identity/_static/membership-tables.png)
 
 To migrate existing apps to ASP.NET Core 2.0 Identity, the data in these tables needs to be migrated to the tables used by the new Identity schema.
 

--- a/aspnetcore/mvc/views/tag-helpers/intro.md
+++ b/aspnetcore/mvc/views/tag-helpers/intro.md
@@ -53,7 +53,7 @@ Generates the following HTML:
 <label for="Movie_Title">Title</label>
 ```
 
-The `asp-for` attribute is made available by the `For` property in the [LabelTagHelper](/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.labeltaghelper?view=aspnetcore-2.0). See [Author Tag Helpers](xref:mvc/views/tag-helpers/authoring) for more information.
+The `asp-for` attribute is made available by the `For` property in the <xref:Microsoft.AspNetCore.Mvc.TagHelpers.LabelTagHelper>. See [Author Tag Helpers](xref:mvc/views/tag-helpers/authoring) for more information.
 
 ## Managing Tag Helper scope
 
@@ -124,7 +124,7 @@ The `@tagHelperPrefix` directive allows you to specify a tag prefix string to en
 
 In the code image below, the Tag Helper prefix is set to `th:`, so only those elements using the prefix `th:` support Tag Helpers (Tag Helper-enabled elements have a distinctive font). The `<label>` and `<input>` elements have the Tag Helper prefix and are Tag Helper-enabled, while the `<span>` element doesn't.
 
-![image](intro/_static/thp.png)
+![Razor markup with Tag Helper prefix set to "th:" for a label and an input element name](intro/_static/thp.png)
 
 The same hierarchy rules that apply to `@addTagHelper` also apply to `@tagHelperPrefix`.
 
@@ -132,7 +132,7 @@ The same hierarchy rules that apply to `@addTagHelper` also apply to `@tagHelper
 
 Many Tag Helpers can't be used as self-closing tags. Some Tag Helpers are designed to be self-closing tags. Using a Tag Helper that was not designed to be self-closing suppresses the rendered output. Self-closing a Tag Helper results in a self-closing tag in the rendered output. For more information, see [this note](xref:mvc/views/tag-helpers/authoring#self-closing) in [Authoring Tag Helpers](xref:mvc/views/tag-helpers/authoring).
 
-## C# in Tag Helpers attribute/declaration 
+## C# in Tag Helpers attribute/declaration
 
 Tag Helpers do not allow C# in the element's attribute or tag declaration area. For example, the following code is not valid:
 
@@ -154,39 +154,39 @@ When you create a new ASP.NET Core web app in Visual Studio, it adds the NuGet p
 
 Consider writing an HTML `<label>` element. As soon as you enter `<l` in the Visual Studio editor, IntelliSense displays matching elements:
 
-![image](intro/_static/label.png)
+![After typing "l" on the keyboard, IntelliSense suggests a list of possible tag names with "label" selected.](intro/_static/label.png)
 
 Not only do you get HTML help, but the icon (the "@" symbol with "<>" under it).
 
-![image](intro/_static/tagSym.png)
+![The the "@" symbol with "<>" under it.](intro/_static/tagSym.png)
 
-identifies the element as targeted by Tag Helpers. Pure HTML elements (such as the `fieldset`) display the "<>" icon.
+The icon identifies the element as targeted by Tag Helpers. Pure HTML elements (such as the `fieldset`) display the "<>" icon.
 
 A pure HTML `<label>` tag displays the HTML tag (with the default Visual Studio color theme) in a brown font, the attributes in red, and the attribute values in blue.
 
-![image](intro/_static/LableHtmlTag.png)
+![Example "label" HTMl tag](intro/_static/LableHtmlTag.png)
 
 After you enter `<label`, IntelliSense lists the available HTML/CSS attributes and the Tag Helper-targeted attributes:
 
-![image](intro/_static/labelattr.png)
+![The user has typed an opening bracket and the HTML element name "label". IntelliSense presents a list of possible attributes (none are preselected).](intro/_static/labelattr.png)
 
 IntelliSense statement completion allows you to enter the tab key to complete the statement with the selected value:
 
-![image](intro/_static/stmtcomplete.png)
+![The user has typed an opening bracket, the HTML element name "label", and begins to type an attribute name ("as"). IntelliSense presents a dialog of suggestions with "asp-for" selected.](intro/_static/stmtcomplete.png)
 
 As soon as a Tag Helper attribute is entered, the tag and attribute fonts change. Using the default Visual Studio "Blue" or "Light" color theme, the font is bold purple. If you're using the "Dark" theme the font is bold teal. The images in this document were taken using the default theme.
 
-![image](intro/_static/labelaspfor2.png)
+![The user selected "asp-for", which is now in bold purple because the user isn't using the Dark theme.](intro/_static/labelaspfor2.png)
 
 You can enter the Visual Studio *CompleteWord* shortcut (Ctrl +spacebar is the [default](/visualstudio/ide/default-keyboard-shortcuts-in-visual-studio) inside the double quotes (""), and you are now in C#, just like you would be in a C# class. IntelliSense displays all the methods and properties on the page model. The methods and properties are available because the property type is `ModelExpression`. In the image below, I'm editing the `Register` view, so the `RegisterViewModel` is available.
 
-![image](intro/_static/intellemail.png)
+![The user types "e" in the value for the "asp-for" attribute. IntelliSense suggests possible completion with "Email" selected.](intro/_static/intellemail.png)
 
 IntelliSense lists the properties and methods available to the model on the page. The rich IntelliSense environment helps you select the CSS class:
 
-![image](intro/_static/iclass.png)
+![The user types "cl" to add an attribute to an "input" element. IntelliSense presents a list of completion suggestions with "class" selected.](intro/_static/iclass.png)
 
-![image](intro/_static/intel3.png)
+![The user types "co" as the value for the "class" attribute of an "input" element. IntelliSense provides a list of completion suggestions with "col" selected.](intro/_static/intel3.png)
 
 ## Tag Helpers compared to HTML Helpers
 
@@ -212,13 +212,13 @@ Using the `LabelTagHelper`, the same markup can be written as:
 
 With the Tag Helper version, as soon as you enter `<l` in the Visual Studio editor, IntelliSense displays matching elements:
 
-![image](intro/_static/label.png)
+![The user types "l" on the keyboard. IntelliSense suggests HTML element completion with "label" selected.](intro/_static/label.png)
 
 IntelliSense helps you write the entire line.
 
 The following code image shows the Form portion of the *Views/Account/Register.cshtml* Razor view generated from the ASP.NET 4.5.x MVC template included with Visual Studio.
 
-![image](intro/_static/regCS.png)
+![Razor markup for the form portion of the Register Razor view for ASP.NET 4.5 MVC project template](intro/_static/regCS.png)
 
 The Visual Studio editor displays C# code with a grey background. For example, the `AntiForgeryToken` HTML Helper:
 
@@ -228,7 +228,7 @@ The Visual Studio editor displays C# code with a grey background. For example, t
 
 is displayed with a grey background. Most of the markup in the Register view is C#. Compare that to the equivalent approach using Tag Helpers:
 
-![image](intro/_static/regTH.png)
+![Razor markup with Tag Helpers for the form portion of the Register Razor view for an ASP.NET Core project template](intro/_static/regTH.png)
 
 The markup is much cleaner and easier to read, edit, and maintain than the HTML Helpers approach. The C# code is reduced to the minimum that the server needs to know about. The Visual Studio editor displays markup targeted by a Tag Helper in a distinctive font.
 
@@ -262,7 +262,7 @@ The Visual Studio editor helps you write **all** of the markup in the Tag Helper
 
 You can customize the font and colorization from **Tools** > **Options** > **Environment** > **Fonts and Colors**:
 
-![image](intro/_static/fontoptions2.png)
+![Options dialog in Visual Studio](intro/_static/fontoptions2.png)
 
 [!INCLUDE[](~/includes/built-in-TH.md)]
 

--- a/aspnetcore/mvc/views/tag-helpers/intro.md
+++ b/aspnetcore/mvc/views/tag-helpers/intro.md
@@ -242,9 +242,9 @@ The Visual Studio editor helps you write **all** of the markup in the Tag Helper
 
 ## Tag Helpers compared to Web Server Controls
 
-* Tag Helpers don't own the element they're associated with; they simply participate in the rendering of the element and content. ASP.NET <https://docs.microsoft.com/previous-versions/dotnet/netframework-3.0/7698y1f0(v=vs.85)> are declared and invoked on a page.
+* Tag Helpers don't own the element they're associated with; they simply participate in the rendering of the element and content. ASP.NET Web Server Controls are declared and invoked on a page.
 
-* <https://docs.microsoft.com/previous-versions/zsyt68f1(v=vs.140)> have a non-trivial lifecycle that can make developing and debugging difficult.
+* ASP.NET Web Server Controls have a non-trivial lifecycle that can make developing and debugging difficult.
 
 * Web Server controls allow you to add functionality to the client Document Object Model (DOM) elements by using a client control. Tag Helpers have no DOM.
 

--- a/aspnetcore/razor-pages/sdk.md
+++ b/aspnetcore/razor-pages/sdk.md
@@ -50,13 +50,15 @@ The properties and items in the following table are used to configure inputs and
 | `RazorCompile` | Item elements (*.cs* files) that are inputs to Razor compilation targets. Use this `ItemGroup` to specify additional files to be compiled into the Razor assembly. |
 | `RazorEmbeddedResource` | Item elements added as embedded resources to the generated Razor assembly. |
 
+<!-- In the following table, should the entry for 'GenerateRazorTargetAssemblyInfo' be deleted? -->
+
 | Property | Description |
 | -------- | ----------- |
 | `RazorOutputPath` | The Razor output directory. |
 | `RazorCompileToolset` | Used to determine the toolset used to build the Razor assembly. Valid values are `Implicit`, `RazorSDK`, and `PrecompilationTool`. |
 | [EnableDefaultContentItems](https://github.com/aspnet/websdk/blob/rel-2.0.0/src/ProjectSystem/Microsoft.NET.Sdk.Web.ProjectSystem.Targets/netstandard1.0/Microsoft.NET.Sdk.Web.ProjectSystem.targets#L21) | Default is `true`. When `true`, includes *web.config*, *.json*, and *.cshtml* files as content in the project. When referenced via `Microsoft.NET.Sdk.Web`, files under *wwwroot* and config files are also included. |
 | `EnableDefaultRazorGenerateItems` | When `true`, includes *.cshtml* files from `Content` items in `RazorGenerate` items. |
-| `GenerateRazorTargetAssemblyInfo` | Not used in .NET 6 and later. | <!-- should I delete?-->
+| `GenerateRazorTargetAssemblyInfo` | Not used in .NET 6 and later. |
 | `EnableDefaultRazorTargetAssemblyInfoAttributes` | Not used in .NET 6 and later. |
 | `CopyRazorGenerateFilesToPublishDirectory` | When `true`, copies `RazorGenerate` items (*.cshtml*) files to the publish directory. Typically, Razor files aren't required for a published app if they participate in compilation at build-time or publish-time. Defaults to `false`. |
 | `PreserveCompilationReferences` | When `true`, copy reference assembly items to the publish directory. Typically, reference assemblies aren't required for a published app if Razor compilation occurs at build-time or publish-time. Set to `true` if your published app requires runtime compilation. For example, set the value to `true` if the app modifies *.cshtml* files at runtime or uses embedded views. Defaults to `false`. |


### PR DESCRIPTION
Fixes #22376

I only had a few minutes left this week, so this seemed like a good thing to squeeze in here. This should clean up the build report. In a couple of spots the cross-linked coverage was legacy without a suitable, current replacement, and I think it was fine to just mention the name of the thing without a cross-link in those few cases. In other spots, the current API docs have the information.