### PR TITLE
fix docker 128 error /9

### DIFF
--- a/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
+++ b/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
@@ -326,6 +326,7 @@ ENTRYPOINT ["dotnet", "aspnetapp.dll"]
 * [Working with Visual Studio Docker Tools](./visual-studio-tools-for-docker.md)
 * [Debugging with Visual Studio Code](https://code.visualstudio.com/docs/nodejs/debugging-recipes#_debug-nodejs-in-docker-containers)
 * [GC using Docker and small containers](xref:performance/memory#sc)
+* [System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached](xref:aspnet/core/host-and-deploy/docker#d128)
 
 ## Next steps
 

--- a/aspnetcore/host-and-deploy/docker/index.md
+++ b/aspnetcore/host-and-deploy/docker/index.md
@@ -38,3 +38,5 @@ Additional configuration might be required for apps hosted behind proxy servers 
 
 [GC using Docker and small containers](xref:performance/memory#sc)
 Discusses GC selection with small containers.
+
+[!INCLUDE[](~/includes/docker-128.md)]

--- a/aspnetcore/host-and-deploy/docker/visual-studio-tools-for-docker.md
+++ b/aspnetcore/host-and-deploy/docker/visual-studio-tools-for-docker.md
@@ -238,3 +238,4 @@ There may be an expectation for the production or release image to be smaller in
 * [Troubleshoot Visual Studio development with Docker](/azure/vs-azure-tools-docker-troubleshooting-docker-errors)
 * [Visual Studio Container Tools GitHub repository](https://github.com/Microsoft/DockerTools)
 * [GC using Docker and small containers](xref:performance/memory#sc)
+* [System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached](xref:aspnet/core/host-and-deploy/docker#d128)

--- a/aspnetcore/includes/docker-128.md
+++ b/aspnetcore/includes/docker-128.md
@@ -15,4 +15,6 @@ The preceding code:
 * Can help prevent the user limit (128) when the app doesn't depend on reloading the *appsettings.json* file.
 * Reads *appsettings.json* as the last configuration provider, therefore settings in *appsettings.json* override those set in the environment and the command line. For more information, see [Configuration](xref:fundamentals/configuration/index).
 
+To disable reloading configuration files from the environment, set `DOTNET_HOSTBUILDER__RELOADCONFIGONCHANGE=false`
+
 For alternative approaches or to leave feedback on this problem, see [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/19814).

--- a/aspnetcore/includes/docker-128.md
+++ b/aspnetcore/includes/docker-128.md
@@ -1,0 +1,9 @@
+---
+no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
+
+## System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached.
+
+Disabling `reloadOnChange` can significantly reduce the number of opened files:
+
+[!code-csharp[](~/includes/docker-128/Program.cs?hightlight=14)]

--- a/aspnetcore/includes/docker-128.md
+++ b/aspnetcore/includes/docker-128.md
@@ -12,4 +12,4 @@ Disabling `reloadOnChange` can significantly reduce the number of opened files:
 
 The preceding code can help prevent the user limit (128) when the app doesn't depend on reloading the *appsettings.json* file.
 
-When adding multiple docker containers using the same host, consider specifying a randomized user ID in each Dockerfile. For more information, see [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/19814).
+For alternative approaches or to leave feedback on this problem, see [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/19814).

--- a/aspnetcore/includes/docker-128.md
+++ b/aspnetcore/includes/docker-128.md
@@ -10,6 +10,9 @@ Disabling `reloadOnChange` can significantly reduce the number of opened files:
 
 [!code-csharp[](~/includes/docker-128/Program.cs?highlight=14&name=snippet)]
 
-The preceding code can help prevent the user limit (128) when the app doesn't depend on reloading the *appsettings.json* file.
+The preceding code:
+
+* Can help prevent the user limit (128) when the app doesn't depend on reloading the *appsettings.json* file.
+* Reads *appsettings.json* as the last configuration provider, therefore settings in *appsettings.json* override those set in the environment and the command line. For more information, see [Configuration](xref:fundamentals/configuration/index).
 
 For alternative approaches or to leave feedback on this problem, see [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/19814).

--- a/aspnetcore/includes/docker-128.md
+++ b/aspnetcore/includes/docker-128.md
@@ -8,7 +8,7 @@ no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cook
 
 Disabling `reloadOnChange` can significantly reduce the number of opened files:
 
-[!code-csharp[](~/includes/docker-128/Program.cs?hightlight=14&name=snippet)]
+[!code-csharp[](~/includes/docker-128/Program.cs?highlight=14&name=snippet)]
 
 The preceding code can help prevent the user limit (128) when the app doesn't depend on reloading the *appsettings.json* file.
 

--- a/aspnetcore/includes/docker-128.md
+++ b/aspnetcore/includes/docker-128.md
@@ -4,7 +4,7 @@ no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cook
 
 <a name="d128"></a>
 
-## System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached.
+## System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached
 
 Disabling `reloadOnChange` can significantly reduce the number of opened files:
 

--- a/aspnetcore/includes/docker-128.md
+++ b/aspnetcore/includes/docker-128.md
@@ -2,8 +2,14 @@
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
 
+<a name="d128"></a>
+
 ## System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached.
 
 Disabling `reloadOnChange` can significantly reduce the number of opened files:
 
-[!code-csharp[](~/includes/docker-128/Program.cs?hightlight=14)]
+[!code-csharp[](~/includes/docker-128/Program.cs?hightlight=14&name=snippet)]
+
+The preceding code can help prevent the user limit (128) when the app doesn't depend on reloading the *appsettings.json* file.
+
+When adding multiple docker containers using the same host, consider specifying a randomized user ID in each Dockerfile. For more information, see [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/19814).

--- a/aspnetcore/includes/docker-128/Program.cs
+++ b/aspnetcore/includes/docker-128/Program.cs
@@ -1,0 +1,27 @@
+using Docker128;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+#region snippet
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        CreateHostBuilder(args).Build().Run();
+    }
+
+public static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureAppConfiguration((hostingContext, config) =>
+        {
+            config.AddJsonFile("appsettings.json",
+                optional: true,
+                reloadOnChange: false);
+        })
+        .ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.UseStartup<Startup>();
+        });
+}
+#endregion


### PR DESCRIPTION
Fixes #19814

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/?view=aspnetcore-1.0&branch=pr-en-us-22391#systemioioexception-the-configured-user-limit-128-on-the-number-of-inotify-instances-has-been-reached)

Per @travisgosselin

> In the ASP.NET Core world driven inside a container, there is next to zero reasons I can think of in which I would want to enforce reloading of that configuration file. Once my container is built and pushed to its container repository with an immutable version it does not change (only environment variables on deploy modify its behavior). In this straightforward scenario, there is very little reason to turn on “reloadOnChange”. Turning it off, lead to slightly less number of occurrences of this problem.

@travisgosselin writes
> The documentation is not great in telling you the default.

Just  above [Combining service collection](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-5.0#combining-service-collection)

Using the default configuration, the appsettings.json and appsettings.Environment.json files are enabled with reloadOnChange: true. Changes made to the appsettings.json and appsettings.Environment.json file after the app starts are read by the JSON configuration provider.

See #22392