### PR TITLE
Swap 'main' for 'master' branch in cross-links

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/configure-linker.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-linker.md
@@ -114,7 +114,7 @@ To control which I18N assemblies are retained, set the `<BlazorWebAssemblyI18NAs
 
 Use a comma to separate multiple values (for example, `mideast,west`).
 
-For more information, see [I18N: Pnetlib Internationalization Framework Library (mono/mono GitHub repository)](https://github.com/mono/mono/tree/master/mcs/class/I18N).
+For more information, see [I18N: Pnetlib Internationalization Framework Library (mono/mono GitHub repository)](https://github.com/mono/mono/tree/main/mcs/class/I18N).
 
 ## Additional resources
 

--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -17,7 +17,7 @@ By [Tom Dykstra](https://github.com/tdykstra), [Jeremy Likness](https://twitter.
 
 This is the first in a series of tutorials that show how to use Entity Framework (EF) Core in an [ASP.NET Core Razor Pages](xref:razor-pages/index) app. The tutorials build a web site for a fictional Contoso University. The site includes functionality such as student admission, course creation, and instructor assignments. The tutorial uses the code first approach. For information on following this tutorial using the database first approach, see [this Github issue](https://github.com/dotnet/AspNetCore.Docs/issues/16897).
 
-[Download or view the completed app.](https://github.com/dotnet/AspNetCore.Docs/tree/master/aspnetcore/data/ef-rp/intro/samples/cu50) [Download instructions](xref:index#how-to-download-a-sample).
+[Download or view the completed app.](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/ef-rp/intro/samples/cu50) [Download instructions](xref:index#how-to-download-a-sample).
 
 ## Prerequisites
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -633,7 +633,7 @@ If the app doesn't build the host with `CreateDefaultBuilder`, add the [Event So
 For more information, see:
 
 * [Trace for performance analysis utility (dotnet-trace)](/dotnet/core/diagnostics/dotnet-trace) (.NET Core documentation)
-* [Trace for performance analysis utility (dotnet-trace)](https://github.com/dotnet/diagnostics/blob/master/documentation/dotnet-trace-instructions.md) (dotnet/diagnostics GitHub repository documentation)
+* [Trace for performance analysis utility (dotnet-trace)](https://github.com/dotnet/diagnostics/blob/main/documentation/dotnet-trace-instructions.md) (dotnet/diagnostics GitHub repository documentation)
 * [LoggingEventSource Class](xref:Microsoft.Extensions.Logging.EventSource.LoggingEventSource) (.NET API Browser)
 * <xref:System.Diagnostics.Tracing.EventLevel>
 * [LoggingEventSource reference source (3.0)](https://github.com/dotnet/extensions/blob/release/3.0/src/Logging/Logging.EventSource/src/LoggingEventSource.cs): To obtain reference source for a different version, change the branch to `release/{Version}`, where `{Version}` is the version of ASP.NET Core desired.

--- a/aspnetcore/fundamentals/servers/index.md
+++ b/aspnetcore/fundamentals/servers/index.md
@@ -42,7 +42,7 @@ Kestrel has the following advantages over HTTP.sys:
   * Cross platform
   * Agility, it's developed and patched independent of the OS.
   * Programmatic port and TLS configuration
-  * Extensibility that allows for protocols like [PPv2](https://github.com/aspnet/AspLabs/blob/master/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocol.cs) and alternate transports.
+  * Extensibility that allows for protocols like [PPv2](https://github.com/aspnet/AspLabs/blob/main/src/ProxyProtocol/ProxyProtocol.Sample/ProxyProtocol.cs) and alternate transports.
 
 Http.Sys operates as a shared kernel mode component with the following features that kestrel does not have:
 

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -457,7 +457,7 @@ The preceding example uses the `ResolvedFileToPublish` item, whose default behav
 </ResolvedFileToPublish>
 ```
 
-For more deployment samples, see the [Web SDK README file](https://github.com/dotnet/sdk/tree/master/src/WebSdk).
+For more deployment samples, see the [Web SDK README file](https://github.com/dotnet/sdk/tree/main/src/WebSdk).
 
 ## Run a target before or after publishing
 

--- a/aspnetcore/migration/22-to-30.md
+++ b/aspnetcore/migration/22-to-30.md
@@ -1148,7 +1148,7 @@ To enable runtime compilation in your ASP.NET Core 3.0 project:
         .AddRazorRuntimeCompilation(...);
     ```
  
-The sample at https://github.com/aspnet/samples/tree/master/samples/aspnetcore/mvc/runtimecompilation shows an example of enabling runtime compilation conditionally in Development environments.
+The sample at https://github.com/aspnet/samples/tree/main/samples/aspnetcore/mvc/runtimecompilation shows an example of enabling runtime compilation conditionally in Development environments.
 
 For more information on Razor file compilation, see <xref:mvc/views/view-compilation>.
 


### PR DESCRIPTION
Fixes #22461

Found two 'master' branch cross-links in Blazor docs. Repo-wide search turned up a handful more that can be updated.