### PR TITLE
Blazor route constraints with optional params

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -191,7 +191,7 @@ The route constraints shown in the following table are available. For the route 
 
 ::: moniker range=">= aspnetcore-5.0"
 
-Route contraints also work with [optional parameters](#optional-parameters):
+Route contraints also work with [optional parameters](#route-parameters):
 
 ```razor
 @page "/user/{Id:int?}"

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -150,6 +150,9 @@ protected override void OnParametersSet()
 }
 ```
 
+> [!NOTE]
+> Route parameters don't work with query string values. To work with query strings, see the [Query string and parse parameters](#query-string-and-parse-parameters) section.
+
 ## Route constraints
 
 A route constraint enforces type matching on a route segment to a component.
@@ -173,6 +176,9 @@ In the following example, the route to the `User` component only matches if:
 
 ::: moniker-end
 
+> [!NOTE]
+> Route contraints don't work with query string values. To work with query strings, see the [Query string and parse parameters](#query-string-and-parse-parameters) section.
+
 The route constraints shown in the following table are available. For the route constraints that match the invariant culture, see the warning below the table for more information.
 
 | Constraint | Example           | Example Matches                                                                  | Invariant<br>culture<br>matching |
@@ -191,10 +197,28 @@ The route constraints shown in the following table are available. For the route 
 
 ::: moniker range=">= aspnetcore-5.0"
 
-Route contraints also work with [optional parameters](#route-parameters):
+Route contraints also work with [optional parameters](#route-parameters). In the following example, `Id` is required, but `Option` is an optional boolean route parameter.
+
+`Pages/User.razor`:
 
 ```razor
-@page "/user/{Id:int?}"
+@page "/user/{Id:int}/{Option:bool?}"
+
+<p>
+    Id: @Id
+</p>
+
+<p>
+    Option: @Option
+</p>
+
+@code {
+    [Parameter]
+    public int Id { get; set; }
+
+    [Parameter]
+    public bool Option { get; set; }
+}
 ```
 
 ::: moniker-end

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -63,6 +63,9 @@ Components support multiple route templates using multiple [`@page` directives](
 > [!IMPORTANT]
 > For URLs to resolve correctly, the app must include a `<base>` tag in its `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server) with the app base path specified in the `href` attribute. For more information, see <xref:blazor/host-and-deploy/index#app-base-path>.
 
+> [!NOTE]
+> The <xref:Microsoft.AspNetCore.Components.Routing.Router> doesn't interact with query string values. To work with query strings, see the [Query string and parse parameters](#query-string-and-parse-parameters) section.
+
 ## Provide custom content when content isn't found
 
 The <xref:Microsoft.AspNetCore.Components.Routing.Router> component allows the app to specify custom content if content isn't found for the requested route.

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -189,6 +189,16 @@ The route constraints shown in the following table are available. For the route 
 > [!WARNING]
 > Route constraints that verify the URL and are converted to a CLR type (such as `int` or <xref:System.DateTime>) always use the invariant culture. These constraints assume that the URL is non-localizable.
 
+::: moniker range=">= aspnetcore-5.0"
+
+Route contraints also work with [optional parameters](#optional-parameters):
+
+```razor
+@page "/user/{Id:int?}"
+```
+
+::: moniker-end
+
 ## Routing with URLs that contain dots
 
 For hosted Blazor WebAssembly and Blazor Server apps, the server-side default route template assumes that if the last segment of a request URL contains a dot (`.`) that a file is requested. For example, the URL `https://localhost.com:5001/example/some.thing` is interpreted by the router as a request for a file named `some.thing`. Without additional configuration, an app returns a *404 - Not Found* response if `some.thing` was meant to route to a component with an [`@page` directive](xref:mvc/views/razor#page) and `some.thing` is a route parameter value. To use a route with one or more parameters that contain a dot, the app must configure the route with a custom template.


### PR DESCRIPTION
Fixes #22477

Thanks @ErikApption! :rocket:

Pranav: Optional parameters are covered in the *Route parameters* section, so that's why the bookmark link is set up the way that it is.