### PR TITLE
Blazor interaction with the DOM

### DIFF
--- a/aspnetcore/blazor/includes/prerendering.md
+++ b/aspnetcore/blazor/includes/prerendering.md
@@ -14,7 +14,7 @@ For the following example, the `setElementText1` function is placed inside the `
 ```
 
 > [!WARNING]
-> **The preceding example modifies the Document Object Model (DOM) directly for demonstration purposes only.** Directly modifying the DOM with JavaScript isn't recommended in most scenarios because JavaScript can interfere with Blazor's change tracking.
+> **The preceding example modifies the Document Object Model (DOM) directly for demonstration purposes only.** Directly modifying the DOM with JavaScript isn't recommended in most scenarios because JavaScript can interfere with Blazor's change tracking. For more information, see <xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom>.
 
 To delay JavaScript interop calls until a point where such calls are guaranteed to work, override the [`OnAfterRender{Async}` lifecycle event](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync). This event is only called after the app is fully rendered.
 
@@ -59,7 +59,7 @@ For the following example, the `setElementText2` function is placed inside the `
 ```
 
 > [!WARNING]
-> **The preceding example modifies the Document Object Model (DOM) directly for demonstration purposes only.** Directly modifying the DOM with JavaScript isn't recommended in most scenarios because JavaScript can interfere with Blazor's change tracking.
+> **The preceding example modifies the Document Object Model (DOM) directly for demonstration purposes only.** Directly modifying the DOM with JavaScript isn't recommended in most scenarios because JavaScript can interfere with Blazor's change tracking. For more information, see <xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom>.
 
 Where <xref:Microsoft.JSInterop.JSRuntime.InvokeAsync%2A?displayProperty=nameWithType> is called, the <xref:Microsoft.AspNetCore.Components.ElementReference> is only used in <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync%2A> and not in any earlier lifecycle method because there's no JavaScript element until after the component is rendered.
 

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -427,3 +427,4 @@ For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#ja
 
 * <xref:blazor/js-interop/call-javascript-from-dotnet>
 * [`InteropComponent.razor` example (dotnet/AspNetCore GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/5.0`), use the **Switch branches or tags** dropdown list to select the branch.
+* [Interaction with the Document Object Model (DOM)](xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom)

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -322,6 +322,8 @@ The following example shows capturing a reference to the `username` `<input>` el
 > ```
 >
 > If JS interop mutates the contents of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM.
+>
+> For more information, see <xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom>.
 
 An <xref:Microsoft.AspNetCore.Components.ElementReference> is passed through to JS code via JS interop. The JS code receives an `HTMLElement` instance, which it can use with normal DOM APIs. For example, the following code defines a .NET extension method (`TriggerClickEvent`) that enables sending a mouse click to an element.
 

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -18,6 +18,16 @@ This overview article covers general concepts. Further JS interop guidance is pr
 * <xref:blazor/js-interop/call-javascript-from-dotnet>
 * <xref:blazor/js-interop/call-dotnet-from-javascript>
 
+## Interaction with the Document Object Model (DOM)
+
+Only mutate the Document Object Model (DOM) with JavaScript (JS) when the object doesn't interact with Blazor. Blazor maintains representations of the DOM and interacts directly with DOM objects. If JS interop mutates an element or its content and Blazor attempts to apply diffs to the element, the diffs won't match the DOM and undefined behavior results. Arbitrary behaviors may merely interfere with the presentation of elements or their behavior but may also introduce security risks to the app or server.
+
+This guidance not only applies to your own JS interop code but also to any JS libraries that the app uses, including anything provided by a third-party framework, such as [Bootstrap JS](https://getbootstrap.com/) and [jQuery](https://jquery.com/).
+
+In a few documentation examples, JS interop is used to mutate an element *purely for demonstration purposes* as part of the example. In those cases, a warning appears in the text.
+
+For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#capture-references-to-elements>.
+
 ## Location of JavaScipt
 
 Load JavaScript (JS) code using any of the following approaches:

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -24,7 +24,7 @@ Only mutate the Document Object Model (DOM) with JavaScript (JS) when the object
 
 This guidance not only applies to your own JS interop code but also to any JS libraries that the app uses, including anything provided by a third-party framework, such as [Bootstrap JS](https://getbootstrap.com/) and [jQuery](https://jquery.com/).
 
-In a few documentation examples, JS interop is used to mutate an element *purely for demonstration purposes* as part of the example. In those cases, a warning appears in the text.
+In a few documentation examples, JS interop is used to mutate an element *purely for demonstration purposes* as part of an example. In those cases, a warning appears in the text.
 
 For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#capture-references-to-elements>.
 


### PR DESCRIPTION
Addresses #19286

Thanks @angelotrivelli! :rocket: ... We just discussed the use of Bootstrap JS offline, and the PU ("product unit") confirmed that it's just like any other JS lib/framework. If the JS interop use of Bootstrap interacts with the same DOM objects that Blazor is tracking, bad results can ensue. If the Bootstrap JS is touching something that Blazor isn't tracking, then it's fine.

I'm improving the coverage on this subject ...

* I add a section to the new JS interop *Overview* topic on this.
* I mention Bootstrap JS and jQuery as examples.
* I mention that a few doc examples do violate the general guidance purely for demonstration purposes as part of an example, and I mention that the text calls out when the docs do this.
* I cross-link to the new section from relevant spots.

cc: @mkArtakMSFT ... This takes care of what we discussed. I'll mod further if additional feedback appears in the offline discussion.