### PR TITLE
Typo on CurrentCount upper/lower case

### DIFF
--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -385,7 +385,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         var result = await ProtectedSessionStore.GetAsync<int>("count");
-        currentCount = result.Success ? result.Value : 0;
+        CurrentCount = result.Success ? result.Value : 0;
         isLoaded = true;
     }
 


### PR DESCRIPTION
There was a typo on `CurrentCount` lower case, should be upper case.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->