### PR TITLE
Google JS Brotli decompression script for Blazor

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -39,12 +39,13 @@ Blazor relies on the host to the serve the appropriate compressed files. When us
 
   * Obtain the JavaScript Brotli decoder from the [google/brotli GitHub repository](https://github.com/google/brotli). The decoder file is named `decode.js` and found in the repository's [`js` folder](https://github.com/google/brotli/tree/master/js).
   
-    > [!NOTE]
-    > A regression is present in the minified version of the `decode.js` script (`decode.min.js`) in the [google/brotli GitHub repository](https://github.com/google/brotli). Until the issue [TypeError in decode.min.js (google/brotli #881)](https://github.com/google/brotli/issues/881) is resolved, take one of the following approaches:
+    > [!WARNING]
+    > Don't use the minified version of the `decode.js` script (`decode.min.js`) in the [google/brotli GitHub repository](https://github.com/google/brotli) repository. A regression was reported in the `decode.min.js` script at [TypeError in decode.min.js (google/brotli #881)](https://github.com/google/brotli/issues/881). Workaround the issue with any of the following approaches:
     >
-    > * Temporarily use the unminified version of the script.
-    > * Automatically minify the script at build-time with a third-party minification tool compatible with ASP.NET Core.
+    > * Use the unminified version of the script until the regression is fixed.
+    > * Automatically minify the script at build-time with a third-party minification tool compatible with ASP.NET Core. For more information, see <xref:client-side/bundling-and-minification>.
     > * Use the [npm package](https://www.npmjs.com/package/brotli).
+    > * Find another JavaScript Brotli decoder to use.
     >
     > The example code in this section uses the **unminified** version of the script (`decode.js`).
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -43,7 +43,7 @@ Blazor relies on the host to the serve the appropriate compressed files. When us
     > Don't use the minified version of the `decode.js` script (`decode.min.js`) in the [google/brotli GitHub repository](https://github.com/google/brotli) repository. A regression was reported in the `decode.min.js` script at [TypeError in decode.min.js (google/brotli #881)](https://github.com/google/brotli/issues/881). Adopt any of the following approaches:
     >
     > * Use the unminified version of the script until the regression is fixed.
-    > * Automatically minify the script at build-time with a third-party minification tool compatible with ASP.NET Core. For more information, see <xref:client-side/bundling-and-minification>.
+    > * Automatically minify the `decode.js` script at build-time with a third-party minification tool compatible with ASP.NET Core. For more information, see <xref:client-side/bundling-and-minification>.
     > * Use the [npm package](https://www.npmjs.com/package/brotli).
     > * Find another JavaScript Brotli decoder to use.
     >

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -40,7 +40,7 @@ Blazor relies on the host to the serve the appropriate compressed files. When us
   * Obtain the JavaScript Brotli decoder from the [google/brotli GitHub repository](https://github.com/google/brotli). The decoder file is named `decode.js` and found in the repository's [`js` folder](https://github.com/google/brotli/tree/master/js).
   
     > [!WARNING]
-    > Don't use the minified version of the `decode.js` script (`decode.min.js`) in the [google/brotli GitHub repository](https://github.com/google/brotli) repository. A regression was reported in the `decode.min.js` script at [TypeError in decode.min.js (google/brotli #881)](https://github.com/google/brotli/issues/881). Workaround the issue with any of the following approaches:
+    > Don't use the minified version of the `decode.js` script (`decode.min.js`) in the [google/brotli GitHub repository](https://github.com/google/brotli) repository. A regression was reported in the `decode.min.js` script at [TypeError in decode.min.js (google/brotli #881)](https://github.com/google/brotli/issues/881). Adopt any of the following approaches:
     >
     > * Use the unminified version of the script until the regression is fixed.
     > * Automatically minify the script at build-time with a third-party minification tool compatible with ASP.NET Core. For more information, see <xref:client-side/bundling-and-minification>.


### PR DESCRIPTION
Fixes #21465

@stefanloerwald ... I'm going to close the issue out with these updates. I don't want an issue lying around here **_forever_**. If they ever fix the script minification and close your issue, would you open a new docs issue from the topic to update the content?