### PR TITLE
fileContent gets disposed prior to upload

### DIFF
--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor
@@ -75,8 +75,9 @@
 
                 if (file.Size < maxFileSize)
                 {
+                    var byteContent = new ByteArrayContent(await fileContent.ReadAsByteArrayAsync());
                     content.Add(
-                        content: fileContent,
+                        content: byteContent,
                         name: "\"files\"",
                         fileName: file.Name);
 


### PR DESCRIPTION
Added the StreamContent as ByteArrayContent to allow the fileContent variable to get disposed as expected without impacting the PostAsync call.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->