### PR TITLE
Cover Blazor InputX DisplayName property generically

### DIFF
--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -257,11 +257,7 @@ In the following example:
 
 ## Display name support
 
-The following built-in components support display names with the <xref:Microsoft.AspNetCore.Components.Forms.InputBase%601.DisplayName%2A?displayProperty=nameWithType> parameter:
-
-* <xref:Microsoft.AspNetCore.Components.Forms.InputDate%601>
-* <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601>
-* <xref:Microsoft.AspNetCore.Components.Forms.InputSelect%601>
+Several built-in components support display names with the <xref:Microsoft.AspNetCore.Components.Forms.InputBase%601.DisplayName%2A?displayProperty=nameWithType> parameter.
 
 In the `Starfleet Starship Database` form (`FormExample2` component) of the [Example form](#example-form) section, the production date of a new starship doesn't specify a display name:
 


### PR DESCRIPTION
Fixes #22515

Thanks @mxmissile! :rocket:

Let's call it out generically. The dev can check the API to see which `Input{X}` components support it. This way, the doc is hardened against future engineering churn (e.g., new `Input{X}` components).