### PR TITLE
Loc Middleware ordering

### DIFF
--- a/aspnetcore/fundamentals/localization-extensibility.md
+++ b/aspnetcore/fundamentals/localization-extensibility.md
@@ -42,28 +42,8 @@ The preceding providers are described in detail in the [Localization Middleware]
 
 <xref:Microsoft.AspNetCore.Localization.CustomRequestCultureProvider> provides a custom <xref:Microsoft.AspNetCore.Localization.RequestCultureProvider> that uses a simple delegate to determine the current localization culture:
 
-::: moniker range="< aspnetcore-3.0"
-```csharp
-options.RequestCultureProviders.Insert(0, new CustomRequestCultureProvider(async context =>
-{
-    var currentCulture = "en";
-    var segments = context.Request.Path.Value.Split(new char[] { '/' }, 
-        StringSplitOptions.RemoveEmptyEntries);
-
-    if (segments.Length > 1 && segments[0].Length == 2)
-    {
-        currentCulture = segments[0];
-    }
-
-    var requestCulture = new ProviderCultureResult(currentCulture);
-    
-    return Task.FromResult(requestCulture);
-}));
-```
-
-::: moniker-end
-
 ::: moniker range=">= aspnetcore-3.0"
+
 ```csharp
 options.AddInitialRequestCultureProvider(new CustomRequestCultureProvider(async context =>
 {
@@ -77,7 +57,29 @@ options.AddInitialRequestCultureProvider(new CustomRequestCultureProvider(async 
     }
 
     var requestCulture = new ProviderCultureResult(currentCulture);
-    
+
+    return Task.FromResult(requestCulture);
+}));
+```
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-3.0"
+
+```csharp
+options.RequestCultureProviders.Insert(0, new CustomRequestCultureProvider(async context =>
+{
+    var currentCulture = "en";
+    var segments = context.Request.Path.Value.Split(new char[] { '/' }, 
+        StringSplitOptions.RemoveEmptyEntries);
+
+    if (segments.Length > 1 && segments[0].Length == 2)
+    {
+        currentCulture = segments[0];
+    }
+
+    var requestCulture = new ProviderCultureResult(currentCulture);
+
     return Task.FromResult(requestCulture);
 }));
 ```
@@ -88,7 +90,7 @@ options.AddInitialRequestCultureProvider(new CustomRequestCultureProvider(async 
 
 A new implementation of <xref:Microsoft.AspNetCore.Localization.RequestCultureProvider> can be created that determines the request culture information from a custom source. For example, the custom source can be a configuration file or database.
 
-The following example shows `AppSettingsRequestCultureProvider`, which extends the <xref:Microsoft.AspNetCore.Localization.RequestCultureProvider> to determine the request culture information from *appsettings.json*:
+The following example shows `AppSettingsRequestCultureProvider`, which extends the <xref:Microsoft.AspNetCore.Localization.RequestCultureProvider> to determine the request culture information from `appsettings.json`:
 
 ```csharp
 public class AppSettingsRequestCultureProvider : RequestCultureProvider
@@ -136,7 +138,7 @@ ASP.NET Core localization provides <xref:Microsoft.Extensions.Localization.Resou
 
 You aren't limited to using `resx` files. By implementing `IStringLocalizer`, any data source can be used.
 
-The following example projects implement <xref:Microsoft.Extensions.Localization.IStringLocalizer>: 
+The following example projects implement <xref:Microsoft.Extensions.Localization.IStringLocalizer>:
 
 * [EFStringLocalizer](https://github.com/aspnet/Entropy/tree/master/samples/Localization.EntityFramework)
 * [JsonStringLocalizer](https://github.com/hishamco/My.Extensions.Localization.Json)

--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -218,7 +218,7 @@ Localization is configured in the `Startup.ConfigureServices` method:
 
 ### Localization middleware
 
-The current culture on a request is set in the localization [Middleware](xref:fundamentals/middleware/index). The localization middleware is enabled in the `Startup.Configure` method. The localization middleware must be configured before any middleware which might check the request culture (for example, `app.UseMvcWithDefaultRoute()`).
+The current culture on a request is set in the localization [Middleware](xref:fundamentals/middleware/index). The localization middleware is enabled in the `Startup.Configure` method. The localization middleware must be configured before any middleware that might check the request culture (for example, `app.UseMvcWithDefaultRoute()`). Localization Middleware must appear after Routing Middleware if using <xref:Microsoft.AspNetCore.Localization.Routing.RouteDataRequestCultureProvider>. For more information on middleware order, see <xref:fundamentals/middleware/index#middleware-order>.
 
 [!code-csharp[](localization/sample/3.x/Localization/Startup.cs?name=snippet2)]
 

--- a/aspnetcore/fundamentals/localization/sample/3.x/Localization/Startup.cs
+++ b/aspnetcore/fundamentals/localization/sample/3.x/Localization/Startup.cs
@@ -76,6 +76,10 @@ namespace Localization
                 catch { }
             }
 
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+            app.UseRouting();
+
             #region snippet2
             var supportedCultures = new[] { "en-US", "fr" };
             var localizationOptions = new RequestLocalizationOptions().SetDefaultCulture(supportedCultures[0])
@@ -83,19 +87,16 @@ namespace Localization
                 .AddSupportedUICultures(supportedCultures);
 
             app.UseRequestLocalization(localizationOptions);
-
-            app.UseRouting();
-            app.UseStaticFiles();
+            #endregion
 
             app.UseAuthentication();
+            app.UseAuthorization();
 
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(name: "default", pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-            #endregion
-
-            app.UseRequestLocalization();
+            
         }
     }
 }

--- a/aspnetcore/fundamentals/localization/sample/3.x/Localization/Startup.cs
+++ b/aspnetcore/fundamentals/localization/sample/3.x/Localization/Startup.cs
@@ -96,7 +96,6 @@ namespace Localization
             {
                 endpoints.MapControllerRoute(name: "default", pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-            
         }
     }
 }

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -80,18 +80,19 @@ The following `Startup.Configure` method adds security-related middleware compon
 In the preceding code:
 
 * Middleware that is not added when creating a new web app with [individual users accounts](xref:security/authentication/identity) is commented out.
-* Not every middleware needs to go in this exact order, but many do. For example:
-  * `UseCors`, `UseAuthentication`, and `UseAuthorization` must go in the order shown.
-  * `UseCors` currently must go before `UseResponseCaching` due to [this bug](https://github.com/dotnet/aspnetcore/issues/23218).
+* Not every middleware appears in this exact order, but many do. For example:
+  * `UseCors`, `UseAuthentication`, and `UseAuthorization` must appear in the order shown.
+  * `UseCors` currently must appear before `UseResponseCaching` due to [this bug](https://github.com/dotnet/aspnetcore/issues/23218).
+  * `UseRequestLocalization` must appear before any middleware that might check the request culture (for example, `app.UseMvcWithDefaultRoute()`).
 
-In some scenarios, middleware will have different ordering. For example, caching and compression ordering is scenario specific, and there's multiple valid orderings. For example:
+In some scenarios, middleware has different ordering. For example, caching and compression ordering is scenario specific, and there's multiple valid orderings. For example:
 
 ```csharp
 app.UseResponseCaching();
 app.UseResponseCompression();
 ```
 
-With the preceding code, CPU could be saved by caching the compressed response, but you might end up caching multiple representations of a resource using different compression algorithms such as gzip or brotli.
+With the preceding code, CPU could be saved by caching the compressed response, but you might end up caching multiple representations of a resource using different compression algorithms such as Gzip or Brotli.
 
 The following ordering combines static files to allow caching compressed static files:
 
@@ -270,7 +271,7 @@ ASP.NET Core ships with the following middleware components. The *Order* column 
 | [OWIN](xref:fundamentals/owin) | Interop with OWIN-based apps, servers, and middleware. | Terminal if the OWIN Middleware fully processes the request. |
 | [Response Caching](xref:performance/caching/middleware) | Provides support for caching responses. | Before components that require caching. `UseCORS` must come before `UseResponseCaching`.|
 | [Response Compression](xref:performance/response-compression) | Provides support for compressing responses. | Before components that require compression. |
-| [Request Localization](xref:fundamentals/localization) | Provides localization support. | Before localization sensitive components. |
+| [Request Localization](xref:fundamentals/localization) | Provides localization support. | Before localization sensitive components. Must appear after Routing Middleware when using <xref:Microsoft.AspNetCore.Localization.Routing.RouteDataRequestCultureProvider>. |
 | [Endpoint Routing](xref:fundamentals/routing) | Defines and constrains request routes. | Terminal for matching routes. |
 | [SPA](xref:Microsoft.AspNetCore.Builder.SpaApplicationBuilderExtensions.UseSpa%2A) | Handles all requests from this point in the middleware chain by returning the default page for the Single Page Application (SPA) | Late in the chain, so that other middleware for serving static files, MVC actions, etc., takes precedence.|
 | [Session](xref:fundamentals/app-state) | Provides support for managing user sessions. | Before components that require Session. | 


### PR DESCRIPTION
Fixes #22512

@hishamco ...

* Places Routing Middleware first with an added bit for `RouteDataRequestCultureProvider`, which isn't covered in docs AFAICT. I cross-link it to its API doc.
* Scoping down the loc topic code sample to just show the pipeline add. The text explains two key ordering concepts and cross-links to the Middleware topic for more info. This has the Middleware topic deal with the broader aspects and show the full example.
* Minor touches to Loc Extensibility doc.

NOTE: In the loc sample app at ...

> aspnetcore\fundamentals\localization\sample\3.x\Localization\Startup.cs

https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/fundamentals/localization/sample/3.x/Localization/Startup.cs#L98

... there was a 2nd `app.UseRequestLocalization()` that appeared at the very end after `UseEndpoints` and that wasn't shown in the topic because it was outside of the snippet. I remove it on this PR. If that was there by-design, let me know. I'll put it back. :ear: