### PR TITLE
Update jsonpatch.md

### DIFF
--- a/aspnetcore/web-api/jsonpatch.md
+++ b/aspnetcore/web-api/jsonpatch.md
@@ -46,6 +46,8 @@ The preceding code requires the `Microsoft.AspNetCore.Mvc.NewtonsoftJson` packag
 
 [!code-csharp[](jsonpatch/samples/3.0/WebApp1/Startup.cs?name=snippet1)]
 
+Use the `Newtonsoft.Json.JsonConvert.SerializeObject` method to serialize a JsonPatchDocument.
+
 ## PATCH HTTP request method
 
 The PUT and [PATCH](https://tools.ietf.org/html/rfc5789) methods are used to update an existing resource. The difference between them is that PUT replaces the entire resource, while PATCH specifies only the changes.


### PR DESCRIPTION
It took me longer than I care to admit before I worked out I was getting a 400 response to a Patch request because I was serialising the request using  `JsonSerializer.Serialize` rather than `JsonConvert.SerializeObject`.  I hope this will help someone avoid the same issue.

