### PR TITLE
Update hosted-with-azure-active-directory.md

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -377,12 +377,12 @@ Support for <xref:System.Net.Http.HttpClient> instances is added that include ac
 `Program.cs`:
 
 ```csharp
-builder.Services.AddHttpClient("{APP ASSEMBLY}.WebAPI", client => 
+builder.Services.AddHttpClient("{APP ASSEMBLY}.ServerAPI", client => 
         client.BaseAddress = new Uri(builder.HostEnvironment.BaseAddress))
     .AddHttpMessageHandler<BaseAddressAuthorizationMessageHandler>();
 
 builder.Services.AddScoped(sp => sp.GetRequiredService<IHttpClientFactory>()
-    .CreateClient("{APP ASSEMBLY}.WebAPI"));
+    .CreateClient("{APP ASSEMBLY}.ServerAPI"));
 ```
 
 The placeholder `{APP ASSEMBLY}` is the app's assembly name (for example, `BlazorSample.Client`).


### PR DESCRIPTION
The document, in the client configuration section reference the auto generated code in the program.cs. In this code it specify the template will produce a name based on the App Assembly concatenated with the ".WebAPI" literal. This has changed in recent versions and the reference should be App Assembly concatenated with the ".ServerAPI" literal.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->