### PR TITLE
Update to include PassThroughAuthorizationHandler

### DIFF
--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -171,7 +171,9 @@ Handlers are registered in the services collection during configuration. For exa
 
 The preceding code registers `MinimumAgeHandler` as a singleton by invoking `services.AddSingleton<IAuthorizationHandler, MinimumAgeHandler>();`. Handlers can be registered using any of the built-in [service lifetimes](xref:fundamentals/dependency-injection#service-lifetimes).
 
-It is possible to bundle both a requirement and a handler in a single class implementing both `IAuthorizationRequirement` and `IAuthorizationHander`. This creates a tight coupling between the handler and requirement and is only recommended for simple requirements and handlers. Creating a class which implements both interfaces removes the need to register the handler in DI due to the built-in `PassThroughtAuthorizationHandler` that allows requirements to handle themselves. 
+It's possible to bundle both a requirement and a handler in a single class implementing both <xref:Microsoft.AspNetCore.Authorization.IAuthorizationRequirement> and /dotnet/api/microsoft.aspnetcore.authorization.iauthorizationhandler. This creates a tight coupling between the handler and requirement and is only recommended for simple requirements and handlers. Creating a class which implements both interfaces removes the need to register the handler in DI due to the built-in [PassThroughtAuthorizationHandler](https://github.com/dotnet/aspnetcore/blob/v5.0.7/src/Security/Authorization/Core/src/PassThroughAuthorizationHandler.cs) that allows requirements to handle themselves.
+
+See the [AssertionRequirement class](https://github.com/dotnet/aspnetcore/blob/52eff90fbcfca39b7eb58baad597df6a99a542b0/src/Security/Authorization/Core/src/AssertionRequirement.cs#L13) for a good example where the `AssertionRequirement` is both a requirement and the handler in a fully self contained class.
 
 ## What should a handler return?
 

--- a/aspnetcore/security/authorization/policies.md
+++ b/aspnetcore/security/authorization/policies.md
@@ -171,6 +171,8 @@ Handlers are registered in the services collection during configuration. For exa
 
 The preceding code registers `MinimumAgeHandler` as a singleton by invoking `services.AddSingleton<IAuthorizationHandler, MinimumAgeHandler>();`. Handlers can be registered using any of the built-in [service lifetimes](xref:fundamentals/dependency-injection#service-lifetimes).
 
+It is possible to bundle both a requirement and a handler in a single class implementing both `IAuthorizationRequirement` and `IAuthorizationHander`. This creates a tight coupling between the handler and requirement and is only recommended for simple requirements and handlers. Creating a class which implements both interfaces removes the need to register the handler in DI due to the built-in `PassThroughtAuthorizationHandler` that allows requirements to handle themselves. 
+
 ## What should a handler return?
 
 Note that the `Handle` method in the [handler example](#security-authorization-handler-example) returns no value. How is a status of either success or failure indicated?


### PR DESCRIPTION
Adding a description of why mixing a handler and policy in the same class removes the need for DI registration.

Fixes https://github.com/dotnet/AspNetCore.Docs/issues/18695



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->