### PR TITLE
Fix broken Blazor file upload component

### DIFF
--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor
@@ -65,7 +65,7 @@
             if (uploadResults.SingleOrDefault(
                 f => f.FileName == file.Name) is null)
             {
-                using var fileContent = new StreamContent(file.OpenReadStream());
+                var fileContent = new StreamContent(file.OpenReadStream());
 
                 files.Add(
                     new()

--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -30,7 +30,7 @@ Web API controllers don't have to check `ModelState.IsValid` if they have the `[
 
 ## Rerun validation
 
-Validation is automatic, but you might want to repeat it manually. For example, you might compute a value for a property and want to rerun validation after setting the property to the computed value. To rerun validation, call [`ModelState.ClearValidationState`](Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary.ClearValidationState) to clear validation specific to the model being validated followed by `TryValidateModel`:
+Validation is automatic, but you might want to repeat it manually. For example, you might compute a value for a property and want to rerun validation after setting the property to the computed value. To rerun validation, call <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary.ClearValidationState%2A?displayProperty=nameWithType> to clear validation specific to the model being validated followed by `TryValidateModel`:
 
 [!code-csharp[](validation/samples/3.x/ValidationSample/Pages/Movies/Create.cshtml.cs?name=snippet_TryValidate&highlight=6-10)]
 


### PR DESCRIPTION
Fixes #22503

Sorry for the trouble @kenjohnson03 and @renner2 ... Since my local test (hosted WASM) app does **_NOT_** have the `using` and the topic's Blazor Server example does **_NOT_** have it, it seems that I missed the update when working on this for the **_pivot_**. On https://github.com/dotnet/AspNetCore.Docs/pull/22161, I made an update to this topic to pivot the text and example between WASM and Server approaches because the text and example code are different. There are **two** examples of the component, one for WASM and one for Server. The WASM one didn't get this change. These 😈 *rotten gremlins* 😈 get in sometimes, and I appreciate your help and patience getting them **_OUT_** 😠 of the docs!