### PR TITLE
Tweak the docker instructions

### DIFF
--- a/aspnetcore/security/data-protection/configuration/overview.md
+++ b/aspnetcore/security/data-protection/configuration/overview.md
@@ -423,7 +423,7 @@ Though not exposed as a first-class API, the Data Protection system is extensibl
 When hosting in a [Docker](/dotnet/standard/microservices-architecture/container-docker-introduction/) container, keys should be maintained in either:
 
 * A folder that's a Docker volume that persists beyond the container's lifetime, such as a shared volume or a host-mounted volume.
-* An external provider, such as [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction/) as shown above or [Redis](https://redis.io/).
+* An external provider, such as [Azure Blob Storage](/azure/storage/blobs/storage-blobs-introduction) (shown above) or [Redis](https://redis.io).
 
 
 ## Persisting keys with Redis

--- a/aspnetcore/security/data-protection/configuration/overview.md
+++ b/aspnetcore/security/data-protection/configuration/overview.md
@@ -423,7 +423,7 @@ Though not exposed as a first-class API, the Data Protection system is extensibl
 When hosting in a [Docker](/dotnet/standard/microservices-architecture/container-docker-introduction/) container, keys should be maintained in either:
 
 * A folder that's a Docker volume that persists beyond the container's lifetime, such as a shared volume or a host-mounted volume.
-* An external provider, such as [Azure Blob Storage](/azure/storage/blobs/storage-blobs-introduction) (shown above) or [Redis](https://redis.io).
+* An external provider, such as [Azure Blob Storage](/azure/storage/blobs/storage-blobs-introduction) (shown in the [`ProtectKeysWithAzureKeyVault`](#ProtectKeysWithAzureKeyVault) section) or [Redis](https://redis.io).
 
 
 ## Persisting keys with Redis

--- a/aspnetcore/security/data-protection/configuration/overview.md
+++ b/aspnetcore/security/data-protection/configuration/overview.md
@@ -423,7 +423,8 @@ Though not exposed as a first-class API, the Data Protection system is extensibl
 When hosting in a [Docker](/dotnet/standard/microservices-architecture/container-docker-introduction/) container, keys should be maintained in either:
 
 * A folder that's a Docker volume that persists beyond the container's lifetime, such as a shared volume or a host-mounted volume.
-* An external provider, such as [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) or [Redis](https://redis.io/).
+* An external provider, such as [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blobs-introduction/) as shown above or [Redis](https://redis.io/).
+
 
 ## Persisting keys with Redis
 

--- a/aspnetcore/security/data-protection/configuration/overview.md
+++ b/aspnetcore/security/data-protection/configuration/overview.md
@@ -423,7 +423,7 @@ Though not exposed as a first-class API, the Data Protection system is extensibl
 When hosting in a [Docker](/dotnet/standard/microservices-architecture/container-docker-introduction/) container, keys should be maintained in either:
 
 * A folder that's a Docker volume that persists beyond the container's lifetime, such as a shared volume or a host-mounted volume.
-* An external provider, such as [Azure Blob Storage](/azure/storage/blobs/storage-blobs-introduction) (shown in the [`ProtectKeysWithAzureKeyVault`](#ProtectKeysWithAzureKeyVault) section) or [Redis](https://redis.io).
+* An external provider, such as [Azure Blob Storage](/azure/storage/blobs/storage-blobs-introduction) (shown in the [`ProtectKeysWithAzureKeyVault`](#protectkeyswithazurekeyvault) section) or [Redis](https://redis.io).
 
 
 ## Persisting keys with Redis


### PR DESCRIPTION
Correct that its blob storage that stores the keys, not keyvault.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->