### PR TITLE
Clarify Blazor chained bind example

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -244,7 +244,7 @@ The `PasswordEntry` component is used in another component, such as the followin
 
 ::: moniker-end
 
-When the `PasswordBinding` component is initially rendered, the `password` value of `Not set` is displayed in the UI. After initial rendering, the value of `password` reflects changes of the `Password` component parameter value in the `PasswordEntry` component.
+When the `PasswordBinding` component is initially rendered, the `password` value of `Not set` is displayed in the UI. After initial rendering, the value of `password` reflects changes made to the `Password` component parameter value in the `PasswordEntry` component.
 
 > [!NOTE]
 > The preceding example binds the password one-way from the child `PasswordEntry` component to the parent `PasswordBinding` component. Two-way binding isn't a requirement in this scenario if the goal is for the app to have a shared password entry component for reuse around the app that merely passes the password to the parent. For an approach that permits two-way binding without [writing directly to the child component's parameter](xref:blazor/components/index#overwritten-parameters), see the `NestedChild` component example in the [Bind across more than two components](#bind-across-more-than-two-components) section of this article.

--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -302,6 +302,9 @@ A common and recommended approach is to only store the underlying data in the pa
 
 ::: moniker-end
 
+> [!WARNING]
+> Generally, avoid creating components that write directly to their own component parameters. The preceding `NestedChild` component makes use of a `BoundValue` property instead of writing directly to its `ChildMessage` parameter. For more information, see <xref:blazor/components/index#overwritten-parameters>.
+
 `Shared/NestedGrandchild.razor`:
 
 ::: moniker range=">= aspnetcore-5.0"

--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -208,7 +208,7 @@ By convention, a property can be bound to a corresponding event handler by inclu
 <ChildBind @bind-Year="year" @bind-Year:event="YearChanged" />
 ```
 
-In a more sophisticated and real-world example, the following `Password` component:
+In a more sophisticated and real-world example, the following `PasswordEntry` component:
 
 * Sets an `<input>` element's value to a `password` field.
 * Exposes changes of a `Password` property to a parent component with an [`EventCallback`](xref:blazor/components/event-handling#eventcallback) that passes in the current value of the child's `password` field as its argument.
@@ -244,7 +244,12 @@ The `PasswordEntry` component is used in another component, such as the followin
 
 ::: moniker-end
 
-Perform checks or trap errors in the method that invokes the binding's delegate. The following revised `PasswordEntry` component provides immediate feedback to the user if a space is used in the password's value.
+When the `PasswordBinding` component is initially rendered, the initial `password` value of `Not set` is displayed in the UI. After initial rendering, the value of `password` reflects any changes made to the password by the user via the `Password` component parameter in the `PasswordEntry` component.
+
+> [!NOTE]
+> The preceding example binds the password one-way from the child `PasswordEntry` component to the parent `PasswordBinding` component. Two-way binding isn't a requirement in this scenario if the goal is for the app to have a shared password entry component for reuse around the app that merely passes the password to the parent. For an approach that permits two-way binding without [writing directly to the child component's parameter](xref:blazor/components/index#overwritten-parameters), see the [Bind across more than two components](#bind-across-more-than-two-components) section of this article.
+
+Perform checks or trap errors in the handler. The following revised `PasswordEntry` component provides immediate feedback to the user if a space is used in the password's value.
 
 `Shared/PasswordEntry.razor`:
 

--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -244,10 +244,10 @@ The `PasswordEntry` component is used in another component, such as the followin
 
 ::: moniker-end
 
-When the `PasswordBinding` component is initially rendered, the initial `password` value of `Not set` is displayed in the UI. After initial rendering, the value of `password` reflects any changes made to the password by the user via the `Password` component parameter in the `PasswordEntry` component.
+When the `PasswordBinding` component is initially rendered, the `password` value of `Not set` is displayed in the UI. After initial rendering, the value of `password` reflects changes of the `Password` component parameter value in the `PasswordEntry` component.
 
 > [!NOTE]
-> The preceding example binds the password one-way from the child `PasswordEntry` component to the parent `PasswordBinding` component. Two-way binding isn't a requirement in this scenario if the goal is for the app to have a shared password entry component for reuse around the app that merely passes the password to the parent. For an approach that permits two-way binding without [writing directly to the child component's parameter](xref:blazor/components/index#overwritten-parameters), see the [Bind across more than two components](#bind-across-more-than-two-components) section of this article.
+> The preceding example binds the password one-way from the child `PasswordEntry` component to the parent `PasswordBinding` component. Two-way binding isn't a requirement in this scenario if the goal is for the app to have a shared password entry component for reuse around the app that merely passes the password to the parent. For an approach that permits two-way binding without [writing directly to the child component's parameter](xref:blazor/components/index#overwritten-parameters), see the `NestedChild` component example in the [Bind across more than two components](#bind-across-more-than-two-components) section of this article.
 
 Perform checks or trap errors in the handler. The following revised `PasswordEntry` component provides immediate feedback to the user if a space is used in the password's value.
 


### PR DESCRIPTION
Fixes #22593

cc: @peterbozso ... **_Baaaaack again!_** 🏃

* Let's see if the additions here to the text explain that this is one-way and that the purpose of the `password` in the parent is to demonstrate an initial value *there* and that it updates from the child.
* I call out the 💀 **_don't write to a component param_** 💀 bit with cross-links to that coverage.
* This links *down* a section for the two-way bit (that includes across a component hierarchy, too).
* The new text on this PR probably needs a little more work ... just a draft at this point. I'll work it a bit more in the morning ☕🍩. Let me know if you have additional feedback here on the PR.