### PR TITLE
Blazor object disposal updates

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample3.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample3.razor
@@ -32,5 +32,5 @@
         await jsClass.TickerChanged(stockSymbol, price);
     }
 
-    public void Dispose() => jsClass.Dispose();
+    public void Dispose() => jsClass?.Dispose();
 }

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample5.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample5.razor
@@ -40,5 +40,5 @@
             $"{price.ToString("c")}: {interopResult}";
     }
 
-    public void Dispose() => jsClass.Dispose();
+    public void Dispose() => jsClass?.Dispose();
 }

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/lifecycle/CounterWithTimerDisposal1.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/lifecycle/CounterWithTimerDisposal1.razor
@@ -1,4 +1,4 @@
-@page "/counter-with-timer-disposal"
+@page "/counter-with-timer-disposal-1"
 @using System.Timers
 @implements IDisposable
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/lifecycle/CounterWithTimerDisposal2.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/lifecycle/CounterWithTimerDisposal2.razor
@@ -1,0 +1,30 @@
+@page "/counter-with-timer-disposal-2"
+@using System.Timers
+@implements IDisposable
+
+<h1>Counter with <code>Timer</code> disposal</h1>
+
+<p>Current count: @currentCount</p>
+
+@code {
+    private int currentCount = 0;
+    private Timer timer;
+
+    protected override void OnInitialized()
+    {
+        timer = new Timer(1000);
+        timer.Elapsed += (sender, eventArgs) => OnTimerCallback();
+        timer.Start();
+    }
+
+    private void OnTimerCallback()
+    {
+        _ = InvokeAsync(() =>
+        {
+            currentCount++;
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose() => timer?.Dispose();
+}

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Shared/SurveyPrompt.razor.cs
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Shared/SurveyPrompt.razor.cs
@@ -15,11 +15,7 @@ namespace BlazorSample.Shared
         {
             base.OnParametersSet();
 
-            if (subscription != null)
-            {
-                subscription.Dispose();
-            }
-
+            subscription?.Dispose();
             subscription = Parent.Subscribe(this);
         }
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample3.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample3.razor
@@ -32,5 +32,5 @@
         await jsClass.TickerChanged(stockSymbol, price);
     }
 
-    public void Dispose() => jsClass.Dispose();
+    public void Dispose() => jsClass?.Dispose();
 }

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample5.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample5.razor
@@ -40,5 +40,5 @@
             $"{price.ToString("c")}: {interopResult}";
     }
 
-    public void Dispose() => jsClass.Dispose();
+    public void Dispose() => jsClass?.Dispose();
 }

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal1.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal1.razor
@@ -1,4 +1,4 @@
-@page "/counter-with-timer-disposal"
+@page "/counter-with-timer-disposal-1"
 @using System.Timers
 @implements IDisposable
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal2.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal2.razor
@@ -1,0 +1,30 @@
+@page "/counter-with-timer-disposal-2"
+@using System.Timers
+@implements IDisposable
+
+<h1>Counter with <code>Timer</code> disposal</h1>
+
+<p>Current count: @currentCount</p>
+
+@code {
+    private int currentCount = 0;
+    private Timer timer;
+
+    protected override void OnInitialized()
+    {
+        timer = new Timer(1000);
+        timer.Elapsed += (sender, eventArgs) => OnTimerCallback();
+        timer.Start();
+    }
+
+    private void OnTimerCallback()
+    {
+        _ = InvokeAsync(() =>
+        {
+            currentCount++;
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose() => timer?.Dispose();
+}

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Shared/SurveyPrompt.razor.cs
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Shared/SurveyPrompt.razor.cs
@@ -15,11 +15,7 @@ namespace BlazorSample.Shared
         {
             base.OnParametersSet();
 
-            if (subscription != null)
-            {
-                subscription.Dispose();
-            }
-
+            subscription?.Dispose();
             subscription = Parent.Subscribe(this);
         }
 

--- a/aspnetcore/blazor/common/samples/3.x/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/EditContact.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/EditContact.razor
@@ -182,7 +182,7 @@ else
     #region snippet1
     public void Dispose()
     {
-        Context.Dispose();
+        Context?.Dispose();
     }
     #endregion
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample3.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample3.razor
@@ -32,5 +32,5 @@
         await jsClass.TickerChanged(stockSymbol, price);
     }
 
-    public void Dispose() => jsClass.Dispose();
+    public void Dispose() => jsClass?.Dispose();
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample5.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample5.razor
@@ -40,5 +40,5 @@
             $"{price.ToString("c")}: {interopResult}";
     }
 
-    public void Dispose() => jsClass.Dispose();
+    public void Dispose() => jsClass?.Dispose();
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -20,7 +20,7 @@
     {
         if (firstRender)
         {
-            module = await JS.InvokeAsync<IJSObjectReference>("import", 
+            module = await JS.InvokeAsync<IJSObjectReference>("import",
                 "./scripts.js");
         }
     }
@@ -37,6 +37,9 @@
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await module?.DisposeAsync();
+        if (module is not null)
+        {
+            await module.DisposeAsync();
+        }
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -41,7 +41,5 @@
         {
             await module.DisposeAsync();
         }
-
-        module = null;
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -37,6 +37,6 @@
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await module.DisposeAsync();
+        await module?.DisposeAsync();
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -40,6 +40,7 @@
         if (module is not null)
         {
             await module.DisposeAsync();
+            module = null;
         }
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -40,7 +40,8 @@
         if (module is not null)
         {
             await module.DisposeAsync();
-            module = null;
         }
+
+        module = null;
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -35,11 +35,13 @@
         if (mapInstance is not null)
         {
             await mapInstance.DisposeAsync();
+            mapInstance = null;
         }
 
         if (mapModule is not null)
         {
             await mapModule.DisposeAsync();
+            mapModule = null;
         }
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -41,8 +41,5 @@
         {
             await mapModule.DisposeAsync();
         }
-
-        mapInstance = null;
-        mapModule = null;
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -35,13 +35,14 @@
         if (mapInstance is not null)
         {
             await mapInstance.DisposeAsync();
-            mapInstance = null;
         }
 
         if (mapModule is not null)
         {
             await mapModule.DisposeAsync();
-            mapModule = null;
         }
+
+        mapInstance = null;
+        mapModule = null;
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -32,7 +32,7 @@
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await mapInstance.DisposeAsync();
-        await mapModule.DisposeAsync();
+        await mapInstance?.DisposeAsync();
+        await mapModule?.DisposeAsync();
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -27,12 +27,19 @@
     }
 
     private async Task ShowAsync(double latitude, double longitude)
-        => await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, latitude, 
+        => await mapModule.InvokeVoidAsync("setMapCenter", mapInstance, latitude,
             longitude).AsTask();
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await mapInstance?.DisposeAsync();
-        await mapModule?.DisposeAsync();
+        if (mapInstance is not null)
+        {
+            await mapInstance.DisposeAsync();
+        }
+
+        if (mapModule is not null)
+        {
+            await mapModule.DisposeAsync();
+        }
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/lifecycle/CounterWithTimerDisposal1.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/lifecycle/CounterWithTimerDisposal1.razor
@@ -1,4 +1,4 @@
-@page "/counter-with-timer-disposal"
+@page "/counter-with-timer-disposal-1"
 @using System.Timers
 @implements IDisposable
 

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/lifecycle/CounterWithTimerDisposal2.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/lifecycle/CounterWithTimerDisposal2.razor
@@ -1,0 +1,30 @@
+@page "/counter-with-timer-disposal-2"
+@using System.Timers
+@implements IDisposable
+
+<h1>Counter with <code>Timer</code> disposal</h1>
+
+<p>Current count: @currentCount</p>
+
+@code {
+    private int currentCount = 0;
+    private Timer timer;
+
+    protected override void OnInitialized()
+    {
+        timer = new Timer(1000);
+        timer.Elapsed += (sender, eventArgs) => OnTimerCallback();
+        timer.Start();
+    }
+
+    private void OnTimerCallback()
+    {
+        _ = InvokeAsync(() =>
+        {
+            currentCount++;
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose() => timer?.Dispose();
+}

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Shared/SurveyPrompt.razor.cs
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Shared/SurveyPrompt.razor.cs
@@ -15,11 +15,7 @@ namespace BlazorSample.Shared
         {
             base.OnParametersSet();
 
-            if (subscription != null)
-            {
-                subscription.Dispose();
-            }
-
+            subscription?.Dispose();
             subscription = Parent.Subscribe(this);
         }
 

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample3.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample3.razor
@@ -32,5 +32,5 @@
         await jsClass.TickerChanged(stockSymbol, price);
     }
 
-    public void Dispose() => jsClass.Dispose();
+    public void Dispose() => jsClass?.Dispose();
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample5.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample5.razor
@@ -40,5 +40,5 @@
             $"{price.ToString("c")}: {interopResult}";
     }
 
-    public void Dispose() => jsClass.Dispose();
+    public void Dispose() => jsClass?.Dispose();
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -41,7 +41,5 @@
         {
             await module.DisposeAsync();
         }
-
-        module = null;
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -37,6 +37,6 @@
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await module.DisposeAsync();
+        await module?.DisposeAsync();
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -40,6 +40,7 @@
         if (module is not null)
         {
             await module.DisposeAsync();
+            module = null;
         }
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -40,7 +40,8 @@
         if (module is not null)
         {
             await module.DisposeAsync();
-            module = null;
         }
+
+        module = null;
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample6.razor
@@ -37,6 +37,9 @@
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await module?.DisposeAsync();
+        if (module is not null)
+        {
+            await module.DisposeAsync();
+        }
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -35,11 +35,13 @@
         if (mapInstance is not null)
         {
             await mapInstance.DisposeAsync();
+            mapInstance = null;
         }
 
         if (mapModule is not null)
         {
             await mapModule.DisposeAsync();
+            mapModule = null;
         }
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -41,8 +41,5 @@
         {
             await mapModule.DisposeAsync();
         }
-
-        mapInstance = null;
-        mapModule = null;
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -32,7 +32,14 @@
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await mapInstance?.DisposeAsync();
-        await mapModule?.DisposeAsync();
+        if (mapInstance is not null)
+        {
+            await mapInstance.DisposeAsync();
+        }
+
+        if (mapModule is not null)
+        {
+            await mapModule.DisposeAsync();
+        }
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -35,13 +35,14 @@
         if (mapInstance is not null)
         {
             await mapInstance.DisposeAsync();
-            mapInstance = null;
         }
 
         if (mapModule is not null)
         {
             await mapModule.DisposeAsync();
-            mapModule = null;
         }
+
+        mapInstance = null;
+        mapModule = null;
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/call-js-from-dotnet/CallJsExample8.razor
@@ -32,7 +32,7 @@
 
     async ValueTask IAsyncDisposable.DisposeAsync()
     {
-        await mapInstance.DisposeAsync();
-        await mapModule.DisposeAsync();
+        await mapInstance?.DisposeAsync();
+        await mapModule?.DisposeAsync();
     }
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal1.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal1.razor
@@ -1,4 +1,4 @@
-@page "/counter-with-timer-disposal"
+@page "/counter-with-timer-disposal-1"
 @using System.Timers
 @implements IDisposable
 

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal2.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal2.razor
@@ -1,0 +1,30 @@
+@page "/counter-with-timer-disposal-2"
+@using System.Timers
+@implements IDisposable
+
+<h1>Counter with <code>Timer</code> disposal</h1>
+
+<p>Current count: @currentCount</p>
+
+@code {
+    private int currentCount = 0;
+    private Timer timer;
+
+    protected override void OnInitialized()
+    {
+        timer = new Timer(1000);
+        timer.Elapsed += (sender, eventArgs) => OnTimerCallback();
+        timer.Start();
+    }
+
+    private void OnTimerCallback()
+    {
+        _ = InvokeAsync(() =>
+        {
+            currentCount++;
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose() => timer?.Dispose();
+}

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Shared/SurveyPrompt.razor.cs
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Shared/SurveyPrompt.razor.cs
@@ -15,11 +15,7 @@ namespace BlazorSample.Shared
         {
             base.OnParametersSet();
 
-            if (subscription != null)
-            {
-                subscription.Dispose();
-            }
-
+            subscription?.Dispose();
             subscription = Parent.Subscribe(this);
         }
 

--- a/aspnetcore/blazor/common/samples/5.x/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/EditContact.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorServerEFCoreSample/BlazorServerDbContextExample/Pages/EditContact.razor
@@ -182,7 +182,7 @@ else
     #region snippet1
     public void Dispose()
     {
-        Context.Dispose();
+        Context?.Dispose();
     }
     #endregion
 }

--- a/aspnetcore/blazor/common/samples/5.x/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/TextFilter.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/TextFilter.razor
@@ -90,10 +90,7 @@ Filter on: <select @bind="SelectedColumn">
             {
                 filterText = value;
                 // more text means restart the debounce timer
-                if (timer != null)
-                {
-                    timer.Dispose();
-                }
+                timer?.Dispose();
                 timer = new(DebounceMs);
                 timer.Elapsed += NotifyTimerElapsed;
                 timer.Enabled = true;
@@ -108,7 +105,7 @@ Filter on: <select @bind="SelectedColumn">
     /// <param name="e">Event args.</param>
     private async void NotifyTimerElapsed(object sender, ElapsedEventArgs e)
     {
-        timer.Dispose();
+        timer?.Dispose();
         timer = null;
         if (Filters.FilterText != filterText)
         {
@@ -124,10 +121,7 @@ Filter on: <select @bind="SelectedColumn">
     /// <param name="disposing"><c>True</c> when disposing.</param>
     public void Dispose()
     {
-        if (timer != null)
-        {
-            timer.Dispose();
-            timer = null;
-        }
+        timer?.Dispose();
+        timer = null;
     }
 }

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -979,7 +979,7 @@ Use the `Notifier` service to update a component.
 In the preceding example:
 
 * `Notifier` invokes the component's `OnNotify` method outside of Blazor's synchronization context. `InvokeAsync` is used to switch to the correct context and queue a render. For more information, see <xref:blazor/components/rendering>.
-* The component implements <xref:System.IDisposable>. The `OnNotify` delegate is unsubscribed in the `Dispose` method, which is called by the framework when the component is disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+* The component implements <xref:System.IDisposable>. The `OnNotify` delegate is unsubscribed in the `Dispose` method, which is called by the framework when the component is disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
 
 ## Use \@key to control the preservation of elements and components
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -979,7 +979,7 @@ Use the `Notifier` service to update a component.
 In the preceding example:
 
 * `Notifier` invokes the component's `OnNotify` method outside of Blazor's synchronization context. `InvokeAsync` is used to switch to the correct context and queue a render. For more information, see <xref:blazor/components/rendering>.
-* The component implements <xref:System.IDisposable>. The `OnNotify` delegate is unsubscribed in the `Dispose` method, which is called by the framework when the component is disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
+* The component implements <xref:System.IDisposable>. The `OnNotify` delegate is unsubscribed in the `Dispose` method, which is called by the framework when the component is disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 ## Use \@key to control the preservation of elements and components
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -375,10 +375,10 @@ For more information, see:
 
 Usually, there's no need to assign `null` to disposed objects after calling <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>. Rare cases for assigning `null` include the following:
 
-* If the object's type is poorly implemented and doesn't tolerate repeat calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>, assign `null` after disposal to ensure gracefully skipping further calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>.
+* If the object's type is poorly implemented and doesn't tolerate repeat calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>, assign `null` after disposal to gracefully skip further calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>.
 * If a long-lived process continues to hold a reference to a disposed object, assigning `null` allows the [garbage collector](/dotnet/standard/garbage-collection/fundamentals) to free the object in spite of the long-lived process holding a reference to it.
 
-These are unusual scenarios. For objects that are implemented correctly and behave normally, there's no point in assigning `null` to disposed objects. In the rare cases where an object must be assigned `null`, we recommend clearly documenting the reason in code and seeking a solution that prevents the need for it.
+These are unusual scenarios. For objects that are implemented correctly and behave normally, there's no point in assigning `null` to disposed objects. In the rare cases where an object must be assigned `null`, we recommend documenting the reason and seeking a solution that prevents the need to assign `null`.
 
 ### `StateHasChanged`
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -59,7 +59,7 @@ The default implementation of <xref:Microsoft.AspNetCore.Components.ComponentBas
 
 If [`base.SetParametersAsync`](xref:Microsoft.AspNetCore.Components.ComponentBase.SetParametersAsync%2A) isn't invoked, developer code can interpret the incoming parameters' values in any way required. For example, there's no requirement to assign the incoming parameters to the properties of the class.
 
-If event handlers are provided in developer code, unhook them on disposal. For more information, see the [Component disposal with `IDisposable`](#component-disposal-with-idisposable) section.
+If event handlers are provided in developer code, unhook them on disposal. For more information, see the [Component disposal with `IDisposable` `IAsyncDisposable`](#component-disposal-with-idisposable-iasyncdisposable) section.
 
 In the following example, <xref:Microsoft.AspNetCore.Components.ParameterView.TryGetValue%2A?displayProperty=nameWithType> assigns the `Param` parameter's value to `value` if parsing a route parameter for `Param` is successful. When `value` isn't `null`, the value is displayed by the component.
 
@@ -117,7 +117,7 @@ To prevent developer code in <xref:Microsoft.AspNetCore.Components.ComponentBase
 
 While a Blazor app is prerendering, certain actions, such as calling into JavaScript (JS interop), aren't possible. Components may need to render differently when prerendered. For more information, see the [Detect when the app is prerendering](#detect-when-the-app-is-prerendering) section.
 
-If event handlers are provided in developer code, unhook them on disposal. For more information, see the [Component disposal with `IDisposable`](#component-disposal-with-idisposable) section.
+If event handlers are provided in developer code, unhook them on disposal. For more information, see the [Component disposal with `IDisposable` `IAsyncDisposable`](#component-disposal-with-idisposable-iasyncdisposable) section.
 
 ## After parameters are set (`OnParametersSet{Async}`)
 
@@ -159,7 +159,7 @@ protected override async Task OnParametersSetAsync()
 }
 ```
 
-If event handlers are provided in developer code, unhook them on disposal. For more information, see the [Component disposal with `IDisposable`](#component-disposal-with-idisposable) section.
+If event handlers are provided in developer code, unhook them on disposal. For more information, see the [Component disposal with `IDisposable` `IAsyncDisposable`](#component-disposal-with-idisposable-iasyncdisposable) section.
 
 For more information on route parameters and constraints, see <xref:blazor/fundamentals/routing>.
 
@@ -205,7 +205,7 @@ Even if you return a <xref:System.Threading.Tasks.Task> from <xref:Microsoft.Asp
 1. The component executes on the server to produce some static HTML markup in the HTTP response. During this phase, <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRender%2A> and <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync%2A> aren't called.
 1. When the Blazor script (`blazor.webassembly.js` or `blazor.server.js`) start in the browser, the component is restarted in an interactive rendering mode. After a component is restarted, <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRender%2A> and <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync%2A> **are** called because the app isn't in the prerendering phase any longer.
 
-If event handlers are provided in developer code, unhook them on disposal. For more information, see the [Component disposal with `IDisposable`](#component-disposal-with-idisposable) section.
+If event handlers are provided in developer code, unhook them on disposal. For more information, see the [Component disposal with `IDisposable` `IAsyncDisposable`](#component-disposal-with-idisposable-iasyncdisposable) section.
 
 ## State changes (`StateHasChanged`)
 
@@ -272,7 +272,7 @@ Although the content in this section focuses on Blazor Server and stateful Signa
 
 [!INCLUDE[](~/blazor/includes/prerendering.md)]
 
-## Component disposal with `IDisposable`
+## Component disposal with `IDisposable` `IAsyncDisposable`
 
 If a component implements <xref:System.IDisposable>, the framework calls the [disposal method](/dotnet/standard/garbage-collection/implementing-dispose) when the component is removed from the UI, where unmanaged resources can be released. Disposal can occur at any time, including during [component initialization](#component-initialization-oninitializedasync). The following component implements <xref:System.IDisposable> with the [`@implements`](xref:mvc/views/razor#implements) Razor directive:
 
@@ -588,7 +588,7 @@ Other reasons why background work items might require cancellation include:
 To implement a cancelable background work pattern in a component:
 
 * Use a <xref:System.Threading.CancellationTokenSource> and <xref:System.Threading.CancellationToken>.
-* On [disposal of the component](#component-disposal-with-idisposable) and at any point cancellation is desired by manually cancelling the token, call [`CancellationTokenSource.Cancel`](xref:System.Threading.CancellationTokenSource.Cancel%2A) to signal that the background work should be cancelled.
+* On [disposal of the component](#component-disposal-with-idisposable-iasyncdisposable) and at any point cancellation is desired by manually cancelling the token, call [`CancellationTokenSource.Cancel`](xref:System.Threading.CancellationTokenSource.Cancel%2A) to signal that the background work should be cancelled.
 * After the asynchronous call returns, call <xref:System.Threading.CancellationToken.ThrowIfCancellationRequested%2A> on the token.
 
 In the following example:

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -339,6 +339,8 @@ public async ValueTask DisposeAsync()
 
 In the preceding example, the `{TYPE}` placeholder is the type of the disposable object.
 
+For more information, see [Implement a DisposeAsync method (.NET documentation)](/dotnet/standard/garbage-collection/implementing-disposeasync).
+
 > [!NOTE]
 > Calling <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in `Dispose` isn't supported. <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> might be invoked as part of tearing down the renderer, so requesting UI updates at that point isn't supported.
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -292,34 +292,35 @@ If a component implements <xref:System.IDisposable>, the framework calls the [di
 
 If an object requires disposal, a lambda can be used to dispose of the object when <xref:System.IDisposable.Dispose%2A?displayProperty=nameWithType> is called. The following example appears in the <xref:blazor/components/rendering#receiving-a-call-from-something-external-to-the-blazor-rendering-and-event-handling-system> article and demonstrates the use of a lambda expression for the disposal of a <xref:System.Timers.Timer>.
 
-`Pages/CounterWithTimerDisposal.razor`:
+`Pages/CounterWithTimerDisposal1.razor`:
 
 ::: moniker range=">= aspnetcore-5.0"
 
-[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal.razor)]
+[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal1.razor?highlight=28)]
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
 
-[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal.razor)]
+[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal1.razor?highlight=28)]
 
 ::: moniker-end
 
-If the object is created in a lifecycle method, such as `OnInitialized`/`OnInitializedAsync`, check for `null` before calling `Dispose`. For exammple, `timer?.Dispose()` in the following example:
+If the object is created in a lifecycle method, such as `OnInitialized`/`OnInitializedAsync`, check for `null` before calling `Dispose`.
 
-```csharp
-private Timer timer;
+`Pages/CounterWithTimerDisposal2.razor`:
 
-protected override void OnInitialized()
-{
-    timer = new(1000);
-    timer.Elapsed += (sender, eventArgs) => OnTimerCallback();
-    timer.Start();
-}
+::: moniker range=">= aspnetcore-5.0"
 
-public void Dispose() => timer?.Dispose();
-```
+[!code-razor[](~/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal2.razor?highlight=15,29)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-5.0"
+
+[!code-razor[](~/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/lifecycle/CounterWithTimerDisposal2.razor?highlight=15,29)]
+
+::: moniker-end
 
 For asynchronous disposal tasks, use `DisposeAsync` instead of <xref:System.IDisposable.Dispose>. In the following example, `obj` is set in a lifecycle method (not shown), so it's disposed with a `null` check in the `DisposeAsync` method:
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -373,9 +373,9 @@ For more information, see:
 
 ### Assignment of `null` to disposed objects
 
-Usually, there's no need to assign `null` to disposed objects after calling <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>. Rare cases for assigning `null` are:
+Usually, there's no need to assign `null` to disposed objects after calling <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>. Rare cases for assigning `null` include the following:
 
-* If the object's type is poorly implemented and doesn't tolerate repeat calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>. All types should allow multiple disposal calls, but not all implementions permit it. If you know that this is the case, assign `null` after disposal to ensure gracefully skipping further calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>.
+* If the object's type is poorly implemented and doesn't tolerate repeat calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>, assign `null` after disposal to ensure gracefully skipping further calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>.
 * If you find that a long-lived process continues to hold a reference to a disposed object, assigning `null` allows the [garbage collector](/dotnet/standard/garbage-collection/fundamentals) to free the object in spite of the long-lived process holding a reference the object.
 
 These are unusual scenarios. For objects that are implemented correctly and behave normally, there's no point in assigning `null` to disposed objects. In the rare cases where an object must be assigned `null`, we recommend clearly documenting the reason in code and seeking a solution that prevents the need for it.

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -317,7 +317,7 @@ If a single object requires disposal, a lambda can be used to dispose of the obj
 
 ::: moniker-end
 
-If the object is created in a lifecycle method, such as `OnInitialized`/`OnInitializedAsync`, check for `null` before calling `Dispose`.
+If the object is created in a lifecycle method, such as [`OnInitialized`/`OnInitializedAsync`](#component-initialization-oninitializedasync), check for `null` before calling `Dispose`.
 
 `Pages/CounterWithTimerDisposal2.razor`:
 
@@ -370,6 +370,15 @@ For more information, see:
 
 * [Cleaning up unmanaged resources (.NET documentation)](/dotnet/standard/garbage-collection/unmanaged)
 * [Null-conditional operators ?. and ?[]](/dotnet/csharp/language-reference/operators/member-access-operators#null-conditional-operators--and-)
+
+### Assignment of `null` to disposed objects
+
+Usually, there's no need to assign `null` to disposed objects after calling <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>. Rare cases for assigning `null` are:
+
+* If the object's type is poorly implemented and doesn't tolerate repeat calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>. All types should allow multiple disposal calls, but not all implementions permit it. If you know that this is the case, assign `null` after disposal to ensure gracefully skipping further calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>.
+* If you find that a long-lived process continues to hold a reference to a disposed object, assigning `null` allows the [garbage collector](/dotnet/standard/garbage-collection/fundamentals) to free the object in spite of the long-lived process holding a reference the object.
+
+These are unusual scenarios. For objects that are implemented correctly and behave normally, there's no point in assigning `null` to disposed objects. In the rare cases where an object must be assigned `null`, we recommend clearly documenting the reason in code and seeking a solution that prevents the need for it.
 
 ### `StateHasChanged`
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -322,7 +322,7 @@ If the object is created in a lifecycle method, such as `OnInitialized`/`OnIniti
 
 ::: moniker-end
 
-For asynchronous disposal tasks, use `DisposeAsync` instead of <xref:System.IDisposable.Dispose>. In the following example, `obj` is set in a lifecycle method (not shown), so it's disposed with a `null` check in the `DisposeAsync` method and set to `null`:
+For asynchronous disposal tasks, use <xref:System.IAsyncDisposable.DisposeAsync%2A?displayProperty=nameWithType> instead of <xref:System.IDisposable.Dispose>. In the following example, `obj` is set in a lifecycle method (not shown), so it's disposed with a `null` check in the <xref:System.IAsyncDisposable.DisposeAsync%2A> method and set to `null`:
 
 ```csharp
 private {TYPE} obj;
@@ -337,7 +337,7 @@ public async ValueTask DisposeAsync()
 }
 ```
 
-In the preceding example, the `{TYPE}` placeholder is the type of the disposable object.
+In the preceding example, the `{TYPE}` placeholder is the type of the object that implements <xref:System.IAsyncDisposable>.
 
 For more information, see [Implement a DisposeAsync method (.NET documentation)](/dotnet/standard/garbage-collection/implementing-disposeasync).
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -322,7 +322,7 @@ If the object is created in a lifecycle method, such as `OnInitialized`/`OnIniti
 
 ::: moniker-end
 
-For asynchronous disposal tasks, use `DisposeAsync` instead of <xref:System.IDisposable.Dispose>. In the following example, `obj` is set in a lifecycle method (not shown), so it's disposed with a `null` check in the `DisposeAsync` method:
+For asynchronous disposal tasks, use `DisposeAsync` instead of <xref:System.IDisposable.Dispose>. In the following example, `obj` is set in a lifecycle method (not shown), so it's disposed with a `null` check in the `DisposeAsync` method and set to `null`:
 
 ```csharp
 private {TYPE} obj;
@@ -332,6 +332,7 @@ public async ValueTask DisposeAsync()
     if (obj is not null)
     {
         await obj.DisposeAsync();
+        obj = null;
     }
 }
 ```

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -376,7 +376,7 @@ For more information, see:
 Usually, there's no need to assign `null` to disposed objects after calling <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>. Rare cases for assigning `null` include the following:
 
 * If the object's type is poorly implemented and doesn't tolerate repeat calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>, assign `null` after disposal to ensure gracefully skipping further calls to <xref:System.IDisposable.Dispose%2A>/<xref:System.IAsyncDisposable.DisposeAsync%2A>.
-* If you find that a long-lived process continues to hold a reference to a disposed object, assigning `null` allows the [garbage collector](/dotnet/standard/garbage-collection/fundamentals) to free the object in spite of the long-lived process holding a reference the object.
+* If a long-lived process continues to hold a reference to a disposed object, assigning `null` allows the [garbage collector](/dotnet/standard/garbage-collection/fundamentals) to free the object in spite of the long-lived process holding a reference to it.
 
 These are unusual scenarios. For objects that are implemented correctly and behave normally, there's no point in assigning `null` to disposed objects. In the rare cases where an object must be assigned `null`, we recommend clearly documenting the reason in code and seeking a solution that prevents the need for it.
 
@@ -632,7 +632,7 @@ Other reasons why background work items might require cancellation include:
 To implement a cancelable background work pattern in a component:
 
 * Use a <xref:System.Threading.CancellationTokenSource> and <xref:System.Threading.CancellationToken>.
-* On [disposal of the component](#component-disposal-with-idisposable-and-iasyncdisposable) and at any point cancellation is desired by manually cancelling the token, call [`CancellationTokenSource.Cancel`](xref:System.Threading.CancellationTokenSource.Cancel%2A) to signal that the background work should be cancelled.
+* On [disposal of the component](#component-disposal-with-idisposable-and-iasyncdisposable) and at any point cancellation is desired by manually canceling the token, call [`CancellationTokenSource.Cancel`](xref:System.Threading.CancellationTokenSource.Cancel%2A) to signal that the background work should be cancelled.
 * After the asynchronous call returns, call <xref:System.Threading.CancellationToken.ThrowIfCancellationRequested%2A> on the token.
 
 In the following example:

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -306,14 +306,36 @@ If an object requires disposal, a lambda can be used to dispose of the object wh
 
 ::: moniker-end
 
-For asynchronous disposal tasks, use `DisposeAsync` instead of <xref:System.IDisposable.Dispose>:
+If the object is created in a lifecycle method, such as `OnInitialized`/`OnInitializedAsync`, check for `null` before calling `Dispose`. For exammple, `timer?.Dispose()` in the following example:
 
 ```csharp
+private Timer timer;
+
+protected override void OnInitialized()
+{
+    timer = new(1000);
+    timer.Elapsed += (sender, eventArgs) => OnTimerCallback();
+    timer.Start();
+}
+
+public void Dispose() => timer?.Dispose();
+```
+
+For asynchronous disposal tasks, use `DisposeAsync` instead of <xref:System.IDisposable.Dispose>. In the following example, `timer` is set in a lifecycle method (not shown), so it's disposed with a `null` check in the `DisposeAsync` method:
+
+```csharp
+private {TYPE} obj;
+
 public async ValueTask DisposeAsync()
 {
-    await ...
+    if (obj is not null)
+    {
+        await obj.DisposeAsync();
+    }
 }
 ```
+
+In the preceding example, the `{TYPE}` placeholder is the type of the disposable object.
 
 > [!NOTE]
 > Calling <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in `Dispose` isn't supported. <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> might be invoked as part of tearing down the renderer, so requesting UI updates at that point isn't supported.

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -321,7 +321,7 @@ protected override void OnInitialized()
 public void Dispose() => timer?.Dispose();
 ```
 
-For asynchronous disposal tasks, use `DisposeAsync` instead of <xref:System.IDisposable.Dispose>. In the following example, `timer` is set in a lifecycle method (not shown), so it's disposed with a `null` check in the `DisposeAsync` method:
+For asynchronous disposal tasks, use `DisposeAsync` instead of <xref:System.IDisposable.Dispose>. In the following example, `obj` is set in a lifecycle method (not shown), so it's disposed with a `null` check in the `DisposeAsync` method:
 
 ```csharp
 private {TYPE} obj;

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -332,8 +332,9 @@ public async ValueTask DisposeAsync()
     if (obj is not null)
     {
         await obj.DisposeAsync();
-        obj = null;
     }
+
+    obj = null;
 }
 ```
 

--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -100,7 +100,7 @@ Consider the following `CounterState1` component, which updates the count four t
 Consider the following `CounterState2` component that uses <xref:System.Timers.Timer?displayProperty=fullName> to update a count at a regular interval and calls <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> to update the UI:
 
 * `OnTimerCallback` runs outside of any Blazor-managed rendering flow or event notification. Therefore, `OnTimerCallback` must call <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> because Blazor isn't aware of the changes to `currentCount` in the callback.
-* The component implements <xref:System.IDisposable>, where the <xref:System.Timers.Timer> is disposed when the framework calls the `Dispose` method. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+* The component implements <xref:System.IDisposable>, where the <xref:System.Timers.Timer> is disposed when the framework calls the `Dispose` method. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
 
 Because the callback is invoked outside of Blazor's synchronization context, the component must wrap the logic of `OnTimerCallback` in <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType> to move it onto the renderer's synchronization context. <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> can only be called from the renderer's synchronization context and throws an exception otherwise. This is equivalent to marshalling to the UI thread in other UI frameworks.
 

--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -100,7 +100,7 @@ Consider the following `CounterState1` component, which updates the count four t
 Consider the following `CounterState2` component that uses <xref:System.Timers.Timer?displayProperty=fullName> to update a count at a regular interval and calls <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> to update the UI:
 
 * `OnTimerCallback` runs outside of any Blazor-managed rendering flow or event notification. Therefore, `OnTimerCallback` must call <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> because Blazor isn't aware of the changes to `currentCount` in the callback.
-* The component implements <xref:System.IDisposable>, where the <xref:System.Timers.Timer> is disposed when the framework calls the `Dispose` method. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
+* The component implements <xref:System.IDisposable>, where the <xref:System.Timers.Timer> is disposed when the framework calls the `Dispose` method. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 Because the callback is invoked outside of Blazor's synchronization context, the component must wrap the logic of `OnTimerCallback` in <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType> to move it onto the renderer's synchronization context. <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> can only be called from the renderer's synchronization context and throws an exception otherwise. This is equivalent to marshalling to the UI thread in other UI frameworks.
 

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -426,7 +426,7 @@ Create a validator component from <xref:Microsoft.AspNetCore.Components.Componen
 > The `{CLASS NAME}` placeholder is the name of the component class. The custom validator example in this section specifies the example namespace `BlazorSample`.
 
 > [!NOTE]
-> Anonymous lambda expressions are registered event handlers for <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnValidationRequested> and <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnFieldChanged> in the preceding example. It isn't necessary to implement <xref:System.IDisposable> and unsubscribe the event delegates in this scenario. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
+> Anonymous lambda expressions are registered event handlers for <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnValidationRequested> and <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnFieldChanged> in the preceding example. It isn't necessary to implement <xref:System.IDisposable> and unsubscribe the event delegates in this scenario. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 ## Business logic validation
 
@@ -1355,7 +1355,7 @@ To enable and disable the submit button based on form validation, the following 
 * Uses a shortened version of the preceding `Starfleet Starship Database` form (`FormExample2` component) that only accepts a value for the ship's identifier. The other `Starship` properties receive valid default values when an instance of the `Starship` type is created.
 * Uses the form's <xref:Microsoft.AspNetCore.Components.Forms.EditContext> to assign the model when the component is initialized.
 * Validates the form in the context's <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnFieldChanged> callback to enable and disable the submit button.
-* Implements <xref:System.IDisposable> and unsubscribes the event handler in the `Dispose` method. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
+* Implements <xref:System.IDisposable> and unsubscribes the event handler in the `Dispose` method. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 > [!NOTE]
 > When assigning to the <xref:Microsoft.AspNetCore.Components.Forms.EditForm.EditContext?displayProperty=nameWithType>, don't also assign an <xref:Microsoft.AspNetCore.Components.Forms.EditForm.Model?displayProperty=nameWithType> to the <xref:Microsoft.AspNetCore.Components.Forms.EditForm>.

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -426,7 +426,7 @@ Create a validator component from <xref:Microsoft.AspNetCore.Components.Componen
 > The `{CLASS NAME}` placeholder is the name of the component class. The custom validator example in this section specifies the example namespace `BlazorSample`.
 
 > [!NOTE]
-> Anonymous lambda expressions are registered event handlers for <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnValidationRequested> and <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnFieldChanged> in the preceding example. It isn't necessary to implement <xref:System.IDisposable> and unsubscribe the event delegates in this scenario. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+> Anonymous lambda expressions are registered event handlers for <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnValidationRequested> and <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnFieldChanged> in the preceding example. It isn't necessary to implement <xref:System.IDisposable> and unsubscribe the event delegates in this scenario. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
 
 ## Business logic validation
 
@@ -1355,7 +1355,7 @@ To enable and disable the submit button based on form validation, the following 
 * Uses a shortened version of the preceding `Starfleet Starship Database` form (`FormExample2` component) that only accepts a value for the ship's identifier. The other `Starship` properties receive valid default values when an instance of the `Starship` type is created.
 * Uses the form's <xref:Microsoft.AspNetCore.Components.Forms.EditContext> to assign the model when the component is initialized.
 * Validates the form in the context's <xref:Microsoft.AspNetCore.Components.Forms.EditContext.OnFieldChanged> callback to enable and disable the submit button.
-* Implements <xref:System.IDisposable> and unsubscribes the event handler in the `Dispose` method. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+* Implements <xref:System.IDisposable> and unsubscribes the event handler in the `Dispose` method. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
 
 > [!NOTE]
 > When assigning to the <xref:Microsoft.AspNetCore.Components.Forms.EditForm.EditContext?displayProperty=nameWithType>, don't also assign an <xref:Microsoft.AspNetCore.Components.Forms.EditForm.Model?displayProperty=nameWithType> to the <xref:Microsoft.AspNetCore.Components.Forms.EditForm>.

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -174,7 +174,7 @@ A component may be removed from the UI, for example, because the user has naviga
 
 If disposal logic may throw exceptions, the app should trap the exceptions using a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
 
-For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
 
 <h3 id="javascript-interop-webassembly">JavaScript interop</h3>
 
@@ -458,7 +458,7 @@ A component may be removed from the UI, for example, because the user has naviga
 
 If the component's `Dispose` method throws an unhandled exception, the exception is fatal to a Blazor Server circuit. If disposal logic may throw exceptions, the app should trap the exceptions using a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
 
-For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
 
 <h3 id="javascript-interop-server">JavaScript interop</h3>
 

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -174,7 +174,7 @@ A component may be removed from the UI, for example, because the user has naviga
 
 If disposal logic may throw exceptions, the app should trap the exceptions using a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
 
-For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
+For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 <h3 id="javascript-interop-webassembly">JavaScript interop</h3>
 
@@ -458,7 +458,7 @@ A component may be removed from the UI, for example, because the user has naviga
 
 If the component's `Dispose` method throws an unhandled exception, the exception is fatal to a Blazor Server circuit. If disposal logic may throw exceptions, the app should trap the exceptions using a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement with error handling and logging.
 
-For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
+For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 <h3 id="javascript-interop-server">JavaScript interop</h3>
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -333,7 +333,7 @@ The following component:
 
 ::: moniker-end
 
-For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
+For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 ## Query string and parse parameters
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -333,7 +333,7 @@ The following component:
 
 ::: moniker-end
 
-For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
 
 ## Query string and parse parameters
 

--- a/aspnetcore/blazor/includes/state-container.md
+++ b/aspnetcore/blazor/includes/state-container.md
@@ -116,4 +116,4 @@ services.AddScoped<StateContainer>();
 }
 ```
 
-The preceding components implement <xref:System.IDisposable>, and the `OnChange` delegates are unsubscribed in the `Dispose` methods, which are called by the framework when the components are disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable>.
+The preceding components implement <xref:System.IDisposable>, and the `OnChange` delegates are unsubscribed in the `Dispose` methods, which are called by the framework when the components are disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.

--- a/aspnetcore/blazor/includes/state-container.md
+++ b/aspnetcore/blazor/includes/state-container.md
@@ -116,4 +116,4 @@ services.AddScoped<StateContainer>();
 }
 ```
 
-The preceding components implement <xref:System.IDisposable>, and the `OnChange` delegates are unsubscribed in the `Dispose` methods, which are called by the framework when the components are disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-iasyncdisposable>.
+The preceding components implement <xref:System.IDisposable>, and the `OnChange` delegates are unsubscribed in the `Dispose` methods, which are called by the framework when the components are disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -56,6 +56,6 @@
 
     public async ValueTask DisposeAsync()
     {
-        await hubConnection.DisposeAsync();
+        await hubConnection?.DisposeAsync();
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/3.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -56,6 +56,6 @@
 
     public void Dispose()
     {
-        _ = hubConnection.DisposeAsync();
+        _ = hubConnection?.DisposeAsync();
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -56,6 +56,9 @@
 
     public async ValueTask DisposeAsync()
     {
-        await hubConnection.DisposeAsync();
+        if (hubConnection is not null)
+        {
+            await hubConnection.DisposeAsync();
+        }
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -59,7 +59,8 @@
         if (hubConnection is not null)
         {
             await hubConnection.DisposeAsync();
-            hubConnection = null;
         }
+
+        hubConnection = null;
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -60,7 +60,5 @@
         {
             await hubConnection.DisposeAsync();
         }
-
-        hubConnection = null;
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorServerSignalRApp/Pages/Index.razor
@@ -59,6 +59,7 @@
         if (hubConnection is not null)
         {
             await hubConnection.DisposeAsync();
+            hubConnection = null;
         }
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -56,6 +56,9 @@
 
     public async ValueTask DisposeAsync()
     {
-        await hubConnection.DisposeAsync();
+        if (hubConnection is not null)
+        {
+            await hubConnection.DisposeAsync();
+        }
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -59,7 +59,8 @@
         if (hubConnection is not null)
         {
             await hubConnection.DisposeAsync();
-            hubConnection = null;
         }
+
+        hubConnection = null;
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -60,7 +60,5 @@
         {
             await hubConnection.DisposeAsync();
         }
-
-        hubConnection = null;
     }
 }

--- a/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
+++ b/aspnetcore/tutorials/signalr-blazor/samples/5.x/BlazorWebAssemblySignalRApp/Client/Pages/Index.razor
@@ -59,6 +59,7 @@
         if (hubConnection is not null)
         {
             await hubConnection.DisposeAsync();
+            hubConnection = null;
         }
     }
 }


### PR DESCRIPTION
Fixes #22592

Jeremy, I have you on here for a couple of EFCore-Blazor Server sample app updates (these are mostly null checks with `?` for calling `Dispose` on objects). I'll revert the PR's changes to your sample if incorrect. You don't need to look at everything on the PR ... just your EFCore sample app ... unless you want to :eye: everything. Search the diff with ...

```
BlazorServerDbContextExample
```

... to see the three files.

**UPDATE**: *Spoke with Steve.* We're probably good here so long as ur ok with the EFCore-Blazor Server sample updates.

**UPDATE**: We also just discussed setting disposed objects to `null`. The ordinary cases outside of the EFCore-Blazor sample don't require this pattern. I've left your `null` sets alone for this. I'm sure you had a good reason for doing it.