### PR TITLE
Call out optional claims for tokens

### DIFF
--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -32,6 +32,8 @@ The OAuth authentication provider establishes a trust relationship with an app u
 * [Other authentication providers](xref:security/authentication/otherlogins)
 * [OpenIdConnect](https://github.com/Azure-Samples/active-directory-aspnetcore-webapp-openidconnect-v2)
 
+Optional claims sent in the ID or access token from the authenticaion provider are usually configured in the provider's online portal. For example, Microsoft Azure Active Directory (AAD) permits you to assign optional claims to the app's ID token in the app registration's **Token configuration** blade. For more information, see [How to: Provide optional claims to your app (Azure documentation)](/azure/active-directory/develop/active-directory-optional-claims). For other providers, consult their external documentation sets.
+
 The sample app configures the Google authentication provider with a client ID and client secret provided by Google:
 
 [!code-csharp[](additional-claims/samples/3.x/ClaimsSample/Startup.cs?name=snippet_AddGoogle&highlight=4,9)]


### PR DESCRIPTION
Fixes #22613

Thanks @KurtP20! :rocket:

I think we can keep this only in the additional claims topic. It looks like a good spot to mention it is immediately after we list the registration topics. This is a general aspect of provider config on the provider side, so it generally applies. We can use AAD as an example and have a quick cross-link to the AAD topic that covers it, then we tell the reader to consult the external docs for the other providers for similar guidance.