### PR TITLE
Update Blazor @key example

### DIFF
--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/index/People.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/index/People.razor
@@ -1,15 +1,12 @@
-﻿@page "/people"
+@page "/people"
 @using System.Timers
 @implements IDisposable
 
-<ol>
-    @foreach (var person in people)
-    {
-        <li>
-            <Details Data="@person.Data" />
-        </li>
-    }
-</ol>
+@foreach (var person in people)
+{
+    <Details Data="@person.Data" />
+    <br>
+}
 
 @code {
     private Timer timer = new Timer(3000);

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/index/People.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_Server/Pages/index/People.razor
@@ -5,7 +5,6 @@
 @foreach (var person in people)
 {
     <Details Data="@person.Data" />
-    <br>
 }
 
 @code {

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/index/People.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/index/People.razor
@@ -2,14 +2,11 @@
 @using System.Timers
 @implements IDisposable
 
-<ol>
-    @foreach (var person in people)
-    {
-        <li>
-            <Details Data="@person.Data" />
-        </li>
-    }
-</ol>
+@foreach (var person in people)
+{
+    <Details Data="@person.Data" />
+    <br>
+}
 
 @code {
     private Timer timer = new Timer(3000);

--- a/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/index/People.razor
+++ b/aspnetcore/blazor/common/samples/3.x/BlazorSample_WebAssembly/Pages/index/People.razor
@@ -5,7 +5,6 @@
 @foreach (var person in people)
 {
     <Details Data="@person.Data" />
-    <br>
 }
 
 @code {

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/index/People.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/index/People.razor
@@ -2,14 +2,11 @@
 @using System.Timers
 @implements IDisposable
 
-<ol>
-    @foreach (var person in people)
-    {
-        <li>
-            <Details Data="@person.Data" />
-        </li>
-    }
-</ol>
+@foreach (var person in people)
+{
+    <Details Data="@person.Data" />
+    <br>
+}
 
 @code {
     private Timer timer = new Timer(3000);

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/index/People.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/index/People.razor
@@ -5,7 +5,6 @@
 @foreach (var person in people)
 {
     <Details Data="@person.Data" />
-    <br>
 }
 
 @code {

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/index/People.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/index/People.razor
@@ -2,14 +2,11 @@
 @using System.Timers
 @implements IDisposable
 
-<ol>
-    @foreach (var person in people)
-    {
-        <li>
-            <Details Data="@person.Data" />
-        </li>
-    }
-</ol>
+@foreach (var person in people)
+{
+    <Details Data="@person.Data" />
+    <br>
+}
 
 @code {
     private Timer timer = new Timer(3000);

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/index/People.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/index/People.razor
@@ -5,7 +5,6 @@
 @foreach (var person in people)
 {
     <Details Data="@person.Data" />
-    <br>
 }
 
 @code {


### PR DESCRIPTION
Addresses #22644 

@konstantinovaleksej ... I'm going to put in a quick 🏃 patch fix to make it correct. However, this only *addresses* the issue and won't close it out. I need to hear from Steve on why this behavior occurs. After I hear back from him, I'll make another update that probably will include a new example+paragraph with the `Details` component in a list with the keyed `<li>` tag.