### PR TITLE
EF sqlite package include: Ensure last package installs

### DIFF
--- a/aspnetcore/includes/add-EF-NuGet-SQLite-CLI-5.md
+++ b/aspnetcore/includes/add-EF-NuGet-SQLite-CLI-5.md
@@ -4,11 +4,11 @@ no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cook
 Run the following .NET CLI commands:
 
 ```dotnetcli
-dotnet tool install --global dotnet-ef
-dotnet tool install --global dotnet-aspnet-codegenerator
-dotnet add package Microsoft.EntityFrameworkCore.Design
-dotnet add package Microsoft.EntityFrameworkCore.SQLite
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
+dotnet tool install --global dotnet-ef && \
+dotnet tool install --global dotnet-aspnet-codegenerator && \
+dotnet add package Microsoft.EntityFrameworkCore.Design && \
+dotnet add package Microsoft.EntityFrameworkCore.SQLite && \
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design && \
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
 ```
 

--- a/aspnetcore/includes/add-EF-NuGet-SQLite-CLI-5.md
+++ b/aspnetcore/includes/add-EF-NuGet-SQLite-CLI-5.md
@@ -4,12 +4,13 @@ no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cook
 Run the following .NET CLI commands:
 
 ```dotnetcli
-dotnet tool install --global dotnet-ef && \
-dotnet tool install --global dotnet-aspnet-codegenerator && \
-dotnet add package Microsoft.EntityFrameworkCore.Design && \
-dotnet add package Microsoft.EntityFrameworkCore.SQLite && \
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design && \
+dotnet tool install --global dotnet-ef
+dotnet tool install --global dotnet-aspnet-codegenerator
+dotnet add package Microsoft.EntityFrameworkCore.Design
+dotnet add package Microsoft.EntityFrameworkCore.SQLite
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+
 ```
 
 The preceding commands add:


### PR DESCRIPTION
[Internal Review: First Razor](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-5.0&branch=pr-en-us-22649&tabs=visual-studio)
[Internal Review: First MVC](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-5.0&branch=pr-en-us-22649&tabs=visual-studio)

When CLI code in a doc includes multiple command lines, the last command does not execute.  In this case, the include several docs use for installing EF + SQL Server and SQLite has this issue.   

Adding " && \" after each CLI command to tie them together so they all run.