### PR TITLE
Fix typo on example Hub method name

### DIFF
--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -122,7 +122,7 @@ To make calls to specific clients, use the properties of the `Clients` object. I
 
 * `SendMessage` sends a message to all connected clients, using `Clients.All`.
 * `SendMessageToCaller` sends a message back to the caller, using `Clients.Caller`.
-* `SendMessageToGroups` sends a message to all clients in the `SignalR Users` group.
+* `SendMessageToGroup` sends a message to all clients in the `SignalR Users` group.
 
 [!code-csharp[Send messages](hubs/sample/hubs/chathub.cs?name=HubMethods)]
 


### PR DESCRIPTION
Fix typo on example Hub method name in order to fit with sample method name.

public Task SendMessageToGroup(string user, string message)
{
    return Clients.Group("SignalR Users").SendAsync("ReceiveMessage", user, message);
}



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->