### PR TITLE
Launching Blazor debugging proxy from UI extension

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -28,10 +28,22 @@ Available scenarios include:
 
 For now, you *can't*:
 
+::: moniker range=">= aspnetcore-6.0"
+
+* Break on unhandled exceptions.
+* Hit breakpoints during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` lifecycle methods](xref:blazor/components/lifecycle#component-initialization-oninitializedasync) of components that are loaded by the first page requested from the app.
+* Automatically rebuild the backend `*Server*` app of a hosted Blazor WebAssembly solution during debugging, for example by running the app with [`dotnet watch run`](xref:tutorials/dotnet-watch).
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-6.0"
+
 * Break on unhandled exceptions.
 * Hit breakpoints during app startup before the debug proxy is running. This includes breakpoints in `Program.Main` (`Program.cs`) and breakpoints in the [`OnInitialized{Async}` lifecycle methods](xref:blazor/components/lifecycle#component-initialization-oninitializedasync) of components that are loaded by the first page requested from the app.
 * Debug in non-local scenarios (for example, [Windows Subsystem for Linux (WSL)](/windows/wsl/) or [Visual Studio Codespaces](/visualstudio/codespaces/overview/what-is-vsonline)).
 * Automatically rebuild the backend `*Server*` app of a hosted Blazor WebAssembly solution during debugging, for example by running the app with [`dotnet watch run`](xref:tutorials/dotnet-watch).
+
+::: moniker-end
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixes #22443
Addresses #22045

Looks like we just need to version **_out_** the line that we added earlier ...

> \* Debug in non-local scenarios (for example, \[Windows Subsystem for Linux (WSL)](/windows/wsl/) or \[Visual Studio Codespaces](/visualstudio/codespaces/overview/what-is-vsonline)).

Note that the whole list must be versioned: This docs feature will 💥 if you try to do it on a single listitem. 

Is there anything else for docs to cover [Add support for launching DebugProxy from blazorwasm debug type in VS Code (dotnet/aspnetcore #22587)](https://github.com/dotnet/aspnetcore/issues/22587)?