### PR TITLE
Use the automatic SignalR reconnect feature

### DIFF
--- a/aspnetcore/signalr/javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js
+++ b/aspnetcore/signalr/javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js
@@ -2,6 +2,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // <snippet_Connection>
     const connection = new signalR.HubConnectionBuilder()
         .withUrl("/chathub")
+        .withAutomaticReconnect()
         .configureLogging(signalR.LogLevel.Information)
         .build();
     // </snippet_Connection>
@@ -36,8 +37,6 @@ document.addEventListener("DOMContentLoaded", () => {
             setTimeout(start, 5000);
         }
     };
-
-    connection.onclose(start);
 
     // Start the connection.
     start();

--- a/aspnetcore/signalr/javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js
+++ b/aspnetcore/signalr/javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js
@@ -2,7 +2,6 @@ document.addEventListener("DOMContentLoaded", () => {
     // <snippet_Connection>
     const connection = new signalR.HubConnectionBuilder()
         .withUrl("/chathub")
-        .withAutomaticReconnect()
         .configureLogging(signalR.LogLevel.Information)
         .build();
     // </snippet_Connection>
@@ -37,6 +36,14 @@ document.addEventListener("DOMContentLoaded", () => {
             setTimeout(start, 5000);
         }
     };
+    
+    connection.onclose(function (error) {
+        if (error) {
+            console.log(`Connection closed with error: ${error}`);
+        } else {
+            console.log("Connection closed.");
+        }
+    });
 
     // Start the connection.
     start();


### PR DESCRIPTION
> **Warning**: This code snippet is used as a [Sample](https://docs.microsoft.com/en-us/aspnet/core/signalr/javascript-client?view=aspnetcore-5.0#connect-to-a-hub).

I am not sure, if the behavior stays the same after this change. For me it looks like the intent should be the same though.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->