### PR TITLE
Generic type support updates (including 6.0 updates)

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1348,6 +1348,29 @@ Whitespace isn't preserved from the preceding markup:
 
 ::: moniker-end
 
+## Generic type parameter support
+
+The [`@typeparam`][11] directive declares a [generic type parameter](/dotnet/csharp/programming-guide/generics/generic-type-parameters) for the generated component class:
+
+```razor
+@typeparam TItem
+```
+
+::: moniker range=">= aspnetcore-6.0"
+
+C# syntax with [`where`](/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) type constraints is supported:
+
+```razor
+@typeparam TEntity where TEntity : IEntity
+```
+
+For more information, see the following articles:
+
+* <xref:mvc/views/razor#typeparam>
+* <xref:blazor/components/templated-components>
+
+::: moniker-end
+
 <!--Reference links in article-->
 [1]: <xref:mvc/views/razor#code>
 [2]: <xref:mvc/views/razor#using>
@@ -1359,3 +1382,4 @@ Whitespace isn't preserved from the preceding markup:
 [8]: <xref:mvc/views/razor#namespace>
 [9]: <xref:mvc/views/razor#page>
 [10]: <xref:mvc/views/razor#bind>
+[11]: <xref:mvc/views/razor#typeparam>

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1364,12 +1364,12 @@ C# syntax with [`where`](/dotnet/csharp/language-reference/keywords/where-generi
 @typeparam TEntity where TEntity : IEntity
 ```
 
+::: moniker-end
+
 For more information, see the following articles:
 
 * <xref:mvc/views/razor#typeparam>
 * <xref:blazor/components/templated-components>
-
-::: moniker-end
 
 <!--Reference links in article-->
 [1]: <xref:mvc/views/razor#code>

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -187,7 +187,7 @@ For more information, see the following articles:
 
 ::: moniker range="< aspnetcore-6.0"
 
-Inferred generic types are supported in ASP.NET Core 6.0 or later. For more information, see the 6.0 or a later version of this article.
+Inferred generic types are supported in ASP.NET Core 6.0 or later. For more information, see a 6.0 or later version of this article.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -172,12 +172,22 @@ When receiving a cascaded type parameter, components obtain the parameter value 
 
 Matching is only performed by name. Therefore, we recommend avoiding a cascaded generic type parameter with a generic name, for example `T` or `TItem`. If a developer opts into cascading a type parameter, they're implicitly promising that its name is unique enough not to clash with other cascaded type parameters from unrelated components.
 
+Generic types with [`where`](/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) type constraints are supported:
+
+```razor
+@typeparam TEntity where TEntity : IEntity
+```
+
+For more information, see the following articles:
+
+* <xref:mvc/views/razor#typeparam>
+* <xref:blazor/components/index#generic-type-parameter-support>
+
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-6.0"
 
-> [!NOTE]
-> Inferred generic types are supported in ASP.NET Core 6.0 or later. For more information, see a version of this article later than ASP.NET Core 5.0.
+Inferred generic types are supported in ASP.NET Core 6.0 or later. For more information, see the 6.0 or a later version of this article.
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -1055,6 +1055,12 @@ When working with radio buttons in a form, data binding is handled differently t
 }
 ```
 
+For more information on generic type parameters (`@typeparam`), see the following articles:
+
+* <xref:mvc/views/razor#typeparam>
+* <xref:blazor/components/index#generic-type-parameter-support>
+* <xref:blazor/components/templated-components>
+
 The following `RadioButtonExample` component uses the preceding `InputRadio` component to obtain and validate a rating from the user:
 
 `Pages/RadioButtonExample.razor`:

--- a/aspnetcore/blazor/webassembly-performance-best-practices.md
+++ b/aspnetcore/blazor/webassembly-performance-best-practices.md
@@ -238,6 +238,12 @@ To reduce this load, you could bundle together multiple parameters via custom cl
 
 In the preceding example, `Data` is different for every cell, but `Options` is common across all of them. Of course, it might be an improvement not to have a `<TableCell>` component and instead inline its logic into the parent component.
 
+For more information on generic type parameters (`@typeparam`), see the following articles:
+
+* <xref:mvc/views/razor#typeparam>
+* <xref:blazor/components/index#generic-type-parameter-support>
+* <xref:blazor/components/templated-components>
+
 #### Ensure cascading parameters are fixed
 
 The `<CascadingValue>` component has an optional parameter called `IsFixed`.

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -776,11 +776,35 @@ The `@key` directive attribute causes the components diffing algorithm to guaran
 
 Component references (`@ref`) provide a way to reference a component instance so that you can issue commands to that instance. For more information, see <xref:blazor/components/index#capture-references-to-components>.
 
+::: moniker-end
+
+::: moniker range=">= aspnetcore-6.0"
+
 ### `@typeparam`
 
 *This scenario only applies to Razor components (.razor).*
 
-The `@typeparam` directive declares a generic type parameter for the generated component class. For more information, see <xref:blazor/components/templated-components>.
+The `@typeparam` directive declares a [generic type parameter](/dotnet/csharp/programming-guide/generics/generic-type-parameters) for the generated component class. Generic types with [`where`](/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) type constraints are supported.
+
+For more information, see the following articles:
+
+* <xref:blazor/components/index#generic-type-parameter-support>
+* <xref:blazor/components/templated-components>
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-6.0 > aspnetcore-3.0"
+
+### `@typeparam`
+
+*This scenario only applies to Razor components (.razor).*
+
+The `@typeparam` directive declares a [generic type parameter](/dotnet/csharp/programming-guide/generics/generic-type-parameters) for the generated component class.
+
+For more information, see the following articles:
+
+* <xref:blazor/components/index#generic-type-parameter-support>
+* <xref:blazor/components/templated-components>
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -452,7 +452,7 @@ The `@attribute` directive adds the given attribute to the class of the generate
 
 ### `@code`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 The `@code` block enables a [Razor component](xref:blazor/components/index) to add C# members (fields, properties, and methods) to a component:
 
@@ -594,7 +594,7 @@ The `@inject` directive enables the Razor Page to inject a service from the [ser
 
 ### `@layout`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 The `@layout` directive specifies a layout for routable Razor components that have an [`@page`](#page) directive. Layout components are used to avoid code duplication and inconsistency. For more information, see <xref:blazor/components/layouts>.
 
@@ -722,25 +722,25 @@ Razor directive attributes are represented by implicit expressions with reserved
 
 ### `@attributes`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 `@attributes` allows a component to render non-declared attributes. For more information, see <xref:blazor/components/index#attribute-splatting-and-arbitrary-parameters>.
 
 ### `@bind`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 Data binding in components is accomplished with the `@bind` attribute. For more information, see <xref:blazor/components/data-binding>.
 
 ### `@bind:culture`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 Use the `@bind:culture` attribute with the [`@bind`](#bind) attribute to provide a <xref:System.Globalization.CultureInfo?displayProperty=fullName> for parsing and formatting a value. For more information, see <xref:blazor/globalization-localization#globalization>.
 
 ### `@on{EVENT}`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 Razor provides event handling features for components. For more information, see <xref:blazor/components/event-handling>.
 
@@ -750,13 +750,13 @@ Razor provides event handling features for components. For more information, see
 
 ### `@on{EVENT}:preventDefault`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 Prevents the default action for the event.
 
 ### `@on{EVENT}:stopPropagation`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 Stops event propagation for the event.
 
@@ -766,13 +766,13 @@ Stops event propagation for the event.
 
 ### `@key`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 The `@key` directive attribute causes the components diffing algorithm to guarantee preservation of elements or components based on the key's value. For more information, see <xref:blazor/components/index#use-key-to-control-the-preservation-of-elements-and-components>.
 
 ### `@ref`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
 Component references (`@ref`) provide a way to reference a component instance so that you can issue commands to that instance. For more information, see <xref:blazor/components/index#capture-references-to-components>.
 
@@ -782,9 +782,19 @@ Component references (`@ref`) provide a way to reference a component instance so
 
 ### `@typeparam`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
-The `@typeparam` directive declares a [generic type parameter](/dotnet/csharp/programming-guide/generics/generic-type-parameters) for the generated component class. Generic types with [`where`](/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) type constraints are supported.
+The `@typeparam` directive declares a [generic type parameter](/dotnet/csharp/programming-guide/generics/generic-type-parameters) for the generated component class:
+
+```razor
+@typeparam TEntity
+```
+
+Generic types with [`where`](/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) type constraints are supported:
+
+```razor
+@typeparam TEntity where TEntity : IEntity
+```
 
 For more information, see the following articles:
 
@@ -793,13 +803,17 @@ For more information, see the following articles:
 
 ::: moniker-end
 
-::: moniker range="< aspnetcore-6.0 > aspnetcore-3.0"
+::: moniker range="< aspnetcore-6.0 >= aspnetcore-3.0"
 
 ### `@typeparam`
 
-*This scenario only applies to Razor components (.razor).*
+*This scenario only applies to Razor components (`.razor`).*
 
-The `@typeparam` directive declares a [generic type parameter](/dotnet/csharp/programming-guide/generics/generic-type-parameters) for the generated component class.
+The `@typeparam` directive declares a [generic type parameter](/dotnet/csharp/programming-guide/generics/generic-type-parameters) for the generated component class:
+
+```razor
+@typeparam TEntity
+```
 
 For more information, see the following articles:
 


### PR DESCRIPTION
Fixes #17351
Addresses #22045

* We're currently lacking some basic coverage in the *Components* overview for generic type params. This PR fixes that.
* The new 6.0 feature that allows `where` constraints with standard C# syntax is included.
* Improve cross-linking and lingo.