### PR TITLE
Fixed unreachable code error in file upload example

### DIFF
--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor
@@ -65,7 +65,7 @@
             if (uploadResults.SingleOrDefault(
                 f => f.FileName == file.Name) is null)
             {
-                var fileContent = new StreamContent(file.OpenReadStream());
+                var fileContent = new StreamContent(file.OpenReadStream(long.MaxValue));
 
                 files.Add(
                     new()


### PR DESCRIPTION
Max file size check is limited to 500kb without specifying long.MaxValue in file.OpenReadStream

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->