### PR TITLE
docs: Fix typo in environment variable.

### DIFF
--- a/aspnetcore/client-side/spa/angular.md
+++ b/aspnetcore/client-side/spa/angular.md
@@ -36,7 +36,7 @@ The build process restores npm dependencies on the first run, which can take sev
 
 # [.NET Core CLI](#tab/netcore-cli/)
 
-Ensure you have an environment variable called `ASPNETCORE_Environment` with a value of `Development`. On Windows (in non-PowerShell prompts), run `SET ASPNETCORE_Environment=Development`. On Linux or macOS, run `export ASPNETCORE_Environment=Development`.
+Ensure you have an environment variable called `ASPNETCORE_ENVIRONMENT` with a value of `Development`. On Windows (in non-PowerShell prompts), run `SET ASPNETCORE_ENVIRONMENT=Development`. On Linux or macOS, run `export ASPNETCORE_ENVIRONMENT=Development`.
 
 Run [dotnet build](/dotnet/core/tools/dotnet-build) to verify the app builds correctly. On the first run, the build process restores npm dependencies, which can take several minutes. Subsequent builds are much faster.
 

--- a/aspnetcore/client-side/spa/react.md
+++ b/aspnetcore/client-side/spa/react.md
@@ -38,7 +38,7 @@ The build process restores npm dependencies on the first run, which can take sev
 
 # [.NET Core CLI](#tab/netcore-cli)
 
-Ensure you have an environment variable called `ASPNETCORE_Environment` with value of `Development`. On Windows (in non-PowerShell prompts), run `SET ASPNETCORE_Environment=Development`. On Linux or macOS, run `export ASPNETCORE_Environment=Development`.
+Ensure you have an environment variable called `ASPNETCORE_ENVIRONMENT` with value of `Development`. On Windows (in non-PowerShell prompts), run `SET ASPNETCORE_ENVIRONMENT=Development`. On Linux or macOS, run `export ASPNETCORE_ENVIRONMENT=Development`.
 
 Run [dotnet build](/dotnet/core/tools/dotnet-build) to verify your app builds correctly. On the first run, the build process restores npm dependencies, which can take several minutes. Subsequent builds are much faster.
 


### PR DESCRIPTION
# Summary

This patch renames the environment variable `ASPNETCORE_Environment` to `ASPNETCORE_ENVIRONMENT`.