### PR TITLE
Refactor approach on max file size

### DIFF
--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/file-uploads/FileUpload2.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_Server/Pages/file-uploads/FileUpload2.razor
@@ -66,16 +66,13 @@
             if (uploadResults.SingleOrDefault(
                 f => f.FileName == file.Name) is null)
             {
-                var fileContent = new StreamContent(file.OpenReadStream());
-
-                files.Add(
-                    new()
-                    {
-                        Name = file.Name
-                    });
-
-                if (file.Size < maxFileSize)
+                try
                 {
+                    var fileContent = 
+                        new StreamContent(file.OpenReadStream(maxFileSize));
+
+                    files.Add(new() { Name = file.Name });
+
                     content.Add(
                         content: fileContent,
                         name: "\"files\"",
@@ -83,10 +80,11 @@
 
                     upload = true;
                 }
-                else
+                catch (Exception ex)
                 {
-                    Logger.LogInformation("{FileName} not uploaded (Err: 6)", 
-                        file.Name);
+                    Logger.LogInformation(
+                        "{FileName} not uploaded (Err: 6): {Message}", 
+                        file.Name, ex.Message);
 
                     uploadResults.Add(
                         new()

--- a/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor
+++ b/aspnetcore/blazor/common/samples/5.x/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor
@@ -65,16 +65,13 @@
             if (uploadResults.SingleOrDefault(
                 f => f.FileName == file.Name) is null)
             {
-                var fileContent = new StreamContent(file.OpenReadStream());
-
-                files.Add(
-                    new()
-                    {
-                        Name = file.Name
-                    });
-
-                if (file.Size < maxFileSize)
+                try
                 {
+                    var fileContent = 
+                        new StreamContent(file.OpenReadStream(maxFileSize));
+
+                    files.Add(new() { Name = file.Name });
+
                     content.Add(
                         content: fileContent,
                         name: "\"files\"",
@@ -82,10 +79,11 @@
 
                     upload = true;
                 }
-                else
+                catch (Exception ex)
                 {
-                    Logger.LogInformation("{FileName} not uploaded (Err: 6)", 
-                        file.Name);
+                    Logger.LogInformation(
+                        "{FileName} not uploaded (Err: 6): {Message}", 
+                        file.Name, ex.Message);
 
                     uploadResults.Add(
                         new()


### PR DESCRIPTION
Fixes #22703

Thanks @dustout! :rocket: ... Good news is that the topic already had the text to cover it ...

> The `maxAllowedSize` parameter of `OpenReadStream` can be used to specify a larger size if required.

I just didn't implement **_what I wrote in the topic in the sample app!_** 🙈 Did I have too much 🍺???? ... **_Or, not enough!??_** 😆

Thanks again for the catch. I'll merge this to the live doc immediately.