### PR TITLE
removed implied comment

### DIFF
--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -21,7 +21,7 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
 * Deploy a Redis server.
 
   > [!IMPORTANT] 
-  > For production use, a Redis backplane is recommended only when it runs in the same data center as the SignalR app. Otherwise, network latency degrades performance. If your SignalR app is running in the Azure cloud, we recommend Azure SignalR Service instead of a Redis backplane. You can use the Azure Redis Cache Service for development and test environments.
+  > For production use, a Redis backplane is recommended only when it runs in the same data center as the SignalR app. Otherwise, network latency degrades performance. If your SignalR app is running in the Azure cloud, we recommend Azure SignalR Service instead of a Redis backplane. 
 
   For more information, see the following resources:
 


### PR DESCRIPTION
Comment in prior to this edit implied that Redis would be only good for development and test, when in fact, Redis is great for production usage and we want to make sure we don't imply anything to the contrary.