### PR TITLE
cutoff snippets fixed

### DIFF
--- a/aspnetcore/signalr/javascript-client.md
+++ b/aspnetcore/signalr/javascript-client.md
@@ -60,7 +60,7 @@ The client library is available on the following CDNs:
 
 The following code creates and starts a connection. The hub's name is case insensitive:
 
-[!code-javascript[](javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js?range=3-6,29-43)]
+[!code-javascript[](javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js?range=3-6,29-45)]
 
 ### Cross-origin connections
 
@@ -261,7 +261,7 @@ The following code demonstrates a typical manual reconnection approach:
 1. A function (in this case, the `start` function) is created to start the connection.
 1. Call the `start` function in the connection's `onclose` event handler.
 
-[!code-javascript[](javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js?range=30-40)]
+[!code-javascript[](javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js?range=30-42)]
 
 A real-world implementation would use an exponential back-off or retry a specified number of times before giving up.
 

--- a/aspnetcore/signalr/javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js
+++ b/aspnetcore/signalr/javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js
@@ -37,12 +37,8 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     };
     
-    connection.onclose(function (error) {
-        if (error) {
-            console.log(`Connection closed with error: ${error}`);
-        } else {
-            console.log("Connection closed.");
-        }
+    connection.onclose(async () => {
+        await start();
     });
 
     // Start the connection.


### PR DESCRIPTION
There are some cut-off snippets for version 3.1 of [ASP.NET Core SignalR JavaScript client](https://docs.microsoft.com/en-us/aspnet/core/signalr/javascript-client?view=aspnetcore-3.1) i.e. in [connect-to-a-hub](https://docs.microsoft.com/en-us/aspnet/core/signalr/javascript-client?view=aspnetcore-3.1#connect-to-a-hub) and [manually-reconnect](https://docs.microsoft.com/en-us/aspnet/core/signalr/javascript-client?view=aspnetcore-3.1#manually-reconnect) section. Fixed on my basic understanding. @Rick-Anderson please review