### PR TITLE
Linkfix: ASP.NET (2021-07)

### DIFF
--- a/aspnetcore/3.1/blazor/doc1.md
+++ b/aspnetcore/3.1/blazor/doc1.md
@@ -23,7 +23,7 @@ uid: blazor-doc1
 
 * [XREF with `xref:blazor-doc2?view=aspnetcore-5.0&preserve-view=true`](xref:blazor-doc2?view=aspnetcore-5.0&preserve-view=true)
 * [MD link with `5.0/blazor/doc2.md?view=aspnetcore-5.0&preserve-view=true`](../../5.0/blazor/doc2.md?view=aspnetcore-5.0&preserve-view=true)
-* [Relative link with `/aspnet/core/blazor/doc2?view=aspnetcore-5.0&preserve-view=true`](/aspnet/core/blazor/doc2?view=aspnetcore-5.0&preserve-view=true)
+* [Relative link with `/aspnet/core/blazor/doc2?view=aspnetcore-5.0&preserve-view=true`](./doc2.md?preserve-view=true&view=aspnetcore-5.0)
 
 ## Self-links
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -374,6 +374,6 @@ We recommend using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-
 * [Blazor Server reconnection events and component lifecycle events](xref:blazor/components/lifecycle#blazor-server-reconnection-events)
 * [What is Azure SignalR Service?](/azure/azure-signalr/signalr-overview)
 * [Performance guide for Azure SignalR Service](/azure-signalr/signalr-concept-performance#performance-factors)
-* [Publish an ASP.NET Core SignalR app to Azure App Service](/aspnet/core/signalr/publish-to-azure-web-app)
+* [Publish an ASP.NET Core SignalR app to Azure App Service](../../signalr/publish-to-azure-web-app.md)
 
 ::: zone-end

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -58,7 +58,7 @@ We recommend using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-
 >
 > * [What is Azure SignalR Service?](/azure/azure-signalr/signalr-overview)
 > * [Performance guide for Azure SignalR Service](/azure-signalr/signalr-concept-performance#performance-factors)
-> * [Publish an ASP.NET Core SignalR app to Azure App Service](/aspnet/core/signalr/publish-to-azure-web-app)
+> * [Publish an ASP.NET Core SignalR app to Azure App Service](../../signalr/publish-to-azure-web-app.md)
 
 ### Configuration
 

--- a/aspnetcore/includes/sql-log.md
+++ b/aspnetcore/includes/sql-log.md
@@ -10,4 +10,4 @@ Logging configuration is commonly provided by the `Logging` section of *appsetti
 
 With the preceding JSON, SQL statements are displayed on the command line and in the Visual Studio output window.
 
-For more information, see [Configure logging in ASP.NET Core](/aspnet/core/fundamentals/logging#configure-logging) and this [GitHub issue](https://github.com/dotnet/aspnetcore/issues/32977).
+For more information, see [Configure logging in ASP.NET Core](../fundamentals/logging/index.md#configure-logging) and this [GitHub issue](https://github.com/dotnet/aspnetcore/issues/32977).


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to cleanup links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->