### PR TITLE
signalr javascript snippet reverted

### DIFF
--- a/aspnetcore/signalr/javascript-client.md
+++ b/aspnetcore/signalr/javascript-client.md
@@ -60,7 +60,7 @@ The client library is available on the following CDNs:
 
 The following code creates and starts a connection. The hub's name is case insensitive:
 
-[!code-javascript[](javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js?range=3-6,29-45)]
+[!code-javascript[](javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js?range=3-6,29-49)]
 
 ### Cross-origin connections
 
@@ -261,7 +261,7 @@ The following code demonstrates a typical manual reconnection approach:
 1. A function (in this case, the `start` function) is created to start the connection.
 1. Call the `start` function in the connection's `onclose` event handler.
 
-[!code-javascript[](javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js?range=30-42)]
+[!code-javascript[](javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js?range=30-40)]
 
 A real-world implementation would use an exponential back-off or retry a specified number of times before giving up.
 

--- a/aspnetcore/signalr/javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js
+++ b/aspnetcore/signalr/javascript-client/samples/3.x/SignalRChat/wwwroot/chat.js
@@ -37,8 +37,12 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     };
     
-    connection.onclose(async () => {
-        await start();
+    connection.onclose(function (error) {
+        if (error) {
+            console.log(`Connection closed with error: ${error}`);
+        } else {
+            console.log("Connection closed.");
+        }
     });
 
     // Start the connection.


### PR DESCRIPTION
***@Rick-Anderson  edit:*** [Internal review url](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/javascript-client?view=aspnetcore-5.0&branch=pr-en-us-22861#connect-to-a-hub)


@Rick-Anderson @BrennanConroy snippet reverted. But the information in this [section](https://docs.microsoft.com/en-us/aspnet/core/signalr/javascript-client?view=aspnetcore-5.0#manually-reconnect) is wrong. Please apply a fix for it. Thanks 🙌 
![image](https://user-images.githubusercontent.com/6568968/127031254-406779bf-6c22-4028-8a7b-7caa99e722b6.png)
