### PR TITLE
Add info on security risk of redistribution of dev cert

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -345,8 +345,8 @@ The following command provides help on the `dev-certs` tool:
 dotnet dev-certs https --help
 ```
 
-[!WARNING]
-Do not create a development certificate in an environment that will be redistributed, such as a container image or virtual machine. Doing so can lead to spoofing and elevation of privilege. To help prevent this, set the `DOTNET_GENERATE_ASPNET_CERTIFICATE` environment variable to `false` prior to calling the .NET CLI for the first time. This will skip the automatic generation of the ASP.NET Core development certificate during the CLI's first-run experience.
+> [!WARNING]
+> Do not create a development certificate in an environment that will be redistributed, such as a container image or virtual machine. Doing so can lead to spoofing and elevation of privilege. To help prevent this, set the `DOTNET_GENERATE_ASPNET_CERTIFICATE` environment variable to `false` prior to calling the .NET CLI for the first time. This will skip the automatic generation of the ASP.NET Core development certificate during the CLI's first-run experience.
 
 <a name="trust-ff"></a>
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -345,7 +345,7 @@ The following command provides help on the `dev-certs` tool:
 dotnet dev-certs https --help
 ```
 
-Be aware of the environment in which the ASP.NET Core development certificate is being installed. It's important to avoid having it installed in an environment that will be redistributed, such as a container image or virtual machine. Redistribution of the certificate's private key risks it being maliciously used to spoof the identity of a victim. In order to prevent the certificate from being generated during the .NET CLI's first-run experience, set the `DOTNET_GENERATE_ASPNET_CERTIFICATE` environment variable to `false`.
+You must not create a development certificate in an environment that will be redistributed, such as a container image or virtual machine. Doing so can lead to spoofing and elevation of privilege. To help prevent against this, set the `DOTNET_GENERATE_ASPNET_CERTIFICATE` environment variable to `false` prior to calling the .NET CLI for the first time. This will skip the automatic generation of the ASP.NET Core development certificate during the CLI's first-run experience.
 
 <a name="trust-ff"></a>
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -345,7 +345,8 @@ The following command provides help on the `dev-certs` tool:
 dotnet dev-certs https --help
 ```
 
-You must not create a development certificate in an environment that will be redistributed, such as a container image or virtual machine. Doing so can lead to spoofing and elevation of privilege. To help prevent against this, set the `DOTNET_GENERATE_ASPNET_CERTIFICATE` environment variable to `false` prior to calling the .NET CLI for the first time. This will skip the automatic generation of the ASP.NET Core development certificate during the CLI's first-run experience.
+[!WARNING]
+Do not create a development certificate in an environment that will be redistributed, such as a container image or virtual machine. Doing so can lead to spoofing and elevation of privilege. To help prevent this, set the `DOTNET_GENERATE_ASPNET_CERTIFICATE` environment variable to `false` prior to calling the .NET CLI for the first time. This will skip the automatic generation of the ASP.NET Core development certificate during the CLI's first-run experience.
 
 <a name="trust-ff"></a>
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -345,6 +345,8 @@ The following command provides help on the `dev-certs` tool:
 dotnet dev-certs https --help
 ```
 
+Be aware of the environment in which the ASP.NET Core development certificate is being installed. It's important to avoid having it installed in an environment that will be redistributed, such as a container image or virtual machine. Redistribution of the certificate's private key risks it being maliciously used to spoof the identity of a victim. In order to prevent the certificate from being generated during the .NET CLI's first-run experience, set the `DOTNET_GENERATE_ASPNET_CERTIFICATE` environment variable to `false`.
+
 <a name="trust-ff"></a>
 
 ### Trust the HTTPS certificate with Firefox to prevent SEC_ERROR_INADEQUATE_KEY_USAGE error


### PR DESCRIPTION
Adds more detail to the security implications of having the ASP.NET Core dev cert generated in an environment that could be redistributed and how to disable it from being generated.

[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-5.0&branch=pr-en-us-22878&tabs=visual-studio)