### PR TITLE
Blazor built-in Razor components topic

### DIFF
--- a/aspnetcore/3.1/blazor/components/built-in-components.md
+++ b/aspnetcore/3.1/blazor/components/built-in-components.md
@@ -1,0 +1,32 @@
+---
+title: ASP.NET Core built-in Razor components
+author: guardrex
+description: Find information on Razor components built-into the Blazor framework.
+monikerRange: '>= aspnetcore-3.1 < aspnetcore-5.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 07/30/2021
+no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+uid: blazor/components/built-in-components
+---
+# ASP.NET Core built-in Razor components
+
+The following built-in Razor components are provided by the Blazor framework:
+
+* [`App`](xref:blazor/project-structure)
+* [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)
+* [`AuthorizeView`](xref:blazor/security/index#authorizeview-component)
+* [`CascadingValue`](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component)
+* [`InputCheckbox`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputDate`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputNumber`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputRadio`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputRadioGroup`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputSelect`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputText`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputTextArea`](xref:blazor/forms-validation#built-in-form-components)
+* [`LayoutView`](xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component)
+* [`MainLayout`](xref:blazor/components/layouts#mainlayout-component)
+* [`NavLink`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
+* [`NavMenu`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
+* [`Router`](xref:blazor/fundamentals/routing#route-templates)

--- a/aspnetcore/5.0/blazor/components/built-in-components.md
+++ b/aspnetcore/5.0/blazor/components/built-in-components.md
@@ -1,0 +1,34 @@
+---
+title: ASP.NET Core built-in Razor components
+author: guardrex
+description: Find information on Razor components built-into the Blazor framework.
+monikerRange: '>= aspnetcore-5.0 < aspnetcore-6.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 07/30/2021
+no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+uid: blazor/components/built-in-components
+---
+# ASP.NET Core built-in Razor components
+
+The following built-in Razor components are provided by the Blazor framework:
+
+* [`App`](xref:blazor/project-structure)
+* [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)
+* [`AuthorizeView`](xref:blazor/security/index#authorizeview-component)
+* [`CascadingValue`](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component)
+* [`InputCheckbox`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputDate`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputFile`](xref:blazor/file-uploads)
+* [`InputNumber`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputRadio`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputRadioGroup`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputSelect`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputText`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputTextArea`](xref:blazor/forms-validation#built-in-form-components)
+* [`LayoutView`](xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component)
+* [`MainLayout`](xref:blazor/components/layouts#mainlayout-component)
+* [`NavLink`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
+* [`NavMenu`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
+* [`Router`](xref:blazor/fundamentals/routing#route-templates)
+* [`Virtualize`](xref:blazor/components/virtualization)

--- a/aspnetcore/6.0/blazor/components/built-in-components.md
+++ b/aspnetcore/6.0/blazor/components/built-in-components.md
@@ -1,0 +1,36 @@
+---
+title: ASP.NET Core built-in Razor components
+author: guardrex
+description: Find information on Razor components built-into the Blazor framework.
+monikerRange: '>= aspnetcore-6.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 07/30/2021
+no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+uid: blazor/components/built-in-components
+---
+# ASP.NET Core built-in Razor components
+
+The following built-in Razor components are provided by the Blazor framework:
+
+* [`App`](xref:blazor/project-structure)
+* [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)
+* [`AuthorizeView`](xref:blazor/security/index#authorizeview-component)
+* [`CascadingValue`](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component)
+* [`ErrorBoundary`](xref:blazor/fundamentals/handle-errors#error-boundaries)
+* [`FocusOnNavigate`](xref:blazor/fundamentals/routing#focus-an-element-on-navigation)
+* [`InputCheckbox`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputDate`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputFile`](xref:blazor/file-uploads)
+* [`InputNumber`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputRadio`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputRadioGroup`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputSelect`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputText`](xref:blazor/forms-validation#built-in-form-components)
+* [`InputTextArea`](xref:blazor/forms-validation#built-in-form-components)
+* [`LayoutView`](xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component)
+* [`MainLayout`](xref:blazor/components/layouts#mainlayout-component)
+* [`NavLink`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
+* [`NavMenu`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
+* [`Router`](xref:blazor/fundamentals/routing#route-templates)
+* [`Virtualize`](xref:blazor/components/virtualization)

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -496,6 +496,12 @@
               href: 5.0/blazor/components/class-libraries.md
             - name: Class libraries
               href: 6.0/blazor/components/class-libraries.md
+            - name: Built-in components
+              href: 3.1/blazor/components/built-in-components.md
+            - name: Built-in components
+              href: 5.0/blazor/components/built-in-components.md
+            - name: Built-in components
+              href: 6.0/blazor/components/built-in-components.md
         - name: Globalization and localization
           href: 3.1/blazor/globalization-localization.md
         - name: Globalization and localization
@@ -710,122 +716,6 @@
           href: 5.0/blazor/advanced-scenarios.md
         - name: Advanced scenarios
           href: 6.0/blazor/advanced-scenarios.md
-        - name: Built-in components
-          items:
-            - name: App
-              href: 3.1/blazor/project-structure.md
-            - name: App
-              href: 5.0/blazor/project-structure.md
-            - name: App
-              href: 6.0/blazor/project-structure.md
-            - name: Authentication
-              href: 3.1/blazor/security/webassembly/index.md#authentication-component
-            - name: Authentication
-              href: 5.0/blazor/security/webassembly/index.md#authentication-component
-            - name: Authentication
-              href: 6.0/blazor/security/webassembly/index.md#authentication-component
-            - name: AuthorizeView
-              href: 3.1/blazor/security/index.md#authorizeview-component
-            - name: AuthorizeView
-              href: 5.0/blazor/security/index.md#authorizeview-component
-            - name: AuthorizeView
-              href: 6.0/blazor/security/index.md#authorizeview-component
-            - name: CascadingValue
-              href: 3.1/blazor/components/cascading-values-and-parameters.md#cascadingvalue-component
-            - name: CascadingValue
-              href: 5.0/blazor/components/cascading-values-and-parameters.md#cascadingvalue-component
-            - name: CascadingValue
-              href: 6.0/blazor/components/cascading-values-and-parameters.md#cascadingvalue-component
-            - name: ErrorBoundary
-              href: 6.0/blazor/fundamentals/handle-errors.md#error-boundaries
-            - name: FocusOnNavigate
-              href: 6.0/blazor/fundamentals/routing.md#focus-an-element-on-navigation
-            - name: InputCheckbox
-              href: 3.1/blazor/forms-validation.md#built-in-form-components
-            - name: InputCheckbox
-              href: 5.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputCheckbox
-              href: 6.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputDate
-              href: 3.1/blazor/forms-validation.md#built-in-form-components
-            - name: InputDate
-              href: 5.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputDate
-              href: 6.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputFile
-              href: 5.0/blazor/file-uploads.md
-            - name: InputFile
-              href: 6.0/blazor/file-uploads.md
-            - name: InputNumber
-              href: 3.1/blazor/forms-validation.md#built-in-form-components
-            - name: InputNumber
-              href: 5.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputNumber
-              href: 6.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputRadio
-              href: 3.1/blazor/forms-validation.md#built-in-form-components
-            - name: InputRadio
-              href: 5.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputRadio
-              href: 6.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputRadioGroup
-              href: 3.1/blazor/forms-validation.md#built-in-form-components
-            - name: InputRadioGroup
-              href: 5.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputRadioGroup
-              href: 6.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputSelect
-              href: 3.1/blazor/forms-validation.md#built-in-form-components
-            - name: InputSelect
-              href: 5.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputSelect
-              href: 6.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputText
-              href: 3.1/blazor/forms-validation.md#built-in-form-components
-            - name: InputText
-              href: 5.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputText
-              href: 6.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputTextArea
-              href: 3.1/blazor/forms-validation.md#built-in-form-components
-            - name: InputTextArea
-              href: 5.0/blazor/forms-validation.md#built-in-form-components
-            - name: InputTextArea
-              href: 6.0/blazor/forms-validation.md#built-in-form-components
-            - name: LayoutView
-              href: 3.1/blazor/components/layouts.md#apply-a-layout-to-arbitrary-content-layoutview-component
-            - name: LayoutView
-              href: 5.0/blazor/components/layouts.md#apply-a-layout-to-arbitrary-content-layoutview-component
-            - name: LayoutView
-              href: 6.0/blazor/components/layouts.md#apply-a-layout-to-arbitrary-content-layoutview-component
-            - name: MainLayout
-              href: 3.1/blazor/components/layouts.md#mainlayout-component
-            - name: MainLayout
-              href: 5.0/blazor/components/layouts.md#mainlayout-component
-            - name: MainLayout
-              href: 6.0/blazor/components/layouts.md#mainlayout-component
-            - name: NavLink
-              href: 3.1/blazor/fundamentals/routing.md#navlink-and-navmenu-components
-            - name: NavLink
-              href: 5.0/blazor/fundamentals/routing.md#navlink-and-navmenu-components
-            - name: NavLink
-              href: 6.0/blazor/fundamentals/routing.md#navlink-and-navmenu-components
-            - name: NavMenu
-              href: 3.1/blazor/fundamentals/routing.md#navlink-and-navmenu-components
-            - name: NavMenu
-              href: 5.0/blazor/fundamentals/routing.md#navlink-and-navmenu-components
-            - name: NavMenu
-              href: 6.0/blazor/fundamentals/routing.md#navlink-and-navmenu-components
-            - name: Router
-              href: 3.1/blazor/fundamentals/routing.md#route-templates
-            - name: Router
-              href: 5.0/blazor/fundamentals/routing.md#route-templates
-            - name: Router
-              href: 6.0/blazor/fundamentals/routing.md#route-templates
-            - name: Virtualize
-              href: 5.0/blazor/components/virtualization.md
-            - name: Virtualize
-              href: 6.0/blazor/components/virtualization.md
     - name: Client-side development
       items:
         - name: Single Page Apps


### PR DESCRIPTION
Fixes #22897

**UPDATE**: Dan, Artak ... I'm going to go ahead and merge this because I'm going to give the `toc.yml`-per-group (version) test a shot. I'd like this topic in place for the test. The test PR becomes a live merge PR if the test works. Ping me for feedback on this ... concerns ... complaints ... 💀 **_death threats_** 💀😄. I'll mod it separately later on your feedback.

The *Built-in components* ToC node is a **_stinker_** 💩👃😵. The link highlight cues have never worked perfectly well. For example, the highlight cue is applied to the last URL that matches the loaded page, which isn't necessarily the component that the reader selected. Also, the whole node has to reside at the end of the Blazor ToC to get any of the highlighting not to interfere with the regular topics listed in the ToC when the last ToC entry matches by URL.

Therefore, I think we need a proper topic to cover this. This topic hosts well-behaved cross-links to the topics (+sections) where the components are described. We can also place this new topic in the *Components* node, instead of having the links at the end of the Blazor ToC merely to avoid bad link text highlight cue behavior.

Docs engineering might want to take a look at some of the undesirable behaviors. I opened https://github.com/MicrosoftDocs/feedback/issues/3668 on the docs feedback site for the behaviors. btw - The offline discussion with the three DocFX engineers is separate from that public issue. I will send them a link to that, as they might ultimately work all of them together or open internal issues.