### PR TITLE
Fix link anchor

### DIFF
--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -90,7 +90,7 @@ The <xref:Microsoft.Extensions.Hosting.IHostedService> interface defines two met
 
   To extend the default five second shutdown timeout, set:
 
-  * <xref:Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout*> when using Generic Host. For more information, see <xref:fundamentals/host/generic-host#shutdown-timeout>.
+  * <xref:Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout*> when using Generic Host. For more information, see <xref:fundamentals/host/generic-host#shutdowntimeout>.
   * Shutdown timeout host configuration setting when using Web Host. For more information, see <xref:fundamentals/host/web-host#shutdown-timeout>.
 
 The hosted service is activated once at app startup and gracefully shut down at app shutdown. If an error is thrown during background task execution, `Dispose` should be called even if `StopAsync` isn't called.
@@ -204,7 +204,7 @@ Hosted services implement the <xref:Microsoft.Extensions.Hosting.IHostedService>
 
   To extend the default five second shutdown timeout, set:
 
-  * <xref:Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout*> when using Generic Host. For more information, see <xref:fundamentals/host/generic-host#shutdown-timeout>.
+  * <xref:Microsoft.Extensions.Hosting.HostOptions.ShutdownTimeout*> when using Generic Host. For more information, see <xref:fundamentals/host/generic-host#shutdowntimeout>.
   * Shutdown timeout host configuration setting when using Web Host. For more information, see <xref:fundamentals/host/web-host#shutdown-timeout>.
 
 The hosted service is activated once at app startup and gracefully shut down at app shutdown. If an error is thrown during background task execution, `Dispose` should be called even if `StopAsync` isn't called.


### PR DESCRIPTION
Fix the incorrect link anchor in order to point to the ShutdownTimeout section in https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host#shutdowntimeout