### PR TITLE
response cache attribute should be set on page model

### DIFF
--- a/aspnetcore/razor-pages/ui-class/samples/cli/WebApp1/Pages/Error.cshtml.cs
+++ b/aspnetcore/razor-pages/ui-class/samples/cli/WebApp1/Pages/Error.cshtml.cs
@@ -8,13 +8,13 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace WebApp1.Pages
 {
+    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public class ErrorModel : PageModel
     {
         public string RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 
-        [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
         public void OnGet()
         {
             RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;


### PR DESCRIPTION
building the rcl sample was giving a warning. required a minor fix. @Rick-Anderson, please review

tag:  @chengyanbing https://github.com/dotnet/AspNetCore.Docs/pull/22808#issuecomment-890428061