### PR TITLE
Blazor _Host to _Layout updates

### DIFF
--- a/aspnetcore/6.0/blazor/components/class-libraries.md
+++ b/aspnetcore/6.0/blazor/components/class-libraries.md
@@ -239,7 +239,7 @@ When the `Link` component is used in a child component, the linked asset is also
 
 An alternative to using the `Link` component is to link to the library's stylesheet in the app's `<head>` markup.
 
-`wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+`wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server):
 
 ```diff
 + <link href="_content/ComponentLibrary/additionalStyles.css" rel="stylesheet" />

--- a/aspnetcore/6.0/blazor/components/css-isolation.md
+++ b/aspnetcore/6.0/blazor/components/css-isolation.md
@@ -45,7 +45,7 @@ h1 {
 
 ## CSS isolation bundling
 
-CSS isolation occurs at build time. Blazor rewrites CSS selectors to match markup rendered by the component. The rewritten CSS styles are bundled and produced as a static asset. The stylesheet is referenced inside the `<head>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server). The following `<link>` element is added by default to an app created from the Blazor project templates, where the placeholder `{ASSEMBLY NAME}` is the project's assembly name:
+CSS isolation occurs at build time. Blazor rewrites CSS selectors to match markup rendered by the component. The rewritten CSS styles are bundled and produced as a static asset. The stylesheet is referenced inside the `<head>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server). The following `<link>` element is added by default to an app created from the Blazor project templates, where the placeholder `{ASSEMBLY NAME}` is the project's assembly name:
 
 ```html
 <link href="{ASSEMBLY NAME}.styles.css" rel="stylesheet">
@@ -208,7 +208,7 @@ In the following example:
 * The static web asset base path is `_content/ClassLib`.
 * The class library's assembly name is `ClassLib`.
 
-`wwwroot/index.html` (Blazor WebAssembly) or `Pages_Host.cshtml` (Blazor Server):
+`wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <link href="_content/ClassLib/ClassLib.bundle.scp.css" rel="stylesheet">

--- a/aspnetcore/6.0/blazor/components/event-handling.md
+++ b/aspnetcore/6.0/blazor/components/event-handling.md
@@ -94,7 +94,7 @@ Custom events with custom event arguments are generally enabled with the followi
    }
    ```
 
-1. Register the custom event with the preceding handler in `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server) immediately after the Blazor `<script>`:
+1. Register the custom event with the preceding handler in `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server) immediately after the Blazor `<script>`:
 
    ```html
    <script>
@@ -167,9 +167,9 @@ public class CustomPasteEventArgs : EventArgs
 }
 ```
 
-Add JavaScript code to supply data for the <xref:System.EventArgs> subclass. In the `wwwroot/index.html` or `Pages/_Host.cshtml` file, add the following `<script>` tag and content immediately after the Blazor script. The following example only handles pasting text, but you could use arbitrary JavaScript APIs to deal with users pasting other types of data, such as images.
+Add JavaScript code to supply data for the <xref:System.EventArgs> subclass. In the `wwwroot/index.html` or `Pages/_Layout.cshtml` file, add the following `<script>` tag and content immediately after the Blazor script. The following example only handles pasting text, but you could use arbitrary JavaScript APIs to deal with users pasting other types of data, such as images.
 
-`wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server) immediately after the Blazor script:
+`wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server) immediately after the Blazor script:
 
 ```html
 <script>

--- a/aspnetcore/6.0/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/6.0/blazor/components/prerendering-and-integration.md
@@ -37,7 +37,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
    - builder.RootComponents.Add<App>("#app");
    ```
 
-1. Add a `Pages/_Host.cshtml` file to the **`Server`** project's `Pages` folder. You can obtain a `_Host.cshtml` file from a project created from the Blazor Server template with the `dotnet new blazorserver -o BlazorServer` command in a command shell (the `-o BlazorServer` option creates a folder for the project). After placing the `Pages/_Host.cshtml` file into the **`Server`** project of the hosted Blazor WebAssembly solution, make the following changes to the file:
+1. Add `Pages/_Host.cshtml` and `Pages/_Layout.cshtml` files to the **`Server`** project's `Pages` folder. You can obtain a `_Host.cshtml` and `_Layout.cshtml` files from a project created from the Blazor Server template with the `dotnet new blazorserver -o BlazorServer` command in a command shell (the `-o BlazorServer` option creates a folder for the project). After placing the `Pages/_Host.cshtml` and `Pages/_Layout.cshtml` files into the **`Server`** project of the hosted Blazor WebAssembly solution, make the following changes to the `_Layout.cshtml` file:
 
    * Provide an [`@using`](xref:mvc/views/razor#using) directive for the **`Client`** project (for example, `@using BlazorHosted.Client`).
    * Update the stylesheet links to point to the WebAssembly project's stylesheets. In the following example, the client project's namespace is `BlazorHosted.Client`:
@@ -653,16 +653,14 @@ For more information, see <xref:blazor/components/index#namespaces>.
 
 Without preserving prerendered state, any state that used during prerendering is lost and must be recreated when the app is fully loaded. If any state is setup asynchronously, the UI may flicker as the the prerendered UI is replaced with temporary placeholders and then fully rendered again.
 
-To solve these problems, Blazor supports persisting state in a prerendered page using the [Preserve Component State Tag Helper](xref:mvc/views/tag-helpers/builtin-th/preserve-component-state-tag-helper) (`<preserve-component-state />`). Add the `<preserve-component-state />` tag inside the closing `</body>` tag of `_Host.cshtml`.
+To solve these problems, Blazor supports persisting state in a prerendered page using the [Preserve Component State Tag Helper](xref:mvc/views/tag-helpers/builtin-th/preserve-component-state-tag-helper) (`<preserve-component-state />`). Add the `<preserve-component-state />` tag inside the closing `</body>` tag of `_Layout.cshtml`.
 
 ::: zone pivot="webassembly"
 
-`Pages/_Host.cshtml`:
+`Pages/_Layout.cshtml`:
 
 ```cshtml
 <body>
-    <component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
-
     ...
 
     <persist-component-state />
@@ -673,12 +671,10 @@ To solve these problems, Blazor supports persisting state in a prerendered page 
 
 ::: zone pivot="server"
 
-`Pages/_Host.cshtml`:
+`Pages/_Layout.cshtml`:
 
 ```cshtml
 <body>
-    <component type="typeof(App)" render-mode="ServerPrerendered" />
-
     ...
 
     <persist-component-state />

--- a/aspnetcore/6.0/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/6.0/blazor/components/prerendering-and-integration.md
@@ -37,7 +37,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
    - builder.RootComponents.Add<App>("#app");
    ```
 
-1. Add `Pages/_Host.cshtml` and `Pages/_Layout.cshtml` files to the **`Server`** project's `Pages` folder. You can obtain a `_Host.cshtml` and `_Layout.cshtml` files from a project created from the Blazor Server template with the `dotnet new blazorserver -o BlazorServer` command in a command shell (the `-o BlazorServer` option creates a folder for the project). After placing the `Pages/_Host.cshtml` and `Pages/_Layout.cshtml` files into the **`Server`** project of the hosted Blazor WebAssembly solution, make the following changes to the `_Layout.cshtml` file:
+1. Add `_Host.cshtml` and `_Layout.cshtml` files to the **`Server`** project's `Pages` folder. You can obtain `_Host.cshtml` and `_Layout.cshtml` files from a project created from the Blazor Server template with the `dotnet new blazorserver -o BlazorServer` command in a command shell (the `-o BlazorServer` option creates a folder for the project). After placing the files into the **`Server`** project's `Pages` folder, make the following changes to the `_Layout.cshtml` file:
 
    * Provide an [`@using`](xref:mvc/views/razor#using) directive for the **`Client`** project (for example, `@using BlazorHosted.Client`).
    * Update the stylesheet links to point to the WebAssembly project's stylesheets. In the following example, the client project's namespace is `BlazorHosted.Client`:

--- a/aspnetcore/6.0/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/6.0/blazor/components/prerendering-and-integration.md
@@ -52,18 +52,18 @@ To set up prerendering for a hosted Blazor WebAssembly app:
      > [!NOTE]
      > Leave the `<link>` element that requests the Bootstrap stylesheet (`css/bootstrap/bootstrap.min.css`) in place.
 
-   * Update the `render-mode` of the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) to prerender the root `App` component with <xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.WebAssemblyPrerendered>:
-
-     ```diff
-     - <component type="typeof(App)" render-mode="ServerPrerendered" />
-     + <component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
-     ```
-
-   * Update the Blazor script source to use the client-side Blazor WebAssembly script:
+   * In the `_Layout.cshtml` file, update the Blazor script source to use the client-side Blazor WebAssembly script:
 
      ```diff
      - <script src="_framework/blazor.server.js"></script>
      + <script src="_framework/blazor.webassembly.js"></script>
+     ```
+
+   * In the `_Host.cshtml` file, update the `render-mode` of the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) to prerender the root `App` component with <xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode.WebAssemblyPrerendered>:
+
+     ```diff
+     - <component type="typeof(App)" render-mode="ServerPrerendered" />
+     + <component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
      ```
 
 1. In `Startup.Configure` of the **`Server`** project, change the fallback from the `index.html` file to the `_Host.cshtml` page.

--- a/aspnetcore/6.0/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/6.0/blazor/fundamentals/handle-errors.md
@@ -230,7 +230,7 @@ When a Blazor app isn't functioning properly during development, receiving detai
 
 The UI for this error handling experience is part of the [Blazor project templates](xref:blazor/project-structure).
 
-In a Blazor Server app, customize the experience in the `Pages/_Host.cshtml` file:
+In a Blazor Server app, customize the experience in the `Pages/_Layout.cshtml` file:
 
 ```cshtml
 <div id="blazor-error-ui">

--- a/aspnetcore/6.0/blazor/fundamentals/routing.md
+++ b/aspnetcore/6.0/blazor/fundamentals/routing.md
@@ -39,7 +39,7 @@ Components support multiple route templates using multiple [`@page` directives](
 [!code-razor[](~/6.0/blazor/samples/BlazorSample_WebAssembly/Pages/routing/BlazorRoute.razor?highlight=1-2)]
 
 > [!IMPORTANT]
-> For URLs to resolve correctly, the app must include a `<base>` tag in its `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server) with the app base path specified in the `href` attribute. For more information, see <xref:blazor/host-and-deploy/index#app-base-path>.
+> For URLs to resolve correctly, the app must include a `<base>` tag in its `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server) with the app base path specified in the `href` attribute. For more information, see <xref:blazor/host-and-deploy/index#app-base-path>.
 
 The <xref:Microsoft.AspNetCore.Components.Routing.Router> doesn't interact with query string values. To work with query strings, see the [Query string and parse parameters](#query-string-and-parse-parameters) section.
 
@@ -226,7 +226,7 @@ Use <xref:Microsoft.AspNetCore.Components.NavigationManager> to manage URIs and 
 | Member | Description |
 | ------ | ----------- |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.Uri> | Gets the current absolute URI. |
-| <xref:Microsoft.AspNetCore.Components.NavigationManager.BaseUri> | Gets the base URI (with a trailing slash) that can be prepended to relative URI paths to produce an absolute URI. Typically, <xref:Microsoft.AspNetCore.Components.NavigationManager.BaseUri> corresponds to the `href` attribute on the document's `<base>` element in `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server). |
+| <xref:Microsoft.AspNetCore.Components.NavigationManager.BaseUri> | Gets the base URI (with a trailing slash) that can be prepended to relative URI paths to produce an absolute URI. Typically, <xref:Microsoft.AspNetCore.Components.NavigationManager.BaseUri> corresponds to the `href` attribute on the document's `<base>` element in `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server). |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> | Navigates to the specified URI. If `forceLoad` is `true`:<ul><li>Client-side routing is bypassed.</li><li>The browser is forced to load the new page from the server, whether or not the URI is normally handled by the client-side router.</li></ul> |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.LocationChanged> | An event that fires when the navigation location has changed. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri%2A> | Converts a relative URI into an absolute URI. |

--- a/aspnetcore/6.0/blazor/fundamentals/signalr.md
+++ b/aspnetcore/6.0/blazor/fundamentals/signalr.md
@@ -135,9 +135,9 @@ In `Startup.Configure`, Blazor Server apps call <xref:Microsoft.AspNetCore.Build
 
 When the client detects that the connection has been lost, a default UI is displayed to the user while the client attempts to reconnect. If reconnection fails, the user is provided the option to retry.
 
-To customize the UI, define an element with an `id` of `components-reconnect-modal` in the `<body>` of the `_Host.cshtml` Razor page.
+To customize the UI, define an element with an `id` of `components-reconnect-modal` in the `<body>` of the `_Layout.cshtml` Razor page.
 
-`Pages/_Host.cshtml`:
+`Pages/_Layout.cshtml`:
 
 ```cshtml
 <div id="components-reconnect-modal">
@@ -174,7 +174,7 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor Server app's [SignalR circuit](xref:blazor/hosting-models#circuits) in the `Pages/_Host.cshtml` file:
+Configure the manual start of a Blazor Server app's [SignalR circuit](xref:blazor/hosting-models#circuits) in the `Pages/_Layout.cshtml` file:
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
 * Place a script that calls `Blazor.start` after the `blazor.server.js` script's `<script>` tag and inside the closing `</body>` tag.
@@ -187,7 +187,7 @@ For more information, including how to initialize Blazor when the document is re
 
 On the client builder, pass in the `configureSignalR` configuration object that calls `configureLogging` with the log level.
 
-`Pages/_Host.cshtml`:
+`Pages/_Layout.cshtml`:
 
 ```cshtml
 <body>
@@ -222,7 +222,7 @@ To modify the connection events, register callbacks for the following connection
 
 **Both `onConnectionDown` and `onConnectionUp` must be specified.**
 
-`Pages/_Host.cshtml`:
+`Pages/_Layout.cshtml`:
 
 ```cshtml
 <body>
@@ -246,7 +246,7 @@ For more information on Blazor startup, see <xref:blazor/fundamentals/startup>.
 
 To adjust the reconnection retry count and interval, set the number of retries (`maxRetries`) and period in milliseconds permitted for each retry attempt (`retryIntervalMilliseconds`).
 
-`Pages/_Host.cshtml`:
+`Pages/_Layout.cshtml`:
 
 ```cshtml
 <body>
@@ -270,7 +270,7 @@ For more information on Blazor startup, see <xref:blazor/fundamentals/startup>.
 
 To hide the reconnection display, set the reconnection handler's `_reconnectionDisplay` to an empty object (`{}` or `new Object()`).
 
-`Pages/_Host.cshtml`:
+`Pages/_Layout.cshtml`:
 
 ```cshtml
 <body>

--- a/aspnetcore/6.0/blazor/fundamentals/startup.md
+++ b/aspnetcore/6.0/blazor/fundamentals/startup.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/startup
 ---
 # ASP.NET Core Blazor Startup
 
-Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server):
 
 * Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.

--- a/aspnetcore/6.0/blazor/globalization-localization.md
+++ b/aspnetcore/6.0/blazor/globalization-localization.md
@@ -439,14 +439,14 @@ For information on ordering the Localization Middleware in the middleware pipeli
 
 The following example shows how to set the current culture in a cookie that can be read by the Localization Middleware.
 
-Add the following namespaces to the top of the `Pages/_Host.cshtml` file:
+Add the following namespaces to the top of the `Pages/_Layout.cshtml` file:
 
 ```csharp
 @using System.Globalization
 @using Microsoft.AspNetCore.Localization
 ```
 
-Immediately after the opening `<body>` tag of `Pages/_Host.cshtml`, add the following Razor expression:
+Immediately after the opening `<body>` tag of `Pages/_Layout.cshtml`, add the following Razor expression:
 
 ```cshtml
 @{
@@ -644,7 +644,7 @@ app.UseRequestLocalization(localizationOptions);
 
 For information on ordering the Localization Middleware in the middleware pipeline of `Startup.Configure`, see <xref:fundamentals/middleware/index#middleware-order>.
 
-If the app should localize resources based on storing a user's culture setting, use a localization culture cookie. Use of a cookie ensures that the WebSocket connection can correctly propagate the culture. If localization schemes are based on the URL path or query string, the scheme might not be able to work with [WebSockets](xref:fundamentals/websockets), thus fail to persist the culture. Therefore, the recommended approach is to use a localization culture cookie. See the [Dynamically set the culture by user preference](#dynamically-set-the-culture-by-user-preference) section of this article to see an example Razor expression for the `Pages/_Host.cshtml` file that persists the user's culture selection.
+If the app should localize resources based on storing a user's culture setting, use a localization culture cookie. Use of a cookie ensures that the WebSocket connection can correctly propagate the culture. If localization schemes are based on the URL path or query string, the scheme might not be able to work with [WebSockets](xref:fundamentals/websockets), thus fail to persist the culture. Therefore, the recommended approach is to use a localization culture cookie. See the [Dynamically set the culture by user preference](#dynamically-set-the-culture-by-user-preference) section of this article to see an example Razor expression for the `Pages/_Layout.cshtml` file that persists the user's culture selection.
 
 ::: zone-end
 

--- a/aspnetcore/6.0/blazor/host-and-deploy/index.md
+++ b/aspnetcore/6.0/blazor/host-and-deploy/index.md
@@ -60,7 +60,7 @@ The *app base path* is the app's root URL path. Consider the following ASP.NET C
 
 Without specifying additional configuration for `CoolApp`, the sub-app in this scenario has no knowledge of where it resides on the server. For example, the app can't construct correct relative URLs to its resources without knowing that it resides at the relative URL path `/CoolApp/`.
 
-To provide configuration for the Blazor app's base path of `https://www.contoso.com/CoolApp/`, the `<base>` tag's `href` attribute is set to the relative root path in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server).
+To provide configuration for the Blazor app's base path of `https://www.contoso.com/CoolApp/`, the `<base>` tag's `href` attribute is set to the relative root path in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server).
 
 Blazor WebAssembly (`wwwroot/index.html`):
 
@@ -68,7 +68,7 @@ Blazor WebAssembly (`wwwroot/index.html`):
 <base href="/CoolApp/">
 ```
 
-Blazor Server (`Pages/_Host.cshtml`):
+Blazor Server (`Pages/_Layout.cshtml`):
 
 ```html
 <base href="~/CoolApp/">
@@ -84,7 +84,7 @@ By providing the relative URL path, a component that isn't in the root directory
 
 In many hosting scenarios, the relative URL path to the app is the root of the app. In these cases, the app's relative URL base path is a forward slash (`<base href="/" />`), which is the default configuration for a Blazor app. In other hosting scenarios, such as GitHub Pages and IIS sub-apps, the app base path must be set to the server's relative URL path of the app.
 
-To set the app's base path, update the `<base>` tag within the `<head>` tag elements of the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` file (Blazor WebAssembly). Set the `href` attribute value to `/{RELATIVE URL PATH}/` (Blazor WebAssembly) or `~/{RELATIVE URL PATH}/` (Blazor Server). **The trailing slash is required.** The placeholder `{RELATIVE URL PATH}` is the app's full relative URL path.
+To set the app's base path, update the `<base>` tag within the `<head>` tag elements of the `Pages/_Layout.cshtml` file (Blazor Server) or `wwwroot/index.html` file (Blazor WebAssembly). Set the `href` attribute value to `/{RELATIVE URL PATH}/` (Blazor WebAssembly) or `~/{RELATIVE URL PATH}/` (Blazor Server). **The trailing slash is required.** The placeholder `{RELATIVE URL PATH}` is the app's full relative URL path.
 
 For a Blazor WebAssembly app with a non-root relative URL path (for example, `<base href="/CoolApp/">`), the app fails to find its resources *when run locally*. To overcome this problem during local development and testing, you can supply a *path base* argument that matches the `href` value of the `<base>` tag at runtime. **Don't include a trailing slash.** To pass the path base argument when running the app locally, execute the `dotnet run` command from the app's directory with the `--pathbase` option:
 

--- a/aspnetcore/6.0/blazor/includes/prerendering.md
+++ b/aspnetcore/6.0/blazor/includes/prerendering.md
@@ -5,7 +5,7 @@ no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cook
 
 While an app is prerendering, certain actions, such as calling into JavaScript, aren't possible. Components may need to render differently when prerendered.
 
-For the following example, the `setElementText1` function is placed inside the `<head>` element of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server). The function is called with <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A?displayProperty=nameWithType> and doesn't return a value:
+For the following example, the `setElementText1` function is placed inside the `<head>` element of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server). The function is called with <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A?displayProperty=nameWithType> and doesn't return a value:
 
 ```html
 <script>
@@ -33,7 +33,7 @@ To delay JavaScript interop calls until a point where such calls are guaranteed 
 
 The following component demonstrates how to use JavaScript interop as part of a component's initialization logic in a way that's compatible with prerendering. The component shows that it's possible to trigger a rendering update from inside <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync%2A>. The developer must be careful to avoid creating an infinite loop in this scenario.
 
-For the following example, the `setElementText2` function is placed inside the `<head>` element of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server). The function is called with<xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A?displayProperty=nameWithType> and returns a value:
+For the following example, the `setElementText2` function is placed inside the `<head>` element of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server). The function is called with<xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A?displayProperty=nameWithType> and returns a value:
 
 ```html
 <script>

--- a/aspnetcore/6.0/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/6.0/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -60,7 +60,7 @@ The `<button>` element's `onclick` HTML attribute is JavaScript's [`onclick`](ht
 
 The following `returnArrayAsync` JS function, calls the `ReturnArrayAsync` .NET method of the preceding `CallDotNetExample1` component and logs the result to the browser's web developer tools console. `BlazorSample` is the app's assembly name.
 
-Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <script>
@@ -117,7 +117,7 @@ To invoke an instance .NET method from JavaScript (JS):
 
 The following `sayHello1` JS function receives a <xref:Microsoft.JSInterop.DotNetObjectReference> and calls `invokeMethodAsync` to call the `GetHelloMethod` .NET method of a component.
 
-Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <script>
@@ -166,7 +166,7 @@ The following `sayHello1` JS function:
 * Calls the `GetHelloMessage` .NET method on the passed <xref:Microsoft.JSInterop.DotNetObjectReference>.
 * Returns the message from `GetHelloMessage` to the `sayHello1` caller.
 
-Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <script>
@@ -245,7 +245,7 @@ The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET me
 
 The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method. `BlazorSample` is the app's assembly name.
 
-Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <script>
@@ -304,7 +304,7 @@ Objects that contain circular references can't be serialized on the client for e
 
 Blazor supports optimized byte array JS interop that avoids encoding/decoding byte arrays into Base64. The following example uses JS interop to pass a byte array to .NET.
 
-Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server), provide a `sendByteArray` JS function. The function is called by a button in the component and doesn't return a value:
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server), provide a `sendByteArray` JS function. The function is called by a button in the component and doesn't return a value:
 
 ```html
 <script>

--- a/aspnetcore/6.0/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/6.0/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -32,7 +32,7 @@ For Blazor Server apps with prerendering enabled, calling into JS isn't possible
 
 The following example is based on [`TextDecoder`](https://developer.mozilla.org/docs/Web/API/TextDecoder), a JS-based decoder. The example demonstrates how to invoke a JS function from a C# method that offloads a requirement from developer code to an existing JS API. The JS function accepts a byte array from a C# method, decodes the array, and returns the text to the component for display.
 
-Add the following JS code inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Add the following JS code inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <script>
@@ -62,7 +62,7 @@ Use <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A> when:
 * .NET isn't required to read the result of a JS call.
 * JS functions return [void(0)/void 0](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/void) or [undefined](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/undefined).
 
-Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server), provide a `displayTickerAlert1` JS function. The function is called with <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A> and doesn't return a value:
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server), provide a `displayTickerAlert1` JS function. The function is called with <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A> and doesn't return a value:
 
 ```html
 <script>
@@ -96,7 +96,7 @@ Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or
 
 Use <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeAsync%2A> when .NET should read the result of a JS call.
 
-Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server), provide a `displayTickerAlert2` JS function. The following example returns a string for display by the caller:
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server), provide a `displayTickerAlert2` JS function. The following example returns a string for display by the caller:
 
 ```html
 <script>
@@ -365,7 +365,7 @@ For a parent component to make an element reference available to other component
 * Allow child components to register callbacks.
 * Invoke the registered callbacks during the <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRender%2A> event with the passed element reference. Indirectly, this approach allows child components to interact with the parent's element reference.
 
-Add the following style to the `<head>` of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Add the following style to the `<head>` of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <style>
@@ -373,7 +373,7 @@ Add the following style to the `<head>` of `wwwroot/index.html` (Blazor WebAssem
 </style>
 ```
 
-Add the following script inside closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Add the following script inside closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <script>
@@ -497,7 +497,7 @@ export function setMapCenter(map, latitude, longitude) {
 
 To produce correct styling, add the following stylesheet tag to the host HTML page.
 
-In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server), add the following `<link>` element to the `<head>` element markup:
+In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server), add the following `<link>` element to the `<head>` element markup:
 
 ```html
 <link href="https://api.mapbox.com/mapbox-gl-js/v1.12.0/mapbox-gl.css" 
@@ -525,7 +525,7 @@ In the preceding example:
 
 Blazor supports optimized byte array JS interop that avoids encoding/decoding byte arrays into Base64. The following example uses JS interop to pass a byte array to JavaScript.
 
-Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server), provide a `receiveByteArray` JS function. The function is called with <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A> and doesn't return a value:
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server), provide a `receiveByteArray` JS function. The function is called with <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A> and doesn't return a value:
 
 ```html
 <script>
@@ -598,7 +598,7 @@ In the following example:
 > [!NOTE]
 > The following examples aren't typical use cases for this scenario because the [struct](/dotnet/csharp/language-reference/builtin-types/struct) passed to JS doesn't result in poor component performance. The example uses a small object merely to demonstrate the concepts for passing unserialized .NET data.
 
-Place the following `<script>` block in `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server). Alternatively, you can place the JS in an external JS file referenced inside the closing `</body>` tag with `<script src="{SCRIPT PATH AND FILE NAME (.js)}></script>`, where the `{SCRIPT PATH AND FILE NAME (.js)}` placeholder is the path and file name of the script.
+Place the following `<script>` block in `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server). Alternatively, you can place the JS in an external JS file referenced inside the closing `</body>` tag with `<script src="{SCRIPT PATH AND FILE NAME (.js)}></script>`, where the `{SCRIPT PATH AND FILE NAME (.js)}` placeholder is the path and file name of the script.
 
 ```javascript
 <script>

--- a/aspnetcore/6.0/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/6.0/blazor/javascript-interoperability/index.md
@@ -47,7 +47,7 @@ Load JavaScript (JS) code using any of the following approaches:
 
 *The approach in this section isn't generally recommended.*
 
-Place the script  (`<script>...</script>`) in the `<head>` element markup of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Place the script  (`<script>...</script>`) in the `<head>` element markup of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <head>
@@ -68,7 +68,7 @@ Loading JS from the `<head>` isn't the best approach for the following reasons:
 
 ### Load a script in `<body>` markup
 
-Place the script  (`<script>...</script>`) inside the closing `</body>` element markup of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+Place the script  (`<script>...</script>`) inside the closing `</body>` element markup of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <body>
@@ -89,7 +89,7 @@ The `{webassembly|server}` placeholder in the preceding markup is either `webass
 
 Place the script  (`<script>...</script>`) with a script `src` path inside the closing `</body>` tag after the Blazor script reference.
 
-In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
+In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <body>
@@ -136,7 +136,7 @@ For more information, see <xref:blazor/components/class-libraries>.
 
 ### Inject a script after Blazor starts
 
-Load JS from an injected script in `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server) when the app is initialized:
+Load JS from an injected script in `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server) when the app is initialized:
 
 * Add `autostart="false"` to the `<script>` tag that loads the Blazor script.
 * Inject a script into the `<head>` element markup that references a custom JS file after starting Blazor by calling `Blazor.start().then(...)`. Place the script (`<script>...</script>`) inside the closing `</body>` tag after the Blazor script is loaded.

--- a/aspnetcore/6.0/blazor/project-structure.md
+++ b/aspnetcore/6.0/blazor/project-structure.md
@@ -61,13 +61,14 @@ The Blazor Server template creates the initial files and directory structure for
   * `_Host.cshtml`: The root page of the app implemented as a Razor Page:
     * When any page of the app is initially requested, this page is rendered and returned in the response.
     * The Host page specifies where the root `App` component (`App.razor`) is rendered.
+  * `_Layout.cshtml`: The layout page for the `_Host.cshtml` root page of the app.
   * `Counter` component (`Counter.razor`): Implements the Counter page.
   * `Error` component (`Error.razor`): Rendered when an unhandled exception occurs in the app.
   * `FetchData` component (`FetchData.razor`): Implements the Fetch data page.
   * `Index` component (`Index.razor`): Implements the Home page.
 
 > [!NOTE]
-> JavaScript (JS) files added to the `Pages/_Host.cshtml` file should appear before the closing `</body>` tag. The order that custom JS code is loaded from JS files is important in some scenarios. For example, ensure that JS files with interop methods are included before Blazor framework JS files.
+> JavaScript (JS) files added to the `Pages/_Layout.cshtml` file should appear before the closing `</body>` tag. The order that custom JS code is loaded from JS files is important in some scenarios. For example, ensure that JS files with interop methods are included before Blazor framework JS files.
 
 * `Properties/launchSettings.json`: Holds [development environment configuration](xref:fundamentals/environments#development-and-launchsettingsjson).
 

--- a/aspnetcore/6.0/blazor/security/content-security-policy.md
+++ b/aspnetcore/6.0/blazor/security/content-security-policy.md
@@ -96,7 +96,7 @@ The particular script associated with the error is displayed in the console next
 
 ### Blazor Server
 
-In the `<head>` content of the `Pages/_Host.cshtml` host page, apply the directives described in the [Policy directives](#policy-directives) section:
+In the `<head>` content of the `Pages/_Layout.cshtml` host page, apply the directives described in the [Policy directives](#policy-directives) section:
 
 ```cshtml
 <meta http-equiv="Content-Security-Policy" 

--- a/aspnetcore/6.0/blazor/security/server/additional-scenarios.md
+++ b/aspnetcore/6.0/blazor/security/server/additional-scenarios.md
@@ -64,7 +64,7 @@ public class InitialApplicationState
 }
 ```
 
-In the `_Host.cshtml` file, create and instance of `InitialApplicationState` and pass it as a parameter to the app:
+In the `Pages/_Host.cshtml` file, create and instance of `InitialApplicationState` and pass it as a parameter to the app:
 
 ```cshtml
 @using Microsoft.AspNetCore.Authentication

--- a/aspnetcore/6.0/blazor/state-management.md
+++ b/aspnetcore/6.0/blazor/state-management.md
@@ -307,6 +307,12 @@ To disable prerendering, open the `Pages/_Host.cshtml` file and change the `rend
 <component type="typeof(App)" render-mode="Server" />
 ```
 
+Prerendering of `<head>` content is disabled in `Pages/_Layout.cshtml`:
+
+```cshtml
+<component type="typeof(HeadOutlet)" render-mode="Server" />
+```
+
 Prerendering might be useful for other pages that don't use `localStorage` or `sessionStorage`. To retain prerendering, defer the loading operation until the browser is connected to the circuit. The following is an example for storing a counter value:
 
 ```razor


### PR DESCRIPTION
Addresses #20319
Addresses #22045

This is step one of what will be a three step process:

1. `_Layout.cshtml` coverage generally across 6.0 topics. **This PR.**
2. Control of `<head>` content. Can be worked immediately after this goes in.
3. Prerendering and integration updates. The setup is so complex that it will need to be tested locally using prerelease bits, so the last step will be on hold until RC1 releases.