### PR TITLE
Update dependency-injection.md

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -245,12 +245,12 @@ For more information, see [Scope validation](xref:fundamentals/host/web-host#sco
 
 ## Request Services
 
-The services available within an ASP.NET Core request are exposed through the [HttpContext.RequestServices](xref:Microsoft.AspNetCore.Http.HttpContext.RequestServices) collection. When services are requested from inside of a request, the services and their dependencies are resolved from the `RequestServices` collection.
+The services available within an ASP.NET Core request are exposed through the [HttpContext.RequestServices](xref:Microsoft.AspNetCore.Http.HttpContext.RequestServices). When services are requested from inside of a request, the services and their dependencies are resolved from the `RequestServices`.
 
 The framework creates a scope per request and `RequestServices` exposes the scoped service provider. All scoped services are valid for as long as the request is active.
 
 > [!NOTE]
-> Prefer requesting dependencies as constructor parameters to resolving services from the `RequestServices` collection. This results in classes that are easier to test.
+> Prefer requesting dependencies as constructor parameters to resolving services from the `RequestServices`. This results in classes that are easier to test.
 
 ## Design services for dependency injection
 

--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -245,12 +245,12 @@ For more information, see [Scope validation](xref:fundamentals/host/web-host#sco
 
 ## Request Services
 
-The services available within an ASP.NET Core request are exposed through the [HttpContext.RequestServices](xref:Microsoft.AspNetCore.Http.HttpContext.RequestServices). When services are requested from inside of a request, the services and their dependencies are resolved from the `RequestServices`.
+Services and their dependencies within an ASP.NET Core request are exposed through <xref:Microsoft.AspNetCore.Http.HttpContext.RequestServices?displayProperty=nameWithType>.
 
-The framework creates a scope per request and `RequestServices` exposes the scoped service provider. All scoped services are valid for as long as the request is active.
+The framework creates a scope per request, and `RequestServices` exposes the scoped service provider. All scoped services are valid for as long as the request is active.
 
 > [!NOTE]
-> Prefer requesting dependencies as constructor parameters to resolving services from the `RequestServices`. This results in classes that are easier to test.
+> Prefer requesting dependencies as constructor parameters over resolving services from `RequestServices`. Requesting dependencies as constructor parameters yields classes that are easier to test.
 
 ## Design services for dependency injection
 


### PR DESCRIPTION
https://github.com/dotnet/aspnetcore/blob/b7528e5214158fe2d3095e7064e63adbe0c2edd4/src/Http/Http.Abstractions/src/HttpContext.cs#L55

`RequestServices` is not a collection. I understand by saying **collection** it refers to the container, but I think this might create confusion so I think it better be removed.