### PR TITLE
Highlight the correct line of code

### DIFF
--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -458,7 +458,7 @@ dotnet ef database update
 
 Append [AddRoles](/dotnet/api/microsoft.aspnetcore.identity.identitybuilder.addroles#Microsoft_AspNetCore_Identity_IdentityBuilder_AddRoles__1) to add Role services:
 
-[!code-csharp[](secure-data/samples/final2.1/Startup.cs?name=snippet2&highlight=11)]
+[!code-csharp[](secure-data/samples/final2.1/Startup.cs?name=snippet2&highlight=12)]
 
 ### Require authenticated users
 

--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -102,7 +102,7 @@ dotnet ef database update
 
 Append [AddRoles](/dotnet/api/microsoft.aspnetcore.identity.identitybuilder.addroles#Microsoft_AspNetCore_Identity_IdentityBuilder_AddRoles__1) to add Role services:
 
-[!code-csharp[](secure-data/samples/final3/Startup.cs?name=snippet2&highlight=9)]
+[!code-csharp[](secure-data/samples/final3/Startup.cs?name=snippet2&highlight=8)]
 
 <a name="rau"></a>
 


### PR DESCRIPTION
Highlight call to `AddRoles<IdentityRole>()` instead of `AddEntityFrameworkStores<ApplicationDbContext>()` in the **Add Role services to Identity** section



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->