### PR TITLE
Blazor 6.0 query string enhancements

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -333,7 +333,6 @@ For the preceding example:
 * The correct culture-invariant formatting is applied for the given type (<xref:System.Globalization.CultureInfo.InvariantCulture?displayProperty=nameWithType>).
 * The query parameter name and value are URL-encoded.
 * All of the values with the matching query parameter name are replaced if there are multiple instances of the type.
-* If the value is an `IEnumerable<T>` for one of the supported types, then multiple name/value pairs are emitted. Supported types are listed later in this section.
 
 Call `NavigationManager.GetUriWithQueryParameters` to create a URI constructed from <xref:Microsoft.AspNetCore.Components.NavigationManager.Uri> with multiple parameters added, updated, or removed. For each value, the framework uses `value?.GetType()` to determine the runtime type for each query parameter and selects the correct culture-invariant formatting. The framework throws an error for unsupported types.
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -43,8 +43,6 @@ Components support multiple route templates using multiple [`@page` directives](
 > [!IMPORTANT]
 > For URLs to resolve correctly, the app must include a `<base>` tag in its `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server) with the app base path specified in the `href` attribute. For more information, see <xref:blazor/host-and-deploy/index#app-base-path>.
 
-[!INCLUDE[](~/6.0/blazor/includes/layout-page-preview-7.md)]
-
 ## Focus an element on navigation
 
 Use the `FocusOnNavigate` component to set the UI focus to an element based on a CSS selector after navigating from one page to another. You can see the `FocusOnNavigate` component in use by the `App` component of an app generated from a Blazor project template.
@@ -229,8 +227,6 @@ Use <xref:Microsoft.AspNetCore.Components.NavigationManager> to manage URIs and 
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.ToBaseRelativePath%2A> | Given a base URI (for example, a URI previously returned by <xref:Microsoft.AspNetCore.Components.NavigationManager.BaseUri>), converts an absolute URI into a URI relative to the base URI prefix. |
 | `GetUriWithQueryParameter` | Returns a URI constructed by updating <xref:Microsoft.AspNetCore.Components.NavigationManager.Uri?displayProperty=nameWithType> with a single parameter added, updated, or removed. For more information, see the [Query strings](#query-strings) section. |
 
-[!INCLUDE[](~/6.0/blazor/includes/layout-page-preview-7.md)]
-
 ## Location changes
 
 For the <xref:Microsoft.AspNetCore.Components.NavigationManager.LocationChanged> event, <xref:Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs> provides the following information about navigation events:
@@ -254,8 +250,6 @@ The following component:
 For more information on component disposal, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 ## Query strings
-
-*The features described in this section apply to ASP.NET Core 6.0 Preview 7 or later. ASP.NET Core 6.0 Preview 7 is scheduled for release in August. ASP.NET Core 6.0 is scheduled for release later this year.*
 
 ### Supply a parameter value from a query string parameter
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -385,8 +385,8 @@ NavigationManager.GetUriWithQueryParameter("full name", "Morena Baccarin")
 
 | Current URL | Generated URL |
 | --- | --- |
-| `scheme://host/?full%20name=David%20Krumholtze&age=42` | `scheme://host/?full%20name=Morena%20Baccarin&age=42` |
-| `scheme://host/?fUlL%20nAmE=David%20Krumholtze&AgE=42` | `scheme://host/?full%20name=Morena%20Baccarin&AgE=42` |
+| `scheme://host/?full%20name=David%20Krumholtz&age=42` | `scheme://host/?full%20name=Morena%20Baccarin&age=42` |
+| `scheme://host/?fUlL%20nAmE=David%20Krumholtz&AgE=42` | `scheme://host/?full%20name=Morena%20Baccarin&AgE=42` |
 | `scheme://host/?full%20name=Jewel%20Staite&age=42&full%20name=Summer%20Glau` | `scheme://host/?full%20name=Morena%20Baccarin&age=42&full%20name=Morena%20Baccarin` |
 | `scheme://host/?full%20name=&age=42` | `scheme://host/?full%20name=Morena%20Baccarin&age=42` |
 | `scheme://host/?full%20name=` | `scheme://host/?full%20name=Morena%20Baccarin` |
@@ -411,7 +411,7 @@ NavigationManager.GetUriWithQueryParameter("full name", (string)null)
 
 | Current URL | Generated URL |
 | --- | --- |
-| `scheme://host/?full%20name=David%20Krumholtze&age=42` | `scheme://host/?age=42` |
+| `scheme://host/?full%20name=David%20Krumholtz&age=42` | `scheme://host/?age=42` |
 | `scheme://host/?full%20name=Sally%20Smith&age=42&full%20name=Summer%20Glau` | `scheme://host/?age=42` |
 | `scheme://host/?full%20name=Sally%20Smith&age=42&FuLl%20NaMe=Summer%20Glau` | `scheme://host/?age=42` |
 | `scheme://host/?full%20name=&age=42` | `scheme://host/?age=42` |
@@ -437,9 +437,9 @@ NavigationManager.GetUriWithQueryParameters(
 
 | Current URL | Generated URL |
 | --- | --- |
-| `scheme://host/?name=David%20Krumholtze&age=42` | `scheme://host/?age=25&eye%20color=green` |
-| `scheme://host/?NaMe=David%20Krumholtze&AgE=42` | `scheme://host/?age=25&eye%20color=green` |
-| `scheme://host/?name=David%20Krumholtze&age=42&keepme=true` | `scheme://host/?age=25&keepme=true&eye%20color=green` |
+| `scheme://host/?name=David%20Krumholtz&age=42` | `scheme://host/?age=25&eye%20color=green` |
+| `scheme://host/?NaMe=David%20Krumholtz&AgE=42` | `scheme://host/?age=25&eye%20color=green` |
+| `scheme://host/?name=David%20Krumholtz&age=42&keepme=true` | `scheme://host/?age=25&keepme=true&eye%20color=green` |
 | `scheme://host/?age=42&eye%20color=87` | `scheme://host/?age=25&eye%20color=green` |
 | `scheme://host/?` | `scheme://host/?age=25&eye%20color=green` |
 | `scheme://host/` | `scheme://host/?age=25&eye%20color=green` |
@@ -462,8 +462,8 @@ NavigationManager.GetUriWithQueryParameters(
 
 | Current URL | Generated URL |
 | --- | --- |
-| `scheme://host/?full%20name=David%20Krumholtze&ping=8&ping=300` | `scheme://host/?full%20name=Morena%20Baccarin&ping=35&ping=16&ping=87&ping=240` |
-| `scheme://host/?ping=8&full%20name=David%20Krumholtze&ping=300` | `scheme://host/?ping=35&full%20name=Morena%20Baccarin&ping=16&ping=87&ping=240` |
+| `scheme://host/?full%20name=David%20Krumholtz&ping=8&ping=300` | `scheme://host/?full%20name=Morena%20Baccarin&ping=35&ping=16&ping=87&ping=240` |
+| `scheme://host/?ping=8&full%20name=David%20Krumholtz&ping=300` | `scheme://host/?ping=35&full%20name=Morena%20Baccarin&ping=16&ping=87&ping=240` |
 | `scheme://host/?ping=8&ping=300&ping=50&ping=68&ping=42` | `scheme://host/?ping=35&ping=16&ping=87&ping=240&full%20name=Morena%20Baccarin` |
 
 ### Navigate with an added or modified query string

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -385,8 +385,8 @@ NavigationManager.GetUriWithQueryParameter("full name", "Morena Baccarin")
 
 | Current URL | Generated URL |
 | --- | --- |
-| `scheme://host/?full%20name=Alan%20Tudyk&age=42` | `scheme://host/?full%20name=Morena%20Baccarin&age=42` |
-| `scheme://host/?fUlL%20nAmE=Alan%20Tudyk&AgE=42` | `scheme://host/?full%20name=Morena%20Baccarin&AgE=42` |
+| `scheme://host/?full%20name=David%20Krumholtze&age=42` | `scheme://host/?full%20name=Morena%20Baccarin&age=42` |
+| `scheme://host/?fUlL%20nAmE=David%20Krumholtze&AgE=42` | `scheme://host/?full%20name=Morena%20Baccarin&AgE=42` |
 | `scheme://host/?full%20name=Jewel%20Staite&age=42&full%20name=Summer%20Glau` | `scheme://host/?full%20name=Morena%20Baccarin&age=42&full%20name=Morena%20Baccarin` |
 | `scheme://host/?full%20name=&age=42` | `scheme://host/?full%20name=Morena%20Baccarin&age=42` |
 | `scheme://host/?full%20name=` | `scheme://host/?full%20name=Morena%20Baccarin` |
@@ -411,7 +411,7 @@ NavigationManager.GetUriWithQueryParameter("full name", (string)null)
 
 | Current URL | Generated URL |
 | --- | --- |
-| `scheme://host/?full%20name=Alan%20Tudyk&age=42` | `scheme://host/?age=42` |
+| `scheme://host/?full%20name=David%20Krumholtze&age=42` | `scheme://host/?age=42` |
 | `scheme://host/?full%20name=Sally%20Smith&age=42&full%20name=Summer%20Glau` | `scheme://host/?age=42` |
 | `scheme://host/?full%20name=Sally%20Smith&age=42&FuLl%20NaMe=Summer%20Glau` | `scheme://host/?age=42` |
 | `scheme://host/?full%20name=&age=42` | `scheme://host/?age=42` |
@@ -437,9 +437,9 @@ NavigationManager.GetUriWithQueryParameters(
 
 | Current URL | Generated URL |
 | --- | --- |
-| `scheme://host/?name=Alan%20Tudyk&age=42` | `scheme://host/?age=25&eye%20color=green` |
-| `scheme://host/?NaMe=Alan%20Tudyk&AgE=42` | `scheme://host/?age=25&eye%20color=green` |
-| `scheme://host/?name=Alan%20Tudyk&age=42&keepme=true` | `scheme://host/?age=25&keepme=true&eye%20color=green` |
+| `scheme://host/?name=David%20Krumholtze&age=42` | `scheme://host/?age=25&eye%20color=green` |
+| `scheme://host/?NaMe=David%20Krumholtze&AgE=42` | `scheme://host/?age=25&eye%20color=green` |
+| `scheme://host/?name=David%20Krumholtze&age=42&keepme=true` | `scheme://host/?age=25&keepme=true&eye%20color=green` |
 | `scheme://host/?age=42&eye%20color=87` | `scheme://host/?age=25&eye%20color=green` |
 | `scheme://host/?` | `scheme://host/?age=25&eye%20color=green` |
 | `scheme://host/` | `scheme://host/?age=25&eye%20color=green` |
@@ -462,8 +462,8 @@ NavigationManager.GetUriWithQueryParameters(
 
 | Current URL | Generated URL |
 | --- | --- |
-| `scheme://host/?full%20name=Alan%20Tudyk&ping=8&ping=300` | `scheme://host/?full%20name=Morena%20Baccarin&ping=35&ping=16&ping=87&ping=240` |
-| `scheme://host/?ping=8&full%20name=Alan%20Tudyk&ping=300` | `scheme://host/?ping=35&full%20name=Morena%20Baccarin&ping=16&ping=87&ping=240` |
+| `scheme://host/?full%20name=David%20Krumholtze&ping=8&ping=300` | `scheme://host/?full%20name=Morena%20Baccarin&ping=35&ping=16&ping=87&ping=240` |
+| `scheme://host/?ping=8&full%20name=David%20Krumholtze&ping=300` | `scheme://host/?ping=35&full%20name=Morena%20Baccarin&ping=16&ping=87&ping=240` |
 | `scheme://host/?ping=8&ping=300&ping=50&ping=68&ping=42` | `scheme://host/?ping=35&ping=16&ping=87&ping=240&full%20name=Morena%20Baccarin` |
 
 ### Navigate with an added or modified query string

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -387,7 +387,7 @@ NavigationManager.GetUriWithQueryParameter("full name", "Morena Baccarin")
 | --- | --- |
 | `scheme://host/?full%20name=Alan%20Tudyk&age=42` | `scheme://host/?full%20name=Morena%20Baccarin&age=42` |
 | `scheme://host/?fUlL%20nAmE=Alan%20Tudyk&AgE=42` | `scheme://host/?full%20name=Morena%20Baccarin&AgE=42` |
-| `scheme://host/?full%20name=Jewel%20Staite&age=42&full%20name=Summer` | `scheme://host/?full%20name=Morena%20Baccarin&age=42&full%20name=Morena%20Baccarin` |
+| `scheme://host/?full%20name=Jewel%20Staite&age=42&full%20name=Summer%20Glau` | `scheme://host/?full%20name=Morena%20Baccarin&age=42&full%20name=Morena%20Baccarin` |
 | `scheme://host/?full%20name=&age=42` | `scheme://host/?full%20name=Morena%20Baccarin&age=42` |
 | `scheme://host/?full%20name=` | `scheme://host/?full%20name=Morena%20Baccarin` |
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -227,7 +227,7 @@ Use <xref:Microsoft.AspNetCore.Components.NavigationManager> to manage URIs and 
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.LocationChanged> | An event that fires when the navigation location has changed. For more information, see the [Location changes](#location-changes) section. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri%2A> | Converts a relative URI into an absolute URI. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.ToBaseRelativePath%2A> | Given a base URI (for example, a URI previously returned by <xref:Microsoft.AspNetCore.Components.NavigationManager.BaseUri>), converts an absolute URI into a URI relative to the base URI prefix. |
-| `GetUriWithQueryParameter` | Returns a URI constructed by updating <xref:Microsoft.AspNetCore.Components.NavigationManager.Uri?displayProperty=nameWithType> with a single parameter added, updated, or removed. For more information, see the [Query strings](#navigation-manager-query-string-api) section. |
+| `GetUriWithQueryParameter` | Returns a URI constructed by updating <xref:Microsoft.AspNetCore.Components.NavigationManager.Uri?displayProperty=nameWithType> with a single parameter added, updated, or removed. For more information, see the [Query strings](#query-strings) section. |
 
 [!INCLUDE[](~/6.0/blazor/includes/layout-page-preview-7.md)]
 


### PR DESCRIPTION
Fixes #22689
Addresses #22045

[Internal Review Topic](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-3.1&branch=pr-en-us-23000#uri-and-navigation-state-helpers) (links directly to the NavManager table section; the *Query strings* section immediately follows)

Mackinnon ...

* I'd normally 🛌😴 one more night, but let's get this in quickly 🏃. It will be reviewed again at RC.
* Most of this PR pertains to the query string bits, but I do add the `replace` guidance for `NavigateTo` while I'm here.
* URI vs. URL: The API rightly uses "URI" ... but for practical purposes around the doc set, we use URL because that's specifically and usually what the dev is working with. Here, "URI" is used in text *near* API remarks, and "URL" is generally used elsewhere.
* `+` and `%20` in encoding. Let's **_NOT_** get deep into the weeds on it! 😄 lol ... There's a delta in the blog post remarks/examples. I think we want `%20` everywhere.
* WRT the example tables for URL mods: **_Don't_** sweat what looks like awfully **_wide table cells_** at this point. **_Yes!_** ... they are scary 😨 *W....I....D....E* for rendering :smile:. I want to see how they render in the live topic, then I'll make mods to the display on a follow-up PR as needed. I gave your test code names the *Rex treatment* 😆 ... movie stars from *Serenity*.

  ![mruniverse](https://user-images.githubusercontent.com/1622880/129197691-b3a209a6-4681-4f3c-a100-8d422d03d356.png)

  <em>Can't stop the signal, **_Mack_**. Everything goes somewhere, and I go everywhere.</em> - Mr. Universe (David Krumholtz)

  Quote &copy;2005 Universal Pictures: Serenity https://www.uphe.com/movies/serenity David Krumholtz on IMDB: https://www.imdb.com/name/nm0472710/