### PR TITLE
Update passwordhasher.cs

### DIFF
--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/passwordhasher.cs
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/passwordhasher.cs
@@ -1,37 +1,37 @@
 using System;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Cryptography.KeyDerivation;
- 
+
 public class Program
 {
     public static void Main(string[] args)
     {
         Console.Write("Enter a password: ");
         string password = Console.ReadLine();
- 
-        // generate a 128-bit salt using a secure PRNG
+
+        // generate a 128-bit salt using a cryptographically strong random sequence of nonzero values
         byte[] salt = new byte[128 / 8];
-        using (var rng = RandomNumberGenerator.Create())
+        using (var rngCsp = new RNGCryptoServiceProvider())
         {
-            rng.GetBytes(salt);
+            rngCsp.GetNonZeroBytes(salt);
         }
         Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
- 
-        // derive a 256-bit subkey (use HMACSHA1 with 10,000 iterations)
+
+        // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
         string hashed = Convert.ToBase64String(KeyDerivation.Pbkdf2(
             password: password,
             salt: salt,
-            prf: KeyDerivationPrf.HMACSHA1,
-            iterationCount: 10000,
+            prf: KeyDerivationPrf.HMACSHA256,
+            iterationCount: 100000,
             numBytesRequested: 256 / 8));
         Console.WriteLine($"Hashed: {hashed}");
     }
 }
- 
+
 /*
  * SAMPLE OUTPUT
  *
  * Enter a password: Xtw9NMgx
- * Salt: NZsP6NnmfBuYeJrrAKNuVQ==
- * Hashed: /OOoOer10+tGwTRDTrQSoeCxVTFr6dtYly7d0cPxIak=
+ * Salt: CGYzqeN4plZekNC88Umm1Q==
+ * Hashed: Gt9Yc4AiIvmsC1QQbe2RZsCIqvoYlst2xbz0Fs8aHnw=
  */


### PR DESCRIPTION
According to the [official document page for HMACSHA1](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.hmacsha1), it is recommended to not use SHA1 due to the possibility of collisions. However, the example code here still utilizes HMACSHA1. My recommendation is to replace the example code here with something more secure.

Comparing this to the original code, the above changes the random byte generator to use RNGCryptoServiceProvider (which seems to be used in the [official documentation](https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.randomnumbergenerator.getbytes) instead of RandomNumberGenerator anyway) with non-zero bytes. We also swap HMACSHA1 out for HMACSHA256. Finally, we increase the iteration count to 100,000 from 10,000, which seems to be a common middle-ground for security and speed for the time being.

***@Rick-Anderson  EDIT:*** [Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/data-protection/consumer-apis/password-hashing?view=aspnetcore-1.0&branch=pr-en-us-23003)