### PR TITLE
Remove language stating that Blazor WebAssembly is the primary hosting model

### DIFF
--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -17,7 +17,7 @@ Blazor is a web framework designed to run client-side in the browser on a [WebAs
 
 ## Blazor WebAssembly
 
-The primary Blazor hosting model is running client-side in the browser on WebAssembly. The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process. The app's assets are deployed as static files to a web server or service capable of serving static content to clients.
+Blazor WebAssembly apps run client-side in the browser on a WebAssembly-based .NET runtime. The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process. The app's assets are deployed as static files to a web server or service capable of serving static content to clients.
 
 ![Blazor WebAssembly: The Blazor app runs on a UI thread inside the browser.](~/6.0/blazor/hosting-models/_static/blazor-webassembly.png)
 


### PR DESCRIPTION
Blazor has multiple hosting models that are appropriate for different scenarios. There really isn't a primary hosting model. This language incorrectly discourages users from building with Blazor Server.