### PR TITLE
Add Blazor WASM globalization requirement

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -1862,18 +1862,6 @@ The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Heade
 
 The app's culture is set by matching the first requested language that matches a supported culture of the app.
 
-::: zone pivot="webassembly"
-
-Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
-
-```xml
-<PropertyGroup>
-  <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-</PropertyGroup>
-```
-
-::: zone-end
-
 ::: zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
@@ -1964,14 +1952,6 @@ Add a package reference for the [`Microsoft.Extensions.Localization`](https://ww
 ```
 
 The `{VERSION}` placeholder in the preceding package reference is the version of the package.
-
-Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the project file:
-
-```xml
-<PropertyGroup>
-  <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
-</PropertyGroup>
-```
 
 The app's culture in a Blazor WebAssembly app is set using the Blazor framework's API. A user's culture selection can be persisted in browser local storage.
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -136,6 +136,18 @@ The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Heade
 
 The app's culture is set by matching the first requested language that matches a supported culture of the app.
 
+::: zone pivot="webassembly"
+
+Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
+
+```xml
+<PropertyGroup>
+  <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+</PropertyGroup>
+```
+
+::: zone-end
+
 ::: zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
@@ -987,6 +999,18 @@ The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Heade
 
 The app's culture is set by matching the first requested language that matches a supported culture of the app.
 
+::: zone pivot="webassembly"
+
+Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
+
+```xml
+<PropertyGroup>
+  <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+</PropertyGroup>
+```
+
+::: zone-end
+
 ::: zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
@@ -1837,6 +1861,18 @@ The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Heade
 **Accept-Language**: en-US,en;q=0.9,es-CL;q=0.8
 
 The app's culture is set by matching the first requested language that matches a supported culture of the app.
+
+::: zone pivot="webassembly"
+
+Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
+
+```xml
+<PropertyGroup>
+  <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+</PropertyGroup>
+```
+
+::: zone-end
 
 ::: zone pivot="server"
 


### PR DESCRIPTION
Fixes #23010

Thanks @craigbrown! 🎷

@hishamco ... Do you want to review this?

~I can't tell from the PU history if they backported to 3.1. I'll need to test and see what happened. The change that introduced the `BlazorWebAssemblyLoadAllGlobalizationData` property came in for >=5.0. However, I see a reference by the PU that it might have been backported to a 3.1 release to fix some bugs on iOS. I'll take a look ASAP 🏃 ... probably Friday morning.~ **_Answered below._**