### PR TITLE
Broken links sweep

### DIFF
--- a/aspnetcore/data/ef-rp/migrations.md
+++ b/aspnetcore/data/ef-rp/migrations.md
@@ -298,7 +298,7 @@ EF Core uses the `__MigrationsHistory` table to see if any migrations need to ru
 ## Troubleshooting
 
 Download the [completed app](
-https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/ef-rp/intro/samples/cu21snapshots/cu-part4-migrations).
+https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/ef-rp/intro/samples/cu21snapshots/part-4-migrations).
 
 The app generates the following exception:
 

--- a/aspnetcore/data/ef-rp/sort-filter-page.md
+++ b/aspnetcore/data/ef-rp/sort-filter-page.md
@@ -525,7 +525,7 @@ Replace the code in the *Pages/About.cshtml* file with the following code:
 
 Run the app and navigate to the About page. The count of students for each enrollment date is displayed in a table.
 
-If you run into problems you can't solve, download the [completed app for this stage](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/ef-rp/intro/samples/StageSnapShots/cu-part3-sorting).
+If you run into problems you can't solve, download the [completed app for this stage](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/data/ef-rp/intro/samples/cu20snapshots/cu-part3-sorting).
 
 ![About page](sort-filter-page/_static/about.png)
 

--- a/aspnetcore/fundamentals/host/platform-specific-configuration.md
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration.md
@@ -335,7 +335,7 @@ deployment/additionalDeps/shared/Microsoft.AspNetCore.App/3.0.0/StartupDiagnosti
 
 For runtime to discover the runtime store location, the additional dependencies file location is added to the `DOTNET_ADDITIONAL_DEPS` environment variable.
 
-In the sample app (*RuntimeStore* project), building the runtime store and generating the additional dependencies file is accomplished using a [PowerShell](/powershell/scripting/powershell-scripting) script.
+In the sample app (*RuntimeStore* project), building the runtime store and generating the additional dependencies file is accomplished using a [PowerShell](/powershell/scripting/overview) script.
 
 For examples of how to set environment variables for various operating systems, see [Use multiple environments](xref:fundamentals/environments).
 
@@ -428,7 +428,7 @@ dotnet nuget locals all --clear
 
 **Activation from a runtime store-deployed assembly**
 
-1. The *StartupDiagnostics* project uses [PowerShell](/powershell/scripting/powershell-scripting) to modify its *StartupDiagnostics.deps.json* file. PowerShell is installed by default on Windows starting with Windows 7 SP1 and Windows Server 2008 R2 SP1. To obtain PowerShell on other platforms, see [Installing various versions of PowerShell](/powershell/scripting/install/installing-powershell).
+1. The *StartupDiagnostics* project uses [PowerShell](/powershell/scripting/overview) to modify its *StartupDiagnostics.deps.json* file. PowerShell is installed by default on Windows starting with Windows 7 SP1 and Windows Server 2008 R2 SP1. To obtain PowerShell on other platforms, see [Installing various versions of PowerShell](/powershell/scripting/install/installing-powershell).
 1. Execute the *build.ps1* script in the *RuntimeStore* folder. The script:
    * Generates the `StartupDiagnostics` package in the *obj\packages* folder.
    * Generates the runtime store for `StartupDiagnostics` in the *store* folder. The `dotnet store` command in the script uses the `win7-x64` [runtime identifier (RID)](/dotnet/core/rid-catalog) for a hosting startup deployed to Windows. When providing the hosting startup for a different runtime, substitute the correct RID on line 37 of the script. The runtime store for `StartupDiagnostics` would later be moved to the user's or system's runtime store on the machine where the assembly will be consumed. The user runtime store install location for the `StartupDiagnostics` assembly is *.dotnet/store/x64/netcoreapp3.0/startupdiagnostics/1.0.0/lib/netcoreapp3.0/StartupDiagnostics.dll*.
@@ -721,7 +721,7 @@ deployment/additionalDeps/shared/Microsoft.AspNetCore.App/2.1.0/StartupDiagnosti
 
 For runtime to discover the runtime store location, the additional dependencies file location is added to the `DOTNET_ADDITIONAL_DEPS` environment variable.
 
-In the sample app (*RuntimeStore* project), building the runtime store and generating the additional dependencies file is accomplished using a [PowerShell](/powershell/scripting/powershell-scripting) script.
+In the sample app (*RuntimeStore* project), building the runtime store and generating the additional dependencies file is accomplished using a [PowerShell](/powershell/scripting/overview) script.
 
 For examples of how to set environment variables for various operating systems, see [Use multiple environments](xref:fundamentals/environments).
 
@@ -814,7 +814,7 @@ dotnet nuget locals all --clear
 
 **Activation from a runtime store-deployed assembly**
 
-1. The *StartupDiagnostics* project uses [PowerShell](/powershell/scripting/powershell-scripting) to modify its *StartupDiagnostics.deps.json* file. PowerShell is installed by default on Windows starting with Windows 7 SP1 and Windows Server 2008 R2 SP1. To obtain PowerShell on other platforms, see [Installing various versions of PowerShell](/powershell/scripting/install/installing-powershell).
+1. The *StartupDiagnostics* project uses [PowerShell](/powershell/scripting/overview) to modify its *StartupDiagnostics.deps.json* file. PowerShell is installed by default on Windows starting with Windows 7 SP1 and Windows Server 2008 R2 SP1. To obtain PowerShell on other platforms, see [Installing various versions of PowerShell](/powershell/scripting/install/installing-powershell).
 1. Execute the *build.ps1* script in the *RuntimeStore* folder. The script:
    * Generates the `StartupDiagnostics` package in the *obj\packages* folder.
    * Generates the runtime store for `StartupDiagnostics` in the *store* folder. The `dotnet store` command in the script uses the `win7-x64` [runtime identifier (RID)](/dotnet/core/rid-catalog) for a hosting startup deployed to Windows. When providing the hosting startup for a different runtime, substitute the correct RID on line 37 of the script. The runtime store for `StartupDiagnostics` would later be moved to the user's or system's runtime store on the machine where the assembly will be consumed. The user runtime store install location for the `StartupDiagnostics` assembly is *.dotnet/store/x64/netcoreapp2.2/startupdiagnostics/1.0.0/lib/netcoreapp2.2/StartupDiagnostics.dll*.

--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -379,7 +379,7 @@ App localization involves the following:
 1. Provide localized resources for the languages and cultures you support
 1. Implement a strategy to select the language/culture for each request
 
-[View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/fundamentals/localization/sample/Localization) ([how to download](xref:index#how-to-download-a-sample))
+[View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/fundamentals/localization/sample/2.x/Localization) ([how to download](xref:index#how-to-download-a-sample))
 
 ## Make the app's content localizable
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -636,7 +636,7 @@ For more information, see:
 * [Trace for performance analysis utility (dotnet-trace)](https://github.com/dotnet/diagnostics/blob/main/documentation/dotnet-trace-instructions.md) (dotnet/diagnostics GitHub repository documentation)
 * [LoggingEventSource Class](xref:Microsoft.Extensions.Logging.EventSource.LoggingEventSource) (.NET API Browser)
 * <xref:System.Diagnostics.Tracing.EventLevel>
-* [LoggingEventSource reference source (3.0)](https://github.com/dotnet/extensions/blob/release/3.0/src/Logging/Logging.EventSource/src/LoggingEventSource.cs): To obtain reference source for a different version, change the branch to `release/{Version}`, where `{Version}` is the version of ASP.NET Core desired.
+* [LoggingEventSource reference source (3.0)](https://github.com/dotnet/extensions/blob/release/3.1/src/Logging/Logging.EventSource/src/LoggingEventSource.cs): To obtain reference source for a different version, change the branch to `release/{Version}`, where `{Version}` is the version of ASP.NET Core desired.
 * [Perfview](#perfview): Useful for viewing Event Source traces.
 
 #### Perfview
@@ -1217,7 +1217,7 @@ The following code creates `Information` and `Warning` logs:
 
 In the preceding code, the `MyLogEvents.GetItem` and `MyLogEvents.GetItemNotFound` parameters are the [Log event ID](#log-event-id). The second parameter is a message template with placeholders for argument values provided by the remaining method parameters. The method parameters are explained in the [Log message template section](#lmt) in this article.
 
-Log methods that include the level in the method name (for example, `LogInformation` and `LogWarning`) are [extension methods for ILogger](xref:Microsoft.Extensions.Logging.LoggerExtensions). These methods call a `Log` method that takes a `LogLevel` parameter. You can call the `Log` method directly rather than one of these extension methods, but the syntax is relatively complicated. For more information, see <xref:Microsoft.Extensions.Logging.ILogger> and the [logger extensions source code](https://github.com/dotnet/extensions/blob/release/2.2/src/Logging/Logging.Abstractions/src/LoggerExtensions.cs).
+Log methods that include the level in the method name (for example, `LogInformation` and `LogWarning`) are [extension methods for ILogger](xref:Microsoft.Extensions.Logging.LoggerExtensions). These methods call a `Log` method that takes a `LogLevel` parameter. You can call the `Log` method directly rather than one of these extension methods, but the syntax is relatively complicated. For more information, see <xref:Microsoft.Extensions.Logging.ILogger> and the [logger extensions source code](https://github.com/dotnet/extensions/blob/release/3.1/src/Logging/Logging.Abstractions/src/LoggerExtensions.cs).
 
 ASP.NET Core defines the following log levels, ordered here from lowest to highest severity.
 

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -129,7 +129,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
 
 1. Obtain and install X.509 certificates, if required.
 
-   On Windows, create self-signed certificates using the [New-SelfSignedCertificate PowerShell cmdlet](/powershell/module/pkiclient/new-selfsignedcertificate). For an unsupported example, see [UpdateIISExpressSSLForChrome.ps1](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/includes/make-x509-cert/UpdateIISExpressSSLForChrome.ps1).
+   On Windows, create self-signed certificates using the [New-SelfSignedCertificate PowerShell cmdlet](/powershell/module/pki/new-selfsignedcertificate). For an unsupported example, see [UpdateIISExpressSSLForChrome.ps1](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/includes/make-x509-cert/UpdateIISExpressSSLForChrome.ps1).
 
    Install either self-signed or CA-signed certificates in the server's **Local Machine** > **Personal** store.
 

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -495,5 +495,5 @@ Select the [Debug Console](https://github.com/projectkudu/kudu/wiki/Kudu-console
 
 * [Web Deploy](https://www.iis.net/downloads/microsoft/web-deploy) (MSDeploy) simplifies deployment of web apps and websites to IIS servers.
 * [Web SDK GitHub repository](https://github.com/dotnet/websdk/issues): File issues and request features for deployment.
-* <xref:azure-stack-docs/user/azure-stack-dev-start-howto-vm-dotnet>
+* <xref:azure-stack/user/azure-stack-dev-start-howto-vm-dotnet>
 * <xref:host-and-deploy/iis/transform-webconfig>

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -495,5 +495,4 @@ Select the [Debug Console](https://github.com/projectkudu/kudu/wiki/Kudu-console
 
 * [Web Deploy](https://www.iis.net/downloads/microsoft/web-deploy) (MSDeploy) simplifies deployment of web apps and websites to IIS servers.
 * [Web SDK GitHub repository](https://github.com/dotnet/websdk/issues): File issues and request features for deployment.
-* [Deploy C# ASP.NET web app to a VM in Azure Stack Hub](/azure/user/azure-stack-dev-start-howto-vm-dotnet)
 * <xref:host-and-deploy/iis/transform-webconfig>

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -495,5 +495,5 @@ Select the [Debug Console](https://github.com/projectkudu/kudu/wiki/Kudu-console
 
 * [Web Deploy](https://www.iis.net/downloads/microsoft/web-deploy) (MSDeploy) simplifies deployment of web apps and websites to IIS servers.
 * [Web SDK GitHub repository](https://github.com/dotnet/websdk/issues): File issues and request features for deployment.
-* <xref:azure-stack/user/azure-stack-dev-start-howto-vm-dotnet>
+* <xref:azure-stack-docs/blob/master/azure-stack/user/azure-stack-dev-start-howto-vm-dotnet>
 * <xref:host-and-deploy/iis/transform-webconfig>

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -495,5 +495,5 @@ Select the [Debug Console](https://github.com/projectkudu/kudu/wiki/Kudu-console
 
 * [Web Deploy](https://www.iis.net/downloads/microsoft/web-deploy) (MSDeploy) simplifies deployment of web apps and websites to IIS servers.
 * [Web SDK GitHub repository](https://github.com/dotnet/websdk/issues): File issues and request features for deployment.
-* <xref:azure-stack-docs/blob/master/azure-stack/user/azure-stack-dev-start-howto-vm-dotnet>
+* <xref:azure-stack-docs/user/azure-stack-dev-start-howto-vm-dotnet>
 * <xref:host-and-deploy/iis/transform-webconfig>

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -268,8 +268,6 @@ In the preceding example:
     msbuild /p:Configuration=Release /p:DeployOnBuild=true /p:PublishProfile=FolderProfile
     ```
 
-  For more information, see [MSBuild: how to set the configuration property](http://sedodream.com/2012/10/27/MSBuildHowToSetTheConfigurationProperty.aspx).
-
 ## Publish to an MSDeploy endpoint from the command line
 
 The following example uses an ASP.NET Core web app created by Visual Studio named *AzureWebApp*. An Azure Apps publish profile is added with Visual Studio. For more information on how to create a profile, see the [Publish profiles](#publish-profiles) section.
@@ -497,5 +495,5 @@ Select the [Debug Console](https://github.com/projectkudu/kudu/wiki/Kudu-console
 
 * [Web Deploy](https://www.iis.net/downloads/microsoft/web-deploy) (MSDeploy) simplifies deployment of web apps and websites to IIS servers.
 * [Web SDK GitHub repository](https://github.com/dotnet/websdk/issues): File issues and request features for deployment.
-* [Publish an ASP.NET Web App to an Azure VM from Visual Studio](/azure/virtual-machines/windows/publish-web-app-from-visual-studio)
+* [Deploy a C# ASP.NET web app to a VM in Azure Stack Hub](https://docs.microsoft.com/azure-stack/user/azure-stack-dev-start-howto-vm-dotnet)
 * <xref:host-and-deploy/iis/transform-webconfig>

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -495,5 +495,5 @@ Select the [Debug Console](https://github.com/projectkudu/kudu/wiki/Kudu-console
 
 * [Web Deploy](https://www.iis.net/downloads/microsoft/web-deploy) (MSDeploy) simplifies deployment of web apps and websites to IIS servers.
 * [Web SDK GitHub repository](https://github.com/dotnet/websdk/issues): File issues and request features for deployment.
-* [Deploy a C# ASP.NET web app to a VM in Azure Stack Hub](https://docs.microsoft.com/azure-stack/user/azure-stack-dev-start-howto-vm-dotnet)
+* <xref:azure-stack/user/azure-stack-dev-start-howto-vm-dotnet>
 * <xref:host-and-deploy/iis/transform-webconfig>

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -495,5 +495,5 @@ Select the [Debug Console](https://github.com/projectkudu/kudu/wiki/Kudu-console
 
 * [Web Deploy](https://www.iis.net/downloads/microsoft/web-deploy) (MSDeploy) simplifies deployment of web apps and websites to IIS servers.
 * [Web SDK GitHub repository](https://github.com/dotnet/websdk/issues): File issues and request features for deployment.
-* <xref:azure-stack/user/azure-stack-dev-start-howto-vm-dotnet>
+* [Deploy C# ASP.NET web app to a VM in Azure Stack Hub](azure-stack-docs/azure-stack/user/azure-stack-dev-start-howto-vm-dotnet)
 * <xref:host-and-deploy/iis/transform-webconfig>

--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -495,5 +495,5 @@ Select the [Debug Console](https://github.com/projectkudu/kudu/wiki/Kudu-console
 
 * [Web Deploy](https://www.iis.net/downloads/microsoft/web-deploy) (MSDeploy) simplifies deployment of web apps and websites to IIS servers.
 * [Web SDK GitHub repository](https://github.com/dotnet/websdk/issues): File issues and request features for deployment.
-* [Deploy C# ASP.NET web app to a VM in Azure Stack Hub](azure-stack-docs/azure-stack/user/azure-stack-dev-start-howto-vm-dotnet)
+* [Deploy C# ASP.NET web app to a VM in Azure Stack Hub](/azure/user/azure-stack-dev-start-howto-vm-dotnet)
 * <xref:host-and-deploy/iis/transform-webconfig>

--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -665,7 +665,7 @@ Obtain and analyze a dump from [Windows Error Reporting (WER)](/windows/desktop/
    ```
 
 1. Run the app under the conditions that cause the crash to occur.
-1. After the crash has occurred, run the [DisableDumps PowerShell script](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/host-and-deploy/windows-service/scripts/DisableDumps.ps1):
+1. After the crash has occurred, run the [DisableDumps PowerShell script](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/host-and-deploy/windows-service/samples/scripts/DisableDumps.ps1):
 
    ```console
    .\DisableDumps {APPLICATION EXE}

--- a/aspnetcore/mvc/controllers/filters.md
+++ b/aspnetcore/mvc/controllers/filters.md
@@ -936,7 +936,7 @@ Resource filters are useful to short-circuit most of the pipeline. For example, 
 Resource filter examples:
 
 * [The short-circuiting resource filter](#short-circuiting-resource-filter) shown previously.
-* [DisableFormValueModelBindingAttribute](https://github.com/aspnet/Entropy/blob/rel/2.0.0-preview2/samples/Mvc.FileUpload/Filters/DisableFormValueModelBindingAttribute.cs):
+* [DisableFormValueModelBindingAttribute](https://github.com/aspnet/Entropy/blob/master/samples/Mvc.FileUpload/Filters/DisableFormValueModelBindingAttribute.cs):
 
   * Prevents model binding from accessing the form data.
   * Used for large file uploads to prevent the form data from being read into memory.

--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -403,7 +403,7 @@ The preceding approach won't prevent client side validation of ASP.NET Core Iden
 
 This article explains how to validate user input in an ASP.NET Core MVC or Razor Pages app.
 
-[View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/mvc/models/validation/sample) ([how to download](xref:index#how-to-download-a-sample)).
+[View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/mvc/models/validation/samples) ([how to download](xref:index#how-to-download-a-sample)).
 
 ## Model state
 

--- a/aspnetcore/release-notes/aspnetcore-2.1.md
+++ b/aspnetcore/release-notes/aspnetcore-2.1.md
@@ -70,7 +70,7 @@ In production, HTTPS must be explicitly configured. In 2.1, default configuratio
 
 ## GDPR
 
-ASP.NET Core provides APIs and templates to help meet some of the [EU General Data Protection Regulation (GDPR)](https://www.eugdpr.org/) requirements. For more information, see [GDPR support in ASP.NET Core](xref:security/gdpr). A [sample app](https://github.com/dotnet/AspNetCore.Docs/tree/live/aspnetcore/security/gdpr/sample) shows how to use and lets you test most of the GDPR extension points and APIs added to the ASP.NET Core 2.1 templates.
+ASP.NET Core provides APIs and templates to help meet some of the [EU General Data Protection Regulation (GDPR)](https://gdpr.eu) requirements. For more information, see [GDPR support in ASP.NET Core](xref:security/gdpr). A [sample app](https://github.com/dotnet/AspNetCore.Docs/tree/live/aspnetcore/security/gdpr/sample) shows how to use and lets you test most of the GDPR extension points and APIs added to the ASP.NET Core 2.1 templates.
 
 ## Integration tests
 
@@ -80,7 +80,7 @@ A new package is introduced that streamlines test creation and execution. The [M
 * Sets the content root to the tested app's project root so that static files and pages/views are found when the tests are executed.
 * Provides the [WebApplicationFactory](/dotnet/api/microsoft.aspnetcore.mvc.testing.webapplicationfactory-1) class to streamline bootstrapping the tested app with [TestServer](/dotnet/api/microsoft.aspnetcore.testhost.testserver).
 
-The following test uses [xUnit](https://xunit.github.io/) to check that the Index page loads with a success status code and with the correct Content-Type header:
+The following test uses [xUnit](https://github.com/xunit/xunit) to check that the Index page loads with a success status code and with the correct Content-Type header:
 
 ```csharp
 public class BasicTests

--- a/aspnetcore/security/authentication/azure-active-directory/index.md
+++ b/aspnetcore/security/authentication/azure-active-directory/index.md
@@ -25,6 +25,4 @@ These tutorials and samples demonstrate authentication in ASP.NET Core using Mic
 
 * [Enable your ASP.NET Core app to sign-in users and call web APIs using Azure AD V2](/samples/azure-samples/active-directory-aspnetcore-webapp-openidconnect-v2/enable-webapp-signin/): 
   * See [this associated video](https://channel9.msdn.com/Events/Build/2018/THR5001)
-* [Calling an ASP.NET Core 2.0 Web API from a WPF application using Azure AD V2](/samples/azure-samples/active-directory-dotnet-native-aspnetcore-v2/calling-an-aspnet-core-web-api-from-a-wpf-application-using-azure-ad-v2/): 
-  * See [this associated video](https://channel9.msdn.com/Events/Build/2018/THR5000)
-* [An ASP.NET Core web app with Azure AD B2C](/samples/azure-samples/active-directory-b2c-dotnetcore-webapp/an-aspnet-core-web-app-with-azure-ad-b2c/)
+

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -700,7 +700,7 @@ The following approach supports optional client certificates:
 * Set up binding for the domain and subdomain:
   * For example, set up bindings on `contoso.com` and `myClient.contoso.com`. The `contoso.com` host doesn't require a client certificate but `myClient.contoso.com` does.
   * For more information, see:
-    * [Kestrel](/fundamentals/servers/kestrel):
+    * <xref:fundamentals/servers/kestrel>:
       * [ListenOptions.UseHttps](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps)
       * <xref:Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ClientCertificateMode>
       * Note Kestrel does not currently support multiple TLS configurations on one binding, you'll need two bindings with unique IPs or ports. See https://github.com/dotnet/runtime/issues/31097
@@ -716,7 +716,7 @@ The following approach supports optional client certificates:
 * Set up binding for the domain and subdomain:
   * For example, set up bindings on `contoso.com` and `myClient.contoso.com`. The `contoso.com` host doesn't require a client certificate but `myClient.contoso.com` does.
   * For more information, see:
-    * [Kestrel](/fundamentals/servers/kestrel):
+    * <xref:fundamentals/servers/kestrel>:
       * [ListenOptions.UseHttps](xref:fundamentals/servers/kestrel#listenoptionsusehttps)
       * <xref:Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions.ClientCertificateMode>
       * Note Kestrel does not currently support multiple TLS configurations on one binding, you'll need two bindings with unique IPs or ports. See https://github.com/dotnet/runtime/issues/31097

--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -21,7 +21,7 @@ Enabling users to sign in with their existing credentials:
 * Is convenient for the users.
 * Shifts many of the complexities of managing the sign-in process onto a third party.
 
-For examples of how social logins can drive traffic and customer conversions, see case studies by [Facebook](https://www.facebook.com/unsupportedbrowser) and [Twitter](https://dev.twitter.com/resources/case-studies).
+For an example of how social logins can drive traffic and customer conversions, see the case study by [Facebook](https://www.facebook.com/unsupportedbrowser).
 
 ## Create a New ASP.NET Core Project
 

--- a/aspnetcore/security/samesite/mvc21.md
+++ b/aspnetcore/security/samesite/mvc21.md
@@ -12,7 +12,7 @@ uid: security/samesite/mvc21
 
 # ASP.NET Core 2.1 MVC SameSite cookie sample
 
-ASP.NET Core 2.1 has built-in support for the [SameSite](https://www.owasp.org/index.php/SameSite) attribute, but it was written to the original standard. The [patched behavior](https://github.com/dotnet/aspnetcore/issues/8212) changed the meaning of `SameSite.None` to emit the sameSite attribute with a value of `None`, rather than not emit the value at all. If you want to not emit the value you can set the `SameSite` property on a cookie to -1.
+ASP.NET Core 2.1 has built-in support for the [SameSite](https://owasp.org/www-community/samesite) attribute, but it was written to the original standard. The [patched behavior](https://github.com/dotnet/aspnetcore/issues/8212) changed the meaning of `SameSite.None` to emit the sameSite attribute with a value of `None`, rather than not emit the value at all. If you want to not emit the value you can set the `SameSite` property on a cookie to -1.
 
 [!INCLUDE[](~/includes/SameSiteIdentity.md)]
 
@@ -139,7 +139,7 @@ The helper function `CheckSameSite(HttpContext, CookieOptions)`:
 * Is called when cookies are appended to the request or deleted from the request.
 * Checks to see if the `SameSite` property is set to `None`.
 * If `SameSite` is set to `None` and the current user agent is known to not support the
-none attribute value. The check is done using the [SameSiteSupport](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/security/samesite/sample/snippets/SameSiteSupport.cs) class:
+none attribute value. The check is done using the [SameSiteSupport](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/security/samesite/snippets/SameSiteSupport.cs) class:
   * Sets `SameSite` to not emit the value by setting the property to `(SameSiteMode)(-1)`
 
 ## Targeting .NET Framework

--- a/aspnetcore/security/samesite/mvc21.md
+++ b/aspnetcore/security/samesite/mvc21.md
@@ -42,7 +42,7 @@ Response.Cookies.Append(CookieName, "cookieValue", cookieOptions);
 
 ## Setting Cookie Authentication and Session State cookies
 
-Cookie authentication, session state and [various other components](../samesite.md?view=aspnetcore-2.1) set their sameSite options via Cookie options, for example
+Cookie authentication, session state and [various other components](../samesite.md) set their sameSite options via Cookie options, for example
 
 ```csharp
 services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
@@ -159,5 +159,5 @@ versions (2.1.14 or later 2.1 versions).
 ### More Information
  
 [Chrome Updates](https://www.chromium.org/updates/same-site)
-[ASP.NET Core SameSite Documentation](../samesite.md?view=aspnetcore-2.1)
+[ASP.NET Core SameSite Documentation](../samesite.md)
 [ASP.NET Core 2.1 SameSite Change Announcement](https://github.com/dotnet/aspnetcore/issues/8212)

--- a/aspnetcore/security/samesite/rp21.md
+++ b/aspnetcore/security/samesite/rp21.md
@@ -14,7 +14,7 @@ uid: security/samesite/rp21
 
 This sample targets .NET Framework Targeted
 
-ASP.NET Core 2.1 has built-in support for the [SameSite](https://www.owasp.org/index.php/SameSite) attribute, but it was written to the original standard. The [patched behavior](https://github.com/dotnet/aspnetcore/issues/8212) changed the meaning of `SameSite.None` to emit the sameSite attribute with a value of `None`, rather than not emit the value at all. If you want to not emit the value you can set the `SameSite` property on a cookie to -1.
+ASP.NET Core 2.1 has built-in support for the [SameSite](https://owasp.org/www-community/samesite) attribute, but it was written to the original standard. The [patched behavior](https://github.com/dotnet/aspnetcore/issues/8212) changed the meaning of `SameSite.None` to emit the sameSite attribute with a value of `None`, rather than not emit the value at all. If you want to not emit the value you can set the `SameSite` property on a cookie to -1.
 
 [!INCLUDE[](~/includes/SameSiteIdentity.md)]
 

--- a/aspnetcore/security/samesite/rp21.md
+++ b/aspnetcore/security/samesite/rp21.md
@@ -44,7 +44,7 @@ Response.Cookies.Append(CookieName, "cookieValue", cookieOptions);
 
 ## Setting Cookie Authentication and Session State cookies
 
-Cookie authentication, session state and [various other components](../samesite.md?view=aspnetcore-2.1)
+Cookie authentication, session state and [various other components](../samesite.md)
 set their sameSite options via Cookie options, for example
 
 ```csharp
@@ -166,5 +166,5 @@ To get the ASP.NET Core changes for .NET Framework ensure that you have a direct
 ### More Information
  
 [Chrome Updates](https://www.chromium.org/updates/same-site)
-[ASP.NET Core SameSite Documentation](../samesite.md?view=aspnetcore-2.1)
+[ASP.NET Core SameSite Documentation](../samesite.md)
 [ASP.NET Core 2.1 SameSite Change Announcement](https://github.com/dotnet/aspnetcore/issues/8212)

--- a/aspnetcore/security/samesite/rp31.md
+++ b/aspnetcore/security/samesite/rp31.md
@@ -12,7 +12,7 @@ uid: security/samesite/rp31
 
 # ASP.NET Core 3.1 Razor Pages SameSite cookie sample
 
-ASP.NET Core 3.0 has built-in support for the [SameSite](https://www.owasp.org/index.php/SameSite) attribute, including a `SameSiteMode` attribute value of `Unspecified` to suppress writing the attribute.
+ASP.NET Core 3.0 has built-in support for the [SameSite](https://owasp.org/www-community/samesite) attribute, including a `SameSiteMode` attribute value of `Unspecified` to suppress writing the attribute.
 
 [!INCLUDE[](~/includes/SameSiteIdentity.md)]
 

--- a/aspnetcore/security/samesite/rp31.md
+++ b/aspnetcore/security/samesite/rp31.md
@@ -42,7 +42,7 @@ Response.Cookies.Append(CookieName, "cookieValue", cookieOptions);
 
 ## Setting Cookie Authentication and Session State cookies
 
-Cookie authentication, session state and [various other components](../samesite.md?view=aspnetcore-3.0)
+Cookie authentication, session state and [various other components](../samesite.md)
 set their sameSite options via Cookie options, for example
 
 ```csharp

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -131,7 +131,6 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
   * [IIS](/iis/extensions/configuring-application-request-routing-arr/http-load-balancing-using-application-request-routing)
   * [HAProxy](https://www.haproxy.com/blog/load-balancing-affinity-persistence-sticky-sessions-what-you-need-to-know/)
   * [Nginx](https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#sticky)
-  * [pfSense](https://www.netgate.com/docs/pfsense/loadbalancing/inbound-load-balancing.html#sticky-connections)
 
 ## Redis server errors
 

--- a/aspnetcore/test/razor-pages-tests.md
+++ b/aspnetcore/test/razor-pages-tests.md
@@ -51,7 +51,7 @@ The message app is a Razor Pages message system with the following characteristi
 * The app contains a DAL in its database context class, `AppDbContext` (*Data/AppDbContext.cs*). The DAL methods are marked `virtual`, which allows mocking the methods for use in the tests.
 * If the database is empty on app startup, the message store is initialized with three messages. These *seeded messages* are also used in tests.
 
-&#8224;The EF topic, [Test with InMemory](/ef/core/miscellaneous/testing/in-memory), explains how to use an in-memory database for tests with MSTest. This topic uses the [xUnit](https://xunit.github.io/) test framework. Test concepts and test implementations across different test frameworks are similar but not identical.
+&#8224;The EF topic, [Test with InMemory](/ef/core/miscellaneous/testing/in-memory), explains how to use an in-memory database for tests with MSTest. This topic uses the [xUnit](https://github.com/xunit/xunit) test framework. Test concepts and test implementations across different test frameworks are similar but not identical.
 
 Although the sample app doesn't use the repository pattern and isn't an effective example of the [Unit of Work (UoW) pattern](https://martinfowler.com/eaaCatalog/unitOfWork.html), Razor Pages supports these patterns of development. For more information, see [Designing the infrastructure persistence layer](/dotnet/standard/microservices-architecture/microservice-ddd-cqrs-patterns/infrastructure-persistence-layer-design) and <xref:mvc/controllers/testing> (the sample implements the repository pattern).
 
@@ -64,7 +64,7 @@ The test app is a console app inside the *tests/RazorPagesTestSample.Tests* fold
 | *UnitTests*     | <ul><li>*DataAccessLayerTest.cs* contains the unit tests for the DAL.</li><li>*IndexPageTests.cs* contains the unit tests for the Index page model.</li></ul> |
 | *Utilities*     | Contains the `TestDbContextOptions` method used to create new database context options for each DAL unit test so that the database is reset to its baseline condition for each test. |
 
-The test framework is [xUnit](https://xunit.github.io/). The object mocking framework is [Moq](https://github.com/moq/moq4).
+The test framework is [xUnit](https://github.com/xunit/xunit). The object mocking framework is [Moq](https://github.com/moq/moq4).
 
 ## Unit tests of the data access layer (DAL)
 
@@ -187,9 +187,9 @@ Other tests in this group create page model objects that include the <xref:Micro
 * <xref:mvc/controllers/testing>
 * [Unit Test Your Code](/visualstudio/test/unit-test-your-code) (Visual Studio)
 * <xref:test/integration-tests>
-* [xUnit.net](https://xunit.github.io/)
+* [xUnit.net](https://github.com/xunit/xunit)
 * [Building a complete .NET Core solution on macOS using Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution)
-* [Getting started with xUnit.net: Using .NET Core with the .NET SDK command line](https://xunit.github.io/docs/getting-started-dotnet-core)
+* [Getting started with xUnit.net: Using .NET Core with the .NET SDK command line](https://github.com/xunit/xunitdocs/getting-started-dotnet-core)
 * [Moq](https://github.com/moq/moq4)
 * [Moq Quickstart](https://github.com/Moq/moq4/wiki/Quickstart)
 
@@ -235,7 +235,7 @@ The message app is a Razor Pages message system with the following characteristi
 * The app contains a DAL in its database context class, `AppDbContext` (*Data/AppDbContext.cs*). The DAL methods are marked `virtual`, which allows mocking the methods for use in the tests.
 * If the database is empty on app startup, the message store is initialized with three messages. These *seeded messages* are also used in tests.
 
-&#8224;The EF topic, [Test with InMemory](/ef/core/miscellaneous/testing/in-memory), explains how to use an in-memory database for tests with MSTest. This topic uses the [xUnit](https://xunit.github.io/) test framework. Test concepts and test implementations across different test frameworks are similar but not identical.
+&#8224;The EF topic, [Test with InMemory](/ef/core/miscellaneous/testing/in-memory), explains how to use an in-memory database for tests with MSTest. This topic uses the [xUnit](https://github.com/xunit/xunit) test framework. Test concepts and test implementations across different test frameworks are similar but not identical.
 
 Although the sample app doesn't use the repository pattern and isn't an effective example of the [Unit of Work (UoW) pattern](https://martinfowler.com/eaaCatalog/unitOfWork.html), Razor Pages supports these patterns of development. For more information, see [Designing the infrastructure persistence layer](/dotnet/standard/microservices-architecture/microservice-ddd-cqrs-patterns/infrastructure-persistence-layer-design) and <xref:mvc/controllers/testing> (the sample implements the repository pattern).
 
@@ -248,7 +248,7 @@ The test app is a console app inside the *tests/RazorPagesTestSample.Tests* fold
 | *UnitTests*     | <ul><li>*DataAccessLayerTest.cs* contains the unit tests for the DAL.</li><li>*IndexPageTests.cs* contains the unit tests for the Index page model.</li></ul> |
 | *Utilities*     | Contains the `TestDbContextOptions` method used to create new database context options for each DAL unit test so that the database is reset to its baseline condition for each test. |
 
-The test framework is [xUnit](https://xunit.github.io/). The object mocking framework is [Moq](https://github.com/moq/moq4).
+The test framework is [xUnit](https://github.com/xunit/xunit). The object mocking framework is [Moq](https://github.com/moq/moq4).
 
 ## Unit tests of the data access layer (DAL)
 
@@ -371,7 +371,7 @@ Other tests in this group create page model objects that include the <xref:Micro
 * <xref:mvc/controllers/testing>
 * [Unit Test Your Code](/visualstudio/test/unit-test-your-code) (Visual Studio)
 * <xref:test/integration-tests>
-* [xUnit.net](https://xunit.github.io/)
+* [xUnit.net](https://github.com/xunit/xunit)
 * [Building a complete .NET Core solution on macOS using Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution)
 * [Getting started with xUnit.net: Using .NET Core with the .NET SDK command line](https://xunit.net/docs/getting-started/netcore/cmdline)
 * [Moq](https://github.com/moq/moq4)

--- a/aspnetcore/test/troubleshoot-azure-iis.md
+++ b/aspnetcore/test/troubleshoot-azure-iis.md
@@ -338,10 +338,7 @@ For more information, see <xref:host-and-deploy/aspnet-core-module#enhanced-diag
 
 ### Slow or hanging app (Azure App Service)
 
-When an app responds slowly or hangs on a request, see the following articles:
-
-* [Troubleshoot slow web app performance issues in Azure App Service](/azure/app-service/app-service-web-troubleshoot-performance-degradation)
-* [Use Crash Diagnoser Site Extension to Capture Dump for Intermittent Exception issues or performance issues on Azure Web App](https://blogs.msdn.microsoft.com/asiatech/2015/12/28/use-crash-diagnoser-site-extension-to-capture-dump-for-intermittent-exception-issues-or-performance-issues-on-azure-web-app/)
+When an app responds slowly or hangs on a request, see [Troubleshoot slow web app performance issues in Azure App Service](/azure/app-service/app-service-web-troubleshoot-performance-degradation).
 
 ### Monitoring blades
 


### PR DESCRIPTION
Contributes to fixing #21751

This PR fixes all 5.0 to 2.0 version broken links in the repo, except for a few where the link is still good but the issue was that the ssl cert expired, link technically works, plus no alternative.