### PR TITLE
Update EF Core MVC implicit join

### DIFF
--- a/aspnetcore/data/ef-mvc/complex-data-model.md
+++ b/aspnetcore/data/ef-mvc/complex-data-model.md
@@ -364,7 +364,7 @@ Each relationship line has a 1 at one end and an asterisk (*) at the other, indi
 
 If the `Enrollment` table didn't include grade information, it would only need to contain the two foreign keys `CourseID` and `StudentID`. In that case, it would be a many-to-many join table without payload (or a pure join table) in the database. The `Instructor` and `Course` entities have that kind of many-to-many relationship, and your next step is to create an entity class to function as a join table without payload.
 
-EF Core supports implicit join tables for many-to-many relationships, but this tutoral has not been updated to use an implicit join tables. See [Many-to-Many Relationships](xref:data/ef-rp/complex-data-model#many-to-many-relationships), the Razor Pages version of this tutorial which has been updated.
+EF Core supports implicit join tables for many-to-many relationships, but this tutoral has not been updated to use an implicit join table. See [Many-to-Many Relationships](xref:data/ef-rp/complex-data-model#many-to-many-relationships), the Razor Pages version of this tutorial which has been updated.
 
 ## The CourseAssignment entity
 

--- a/aspnetcore/data/ef-mvc/complex-data-model.md
+++ b/aspnetcore/data/ef-mvc/complex-data-model.md
@@ -364,7 +364,7 @@ Each relationship line has a 1 at one end and an asterisk (*) at the other, indi
 
 If the `Enrollment` table didn't include grade information, it would only need to contain the two foreign keys `CourseID` and `StudentID`. In that case, it would be a many-to-many join table without payload (or a pure join table) in the database. The `Instructor` and `Course` entities have that kind of many-to-many relationship, and your next step is to create an entity class to function as a join table without payload.
 
-(EF 6.x supports implicit join tables for many-to-many relationships, but EF Core doesn't. For more information, see the [discussion in the EF Core GitHub repository](https://github.com/aspnet/EntityFramework/issues/1368).)
+(EF Core supports implicit join tables for many-to-many relationships since [version 5.0](/ef/core/what-is-new/ef-core-5.0/whatsnew#many-to-many).)
 
 ## The CourseAssignment entity
 

--- a/aspnetcore/data/ef-mvc/complex-data-model.md
+++ b/aspnetcore/data/ef-mvc/complex-data-model.md
@@ -364,7 +364,7 @@ Each relationship line has a 1 at one end and an asterisk (*) at the other, indi
 
 If the `Enrollment` table didn't include grade information, it would only need to contain the two foreign keys `CourseID` and `StudentID`. In that case, it would be a many-to-many join table without payload (or a pure join table) in the database. The `Instructor` and `Course` entities have that kind of many-to-many relationship, and your next step is to create an entity class to function as a join table without payload.
 
-(EF Core supports implicit join tables for many-to-many relationships since [version 5.0](/ef/core/what-is-new/ef-core-5.0/whatsnew#many-to-many).)
+EF Core supports implicit join tables for many-to-many relationships, but this tutoral has not been updated to use an implicit join tables. See [Many-to-Many Relationships](xref:data/ef-rp/complex-data-model#many-to-many-relationships), the Razor Pages version of this tutorial which has been updated.
 
 ## The CourseAssignment entity
 


### PR DESCRIPTION
Implicit join tables are supported since EF Core 5.0, but the documentation for EF Core + MVC was outdated



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->