### PR TITLE
Dynamically added root components

### DIFF
--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -651,6 +651,32 @@ For more information, see <xref:blazor/components/index#namespaces>.
 
 ::: zone-end
 
+## Dynamically add root components
+
+*This feature applies to ASP.NET Core 6.0 Release Candidate 1 or later. ASP.NET Core 6.0 Release Candidate 1 is scheduled for release in September. ASP.NET Core 6.0 is scheduled for release later this year.*
+
+Razor components can be dynamically rendered with passed parameters directly from JavaScript or HTML after a Blazor app has started.
+
+In the following example, a `ShoppingCart` component is dynamically rendered with a value for its `ShoppingCartId` component parameter.
+
+In JavaScript:
+
+```javascript
+Blazor.renderComponent({ELEMENT}, { componentName: "ShoppingCart" }, 
+  parameters: { shoppingCartId: "1234" });
+```
+
+In the preceding example, the `{ELEMENT}` placeholder is the [HTML element instance](hhttps://developer.mozilla.org/docs/Web/API/HTMLElement) acting as a container for the rendered component.
+
+In HTML:
+
+```html
+<shopping-cart shopping-cart-id="1234" />
+```
+
+> [!NOTE]
+> Rendering child content of a dynamically-rendered component isn't supported.
+
 ## Preserve prerendered state
 
 Without preserving prerendered state, any state that used during prerendering is lost and must be recreated when the app is fully loaded. If any state is setup asynchronously, the UI may flicker as the the prerendered UI is replaced with temporary placeholders and then fully rendered again.


### PR DESCRIPTION
Fixes #22690
Addresses #22045 

* This PR's content and examples are based on the design in the [PU issue](https://github.com/dotnet/aspnetcore/issues/27574). **_IF_** *the design is correct* ...
  * For the `Blazor.renderComponent` example, is "element" a DOM `HTMLElement`?
  * For `<shopping-cart shopping-cart-id="..." />`, are the dashes by convention ✨ for Pascal case component and parameter naming?
  
  If the design there isn't correct, what's the design for this feature?

* I don't see anything fleshed out for ...

  > For server side Blazor there are security implications to this feature that we need to account for, like a limit on the number of components that can be rendered at any time or the list of components that can be rendered as well as their parameters.

  What guidance is required to cover **_security concerns_** 😨?