### PR TITLE
Long Polling disabled update

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -350,27 +350,24 @@ When a circuit ends because a user has disconnected and the framework is cleanin
 
 We recommend using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-service) for Blazor Server apps hosted in Microsoft Azure. The service works in conjunction with the app's Blazor Hub for scaling up a Blazor Server app to a large number of concurrent SignalR connections. In addition, the SignalR Service's global reach and high-performance data centers significantly aid in reducing latency due to geography. For prerendering support with the Azure SignalR Service, configure the app to use *sticky sessions*. For more information, see <xref:blazor/host-and-deploy/server>.
 
-## Enable Long Polling
+## Long Polling
 
-Long Polling was enabled in releases prior to ASP.NET Core 6.0 as a fallback transport for situations in which WebSockets weren't available. If an app targeting ASP.NET Core 6.0 or later must use Long Polling, make the following server-side and client-side changes:
+Long Polling was enabled in releases prior to ASP.NET Core 6.0 as a fallback transport for situations in which the WebSockets transport wasn't available. If an app targeting ASP.NET Core 6.0 or later must use Long Polling, make the following changes:
 
-Server-side update:
-
-In `Startup.cs`, replace `endpoints.MapBlazorHub()` with:
+In the app's `Startup.cs` file, replace `endpoints.MapBlazorHub()` with the following code:
 
 ```csharp
 endpoints.MapBlazorHub(configureOptions: options => 
 { 
-    options.Transports = HttpTransportType.WebSockets | HttpTransportType.LongPolling; 
+    options.Transports = 
+        HttpTransportType.WebSockets | HttpTransportType.LongPolling;
 });
 ```
-
-Client-side update:
 
 Add the following script to the `Shared/_Layout.cshtml` file immediately inside the closing `</body>` tag. WebSockets (`1`) and Long Polling (`4`) are the supported `HTTPTransportTypes`. The following example:
 
 * Specifies support for both WebSockets and Long Polling transports (`1 | 4`).
-* Defaults to WebSockets when a WebSockets connection can be established.
+* Defaults to the WebSockets transport when a WebSockets connection can be established.
 
 ```html
 <script>

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -367,7 +367,7 @@ endpoints.MapBlazorHub(configureOptions: options =>
 
 Client-side update:
 
-Add the following script to the `Shared/_Layout.cshtml` file immediately inside the closing `</body>` tag. WebSockets (`1`) and Long Polling (`4`) are supported `HTTPTransportTypes`. The following example:
+Add the following script to the `Shared/_Layout.cshtml` file immediately inside the closing `</body>` tag. WebSockets (`1`) and Long Polling (`4`) are the supported `HTTPTransportTypes`. The following example:
 
 * Specifies support for both WebSockets and Long Polling transports (`1 | 4`).
 * Defaults to WebSockets when a WebSockets connection can be established.

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -350,6 +350,40 @@ When a circuit ends because a user has disconnected and the framework is cleanin
 
 We recommend using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-service) for Blazor Server apps hosted in Microsoft Azure. The service works in conjunction with the app's Blazor Hub for scaling up a Blazor Server app to a large number of concurrent SignalR connections. In addition, the SignalR Service's global reach and high-performance data centers significantly aid in reducing latency due to geography. For prerendering support with the Azure SignalR Service, configure the app to use *sticky sessions*. For more information, see <xref:blazor/host-and-deploy/server>.
 
+## Enable Long Polling
+
+Long Polling was enabled in releases prior to ASP.NET Core 6.0 as a fallback transport for situations in which WebSockets weren't available. If an app targeting ASP.NET Core 6.0 or later must use Long Polling, make the following server-side and client-side changes:
+
+Server-side update:
+
+In `Startup.cs`, replace `endpoints.MapBlazorHub()` with:
+
+```csharp
+endpoints.MapBlazorHub(configureOptions: options => 
+{ 
+    options.Transports = HttpTransportType.WebSockets | HttpTransportType.LongPolling; 
+});
+```
+
+Client-side update:
+
+Add the following script to the `Shared/_Layout.cshtml` file immediately inside the closing `</body>` tag. WebSockets (`1`) and Long Polling (`4`) are supported `HTTPTransportTypes`. The following example:
+
+* Specifies support for both WebSockets and Long Polling transports (`1 | 4`).
+* Defaults to WebSockets when a WebSockets connection can be established.
+
+```html
+<script>
+  (function start() {
+    Blazor.start({
+      configureSignalR: builder => builder.withUrl('_blazor', 1 | 4)
+    });
+  })()
+</script>
+```
+
+For more information, see [Disable Long Polling Fallback Transport for Blazor Server (ASP.NET Announcements)](https://github.com/aspnet/Announcements/issues/470).
+
 ## Additional resources
 
 * <xref:signalr/introduction>

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -48,7 +48,7 @@ Blazor Server apps use ASP.NET Core SignalR to communicate with the browser. [Si
 Blazor works best when using WebSockets as the SignalR transport due to lower latency, reliability, and [security](xref:signalr/security). When deploying to Azure App Service, configure the app to use WebSockets in the Azure portal settings for the service. For details on configuring the app for Azure App Service, see the [SignalR publishing guidelines](xref:signalr/publish-to-azure-web-app).
 
 > [!NOTE]
-> In releases prior to ASP.NET Core 6.0, Long Polling was enabled as a fallback transport for situations in which WebSockets weren't available. If an app targeting ASP.NET Core 6.0 or later must use Long Polling, see <xref:blazor/fundamentals/signalr?pivots=server#enable-long-polling>.
+> In releases prior to ASP.NET Core 6.0, Long Polling was enabled as a fallback transport for situations in which the WebSockets transport wasn't available. If an app targeting ASP.NET Core 6.0 or later must use Long Polling, see <xref:blazor/fundamentals/signalr?pivots=server#long-polling>.
 >
 > For more information, see [Disable Long Polling Fallback Transport for Blazor Server (ASP.NET Announcements)](https://github.com/aspnet/Announcements/issues/470).
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -45,7 +45,12 @@ Each circuit uses approximately 250 KB of memory for a minimal *Hello World*-sty
 
 Blazor Server apps use ASP.NET Core SignalR to communicate with the browser. [SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply to Blazor Server apps.
 
-Blazor works best when using WebSockets as the SignalR transport due to lower latency, reliability, and [security](xref:signalr/security). Long Polling is used by SignalR when WebSockets isn't available or when the app is explicitly configured to use Long Polling. When deploying to Azure App Service, configure the app to use WebSockets in the Azure portal settings for the service. For details on configuring the app for Azure App Service, see the [SignalR publishing guidelines](xref:signalr/publish-to-azure-web-app).
+Blazor works best when using WebSockets as the SignalR transport due to lower latency, reliability, and [security](xref:signalr/security). When deploying to Azure App Service, configure the app to use WebSockets in the Azure portal settings for the service. For details on configuring the app for Azure App Service, see the [SignalR publishing guidelines](xref:signalr/publish-to-azure-web-app).
+
+> [!NOTE]
+> In releases prior to ASP.NET Core 6.0, Long Polling was enabled as a fallback transport for situations in which WebSockets weren't available. If an app targeting ASP.NET Core 6.0 or later must use Long Polling, see <xref:blazor/fundamentals/signalr?pivots=server#enable-long-polling>.
+>
+> For more information, see [Disable Long Polling Fallback Transport for Blazor Server (ASP.NET Announcements)](https://github.com/aspnet/Announcements/issues/470).
 
 #### Azure SignalR Service
 
@@ -55,6 +60,8 @@ We recommend using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-
 > When [WebSockets](https://wikipedia.org/wiki/WebSocket) are disabled, Azure App Service simulates a real-time connection using HTTP Long Polling. HTTP Long Polling is noticeably slower than running with WebSockets enabled, which doesn't use polling to simulate a client-server connection.
 >
 > We recommend using WebSockets for Blazor Server apps deployed to Azure App Service. The [Azure SignalR Service](xref:signalr/scale#azure-signalr-service) uses WebSockets by default. If the app doesn't use the Azure SignalR Service, see <xref:signalr/publish-to-azure-web-app#configure-the-app-in-azure-app-service>.
+>
+> As of the release of ASP.NET Core 6.0, Long Polling isn't enabled by default. For more information, see the [SignalR configuration](#signalr-configuration) section.
 >
 > For more information, see:
 >

--- a/aspnetcore/blazor/security/server/threat-mitigation.md
+++ b/aspnetcore/blazor/security/server/threat-mitigation.md
@@ -84,10 +84,17 @@ By default, there's no limit on the number of connections per user for a Blazor 
     * Require authentication to connect to the app and keep track of the active sessions per user.
     * Reject new sessions upon reaching a limit.
     * Proxy WebSocket connections to an app through the use of a proxy, such as the [Azure SignalR Service](/azure/azure-signalr/signalr-overview) that multiplexes connections from clients to an app. This provides an app with greater connection capacity than a single client can establish, preventing a client from exhausting the connections to the server.
-  * At the server level: Use a proxy/gateway in front of the app. For example, [Azure Front Door](/azure/frontdoor/front-door-overview) enables you to define, manage, and monitor the global routing of web traffic to an app and works when Blazor Server apps are configured to use Long Polling.
+  * At the server level: Use a proxy/gateway in front of the app.
   
     > [!NOTE]
-    > Although Long Polling is supported for Blazor Server apps, [WebSockets is the recommended transport protocol](xref:blazor/host-and-deploy/server#azure-signalr-service). [Azure Front Door](/azure/frontdoor/front-door-overview) doesn't support WebSockets at this time, but support for WebSockets is under consideration for a future release of the service.
+    > Long Polling isn't enabled by default for ASP.NET Core 6.0 or later Blazor Server apps. [Azure Front Door](/azure/frontdoor/front-door-overview) doesn't support WebSockets at this time, but support for WebSockets is under consideration for a future release of the service.
+    >
+    > For more information, see the following resources:
+    >
+    > * <xref:blazor/host-and-deploy/server#signalr-configuration>
+    > * <xref:blazor/fundamentals/signalr?pivots=server#enable-long-polling>
+    > * [Disable Long Polling Fallback Transport for Blazor Server (ASP.NET Announcements)](https://github.com/aspnet/Announcements/issues/470)
+    > * [Support WebSocket connections on Azure Front Door](https://feedback.azure.com/forums/217313-networking/suggestions/37346371-support-websocket-connections-on-azure-front-door)
 
 ## Denial of service (DoS) attacks
 

--- a/aspnetcore/blazor/security/server/threat-mitigation.md
+++ b/aspnetcore/blazor/security/server/threat-mitigation.md
@@ -92,7 +92,7 @@ By default, there's no limit on the number of connections per user for a Blazor 
     > For more information, see the following resources:
     >
     > * <xref:blazor/host-and-deploy/server#signalr-configuration>
-    > * <xref:blazor/fundamentals/signalr?pivots=server#enable-long-polling>
+    > * <xref:blazor/fundamentals/signalr?pivots=server#long-polling>
     > * [Disable Long Polling Fallback Transport for Blazor Server (ASP.NET Announcements)](https://github.com/aspnet/Announcements/issues/470)
     > * [Support WebSocket connections on Azure Front Door](https://feedback.azure.com/forums/217313-networking/suggestions/37346371-support-websocket-connections-on-azure-front-door)
 


### PR DESCRIPTION
Fixes #22863
Addresses #22045 

* Is `(function start() { ... })()` necessary in this scenario? AFAIK, we document calling `Blazor.XXX` directly in the `<script>` everywhere else.

@danroth27 ... I cross-link to the Azure Feedback item ...

[Support WebSocket connections on Azure Front Door](https://feedback.azure.com/forums/217313-networking/suggestions/37346371-support-websocket-connections-on-azure-front-door)

... is that a good :+1: bikeshedding scenario (they **_should be aware of it and vote_**) or bad :-1: bikeshedding scenario (they'll need to find that on their own and let's chop 🔪 the cross-link here)?

cc: @mkArtakMSFT 
