### PR TITLE
Guidance and migration for Duende IdS

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -13,7 +13,10 @@ uid: blazor/security/webassembly/hosted-with-identity-server
 
 ::: moniker range=">= aspnetcore-6.0"
 
-This article explains how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [IdentityServer](https://identityserver.io/) to authenticate users and API calls.
+This article explains how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Duende Identity Server](https://docs.duendesoftware.com) to authenticate users and API calls.
+
+> [!IMPORTANT]
+> [Duende Software](https://duendesoftware.com/) might require you to pay a license fee for production use of Duende Identity Server. For more information, see <xref:migration/50-to-60#project-templates-use-duende-identity-server>.
 
 > [!NOTE]
 > To configure a standalone or hosted Blazor WebAssembly app to use an existing, external Identity Server instance, follow the guidance in <xref:blazor/security/webassembly/standalone-with-authentication-library>.
@@ -122,7 +125,7 @@ Specify the issuer explicitly when deploying to Azure App Service on Linux. For 
 
 ### AddApiAuthorization
 
-The <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method configures [IdentityServer](https://identityserver.io/) for ASP.NET Core scenarios. IdentityServer is a powerful and extensible framework for handling app security concerns. IdentityServer exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided that we consider a good starting point. Once your authentication needs change, the full power of IdentityServer is available to customize authentication to suit an app's requirements.
+The <xref:Microsoft.Extensions.DependencyInjection.IdentityServerBuilderConfigurationExtensions.AddApiAuthorization%2A> helper method configures [Identity Server](https://docs.duendesoftware.com) for ASP.NET Core scenarios. Identity Server is a powerful and extensible framework for handling app security concerns. IdentityServer exposes unnecessary complexity for the most common scenarios. Consequently, a set of conventions and configuration options is provided that we consider a good starting point. Once your authentication needs change, the full power of IdentityServer is available to customize authentication to suit an app's requirements.
 
 ### AddIdentityServerJwt
 
@@ -401,8 +404,8 @@ In the **`Server`** app, create a `ProfileService` implementation.
 
 ```csharp
 using IdentityModel;
-using IdentityServer4.Models;
-using IdentityServer4.Services;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Services;
 using System.Threading.Tasks;
 
 public class ProfileService : IProfileService
@@ -432,7 +435,7 @@ public class ProfileService : IProfileService
 In the **`Server`** app, register the Profile Service in `Startup.ConfigureServices`:
 
 ```csharp
-using IdentityServer4.Services;
+using Duende.IdentityServer.Services;
 
 ...
 
@@ -469,7 +472,7 @@ The following guidance explains:
 * How to deploy a hosted Blazor WebAssembly app with Identity Server to [Azure App Service](https://azure.microsoft.com/services/app-service/) with a custom domain.
 * How to create and use a TLS certificate for HTTPS protocol communication with browsers. Although the guidance focuses on using the certificate with a custom domain, the guidance is equally applicable to using a default Azure Apps domain, for example `contoso.azurewebsites.net`.
 
-For this hosting scenario, do **not** use the same certificate for [Identity Server's token signing key](https://docs.identityserver.io/en/latest/topics/crypto.html#token-signing-and-validation) and the site's HTTPS secure communication with browsers:
+For this hosting scenario, do **not** use the same certificate for [Identity Server's token signing key](https://docs.duendesoftware.com/identityserver/v5/fundamentals/keys/) and the site's HTTPS secure communication with browsers:
 
 * Using different certificates for these two requirements is a good security practice because it isolates private keys for each purpose.
 * TLS certificates for communication with browsers is managed independently without affecting Identity Server's token signing.
@@ -542,7 +545,7 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
 
    For testing purposes, an app's local [SQLite](https://www.sqlite.org/index.html) database, which is configured by default by the Blazor template, can be deployed with the app without additional configuration. Configuring a different database for Identity Server in production is beyond the scope of this article. For more information, see the database resources in the following documentation sets:
    * [App Service](/azure/app-service/)
-   * [Identity Server](https://identityserver4.readthedocs.io/en/latest/)
+   * [Duende Identity Server](https://docs.duendesoftware.com)
 
 1. Select the **Edit** link under the deployment profile name at the top of the window. Change the destination URL to the site's custom domain URL (for example, `https://www.contoso.com`). Save the settings.
 1. Publish the app. Visual Studio opens a browser window and requests the site at its custom domain.
@@ -575,6 +578,7 @@ Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Sub
 * <xref:host-and-deploy/proxy-load-balancer>: Includes guidance on:
   * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
+* [Duende Identity Server](https://docs.duendesoftware.com)
 
 ::: moniker-end
 

--- a/aspnetcore/blazor/security/webassembly/index.md
+++ b/aspnetcore/blazor/security/webassembly/index.md
@@ -17,7 +17,10 @@ Blazor WebAssembly apps are secured in the same manner as Single Page Applicatio
 
 ## Authentication library
 
-Blazor WebAssembly supports authenticating and authorizing apps using OIDC via the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) library. The library provides a set of primitives for seamlessly authenticating against ASP.NET Core backends. The library integrates ASP.NET Core Identity with API authorization support built on top of [Identity Server](https://identityserver.io/). The library can authenticate against any third-party Identity Provider (IP) that supports OIDC, which are called OpenID Providers (OP).
+Blazor WebAssembly supports authenticating and authorizing apps using OIDC via the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) library. The library provides a set of primitives for seamlessly authenticating against ASP.NET Core backends. The library integrates ASP.NET Core Identity with API authorization support built on top of [Duende Identity Server](https://docs.duendesoftware.com). The library can authenticate against any third-party Identity Provider (IP) that supports OIDC, which are called OpenID Providers (OP).
+
+> [!IMPORTANT]
+> [Duende Software](https://duendesoftware.com/) might require you to pay a license fee for production use of Duende Identity Server. For more information, see <xref:migration/50-to-60#project-templates-use-duende-identity-server>.
 
 The authentication support in Blazor WebAssembly is built on top of the `oidc-client.js` library, which is used to handle the underlying authentication protocol details.
 

--- a/aspnetcore/includes/DuendeIdentityServer.md
+++ b/aspnetcore/includes/DuendeIdentityServer.md
@@ -1,0 +1,20 @@
+---
+no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
+ASP.NET Core Identity adds user interface (UI) login functionality to ASP.NET Core web apps. To secure web APIs and SPAs, use one of the following:
+
+* [Azure Active Directory](/azure/api-management/api-management-howto-protect-backend-with-aad)
+* [Azure Active Directory B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw) (Azure AD B2C)
+* [Duende Identity Server](https://docs.duendesoftware.com)
+
+Duende Identity Server is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core. Duende Identity Server enables the following security features:
+
+* Authentication as a Service (AaaS)
+* Single sign-on/off (SSO) over multiple application types
+* Access control for APIs
+* Federation Gateway
+
+> [!IMPORTANT]
+> [Duende Software](https://duendesoftware.com/) might require you to pay a license fee for production use of Duende Identity Server. For more information, see <xref:migration/50-to-60#project-templates-use-duende-identity-server>.
+
+For more information, see the [Duende Identity Server documentation (Duende Software website)](https://docs.duendesoftware.com).

--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -102,6 +102,26 @@ Make the following changes:
 
 For more information, see [Razor compiler no longer produces a Views assembly](https://github.com/aspnet/Announcements/issues/459).
 
+## Project templates use Duende Identity Server
+
+Project templates now use [Duende Identity Server](https://docs.duendesoftware.com). For migration guidance, see [IdentityServer4 v4.1 to Duende IdentityServer v5](https://docs.duendesoftware.com/identityserver/v5/upgrades/is4_v4_to_dis_v5/).
+
+> [!IMPORTANT]
+> Duende Identity Server is an open source product with a reciprocal license agreement. If you plan to use Duende Identity Server in production, you might be required to obtain a licence from [Duende Software](https://duendesoftware.com/). A licence might require you to pay a license fee to Duende Software.
+>
+> To see how to use [Microsoft Azure Active Directory](https://azure.microsoft.com/services/active-directory/) for ASP.NET Core Identity, see [Identity (dotnet/aspnetcore GitHub repository)](https://aka.ms/aspnetidentityserver).
+>
+> To determine if a commercial license is required for Duende Identity Server, see [Duende Licenses](https://aka.ms/identityserverlicense).
+
+Add a `DbSet<Key>` property named `Keys` to every `IdentityDbContext` to satisfy a new requirement from the updated version of `IPersistedGrantDbContext`. The keys are required as part of the contract with Duende Identity Server's stores.
+
+```csharp
+public DbSet<Key> Keys { get; set; }
+```
+
+> [!NOTE]
+> Existing migrations must be recreated for Duende Identity Server.
+
 ## Review breaking changes
 
 For breaking changes from .NET 5.0 to .NET 6.0, see [Breaking changes for migration from version 5.0 to 6.0](/dotnet/core/compatibility/6.0). ASP.NET Core and Entity Framework Core are also included in the list.

--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -107,11 +107,9 @@ For more information, see [Razor compiler no longer produces a Views assembly](h
 Project templates now use [Duende Identity Server](https://docs.duendesoftware.com). For migration guidance, see [IdentityServer4 v4.1 to Duende IdentityServer v5](https://docs.duendesoftware.com/identityserver/v5/upgrades/is4_v4_to_dis_v5/).
 
 > [!IMPORTANT]
-> Duende Identity Server is an open source product with a reciprocal license agreement. If you plan to use Duende Identity Server in production, you might be required to obtain a licence from [Duende Software](https://duendesoftware.com/). A licence might require you to pay a license fee to Duende Software.
+> Duende Identity Server is an open source product with a reciprocal license agreement. If you plan to use Duende Identity Server in production, you might be required to obtain a commercial licence from [Duende Software](https://duendesoftware.com/) and pay a license fee. For more information, see [Duende Software: Licenses](https://aka.ms/identityserverlicense).
 >
-> To see how to use [Microsoft Azure Active Directory](https://azure.microsoft.com/services/active-directory/) for ASP.NET Core Identity, see [Identity (dotnet/aspnetcore GitHub repository)](https://aka.ms/aspnetidentityserver).
->
-> To determine if a commercial license is required for Duende Identity Server, see [Duende Licenses](https://aka.ms/identityserverlicense).
+> To learn how to use [Microsoft Azure Active Directory](https://azure.microsoft.com/services/active-directory/) for ASP.NET Core Identity, see [Identity (dotnet/aspnetcore GitHub repository)](https://aka.ms/aspnetidentityserver).
 
 Add a `DbSet<Key>` property named `Keys` to every `IdentityDbContext` to satisfy a new requirement from the updated version of `IPersistedGrantDbContext`. The keys are required as part of the contract with Duende Identity Server's stores.
 

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -11,7 +11,20 @@ uid: security/authentication/identity/spa
 ---
 # Authentication and authorization for SPAs
 
+::: moniker range=">= aspnetcore-6.0"
+
+The ASP.NET Core 3.1 and later templates offer authentication in Single Page Apps (SPAs) using the support for API authorization. ASP.NET Core Identity for authenticating and storing users is combined with [Duende Identity Server](https://docs.duendesoftware.com) for implementing OpenID Connect.
+
+> [!IMPORTANT]
+> [Duende Software](https://duendesoftware.com/) might require you to pay a license fee for production use of Duende Identity Server. For more information, see <xref:migration/50-to-60#project-templates-use-duende-identity-server>.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-6.0"
+
 The ASP.NET Core 3.1 and later templates offer authentication in Single Page Apps (SPAs) using the support for API authorization. ASP.NET Core Identity for authenticating and storing users is combined with [IdentityServer](https://identityserver.io/) for implementing OpenID Connect.
+
+::: moniker-end
 
 An authentication parameter was added to the **Angular** and **React** project templates that is similar to the authentication parameter in the **Web Application (Model-View-Controller)** (MVC) and **Web Application** (Razor Pages) project templates. The allowed parameter values are **None** and **Individual**. The **React.js and Redux** project template doesn't support the authentication parameter at this time.
 

--- a/aspnetcore/security/authentication/mfa.md
+++ b/aspnetcore/security/authentication/mfa.md
@@ -399,7 +399,7 @@ If the user is already logged in, the client app:
 * Still validates the `amr` claim.
 * Can set up the MFA with a link to the ASP.NET Core Identity view.
 
-![acr_values-1](mfa/_static/acr_values-1.png)
+![acr_values-1 image](mfa/_static/acr_values-1.png)
 
 ## Force ASP.NET Core OpenID Connect client to require MFA
 
@@ -565,15 +565,15 @@ When logging in without MFA (for example, using just a password):
 
 * The `amr` has the `pwd` value:
 
-    ![require_mfa_oidc_02.png](mfa/_static/require_mfa_oidc_02.png)
+  ![amr has the pwd value](mfa/_static/require_mfa_oidc_02.png)
 
 * Access is denied:
 
-    ![require_mfa_oidc_03.png](mfa/_static/require_mfa_oidc_03.png)
+  ![Access is denied](mfa/_static/require_mfa_oidc_03.png)
 
 Alternatively, logging in using OTP with Identity:
 
-![require_mfa_oidc_01.png](mfa/_static/require_mfa_oidc_01.png)
+![Logging in using OTP with Identity](mfa/_static/require_mfa_oidc_01.png)
 
 ## Additional resources
 

--- a/aspnetcore/security/authentication/mfa.md
+++ b/aspnetcore/security/authentication/mfa.md
@@ -420,7 +420,18 @@ An `AuthorizationHandler` is implemented that will use the `amr` claim and check
 
 The returned value depends on how the identity authenticated and on the OpenID Connect server implementation.
 
+
+::: moniker range=">= aspnetcore-6.0"
+
+The `AuthorizationHandler` uses the `RequireMfa` requirement and validates the `amr` claim. The OpenID Connect server can be implemented using Duende Identity Server with ASP.NET Core Identity. When a user logs in using TOTP, the `amr` claim is returned with an MFA value. If using a different OpenID Connect server implementation or a different MFA type, the `amr` claim will, or can, have a different value. The code must be extended to accept this as well.
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-6.0"
+
 The `AuthorizationHandler` uses the `RequireMfa` requirement and validates the `amr` claim. The OpenID Connect server can be implemented using IdentityServer4 with ASP.NET Core Identity. When a user logs in using TOTP, the `amr` claim is returned with an MFA value. If using a different OpenID Connect server implementation or a different MFA type, the `amr` claim will, or can, have a different value. The code must be extended to accept this as well.
+
+::: moniker-end
 
 ```csharp
 using Microsoft.AspNetCore.Authorization;

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -1124,6 +1124,8 @@
                   href: /samples/azure-samples/active-directory-dotnet-native-aspnetcore-v2/calling-an-aspnet-core-web-api-from-a-wpf-application-using-azure-ad-v2/
                 - name: Web API with Azure AD B2C
                   href: https://azure.microsoft.com/resources/samples/active-directory-b2c-dotnetcore-webapi/
+        - name: Secure ASP.NET Core apps with Duende Identity Server
+          href: https://docs.duendesoftware.com
         - name: Secure ASP.NET Core apps with IdentityServer4
           href: https://identityserver4.readthedocs.io/
         - name: Secure ASP.NET Core apps with Azure App Service authentication (Easy Auth)

--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -713,7 +713,17 @@ To satisfy the preceding requirements, make the following changes:
 
 ## Add authentication support to a web API
 
+::: moniker range=">= aspnetcore-6.0"
+
+[!INCLUDE[](~/includes/DuendeIdentityServer.md)]
+
+::: moniker-end
+
+::: moniker range="< aspnetcore-6.0"
+
 [!INCLUDE[](~/includes/IdentityServer4.md)]
+
+::: moniker-end
 
 ## Next steps
 


### PR DESCRIPTION
Fixes #22355
Addresses https://github.com/dotnet/aspnetcore/issues/32881
Addresses #22045 

This at least gets the ball rolling ... but there are potentially a few little devils 😈 in the details ...

* Not sure on the presence and phrasing of `public DbSet<Key> Keys { get; set; }` in the migration topic.
* I added Duende to the ToC with a cross-link to their docs. This PR keeps the existing ToC cross-link to IdentityServer4 docs. Do u want to keep that cross-link in the ToC?
* Hao, your PU PR didn't include the license text AFAICT ... it might have been a different project template PR tho. I took a shot at wording lingo here for docs.
* I can't quite test all of the Blazor guidance **_YET_**. I do plan to do so tho ... either in the RC period or after GA (possibly as late as January) as part of either testing for 6.0 GA with test apps or for my UE passes when I get back to them early next year. Until then tho, I recommend that we merely take reader feedback on the Blazor IdS topic and see if we get reports of 😈 cropping up.

@Rick-Anderson ... There's one topic (the last one for these updates AFAICT) that I didn't address here ...

**Introduction to Identity on ASP.NET Core**
https://docs.microsoft.com/en-us/aspnet/core/security/authentication/identity?view=aspnetcore-5.0&tabs=visual-studio

It uses the prior versioning approach to *Whole-topic Versioning* ... call it ... er ... **_Flip-mode Versioning_**&trade; 😄. Therefore, I'll probably/possibly butcher how you would want to handle the update. It's a simple update tho for the one IdS line after the versioning is refactored. It just needs ...

```
[!INCLUDE[](~/includes/IdentityServer4.md)]
```

... changed to ...

```
[!INCLUDE[](~/includes/DuendeIdentityServer.md)]
```

... for >=6.0 coverage. That INCLUDE file is on this PR, so a followup PR will have access to it. If you'd like me to try and fix the versioning by refactoring it on this PR, ok ... I'll give it a shot. :ear: