### PR TITLE
Fix broken cross-links

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1958,7 +1958,7 @@ The [`@typeparam`][11] directive declares a [generic type parameter](/dotnet/csh
 For more information, see the following articles:
 
 * <xref:mvc/views/razor#typeparam>
-* <xref:blazor/components/templated-components
+* <xref:blazor/components/templated-components>
 
 ::: moniker-end
 
@@ -2919,7 +2919,7 @@ The [`@typeparam`][11] directive declares a [generic type parameter](/dotnet/csh
 For more information, see the following articles:
 
 * <xref:mvc/views/razor#typeparam>
-* <xref:blazor/components/templated-components
+* <xref:blazor/components/templated-components>
 
 ::: moniker-end
 


### PR DESCRIPTION
Fixes #23056 

Thanks @leotsarev! :rocket: ... **_Indeed!_** ... I'm acquainted with this **_sneaky devil_** 😈 ... this happens when the doc author (**_ME!_** 🙈) isn't aware of the location of the cursor and has a backspace ... er ... **_incident_** 😆😢😆😢. The build report catches some of these types of problems, so I'm a bit surprised when they come in as an issue ... but they sneak by. In this case, it probably just treated that as normal text and didn't flag it. I'll get this merged and live immediately. Thanks again for the report.