### PR TITLE
Library naming behavior

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -256,7 +256,7 @@ The distinction between using the `Link` component in a child component and plac
 
 An RCL's static assets are available to any app that consumes the library.
 
-Place static assets in the `wwwroot` folder of the RCL and reference the static assets with the following path in the app: `_content/{LIBRARY NAME}/{PATH AND FILE NAME}`. The `{LIBRARY NAME}` placeholder is the library name. The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
+Place static assets in the `wwwroot` folder of the RCL and reference the static assets with the following path in the app: `_content/{LIBRARY NAME}/{PATH AND FILE NAME}`. The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties). The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
 
 The following example demonstrates the use of RCL static assets with an RCL named `ComponentLibrary` and a Blazor app that consumes the RCL. The app has a project reference for the `ComponentLibrary` RCL.
 
@@ -540,7 +540,7 @@ The background image is also included from the RCL project template and resides 
 
 An RCL's static assets are available to any app that consumes the library.
 
-Place static assets in the `wwwroot` folder of the RCL and reference the static assets with the following path in the app: `_content/{LIBRARY NAME}/{PATH AND FILE NAME}`. The `{LIBRARY NAME}` placeholder is the library name. The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
+Place static assets in the `wwwroot` folder of the RCL and reference the static assets with the following path in the app: `_content/{LIBRARY NAME}/{PATH AND FILE NAME}`. The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties). The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
 
 The following example demonstrates the use of RCL static assets with an RCL named `ComponentLibrary` and a Blazor app that consumes the RCL. The app has a project reference for the `ComponentLibrary` RCL.
 
@@ -806,7 +806,7 @@ To provide `Component1`'s `my-component` CSS class, link to the library's styles
 
 An RCL's static assets are available to any app that consumes the library.
 
-Place static assets in the `wwwroot` folder of the RCL and reference the static assets with the following path in the app: `_content/{LIBRARY NAME}/{PATH AND FILE NAME}`. The `{LIBRARY NAME}` placeholder is the library name. The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
+Place static assets in the `wwwroot` folder of the RCL and reference the static assets with the following path in the app: `_content/{LIBRARY NAME}/{PATH AND FILE NAME}`. The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties). The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
 
 The following example demonstrates the use of RCL static assets with an RCL named `ComponentLibrary` and a Blazor app that consumes the RCL. The app has a project reference for the `ComponentLibrary` RCL.
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -311,7 +311,7 @@ Use the following approaches to reference static assets:
   <img alt="..." src="_content/{LIBRARY NAME}/{PATH AND FILE NAME}" />
   ```
 
-  The `{LIBRARY NAME}` placeholder is the library name. The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
+  The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties). The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
 
 For more information on RCLs, see:
 
@@ -1118,7 +1118,7 @@ Use the following approaches to reference static assets:
   <img alt="..." src="_content/{LIBRARY NAME}/{PATH AND FILE NAME}" />
   ```
 
-  The `{LIBRARY NAME}` placeholder is the library name. The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
+  The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties). The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
 
 For more information on RCLs, see:
 
@@ -1925,7 +1925,7 @@ Use the following approaches to reference static assets:
   <img alt="..." src="_content/{LIBRARY NAME}/{PATH AND FILE NAME}" />
   ```
 
-  The `{LIBRARY NAME}` placeholder is the library name. The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
+  The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties). The `{PATH AND FILE NAME}` placeholder is path and file name under `wwwroot`.
 
 For more information on RCLs, see:
 

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -202,7 +202,7 @@ Dynamically importing a module requires a network request, so it can only be ach
 > When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the module's JS file using its stable static web asset path: `./_content/{LIBRARY NAME}/{SCRIPT PATH AND FILENAME (.js)}`:
 >
 > * The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
-> * The `{LIBRARY NAME}` placeholder is the library name. In the following example, the library name is `ComponentLibrary`.
+> * The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties). In the following example, the library name is `ComponentLibrary`.
 > * The `{SCRIPT PATH AND FILENAME (.js)}` placeholder is the path and file name under `wwwroot`. In the following example, the external JS file (`script.js`) is placed in the class library's `wwwroot` folder.
 >
 > ```csharp
@@ -941,7 +941,7 @@ Dynamically importing a module requires a network request, so it can only be ach
 > When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the module's JS file using its stable static web asset path: `./_content/{LIBRARY NAME}/{SCRIPT PATH AND FILENAME (.js)}`:
 >
 > * The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
-> * The `{LIBRARY NAME}` placeholder is the library name. In the following example, the library name is `ComponentLibrary`.
+> * The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties). In the following example, the library name is `ComponentLibrary`.
 > * The `{SCRIPT PATH AND FILENAME (.js)}` placeholder is the path and file name under `wwwroot`. In the following example, the external JS file (`script.js`) is placed in the class library's `wwwroot` folder.
 >
 > ```csharp

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -113,7 +113,7 @@ In the following example of the preceding `<script>` tag, the `scripts.js` file 
 When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the JS file using its stable static web asset path: `./_content/{LIBRARY NAME}/{SCRIPT PATH AND FILENAME (.js)}`:
 
 * The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
-* The `{LIBRARY NAME}` placeholder is the library's assembly name.
+* The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties).
 * The `{SCRIPT PATH AND FILENAME (.js)}` placeholder is the path and file name under `wwwroot`.
 
 ```html
@@ -280,7 +280,7 @@ In the following example of the preceding `<script>` tag, the `scripts.js` file 
 When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the JS file using its stable static web asset path: `./_content/{LIBRARY NAME}/{SCRIPT PATH AND FILENAME (.js)}`:
 
 * The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
-* The `{LIBRARY NAME}` placeholder is the library's assembly name.
+* The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties).
 * The `{SCRIPT PATH AND FILENAME (.js)}` placeholder is the path and file name under `wwwroot`.
 
 ```html
@@ -447,7 +447,7 @@ In the following example of the preceding `<script>` tag, the `scripts.js` file 
 When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the JS file using its stable static web asset path: `./_content/{LIBRARY NAME}/{SCRIPT PATH AND FILENAME (.js)}`:
 
 * The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
-* The `{LIBRARY NAME}` placeholder is the library's assembly name.
+* The `{LIBRARY NAME}` placeholder is the library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties).
 * The `{SCRIPT PATH AND FILENAME (.js)}` placeholder is the path and file name under `wwwroot`.
 
 ```html

--- a/aspnetcore/razor-pages/ui-class.md
+++ b/aspnetcore/razor-pages/ui-class.md
@@ -14,7 +14,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 ::: moniker range=">= aspnetcore-3.0 < aspnetcore-5.0"
 
-Razor views, pages, controllers, page models, [Razor components](xref:blazor/components/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence.
+Razor views, pages, controllers, page models, [Razor components](xref:blazor/components/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (`.cshtml` file) in the web app takes precedence.
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/razor-pages/ui-class/samples) ([how to download](xref:index#how-to-download-a-sample))
 
@@ -45,31 +45,31 @@ For more information, see [dotnet new](/dotnet/core/tools/dotnet-new). To avoid 
 
 Add Razor files to the RCL.
 
-The ASP.NET Core templates assume the RCL content is in the *Areas* folder. See [RCL Pages layout](#rcl-pages-layout) to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
+The ASP.NET Core templates assume the RCL content is in the `Areas` folder. See [RCL Pages layout](#rcl-pages-layout) to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
 
 ## Reference RCL content
 
 The RCL can be referenced by:
 
 * NuGet package. See [Creating NuGet packages](/nuget/create-packages/creating-a-package) and [dotnet add package](/dotnet/core/tools/dotnet-add-package) and [Create and publish a NuGet package](/nuget/quickstart/create-and-publish-a-package-using-visual-studio).
-* *{ProjectName}.csproj*. See [dotnet-add reference](/dotnet/core/tools/dotnet-add-reference).
+* `{ProjectName}.csproj`. See [dotnet-add reference](/dotnet/core/tools/dotnet-add-reference).
 
 ## Override views, partial views, and pages
 
-When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence. For example, add *WebApp1/Areas/MyFeature/Pages/Page1.cshtml* to WebApp1, and Page1 in the WebApp1 will take precedence over Page1 in the RCL.
+When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (`.cshtml` file) in the web app takes precedence. For example, add `WebApp1/Areas/MyFeature/Pages/Page1.cshtml` to WebApp1, and Page1 in the WebApp1 will take precedence over Page1 in the RCL.
 
-In the sample download, rename *WebApp1/Areas/MyFeature2* to *WebApp1/Areas/MyFeature* to test precedence.
+In the sample download, rename `WebApp1/Areas/MyFeature2` to `WebApp1/Areas/MyFeature` to test precedence.
 
-Copy the *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml* partial view to *WebApp1/Areas/MyFeature/Pages/Shared/_Message.cshtml*. Update the markup to indicate the new location. Build and run the app to verify the app's version of the partial is being used.
+Copy the `RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml` partial view to `WebApp1/Areas/MyFeature/Pages/Shared/_Message.cshtml`. Update the markup to indicate the new location. Build and run the app to verify the app's version of the partial is being used.
 
 ### RCL Pages layout
 
-To reference RCL content as though it is part of the web app's *Pages* folder, create the RCL project with the following file structure:
+To reference RCL content as though it is part of the web app's `Pages` folder, create the RCL project with the following file structure:
 
-* *RazorUIClassLib/Pages*
-* *RazorUIClassLib/Pages/Shared*
+* `RazorUIClassLib/Pages`
+* `RazorUIClassLib/Pages/Shared`
 
-Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.cshtml* and *_Footer.cshtml*. The `<partial>` tags could be added to *_Layout.cshtml* file:
+Suppose `RazorUIClassLib/Pages/Shared` contains two partial files: `_Header.cshtml` and `_Footer.cshtml`. The `<partial>` tags could be added to `_Layout.cshtml` file:
 
 ```cshtml
 <body>
@@ -79,7 +79,7 @@ Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.csht
 </body>
 ```
 
-Add the *_ViewStart.cshtml* file to the RCL project's *Pages* folder to use the *_Layout.cshtml* file from the host web app:
+Add the `_ViewStart.cshtml` file to the RCL project's `Pages` folder to use the `_Layout.cshtml` file from the host web app:
 
 ```cshtml
 @{
@@ -91,9 +91,9 @@ Add the *_ViewStart.cshtml* file to the RCL project's *Pages* folder to use the 
 
 An RCL may require companion static assets that can be referenced by either the RCL or the consuming app of the RCL. ASP.NET Core allows creating RCLs that include static assets that are available to a consuming app.
 
-To include companion assets as part of an RCL, create a *wwwroot* folder in the class library and include any required files in that folder.
+To include companion assets as part of an RCL, create a `wwwroot` folder in the class library and include any required files in that folder.
 
-When packing an RCL, all companion assets in the *wwwroot* folder are automatically included in the package.
+When packing an RCL, all companion assets in the `wwwroot` folder are automatically included in the package.
 
 Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack`.
 
@@ -101,7 +101,7 @@ Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack`.
 
 To exclude static assets, add the desired exclusion path to the `$(DefaultItemExcludes)` property group in the project file. Separate entries with a semicolon (`;`).
 
-In the following example, the *lib.css* stylesheet in the *wwwroot* folder isn't considered a static asset and isn't included in the published RCL:
+In the following example, the `lib.css` stylesheet in the `wwwroot` folder isn't considered a static asset and isn't included in the published RCL:
 
 ```xml
 <PropertyGroup>
@@ -113,9 +113,9 @@ In the following example, the *lib.css* stylesheet in the *wwwroot* folder isn't
 
 To include TypeScript files in an RCL:
 
-1. Place the TypeScript files (*.ts*) outside of the *wwwroot* folder. For example, place the files in a *Client* folder.
+1. Place the TypeScript files (`.ts`) outside of the `wwwroot` folder. For example, place the files in a `Client` folder.
 
-1. Configure the TypeScript build output for the *wwwroot* folder. Set the `TypescriptOutDir` property inside of a `PropertyGroup` in the project file:
+1. Configure the TypeScript build output for the `wwwroot` folder. Set the `TypescriptOutDir` property inside of a `PropertyGroup` in the project file:
 
    ```xml
    <TypescriptOutDir>wwwroot</TypescriptOutDir>
@@ -132,7 +132,7 @@ To include TypeScript files in an RCL:
 
 ### Consume content from a referenced RCL
 
-The files included in the *wwwroot* folder of the RCL are exposed to either the RCL or the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named *Razor.Class.Lib* results in a path to static content at `_content/Razor.Class.Lib/`. When producing a NuGet package and the assembly name isn't the same as the package ID, use the package ID for `{LIBRARY NAME}`.
+The files included in the `wwwroot` folder of the RCL are exposed to either the RCL or the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named `Razor.Class.Lib` results in a path to static content at `_content/Razor.Class.Lib/`. When producing a NuGet package and the assembly name isn't the same as the package ID ([`PackageId`](/nuget/create-packages/creating-a-package-msbuild#set-properties) in the library's project file), use the package ID for `{LIBRARY NAME}`.
 
 The consuming app references static assets provided by the library with `<script>`, `<style>`, `<img>`, and other HTML tags. The consuming app must have [static file support](xref:fundamentals/static-files) enabled in `Startup.Configure`:
 
@@ -147,7 +147,7 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 }
 ```
 
-When running the consuming app from build output (`dotnet run`), static web assets are enabled by default in the Development environment. To support assets in other environments when running from build output, call `UseStaticWebAssets` on the host builder in *Program.cs*:
+When running the consuming app from build output (`dotnet run`), static web assets are enabled by default in the Development environment. To support assets in other environments when running from build output, call `UseStaticWebAssets` on the host builder in `Program.cs`:
 
 ```csharp
 using Microsoft.AspNetCore.Hosting;
@@ -177,22 +177,23 @@ Calling `UseStaticWebAssets` isn't required when running an app from published o
 When the consuming app runs:
 
 * The assets in the RCL stay in their original folders. The assets aren't moved to the consuming app.
-* Any change within the RCL's *wwwroot* folder is reflected in the consuming app after the RCL is rebuilt and without rebuilding the consuming app.
+* Any change within the RCL's `wwwroot` folder is reflected in the consuming app after the RCL is rebuilt and without rebuilding the consuming app.
 
 When the RCL is built, a manifest is produced that describes the static web asset locations. The consuming app reads the manifest at runtime to consume the assets from referenced projects and packages. When a new asset is added to an RCL, the RCL must be rebuilt to update its manifest before a consuming app can access the new asset.
 
 ### Publish
 
-When the app is published, the companion assets from all referenced projects and packages are copied into the *wwwroot* folder of the published app under `_content/{LIBRARY NAME}/`.
+When the app is published, the companion assets from all referenced projects and packages are copied into the `wwwroot` folder of the published app under `_content/{LIBRARY NAME}/`. When producing a NuGet package and the assembly name isn't the same as the package ID ([`PackageId`](/nuget/create-packages/creating-a-package-msbuild#set-properties) in the library's project file), use the package ID for `{LIBRARY NAME}` when examining the `wwwroot` folder for the published assets.
 
 ## Additional resources
+
 * <xref:blazor/components/class-libraries>
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-3.0"
 
-Razor views, pages, controllers, page models, [Razor components](xref:blazor/components/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence.
+Razor views, pages, controllers, page models, [Razor components](xref:blazor/components/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (`.cshtml` file) in the web app takes precedence.
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/razor-pages/ui-class/samples) ([how to download](xref:index#how-to-download-a-sample))
 
@@ -224,14 +225,14 @@ For more information, see [dotnet new](/dotnet/core/tools/dotnet-new). To avoid 
 
 Add Razor files to the RCL.
 
-The ASP.NET Core templates assume the RCL content is in the *Areas* folder. See [RCL Pages layout](#rcl-pages-layout) to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
+The ASP.NET Core templates assume the RCL content is in the `Areas` folder. See [RCL Pages layout](#rcl-pages-layout) to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
 
 ## Reference RCL content
 
 The RCL can be referenced by:
 
 * NuGet package. See [Creating NuGet packages](/nuget/create-packages/creating-a-package) and [dotnet add package](/dotnet/core/tools/dotnet-add-package) and [Create and publish a NuGet package](/nuget/quickstart/create-and-publish-a-package-using-visual-studio).
-* *{ProjectName}.csproj*. See [dotnet-add reference](/dotnet/core/tools/dotnet-add-reference).
+* `{ProjectName}.csproj`. See [dotnet-add reference](/dotnet/core/tools/dotnet-add-reference).
 
 ## Walkthrough: Create an RCL project and use from a Razor Pages project
 
@@ -243,17 +244,17 @@ If you haven't downloaded the completed app and would rather create the walkthro
 
 # [Visual Studio](#tab/visual-studio)
 
-Open the *.sln* file in Visual Studio. Run the app.
+Open the `.sln` file in Visual Studio. Run the app.
 
 # [.NET Core CLI](#tab/netcore-cli)
 
-From a command prompt in the *cli* directory, build the RCL and web app.
+From a command prompt in the `cli` directory, build the RCL and web app.
 
 ```dotnetcli
 dotnet build
 ```
 
-Move to the *WebApp1* directory and run the app:
+Move to the `WebApp1` directory and run the app:
 
 ```dotnetcli
 dotnet run
@@ -276,7 +277,7 @@ Create the RCL project:
 * Name the app **RazorUIClassLib** > **OK**.
 * Verify **ASP.NET Core 2.1** or later is selected.
 * Select **Razor Class Library** > **OK**.
-* Add a Razor partial view file named *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml*.
+* Add a Razor partial view file named `RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml`.
 
 # [.NET Core CLI](#tab/netcore-cli)
 
@@ -292,29 +293,29 @@ The preceding commands:
 
 * Creates the `RazorUIClassLib` RCL.
 * Creates a Razor _Message page, and adds it to the RCL. The `-np` parameter creates the page without a `PageModel`.
-* Creates a [_ViewStart.cshtml](xref:mvc/views/layout#running-code-before-each-view) file and adds it to the RCL.
+* Creates a [`_ViewStart.cshtml`](xref:mvc/views/layout#running-code-before-each-view) file and adds it to the RCL.
 
-The *_ViewStart.cshtml* file is required to use the layout of the Razor Pages project (which is added in the next section).
+The `_ViewStart.cshtml` file is required to use the layout of the Razor Pages project (which is added in the next section).
 
 ---
 
 ### Add Razor files and folders to the project
 
-* Replace the markup in *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml* with the following code:
+* Replace the markup in `RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml` with the following code:
 
   [!code-cshtml[](ui-class/samples/cli/RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml)]
 
-* Replace the markup in *RazorUIClassLib/Areas/MyFeature/Pages/Page1.cshtml* with the following code:
+* Replace the markup in `RazorUIClassLib/Areas/MyFeature/Pages/Page1.cshtml` with the following code:
 
   [!code-cshtml[](ui-class/samples/cli/RazorUIClassLib/Areas/MyFeature/Pages/Page1.cshtml)]
 
-  `@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers` is required to use the partial view (`<partial name="_Message" />`). Rather than including the `@addTagHelper` directive, you can add a *_ViewImports.cshtml* file. For example:
+  `@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers` is required to use the partial view (`<partial name="_Message" />`). Rather than including the `@addTagHelper` directive, you can add a `_ViewImports.cshtml` file. For example:
 
   ```dotnetcli
   dotnet new viewimports -o RazorUIClassLib/Areas/MyFeature/Pages
   ```
 
-  For more information on *_ViewImports.cshtml*, see [Importing Shared Directives](xref:mvc/views/layout#importing-shared-directives)
+  For more information on `_ViewImports.cshtml`, see [Importing Shared Directives](xref:mvc/views/layout#importing-shared-directives)
 
 * Build the class library to verify there are no compiler errors:
 
@@ -322,7 +323,7 @@ The *_ViewStart.cshtml* file is required to use the layout of the Razor Pages pr
   dotnet build RazorUIClassLib
   ```
 
-The build output contains *RazorUIClassLib.dll* and *RazorUIClassLib.Views.dll*. *RazorUIClassLib.Views.dll* contains the compiled Razor content.
+The build output contains `RazorUIClassLib.dll` and `RazorUIClassLib.Views.dll`. `RazorUIClassLib.Views.dll` contains the compiled Razor content.
 
 ### Use the Razor UI library from a Razor Pages project
 
@@ -371,20 +372,20 @@ Browse to `/MyFeature/Page1` to verify that the Razor UI class library is in use
 
 ## Override views, partial views, and pages
 
-When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence. For example, add *WebApp1/Areas/MyFeature/Pages/Page1.cshtml* to WebApp1, and Page1 in the WebApp1 will take precedence over Page1 in the RCL.
+When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (`.cshtml` file) in the web app takes precedence. For example, add `WebApp1/Areas/MyFeature/Pages/Page1.cshtml` to WebApp1, and Page1 in the WebApp1 will take precedence over Page1 in the RCL.
 
-In the sample download, rename *WebApp1/Areas/MyFeature2* to *WebApp1/Areas/MyFeature* to test precedence.
+In the sample download, rename `WebApp1/Areas/MyFeature2` to `WebApp1/Areas/MyFeature` to test precedence.
 
-Copy the *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml* partial view to *WebApp1/Areas/MyFeature/Pages/Shared/_Message.cshtml*. Update the markup to indicate the new location. Build and run the app to verify the app's version of the partial is being used.
+Copy the `RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml` partial view to `WebApp1/Areas/MyFeature/Pages/Shared/_Message.cshtml`. Update the markup to indicate the new location. Build and run the app to verify the app's version of the partial is being used.
 
 ### RCL Pages layout
 
-To reference RCL content as though it is part of the web app's *Pages* folder, create the RCL project with the following file structure:
+To reference RCL content as though it is part of the web app's `Pages` folder, create the RCL project with the following file structure:
 
-* *RazorUIClassLib/Pages*
-* *RazorUIClassLib/Pages/Shared*
+* `RazorUIClassLib/Pages`
+* `RazorUIClassLib/Pages/Shared`
 
-Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.cshtml* and *_Footer.cshtml*. The `<partial>` tags could be added to *_Layout.cshtml* file:
+Suppose `RazorUIClassLib/Pages/Shared` contains two partial files: `_Header.cshtml` and `_Footer.cshtml`. The `<partial>` tags could be added to `_Layout.cshtml` file:
 
 ```cshtml
 <body>
@@ -397,8 +398,9 @@ Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.csht
 ::: moniker-end
 
 ::: moniker range=">= aspnetcore-5.0"
+
 <!-- Start update here -->
-Razor views, pages, controllers, page models, [Razor components](xref:blazor/components/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence.
+Razor views, pages, controllers, page models, [Razor components](xref:blazor/components/class-libraries), [View components](xref:mvc/views/view-components), and data models can be built into a Razor class library (RCL). The RCL can be packaged and reused. Applications can include the RCL and override the views and pages it contains. When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (`.cshtml` file) in the web app takes precedence.
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/razor-pages/ui-class/samples) ([how to download](xref:index#how-to-download-a-sample))
 
@@ -429,22 +431,22 @@ For more information, see [dotnet new](/dotnet/core/tools/dotnet-new). To avoid 
 
 Add Razor files to the RCL.
 
-The ASP.NET Core templates assume the RCL content is in the *Areas* folder. See [RCL Pages layout](#rcl-lay) below to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
+The ASP.NET Core templates assume the RCL content is in the `Areas` folder. See [RCL Pages layout](#rcl-lay) below to create an RCL that exposes content in `~/Pages` rather than `~/Areas/Pages`.
 
 ## Reference RCL content
 
 The RCL can be referenced by:
 
 * NuGet package. See [Creating NuGet packages](/nuget/create-packages/creating-a-package) and [dotnet add package](/dotnet/core/tools/dotnet-add-package) and [Create and publish a NuGet package](/nuget/quickstart/create-and-publish-a-package-using-visual-studio).
-* *{ProjectName}.csproj*. See [dotnet-add reference](/dotnet/core/tools/dotnet-add-reference).
+* `{ProjectName}.csproj`. See [dotnet-add reference](/dotnet/core/tools/dotnet-add-reference).
 
 ## Override views, partial views, and pages
 
-When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (*.cshtml* file) in the web app takes precedence. For example, add *WebApp1/Areas/MyFeature/Pages/Page1.cshtml* to WebApp1, and Page1 in the WebApp1 will take precedence over Page1 in the RCL.
+When a view, partial view, or Razor Page is found in both the web app and the RCL, the Razor markup (`.cshtml` file) in the web app takes precedence. For example, add `WebApp1/Areas/MyFeature/Pages/Page1.cshtml` to WebApp1, and Page1 in the WebApp1 will take precedence over Page1 in the RCL.
 
-In the sample download, rename *WebApp1/Areas/MyFeature2* to *WebApp1/Areas/MyFeature* to test precedence.
+In the sample download, rename `WebApp1/Areas/MyFeature2` to `WebApp1/Areas/MyFeature` to test precedence.
 
-Copy the *RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml* partial view to *WebApp1/Areas/MyFeature/Pages/Shared/_Message.cshtml*. Update the markup to indicate the new location. Build and run the app to verify the app's version of the partial is being used.
+Copy the `RazorUIClassLib/Areas/MyFeature/Pages/Shared/_Message.cshtml` partial view to `WebApp1/Areas/MyFeature/Pages/Shared/_Message.cshtml`. Update the markup to indicate the new location. Build and run the app to verify the app's version of the partial is being used.
 
 If the RCL uses Razor Pages, enable the Razor Pages services and endpoints in the hosting app:
 
@@ -454,12 +456,12 @@ If the RCL uses Razor Pages, enable the Razor Pages services and endpoints in th
 
 ### RCL Pages layout
 
-To reference RCL content as though it is part of the web app's *Pages* folder, create the RCL project with the following file structure:
+To reference RCL content as though it is part of the web app's `Pages` folder, create the RCL project with the following file structure:
 
-* *RazorUIClassLib/Pages*
-* *RazorUIClassLib/Pages/Shared*
+* `RazorUIClassLib/Pages`
+* `RazorUIClassLib/Pages/Shared`
 
-Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.cshtml* and *_Footer.cshtml*. The `<partial>` tags could be added to *_Layout.cshtml* file:
+Suppose `RazorUIClassLib/Pages/Shared` contains two partial files: `_Header.cshtml` and `_Footer.cshtml`. The `<partial>` tags could be added to `_Layout.cshtml` file:
 
 ```cshtml
 <body>
@@ -469,7 +471,7 @@ Suppose *RazorUIClassLib/Pages/Shared* contains two partial files: *_Header.csht
 </body>
 ```
 
-Add the *_ViewStart.cshtml* file to the RCL project's *Pages* folder to use the *_Layout.cshtml* file from the host web app:
+Add the `_ViewStart.cshtml` file to the RCL project's `Pages` folder to use the `_Layout.cshtml` file from the host web app:
 
 ```cshtml
 @{
@@ -481,9 +483,9 @@ Add the *_ViewStart.cshtml* file to the RCL project's *Pages* folder to use the 
 
 An RCL may require companion static assets that can be referenced by either the RCL or the consuming app of the RCL. ASP.NET Core allows creating RCLs that include static assets that are available to a consuming app.
 
-To include companion assets as part of an RCL, create a *wwwroot* folder in the class library and include any required files in that folder.
+To include companion assets as part of an RCL, create a `wwwroot` folder in the class library and include any required files in that folder.
 
-When packing an RCL, all companion assets in the *wwwroot* folder are automatically included in the package.
+When packing an RCL, all companion assets in the `wwwroot` folder are automatically included in the package.
 
 Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack`.
 
@@ -491,7 +493,7 @@ Use the `dotnet pack` command rather than the NuGet.exe version `nuget pack`.
 
 To exclude static assets, add the desired exclusion path to the `$(DefaultItemExcludes)` property group in the project file. Separate entries with a semicolon (`;`).
 
-In the following example, the *lib.css* stylesheet in the *wwwroot* folder isn't considered a static asset and isn't included in the published RCL:
+In the following example, the `lib.css` stylesheet in the `wwwroot` folder isn't considered a static asset and isn't included in the published RCL:
 
 ```xml
 <PropertyGroup>
@@ -503,9 +505,9 @@ In the following example, the *lib.css* stylesheet in the *wwwroot* folder isn't
 
 To include TypeScript files in an RCL:
 
-1. Place the TypeScript files (*.ts*) outside of the *wwwroot* folder. For example, place the files in a *Client* folder.
+1. Place the TypeScript files (`.ts`) outside of the `wwwroot` folder. For example, place the files in a `Client` folder.
 
-1. Configure the TypeScript build output for the *wwwroot* folder. Set the `TypescriptOutDir` property inside of a `PropertyGroup` in the project file:
+1. Configure the TypeScript build output for the `wwwroot` folder. Set the `TypescriptOutDir` property inside of a `PropertyGroup` in the project file:
 
    ```xml
    <TypescriptOutDir>wwwroot</TypescriptOutDir>
@@ -522,7 +524,7 @@ To include TypeScript files in an RCL:
 
 ### Consume content from a referenced RCL
 
-The files included in the *wwwroot* folder of the RCL are exposed to either the RCL or the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named *Razor.Class.Lib* results in a path to static content at `_content/Razor.Class.Lib/`. When producing a NuGet package and the assembly name isn't the same as the package ID, use the package ID for `{LIBRARY NAME}`.
+The files included in the `wwwroot` folder of the RCL are exposed to either the RCL or the consuming app under the prefix `_content/{LIBRARY NAME}/`. For example, a library named `Razor.Class.Lib` results in a path to static content at `_content/Razor.Class.Lib/`. When producing a NuGet package and the assembly name isn't the same as the package ID ([`PackageId`](/nuget/create-packages/creating-a-package-msbuild#set-properties) in the library's project file), use the package ID for `{LIBRARY NAME}`.
 
 The consuming app references static assets provided by the library with `<script>`, `<style>`, `<img>`, and other HTML tags. The consuming app must have [static file support](xref:fundamentals/static-files) enabled in `Startup.Configure`:
 
@@ -537,7 +539,7 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
 }
 ```
 
-When running the consuming app from build output (`dotnet run`), static web assets are enabled by default in the Development environment. To support assets in other environments when running from build output, call `UseStaticWebAssets` on the host builder in *Program.cs*:
+When running the consuming app from build output (`dotnet run`), static web assets are enabled by default in the Development environment. To support assets in other environments when running from build output, call `UseStaticWebAssets` on the host builder in `Program.cs`:
 
 ```csharp
 using Microsoft.AspNetCore.Hosting;
@@ -567,16 +569,17 @@ Calling `UseStaticWebAssets` isn't required when running an app from published o
 When the consuming app runs:
 
 * The assets in the RCL stay in their original folders. The assets aren't moved to the consuming app.
-* Any change within the RCL's *wwwroot* folder is reflected in the consuming app after the RCL is rebuilt and without rebuilding the consuming app.
+* Any change within the RCL's `wwwroot` folder is reflected in the consuming app after the RCL is rebuilt and without rebuilding the consuming app.
 
 When the RCL is built, a manifest is produced that describes the static web asset locations. The consuming app reads the manifest at runtime to consume the assets from referenced projects and packages. When a new asset is added to an RCL, the RCL must be rebuilt to update its manifest before a consuming app can access the new asset.
 
 ### Publish
 
-When the app is published, the companion assets from all referenced projects and packages are copied into the *wwwroot* folder of the published app under `_content/{LIBRARY NAME}/`.
+When the app is published, the companion assets from all referenced projects and packages are copied into the `wwwroot` folder of the published app under `_content/{LIBRARY NAME}/`. When producing a NuGet package and the assembly name isn't the same as the package ID ([`PackageId`](/nuget/create-packages/creating-a-package-msbuild#set-properties) in the library's project file), use the package ID for `{LIBRARY NAME}` when examining the `wwwroot` folder for the published assets.
 
 ## Additional resources
-* <xref:blazor/components/class-libraries>
+
+* <xref:blazor/components/class-libraries
 * <xref:blazor/components/css-isolation#razor-class-library-rcl-support>
 
 ::: moniker-end


### PR DESCRIPTION
Fixes #23070

Let's see :eye: how this looks. We had some coverage for it, but it was rather weak. Many spots didn't mention it.

I also perform some code-fencing of mostly filenames here.