### PR TITLE
Package ID updates

### DIFF
--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -47,7 +47,7 @@ h1 {
 
 ## CSS isolation bundling
 
-CSS isolation occurs at build time. Blazor rewrites CSS selectors to match markup rendered by the component. The rewritten CSS styles are bundled and produced as a static asset. The stylesheet is referenced inside the `<head>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server). The following `<link>` element is added by default to an app created from the Blazor project templates, where the placeholder `{ASSEMBLY NAME}` is the project's assembly name:
+CSS isolation occurs at build time. Blazor rewrites CSS selectors to match markup rendered by the component. The rewritten CSS styles are bundled and produced as a static asset. The stylesheet is referenced inside the `<head>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server). The following `<link>` element is added by default to an app created from the Blazor project templates, where the placeholder `{ASSEMBLY NAME}` is the project's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties):
 
 ```html
 <link href="{ASSEMBLY NAME}.styles.css" rel="stylesheet">
@@ -203,7 +203,7 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 When a [Razor class library (RCL)](xref:razor-pages/ui-class) provides isolated styles, the `<link>` tag's `href` attribute points to `{STATIC WEB ASSET BASE PATH}/{ASSEMBLY NAME}.bundle.scp.css`, where the placeholders are:
 
 * `{STATIC WEB ASSET BASE PATH}`: The static web asset base path.
-* `{ASSEMBLY NAME}`: The class library's assembly name.
+* `{ASSEMBLY NAME}`: The class library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties).
 
 In the following example:
 
@@ -257,7 +257,7 @@ h1 {
 
 ## CSS isolation bundling
 
-CSS isolation occurs at build time. Blazor rewrites CSS selectors to match markup rendered by the component. The rewritten CSS styles are bundled and produced as a static asset. The stylesheet is referenced inside the `<head>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server). The following `<link>` element is added by default to an app created from the Blazor project templates, where the placeholder `{ASSEMBLY NAME}` is the project's assembly name:
+CSS isolation occurs at build time. Blazor rewrites CSS selectors to match markup rendered by the component. The rewritten CSS styles are bundled and produced as a static asset. The stylesheet is referenced inside the `<head>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server). The following `<link>` element is added by default to an app created from the Blazor project templates, where the placeholder `{ASSEMBLY NAME}` is the project's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties).:
 
 ```html
 <link href="{ASSEMBLY NAME}.styles.css" rel="stylesheet">
@@ -413,7 +413,7 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 When a [Razor class library (RCL)](xref:razor-pages/ui-class) provides isolated styles, the `<link>` tag's `href` attribute points to `{STATIC WEB ASSET BASE PATH}/{ASSEMBLY NAME}.bundle.scp.css`, where the placeholders are:
 
 * `{STATIC WEB ASSET BASE PATH}`: The static web asset base path.
-* `{ASSEMBLY NAME}`: The class library's assembly name.
+* `{ASSEMBLY NAME}`: The class library's assembly name or [NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties).
 
 In the following example:
 


### PR DESCRIPTION
Addresses #23070
Addresses https://github.com/dotnet/aspnetcore/issues/35587

Javier ...

> That's an error on the docs, it's always the package Id that is used.

I think you mean "always" **_for a package_** (and **_if specified_**) ... are those a correct interpretations of your remark?

The docs were too focused on a non-packaged library before I put this PR up and #23070 went in last week.

Let's go over the updates across these two PRs to make sure that we're on the same page. The current approach for docs is ...

* Leave the language: "`{LIBRARY NAME}` placeholder is the library's assembly name"
* Add the following language to it: "or \[NuGet `PackageId` (if specified)](/nuget/create-packages/creating-a-package-msbuild#set-properties)"

... because ...

* There isn't a package produced for a library merely added to a solution (i.e., `<PackageId>` has no influence on static asset paths in this case).
* The `<PackageId>` for packages is used for the library name (and paths) but defaults to the assembly name if not specified.

Is this all ok with you?