### PR TITLE
Generalize skip render remark

### DIFF
--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -26,7 +26,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* All of the parameter values are of known immutable primitive types, such as `int`, `string`, `DateTime`, and haven't changed since the previous set of parameters were set.
+* All of the parameter values, except for complex types, haven't changed since the previous set of parameters were set.
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
 
 ## Control the rendering flow
@@ -121,7 +121,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* All of the parameter values are of known immutable primitive types, such as `int`, `string`, `DateTime`, and haven't changed since the previous set of parameters were set.
+* All of the parameter values, except for complex types, haven't changed since the previous set of parameters were set.
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
 
 ## Control the rendering flow
@@ -216,7 +216,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* All of the parameter values are of known immutable primitive types, such as `int`, `string`, `DateTime`, and haven't changed since the previous set of parameters were set.
+* All of the parameter values, except for complex types, haven't changed since the previous set of parameters were set.
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
 
 ## Control the rendering flow


### PR DESCRIPTION
Addresses #23084

Steve, can I generalize your remark? `DateTime` is a struct, and other unmanaged and reference types (e.g., enums, records) aren't mentioned. If not, do you want to stick with what you have or modify it here?

I'll circle around after 6.0 GA to see if we need further updates (here and elsewhere). This PR is merely a quick fix for this one bit of phrasing.

Thanks @szalapski :rocket: ... This will leave your issue open until I can get back to this subject. Thanks for commenting.