### PR TITLE
Update docfx.json

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -67,7 +67,7 @@
       },
       "recommendations": {
         "**/tutorials/**/**.md": "false"
-      },
+      }
     },
     "template": [],
     "dest": "_site",


### PR DESCRIPTION
Fixes #23128

As long as they're in some top-level or nested folder named `tutorials`, this should work.

The lingering Version by File bits were harmless ... this just cleans those up.