### PR TITLE
Update the usage of ObjectPool's Return()

### DIFF
--- a/aspnetcore/performance/ObjectPool.md
+++ b/aspnetcore/performance/ObjectPool.md
@@ -63,7 +63,7 @@ When <xref:Microsoft.Extensions.ObjectPool.DefaultObjectPoolProvider> is used an
 NOTE: After the pool is disposed:
 
 * Calling `Get` throws a `ObjectDisposedException`.
-* `Return` disposes the given item.
+* Calling `Return` disposes the given item.
 
 ::: moniker-end
 


### PR DESCRIPTION
Otherwise it might be read like the `return` keyword.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->