### PR TITLE
Fix nginx upstream config for SignalR

### DIFF
--- a/aspnetcore/signalr/scale.md
+++ b/aspnetcore/signalr/scale.md
@@ -153,9 +153,9 @@ With [Nginx Open Source](https://nginx.org/en/), use `ip_hash` to route connecti
 http {
   upstream backend {
     # App server 1
-    server http://localhost:5000;
+    server localhost:5000;
     # App server 2
-    server http://localhost:5002;
+    server localhost:5002;
 
     ip_hash;
   }
@@ -168,9 +168,9 @@ With [Nginx Plus](https://www.nginx.com/products/nginx), use `sticky` to add a c
 http {
   upstream backend {
     # App server 1
-    server http://localhost:5000;
+    server localhost:5000;
     # App server 2
-    server http://localhost:5002;
+    server localhost:5002;
 
     sticky cookie srv_id expires=max domain=.example.com path=/ httponly;
   }


### PR DESCRIPTION
If "http://" is added in front of the host, it will report an error
![image](https://user-images.githubusercontent.com/22719048/131099467-05ec435e-6e80-476b-a358-4a3355417b47.png)