### PR TITLE
Removing statement about tooling maturity for Blazor WebAssembly

### DIFF
--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -40,7 +40,6 @@ The Blazor WebAssembly hosting model has the following limitations:
 * The app is restricted to the capabilities of the browser.
 * Capable client hardware and software (for example, WebAssembly support) is required.
 * Download size is larger, and apps take longer to load.
-* .NET runtime and tooling support is less mature. For example, limitations exist in [.NET Standard](/dotnet/standard/net-standard) support and debugging.
 
 To create a Blazor WebAssembly app, see <xref:blazor/tooling>.
 


### PR DESCRIPTION
Blazor WebAssembly has now shipped multiple releases and the tooling has come a long way. It's a fully supported part of .NET and shouldn't be referred to as an immature technology.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->