### PR TITLE
publish when RC1 is shipped on the 14th: Update HTTP3 Sample for RC1

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/http3.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http3.md
@@ -39,7 +39,7 @@ For example, `HttpProtocols.Http1AndHttp2AndHttp3` allows Kestrel to enable HTTP
 
 ### Windows
 
-* Windows 11 Build 22000 or later.
+* Windows 11 Build 22000 or later OR Windows Server 2022.
 * TLS 1.3 or later connection.
 
 The preceding Windows 11 Build versions may require the use of a [Windows Insider](https://insider.windows.com) build.

--- a/aspnetcore/fundamentals/servers/kestrel/http3.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http3.md
@@ -62,13 +62,7 @@ HTTP/3 is discovered as an upgrade from HTTP/1.1 or HTTP/2 via the `alt-svc` hea
 
 ## Get started
 
-HTTP/3 is configured on app start-up. The following code:
-
-* Configures the `WebHost` to `UseQuic`.
-* Sets `EnableAltSvc` to `true` on Kestrel options.
-* Configures port 5001 to use `HttpProtocols.Http1AndHttp2AndHttp3`.
-
-This sample code is specific to .NET 6 Preview 7, and will change in .NET 6 RC 1.
+HTTP/3 is configured on app start-up. The following code configures port 5001 to use `HttpProtocols.Http1AndHttp2AndHttp3`.
 
 [!code-csharp[](samples/6.x/Http3Sample/Program.cs?name=snippet_UseHttp3&highlight=8)]
 

--- a/aspnetcore/fundamentals/servers/kestrel/samples/6.x/Http3Sample/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/6.x/Http3Sample/Program.cs
@@ -13,16 +13,9 @@ namespace Http3Sample
         public static async Task Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
-            builder.WebHost.UseKestrel()
-            // Set up QUIC options
-            .UseQuic(options =>
-            {
-                options.Alpn = "h3-29";
-                options.IdleTimeout = TimeSpan.FromMinutes(1);
-            })
+            builder.WebHost
             .ConfigureKestrel((context, options) =>
             {
-                options.EnableAltSvc = true;
                 options.Listen(IPAddress.Any, 5001, listenOptions =>
                 {
                     // Use HTTP/3


### PR DESCRIPTION
Reflects the more streamlined behavior. We should publish this when RC1 is shipped on the 14th, and reference it from https://github.com/aspnet/specs/pull/602 (CC @danroth27).

Fixes https://github.com/dotnet/aspnetcore/issues/34488