### PR TITLE
Blazor IdS custom domains and token signing

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -1064,6 +1064,7 @@ The guidance in this section explains:
 1. Create a new Azure Key Vault or use an existing key vault in your Azure subscription.
 
 1. Navigate to Azure App Service in the Azure portal and create a new App Service with the following configuration:
+
    * **Publish** set to `Code`.
    * **Runtime stack** set to the app's runtime.
    * For **Sku and size**, confirm that the App Service tier is `Basic B1` or higher if you also plan to use a custom domain. App Service requires a `Basic B1` or higher service tier to use custom domains.
@@ -1083,6 +1084,7 @@ The guidance in this section explains:
    No configuration changes to the default settings are required for the key vault service.
 
    For testing purposes, an app's local [SQLite](https://www.sqlite.org/index.html) database, which is configured by default by the Blazor template, can be deployed with the app without additional configuration. Configuring a different database for Identity Server in production is beyond the scope of this article. For more information, see the database resources in the following documentation sets:
+
    * [App Service](/azure/app-service/)
    * [Identity Server](https://docs.duendesoftware.com/identityserver/v5/overview/)
 
@@ -1141,14 +1143,18 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
    For more information on Azure Key Vault certificates, see [Azure Key Vault: Certificates](/azure/key-vault/certificates/).
 
 1. Navigate to Azure App Service in the Azure portal and create a new App Service with the following configuration:
+
    * **Publish** set to `Code`.
    * **Runtime stack** set to the app's runtime.
    * For **Sku and size**, confirm that the App Service tier is `Basic B1` or higher.  App Service requires a `Basic B1` or higher service tier to use custom domains.
+
 1. After Azure creates the App Service, open the app's **Configuration** and add a new application setting specifying the certificate thumbprint recorded earlier. The app setting key is `WEBSITE_LOAD_CERTIFICATES`:
+
    * Key: `WEBSITE_LOAD_CERTIFICATES`
    * Value: `57443A552A46DB...D55E28D412B943565`
 
    In the Azure portal, saving app settings is a two-step process: Save the `WEBSITE_LOAD_CERTIFICATES` key-value setting, then select the **Save** button at the top of the blade.
+
 1. Select the app's **TLS/SSL settings**. Select **Private Key Certificates (.pfx)**. Use the **Import Key Vault Certificate** process to import the site's self-signed Identity Server token signing certificate.
 
 1. Configure the app to use the token signing certificate based on your choice of host OS, either Windows App Service or Linux App Service:
@@ -1192,18 +1198,20 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
    In `Startup.ConfigureServices`, update the Identity Server configuration to use a manually-loaded certificate. In the following example, the `{THUMBPRINT}` placeholder is the certificate's thumbprint:
 
    ```csharp
-   try
+   var certPath = "/var/ssl/private/{THUMBPRINT}.p12";
+
+   if (File.Exists(certPath))
    {
-       var bytes = File.ReadAllBytes($"/var/ssl/private/{THUMBPRINT}.p12");
+       var bytes = File.ReadAllBytes(certPath);
        var certificate = new X509Certificate2(bytes);
 
        services.AddIdentityServer()
            .AddApiAuthorization<ApplicationUser, ApplicationDbContext>(options => { })
            .AddSigningCredential(certificate);
    }
-   catch (FileNotFoundException)
+   else
    {
-       throw new Exception("The certificate could not be found.");
+       throw new FileNotFoundException($"Certificate path: {certPath}.");
    }
    ```
 
@@ -1214,6 +1222,7 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
    No configuration changes to the default settings are required for the key vault service.
 
    For testing purposes, an app's local [SQLite](https://www.sqlite.org/index.html) database, which is configured by default by the Blazor template, can be deployed with the app without additional configuration. Configuring a different database for Identity Server in production is beyond the scope of this article. For more information, see the database resources in the following documentation sets:
+
    * [App Service](/azure/app-service/)
    * [Identity Server](https://docs.duendesoftware.com/identityserver/v5/overview/)
 
@@ -1240,6 +1249,7 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
 1. Use an [App Service plan](/azure/app-service/overview-hosting-plans) with an plan level of `Basic B1` or higher. App Service requires a `Basic B1` or higher service tier to use custom domains.
 
 1. Create a PFX certificate for the site's secure browser communication (HTTPS protocol) with a common name of the site's fully qualified domain name (FQDN) that your organization controls (for example, `www.contoso.com`). Create the certificate with:
+
    * Key uses
      * Digital signature validation (`digitalSignature`)
      * Key encipherment (`keyEncipherment`)
@@ -1264,6 +1274,7 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
 1. In Azure App Service in the Azure portal for **Sku and size**, confirm that the App Service tier is `Basic B1` or higher. App Service requires a `Basic B1` or higher service tier to use custom domains.
 
 1. Open the app's **Configuration** in App Service and add a new application setting with a key of `WEBSITE_LOAD_CERTIFICATES` (if it doesn't already exist) or modify the existing `WEBSITE_LOAD_CERTIFICATES` application setting. Specify the certificate thumbprint of the TLS certificate recorded earlier:
+
    * When using automatic token signing, there is only a single thumbprint for the HTTPS communication. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565`
    * When using a separate token signing certificate, there are two thumbprints for the setting with thumbprint values separated by a comman. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565,29F43A772CB6AF...1D04F0C67F85FB0B1`
 
@@ -1272,6 +1283,7 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
 1. Select the app's **TLS/SSL settings**. Select **Private Key Certificates (.pfx)**. Use the **Import Key Vault Certificate** process to import the site's certificate for HTTPS communication.
 
 1. Navigate to the **Custom domains** blade. At your domain registrar's website, use the **IP address** and **Custom Domain Verification ID** to configure the domain. A typical domain configuration includes:
+
    * An **A Record** with a **Host** of `@` and a value of the IP address from the Azure portal.
    * A **TXT Record** with a **Host** of `asuid` and the value of the verification ID generated by Azure and provided by the Azure portal.
 

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -1041,9 +1041,14 @@ In the **`Client`** app, component authorization approaches are functional at th
 
 ## Token signing scenarios with Azure App Service
 
+Two scenarios are covered. Follow the guidance in either **one** of the following sections:
+
+* [Host in Azure App Service with automatic token signing and Data Protection key security using Azure Key Vault](#host-in-azure-app-service-with-automatic-token-signing-and-data-protection-key-security-using-azure-key-vault)
+* [Host in Azure App Service with certificate token signing](#host-in-azure-app-service-with-certificate-token-signing)
+
 ### Host in Azure App Service with automatic token signing and Data Protection key security using Azure Key Vault
 
-The following guidance explains:
+The guidance in this section explains:
 
 * How to deploy a hosted Blazor WebAssembly app with Identity Server to [Azure App Service](https://azure.microsoft.com/services/app-service/).
 * How to use automatic Identity Server token signing with Data Protection keys secured by Azure Key Vault.
@@ -1094,7 +1099,7 @@ When App Service configuration is changed in the Azure portal, the updates gener
 
 ### Host in Azure App Service with certificate token signing
 
-The following guidance explains:
+The guidance in this section explains:
 
 * How to deploy a hosted Blazor WebAssembly app with Identity Server to [Azure App Service](https://azure.microsoft.com/services/app-service/).
 * How to create and use a TLS certificate for Identity Server token signing.
@@ -1104,15 +1109,15 @@ The following guidance explains:
 
 In the following guidance, a self-signed certificate is created in Azure Key Vault solely for Identity Server token signing. The Identity Server configuration uses the key vault certificate following different approaches for **Windows** App Service and **Linux** App Service:
 
-* **Windows** App Service: The app's `My` > `CurrentUser` certificate store is accessed by the app.
-* **Linux** App Service: The app loads the certificate manually using a Key Vault Client.
+* **Windows** App Service: The app's `My` > `CurrentUser` certificate store is accessed by the app to load the certificate.
+* **Linux** App Service: The app loads the certificate manually.
 
 > [!WARNING]
 > When seeking to use a certificate for Identity Server token signing and a custom domain, do **not** use the same certificate for Identity Server's token signing and the site's HTTPS secure communication with browsers:
 >
 > * Using different certificates for these two requirements is a good security practice because it isolates private keys for each purpose.
 > * TLS certificates for communication with browsers is managed independently without affecting Identity Server's token signing.
-> * When [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) supplies a certificate to an App Service app for custom domain binding, Identity Server can't obtain the same certificate from Azure Key Vault for token signing. Although configuring Identity Server to use the same TLS certificate from a physical path is possible, placing security certificates into source control is a **poor practice and should be avoided in most scenarios**.
+> * When [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) supplies a certificate to an App Service app for custom domain binding, Identity Server can't obtain the same certificate from Azure Key Vault for token signing. Although configuring Identity Server to use the same TLS certificate from a physical path is possible, placing security certificates into source control is a poor practice and should be avoided in most scenarios.
 
 To configure an app, Azure App Service, and Azure Key Vault to host with a custom token signing certificate:
 
@@ -1174,9 +1179,9 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
 
    **Linux App Service**
 
-   Linux doesn't use a Windows certificate store to load a TLS certificate. On Linux App Service, certificates are placed at the path `/var/ssl/private/`. Manually load and use the certificate from that path for Identity Server token signing.
+   Linux can't use a Windows certificate store to load a TLS certificate. On Linux App Service, certificates are placed at the path `/var/ssl/private/`. Manually load and use the certificate from the preceding path.
 
-   Add the following namespaces to the top of `Startup.cs` in the **Server** project if they don't exist:
+   If the following namespaces aren't already present at the top of `Startup.cs` in the **Server** project, add them to the file:
 
    ```csharp
    using System;
@@ -1198,11 +1203,12 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
    }
    catch (FileNotFoundException)
    {
-       throw new Exception($"The certificate could not be found.");
+       throw new Exception("The certificate could not be found.");
    }
    ```
 
 1. In Visual Studio, create an Azure App Service [publish profile](xref:host-and-deploy/visual-studio-publish-profiles#publish-profiles) for the *Server* project. From the menu bar, select: **Build** > **Publish** > **New** > **Azure** > **Azure App Service** (Windows or Linux). When Visual Studio is connected to an Azure subscription, you can set the **View** of Azure resources by **Resource type**. Navigate within the **Web App** list to find the App Service for the app and select it. Select **Finish**.
+
 1. When Visual Studio returns to the **Publish** window, the key vault and SQL Server database service dependencies are automatically detected.
 
    No configuration changes to the default settings are required for the key vault service.
@@ -1224,10 +1230,7 @@ When App Service configuration is changed in the Azure portal, the updates gener
 
 ## Use a custom domain and TLS certificate for HTTPS protocol communication in Azure App Service
 
-The following guidance explains:
-
-* How to use a custom domain  hosted Blazor WebAssembly app with Identity Server to [Azure App Service](https://azure.microsoft.com/services/app-service/) with a custom domain.
-* How to create and use a TLS certificate for HTTPS protocol communication with browsers for an app that has been deployed to Azure App Service. Although the guidance focuses on using the certificate with a custom domain, the guidance is equally applicable to using a default Azure Apps domain, for example `contoso.azurewebsites.net`.
+The guidance in this section explains how to create and use a TLS certificate for HTTPS protocol communication with browsers for an app that has been deployed to [Azure App Service](https://azure.microsoft.com/services/app-service/). Although the guidance focuses on using the certificate with a custom domain, the guidance is equally applicable to using a default Azure Apps domain, for example, `contoso.azurewebsites.net`.
 
 > [!NOTE]
 > The guidance in this section assumes that the app is already hosted in Azure App Service. If deploying to App Service for the first time, follow the guidance in the [Token signing scenarios with Azure App Service](#token-signing-scenarios-with-azure-app-service) section before using the guidance in this section.
@@ -1235,6 +1238,7 @@ The following guidance explains:
 To configure an app, Azure App Service, and Azure Key Vault to host with a custom domain and HTTPS:
 
 1. Use an [App Service plan](/azure/app-service/overview-hosting-plans) with an plan level of `Basic B1` or higher. App Service requires a `Basic B1` or higher service tier to use custom domains.
+
 1. Create a PFX certificate for the site's secure browser communication (HTTPS protocol) with a common name of the site's fully qualified domain name (FQDN) that your organization controls (for example, `www.contoso.com`). Create the certificate with:
    * Key uses
      * Digital signature validation (`digitalSignature`)
@@ -1252,23 +1256,31 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
    Make note of the password, which is used later to import the certificate into Azure Key Vault.
 
    For more information on Azure Key Vault certificates, see [Azure Key Vault: Certificates](/azure/key-vault/certificates/).
+
 1. Create a new Azure Key Vault or use an existing key vault in your Azure subscription.
+
 1. In the key vault's **Certificates** area, import the PFX site certificate. Record the certificate's thumbprint, which is used in the app's configuration later.
+
 1. In Azure App Service in the Azure portal for **Sku and size**, confirm that the App Service tier is `Basic B1` or higher. App Service requires a `Basic B1` or higher service tier to use custom domains.
+
 1. Open the app's **Configuration** in App Service and add a new application setting with a key of `WEBSITE_LOAD_CERTIFICATES` (if it doesn't already exist) or modify the existing `WEBSITE_LOAD_CERTIFICATES` application setting. Specify the certificate thumbprint of the TLS certificate recorded earlier:
    * When using automatic token signing, there is only a single thumbprint for the HTTPS communication. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565`
    * When using a separate token signing certificate, there are two thumbprints for the setting with thumbprint values separated by a comman. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565,29F43A772CB6AF...1D04F0C67F85FB0B1`
 
    In the Azure portal, saving app settings is a two-step process: Save the `WEBSITE_LOAD_CERTIFICATES` key-value setting, then select the **Save** button at the top of the blade.
+
 1. Select the app's **TLS/SSL settings**. Select **Private Key Certificates (.pfx)**. Use the **Import Key Vault Certificate** process to import the site's certificate for HTTPS communication.
+
 1. Navigate to the **Custom domains** blade. At your domain registrar's website, use the **IP address** and **Custom Domain Verification ID** to configure the domain. A typical domain configuration includes:
    * An **A Record** with a **Host** of `@` and a value of the IP address from the Azure portal.
    * A **TXT Record** with a **Host** of `asuid` and the value of the verification ID generated by Azure and provided by the Azure portal.
 
    Make sure that you save the changes at your domain registrar's website correctly. Some registrar websites require a two-step process to save domain records: One or more records are saved individually followed by updating the domain's registration with a separate button.
+
 1. Return to the **Custom domains** blade in the Azure portal. Select **Add custom domain**. Select the **A Record** option. Provide the domain and select **Validate**. If the domain records are correct and propagated across the Internet, the portal allows you to select the **Add custom domain** button.
 
    It can take a few days for domain registration changes to propagate across Internet domain name servers (DNS) after they're processed by your domain registrar. If domain records aren't updated within three business days, confirm the records are correctly set with the domain registrar and contact their customer support.
+
 1. In the **Custom domains** blade, the **SSL STATE** for the domain is marked `Not Secure`. Select the **Add binding** link. Select the site HTTPS certificate from the key vault for the custom domain binding.
 
 The Azure documentation contains additional detail on using Azure services and custom domains with TLS binding in App Service, including information on using CNAME records instead of A records. For more information, see the following resources:

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -481,7 +481,7 @@ For this hosting scenario, do **not** use the same certificate for [Identity Ser
 * TLS certificates for communication with browsers is managed independently without affecting Identity Server's token signing.
 * When [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) supplies a certificate to an App Service app for custom domain binding, Identity Server can't obtain the same certificate from Azure Key Vault for token signing. Although configuring Identity Server to use the same TLS certificate from a physical path is possible, placing security certificates into source control is a **poor practice and should be avoided in most scenarios**.
 
-In the following guidance, a self-signed certificate is created in Azure Key Vault solely for Identity Server token signing. The Identity Server configuration uses the key vault certificate via the app's `My` > `CurrentUser` certificate store. Other certificates used for HTTPS traffic with custom domains are created and configured separately from the Identity Server signing certificate.
+In the following guidance, a self-signed certificate is created in Azure Key Vault solely for Identity Server token signing. The Identity Server configuration uses the key vault certificate via the app's `CurrentUser` > `My` certificate store. Other certificates used for HTTPS traffic with custom domains are created and configured separately from the Identity Server signing certificate.
 
 To configure an app, Azure App Service, and Azure Key Vault to host with a custom domain and HTTPS:
 
@@ -564,7 +564,7 @@ We recommend using a new in-private or incognito browser window for each app tes
 
 When App Service configuration is changed in the Azure portal, the updates generally take effect quickly but aren't instant. Sometimes, you must wait a short period for an App Service to restart in order for a configuration change to take effect.
 
-If troubleshooting a certificate loading problem, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `My` > `CurrentUser` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
+If troubleshooting a certificate loading problem, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `CurrentUser` > `My` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
 
 ```powershell
 Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Subject, Thumbprint, EnhancedKeyUsageList
@@ -1111,7 +1111,7 @@ The guidance in this section explains:
 
 In the following guidance, a self-signed certificate is created in Azure Key Vault solely for Identity Server token signing. The Identity Server configuration uses the key vault certificate following different approaches for **Windows** App Service and **Linux** App Service:
 
-* **Windows** App Service: The app's `My` > `CurrentUser` certificate store is accessed by the app to load the certificate.
+* **Windows** App Service: The app's `CurrentUser` > `My` certificate store is accessed by the app to load the certificate.
 * **Linux** App Service: The app loads the certificate manually.
 
 > [!WARNING]
@@ -1177,7 +1177,7 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
    },
    ```
 
-   If troubleshooting a certificate loading problem on Windows App Service, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `My` > `CurrentUser` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
+   If troubleshooting a certificate loading problem on Windows App Service, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `CurrentUser` > `My` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
 
    ```powershell
    Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Subject, Thumbprint, EnhancedKeyUsageList
@@ -1276,7 +1276,7 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
 1. Open the app's **Configuration** in App Service and add a new application setting with a key of `WEBSITE_LOAD_CERTIFICATES` (if it doesn't already exist) or modify the existing `WEBSITE_LOAD_CERTIFICATES` application setting. Specify the certificate thumbprint of the TLS certificate recorded earlier:
 
    * When using automatic token signing, there is only a single thumbprint for the HTTPS communication. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565`
-   * When using a separate token signing certificate, there are two thumbprints for the setting with thumbprint values separated by a comman. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565,29F43A772CB6AF...1D04F0C67F85FB0B1`
+   * When using a separate token signing certificate, there are two thumbprints for the setting with thumbprint values separated by a comma. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565,29F43A772CB6AF...1D04F0C67F85FB0B1`
 
    In the Azure portal, saving app settings is a two-step process: Save the `WEBSITE_LOAD_CERTIFICATES` key-value setting, then select the **Save** button at the top of the blade.
 
@@ -1306,7 +1306,7 @@ We recommend using a new in-private or incognito browser window for each app tes
 
 When App Service configuration is changed in the Azure portal, the updates generally take effect quickly but aren't instant. Sometimes, you must wait a short period for an App Service to restart in order for a configuration change to take effect.
 
-If troubleshooting a certificate loading problem on Windows App Service, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `My` > `CurrentUser` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
+If troubleshooting a certificate loading problem on Windows App Service, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `CurrentUser` > `My` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
 
 ```powershell
 Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Subject, Thumbprint, EnhancedKeyUsageList
@@ -1793,7 +1793,7 @@ For this hosting scenario, do **not** use the same certificate for [Identity Ser
 * TLS certificates for communication with browsers is managed independently without affecting Identity Server's token signing.
 * When [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) supplies a certificate to an App Service app for custom domain binding, Identity Server can't obtain the same certificate from Azure Key Vault for token signing. Although configuring Identity Server to use the same TLS certificate from a physical path is possible, placing security certificates into source control is a **poor practice and should be avoided in most scenarios**.
 
-In the following guidance, a self-signed certificate is created in Azure Key Vault solely for Identity Server token signing. The Identity Server configuration uses the key vault certificate via the app's `My` > `CurrentUser` certificate store. Other certificates used for HTTPS traffic with custom domains are created and configured separately from the Identity Server signing certificate.
+In the following guidance, a self-signed certificate is created in Azure Key Vault solely for Identity Server token signing. The Identity Server configuration uses the key vault certificate via the app's `CurrentUser` > `My` certificate store. Other certificates used for HTTPS traffic with custom domains are created and configured separately from the Identity Server signing certificate.
 
 To configure an app, Azure App Service, and Azure Key Vault to host with a custom domain and HTTPS:
 
@@ -1876,7 +1876,7 @@ We recommend using a new in-private or incognito browser window for each app tes
 
 When App Service configuration is changed in the Azure portal, the updates generally take effect quickly but aren't instant. Sometimes, you must wait a short period for an App Service to restart in order for a configuration change to take effect.
 
-If troubleshooting a certificate loading problem, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `My` > `CurrentUser` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
+If troubleshooting a certificate loading problem, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `CurrentUser` > `My` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
 
 ```powershell
 Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Subject, Thumbprint, EnhancedKeyUsageList

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -1039,24 +1039,202 @@ In the **`Client`** app, component authorization approaches are functional at th
 
 [!INCLUDE[](~/blazor/security/includes/usermanager-signinmanager.md)]
 
-## Host in Azure App Service with a custom domain and certificate
+## Token signing scenarios with Azure App Service
+
+### Host in Azure App Service with automatic token signing and Data Protection key security using Azure Key Vault
 
 The following guidance explains:
 
-* How to deploy a hosted Blazor WebAssembly app with Identity Server to [Azure App Service](https://azure.microsoft.com/services/app-service/) with a custom domain.
-* How to create and use a TLS certificate for HTTPS protocol communication with browsers. Although the guidance focuses on using the certificate with a custom domain, the guidance is equally applicable to using a default Azure Apps domain, for example `contoso.azurewebsites.net`.
+* How to deploy a hosted Blazor WebAssembly app with Identity Server to [Azure App Service](https://azure.microsoft.com/services/app-service/).
+* How to use automatic Identity Server token signing with Data Protection keys secured by Azure Key Vault.
 
-For this hosting scenario, do **not** use the same certificate for [Identity Server's token signing key](https://docs.identityserver.io/en/latest/topics/crypto.html#token-signing-and-validation) and the site's HTTPS secure communication with browsers:
+> [!NOTE]
+> To create and deploy a TLS certificate for HTTPS protocol communication after following the guidance in this section, see the [Use a custom domain and TLS certificate for HTTPS protocol communication in Azure App Service](#use-a-custom-domain-and-tls-certificate-for-https-protocol-communication-in-azure-app-service) section of this article.
 
-* Using different certificates for these two requirements is a good security practice because it isolates private keys for each purpose.
-* TLS certificates for communication with browsers is managed independently without affecting Identity Server's token signing.
-* When [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) supplies a certificate to an App Service app for custom domain binding, Identity Server can't obtain the same certificate from Azure Key Vault for token signing. Although configuring Identity Server to use the same TLS certificate from a physical path is possible, placing security certificates into source control is a **poor practice and should be avoided in most scenarios**.
+1. Create an [App Service plan](/azure/app-service/overview-hosting-plans).
 
-In the following guidance, a self-signed certificate is created in Azure Key Vault solely for Identity Server token signing. The Identity Server configuration uses the key vault certificate via the app's `My` > `CurrentUser` certificate store. Other certificates used for HTTPS traffic with custom domains are created and configured separately from the Identity Server signing certificate.
+   > [!NOTE]
+   > An App Service plan with an plan level of `Basic B1` or higher tier is required if you also plan to use one or more custom domains with the app.
+
+1. Create a new Azure Key Vault or use an existing key vault in your Azure subscription.
+
+1. Navigate to Azure App Service in the Azure portal and create a new App Service with the following configuration:
+   * **Publish** set to `Code`.
+   * **Runtime stack** set to the app's runtime.
+   * For **Sku and size**, confirm that the App Service tier is `Basic B1` or higher if you also plan to use a custom domain. App Service requires a `Basic B1` or higher service tier to use custom domains.
+
+1. Configure the app to use automatic token signing and Azure Key Vault to store and protect ASP.NET Core Data Protection keys:
+
+   Identity Server token signing is automatic by default. Identity Server also uses ASP.NET Core Data Protection by default. No configuration in the app is required for these features. For more information, see [Automatic key management (Duende Software documentation)](https://docs.duendesoftware.com/identityserver/v5/fundamentals/keys/#automatic-key-management).
+
+   The app requires configuration to use Azure Key Vault to store and protect the keys used for ASP.NET Core Data Protection. Use the guidance in the following ASP.NET Core documentation resources to configure the required features:
+
+   * [Persist keys to Azure Blob Storage](xref:security/data-protection/implementation/key-storage-providers#azure-storage)
+   * [Configure Data Protection: ProtectKeysWithAzureKeyVault](xref:security/data-protection/configuration/overview#protectkeyswithazurekeyvault)
+
+1. In Visual Studio, create an Azure App Service [publish profile](xref:host-and-deploy/visual-studio-publish-profiles#publish-profiles) for the *Server* project. From the menu bar, select: **Build** > **Publish** > **New** > **Azure** > **Azure App Service** (Windows or Linux). When Visual Studio is connected to an Azure subscription, you can set the **View** of Azure resources by **Resource type**. Navigate within the **Web App** list to find the App Service for the app and select it. Select **Finish**.
+1. When Visual Studio returns to the **Publish** window, the key vault and SQL Server database service dependencies are automatically detected.
+
+   No configuration changes to the default settings are required for the key vault service.
+
+   For testing purposes, an app's local [SQLite](https://www.sqlite.org/index.html) database, which is configured by default by the Blazor template, can be deployed with the app without additional configuration. Configuring a different database for Identity Server in production is beyond the scope of this article. For more information, see the database resources in the following documentation sets:
+   * [App Service](/azure/app-service/)
+   * [Identity Server](https://docs.duendesoftware.com/identityserver/v5/overview/)
+
+1. Publish the app. Visual Studio opens a browser window and requests the site.
+
+The Azure documentation contains additional detail on using Azure services. See the following resources:
+
+* [App Service documentation](/azure/app-service/)
+* [Azure Key Vault](/azure/key-vault/)
+
+We recommend using a new in-private or incognito browser window for each app test run after a change to the app, app configuration, or Azure services in the Azure portal. Lingering cookies from a previous test run can result in failed authentication or authorization when testing the site even when the site's configuration is correct. For more information on how to configure Visual Studio to open a new in-private or incognito browser window for each test run, see the [Cookies and site data](#cookies-and-site-data) section.
+
+When App Service configuration is changed in the Azure portal, the updates generally take effect quickly but aren't instant. Sometimes, you must wait a short period for an App Service to restart in order for a configuration change to take effect.
+
+### Host in Azure App Service with certificate token signing
+
+The following guidance explains:
+
+* How to deploy a hosted Blazor WebAssembly app with Identity Server to [Azure App Service](https://azure.microsoft.com/services/app-service/).
+* How to create and use a TLS certificate for Identity Server token signing.
+
+> [!NOTE]
+> To create and deploy a TLS certificate for HTTPS protocol communication after following the guidance in this section, see the [Use a custom domain and TLS certificate for HTTPS protocol communication in Azure App Service](#use-a-custom-domain-and-tls-certificate-for-https-protocol-communication-in-azure-app-service) section of this article.
+
+In the following guidance, a self-signed certificate is created in Azure Key Vault solely for Identity Server token signing. The Identity Server configuration uses the key vault certificate following different approaches for **Windows** App Service and **Linux** App Service:
+
+* **Windows** App Service: The app's `My` > `CurrentUser` certificate store is accessed by the app.
+* **Linux** App Service: The app loads the certificate manually using a Key Vault Client.
+
+> [!WARNING]
+> When seeking to use a certificate for Identity Server token signing and a custom domain, do **not** use the same certificate for Identity Server's token signing and the site's HTTPS secure communication with browsers:
+>
+> * Using different certificates for these two requirements is a good security practice because it isolates private keys for each purpose.
+> * TLS certificates for communication with browsers is managed independently without affecting Identity Server's token signing.
+> * When [Azure Key Vault](https://azure.microsoft.com/services/key-vault/) supplies a certificate to an App Service app for custom domain binding, Identity Server can't obtain the same certificate from Azure Key Vault for token signing. Although configuring Identity Server to use the same TLS certificate from a physical path is possible, placing security certificates into source control is a **poor practice and should be avoided in most scenarios**.
+
+To configure an app, Azure App Service, and Azure Key Vault to host with a custom token signing certificate:
+
+1. Create an [App Service plan](/azure/app-service/overview-hosting-plans).
+
+   > [!NOTE]
+   > An App Service plan with an plan level of `Basic B1` or higher tier is required if you also plan to use one or more custom domains with the app.
+
+1. Create a new Azure Key Vault or use an existing key vault in your Azure subscription.
+
+1. In Azure Key Vault, generate a new self-signed certificate for Identity Server token signing. Give the certificate a **Certificate Name** and **Subject**. The **Subject** is specified as `CN={COMMON NAME}`, where the `{COMMON NAME}` placeholder is the certificate's common name. The common name can be any alphanumeric string. For example, `CN=IdentityServerSigning` is a valid certificate **Subject**. Use the default **Advanced Policy Configuration** settings.
+
+   To create the certificate, use one of the following approaches or any other suitable tool or online service:
+
+   * [Azure Key Vault](/azure/key-vault/certificates/quick-create-portal#add-a-certificate-to-key-vault)
+   * [MakeCert on Windows](/windows/desktop/seccrypto/makecert)
+   * [OpenSSL](https://www.openssl.org)
+
+   Record the certificate's thumbprint, which is used in the app's configuration later.
+
+   For more information on Azure Key Vault certificates, see [Azure Key Vault: Certificates](/azure/key-vault/certificates/).
+
+1. Navigate to Azure App Service in the Azure portal and create a new App Service with the following configuration:
+   * **Publish** set to `Code`.
+   * **Runtime stack** set to the app's runtime.
+   * For **Sku and size**, confirm that the App Service tier is `Basic B1` or higher.  App Service requires a `Basic B1` or higher service tier to use custom domains.
+1. After Azure creates the App Service, open the app's **Configuration** and add a new application setting specifying the certificate thumbprint recorded earlier. The app setting key is `WEBSITE_LOAD_CERTIFICATES`:
+   * Key: `WEBSITE_LOAD_CERTIFICATES`
+   * Value: `57443A552A46DB...D55E28D412B943565`
+
+   In the Azure portal, saving app settings is a two-step process: Save the `WEBSITE_LOAD_CERTIFICATES` key-value setting, then select the **Save** button at the top of the blade.
+1. Select the app's **TLS/SSL settings**. Select **Private Key Certificates (.pfx)**. Use the **Import Key Vault Certificate** process to import the site's self-signed Identity Server token signing certificate.
+
+1. Configure the app to use the token signing certificate based on your choice of host OS, either Windows App Service or Linux App Service:
+
+   **Windows App Service**
+
+   In Visual Studio, open the *Server* project's app settings file (`appsettings.json` or `appsettings.Production.json`). In the Identity Server configuration, add the following `Key` section. Specify the self-signed certificate **Subject** for the `Name` key. In the following example, the certificate's common name assigned in the key vault is `IdentityServerSigning`, which yields a **Subject** of `CN=IdentityServerSigning`:
+
+   ```json
+   "IdentityServer": {
+
+     ...
+
+     "Key": {
+       "Type": "Store",
+       "StoreName": "My",
+       "StoreLocation": "CurrentUser",
+       "Name": "CN=IdentityServerSigning"
+     }
+   },
+   ```
+
+   If troubleshooting a certificate loading problem on Windows App Service, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `My` > `CurrentUser` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
+
+   ```powershell
+   Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Subject, Thumbprint, EnhancedKeyUsageList
+   ```
+
+   **Linux App Service**
+
+   Linux doesn't use a Windows certificate store to load a TLS certificate. On Linux App Service, certificates are placed at the path `/var/ssl/private/`. Manually load and use the certificate from that path for Identity Server token signing.
+
+   Add the following namespaces to the top of `Startup.cs` in the **Server** project if they don't exist:
+
+   ```csharp
+   using System;
+   using System.IO;
+   using System.Security.Cryptography.X509Certificates;
+   ```
+
+   In `Startup.ConfigureServices`, update the Identity Server configuration to use a manually-loaded certificate. In the following example, the `{THUMBPRINT}` placeholder is the certificate's thumbprint:
+
+   ```csharp
+   try
+   {
+       var bytes = File.ReadAllBytes($"/var/ssl/private/{THUMBPRINT}.p12");
+       var certificate = new X509Certificate2(bytes);
+
+       services.AddIdentityServer()
+           .AddApiAuthorization<ApplicationUser, ApplicationDbContext>(options => { })
+           .AddSigningCredential(certificate);
+   }
+   catch (FileNotFoundException)
+   {
+       throw new Exception($"The certificate could not be found.");
+   }
+   ```
+
+1. In Visual Studio, create an Azure App Service [publish profile](xref:host-and-deploy/visual-studio-publish-profiles#publish-profiles) for the *Server* project. From the menu bar, select: **Build** > **Publish** > **New** > **Azure** > **Azure App Service** (Windows or Linux). When Visual Studio is connected to an Azure subscription, you can set the **View** of Azure resources by **Resource type**. Navigate within the **Web App** list to find the App Service for the app and select it. Select **Finish**.
+1. When Visual Studio returns to the **Publish** window, the key vault and SQL Server database service dependencies are automatically detected.
+
+   No configuration changes to the default settings are required for the key vault service.
+
+   For testing purposes, an app's local [SQLite](https://www.sqlite.org/index.html) database, which is configured by default by the Blazor template, can be deployed with the app without additional configuration. Configuring a different database for Identity Server in production is beyond the scope of this article. For more information, see the database resources in the following documentation sets:
+   * [App Service](/azure/app-service/)
+   * [Identity Server](https://docs.duendesoftware.com/identityserver/v5/overview/)
+
+1. Publish the app. Visual Studio opens a browser window and requests the site.
+
+The Azure documentation contains additional detail on using Azure services. See the following resources:
+
+* [App Service documentation](/azure/app-service/)
+* [Azure Key Vault](/azure/key-vault/)
+
+We recommend using a new in-private or incognito browser window for each app test run after a change to the app, app configuration, or Azure services in the Azure portal. Lingering cookies from a previous test run can result in failed authentication or authorization when testing the site even when the site's configuration is correct. For more information on how to configure Visual Studio to open a new in-private or incognito browser window for each test run, see the [Cookies and site data](#cookies-and-site-data) section.
+
+When App Service configuration is changed in the Azure portal, the updates generally take effect quickly but aren't instant. Sometimes, you must wait a short period for an App Service to restart in order for a configuration change to take effect.
+
+## Use a custom domain and TLS certificate for HTTPS protocol communication in Azure App Service
+
+The following guidance explains:
+
+* How to use a custom domain  hosted Blazor WebAssembly app with Identity Server to [Azure App Service](https://azure.microsoft.com/services/app-service/) with a custom domain.
+* How to create and use a TLS certificate for HTTPS protocol communication with browsers for an app that has been deployed to Azure App Service. Although the guidance focuses on using the certificate with a custom domain, the guidance is equally applicable to using a default Azure Apps domain, for example `contoso.azurewebsites.net`.
+
+> [!NOTE]
+> The guidance in this section assumes that the app is already hosted in Azure App Service. If deploying to App Service for the first time, follow the guidance in the [Token signing scenarios with Azure App Service](#token-signing-scenarios-with-azure-app-service) section before using the guidance in this section.
 
 To configure an app, Azure App Service, and Azure Key Vault to host with a custom domain and HTTPS:
 
-1. Create an [App Service plan](/azure/app-service/overview-hosting-plans) with an plan level of `Basic B1` or higher. App Service requires a `Basic B1` or higher service tier to use custom domains.
+1. Use an [App Service plan](/azure/app-service/overview-hosting-plans) with an plan level of `Basic B1` or higher. App Service requires a `Basic B1` or higher service tier to use custom domains.
 1. Create a PFX certificate for the site's secure browser communication (HTTPS protocol) with a common name of the site's fully qualified domain name (FQDN) that your organization controls (for example, `www.contoso.com`). Create the certificate with:
    * Key uses
      * Digital signature validation (`digitalSignature`)
@@ -1076,17 +1254,13 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
    For more information on Azure Key Vault certificates, see [Azure Key Vault: Certificates](/azure/key-vault/certificates/).
 1. Create a new Azure Key Vault or use an existing key vault in your Azure subscription.
 1. In the key vault's **Certificates** area, import the PFX site certificate. Record the certificate's thumbprint, which is used in the app's configuration later.
-1. In Azure Key Vault, generate a new self-signed certificate for Identity Server token signing. Give the certificate a **Certificate Name** and **Subject**. The **Subject** is specified as `CN={COMMON NAME}`, where the `{COMMON NAME}` placeholder is the certificate's common name. The common name can be any alphanumeric string. For example, `CN=IdentityServerSigning` is a valid certificate **Subject**. Use the default **Advanced Policy Configuration** settings. Record the certificate's thumbprint, which is used in the app's configuration later.
-1. Navigate to Azure App Service in the Azure portal and create a new App Service with the following configuration:
-   * **Publish** set to `Code`.
-   * **Runtime stack** set to the app's runtime.
-   * For **Sku and size**, confirm that the App Service tier is `Basic B1` or higher.  App Service requires a `Basic B1` or higher service tier to use custom domains.
-1. After Azure creates the App Service, open the app's **Configuration** and add a new application setting specifying the certificate thumbprints recorded earlier. The app setting key is `WEBSITE_LOAD_CERTIFICATES`. Separate the certificate thumbprints in the app setting value with a comma, as the following example shows:
-   * Key: `WEBSITE_LOAD_CERTIFICATES`
-   * Value: `57443A552A46DB...D55E28D412B943565,29F43A772CB6AF...1D04F0C67F85FB0B1`
+1. In Azure App Service in the Azure portal for **Sku and size**, confirm that the App Service tier is `Basic B1` or higher. App Service requires a `Basic B1` or higher service tier to use custom domains.
+1. Open the app's **Configuration** in App Service and add a new application setting with a key of `WEBSITE_LOAD_CERTIFICATES` (if it doesn't already exist) or modify the existing `WEBSITE_LOAD_CERTIFICATES` application setting. Specify the certificate thumbprint of the TLS certificate recorded earlier:
+   * When using automatic token signing, there is only a single thumbprint for the HTTPS communication. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565`
+   * When using a separate token signing certificate, there are two thumbprints for the setting with thumbprint values separated by a comman. Example key: `WEBSITE_LOAD_CERTIFICATES` Example value: `57443A552A46DB...D55E28D412B943565,29F43A772CB6AF...1D04F0C67F85FB0B1`
 
    In the Azure portal, saving app settings is a two-step process: Save the `WEBSITE_LOAD_CERTIFICATES` key-value setting, then select the **Save** button at the top of the blade.
-1. Select the app's **TLS/SSL settings**. Select **Private Key Certificates (.pfx)**. Use the **Import Key Vault Certificate** process twice to import both the site's certificate for HTTPS communication and the site's self-signed Identity Server token signing certificate.
+1. Select the app's **TLS/SSL settings**. Select **Private Key Certificates (.pfx)**. Use the **Import Key Vault Certificate** process to import the site's certificate for HTTPS communication.
 1. Navigate to the **Custom domains** blade. At your domain registrar's website, use the **IP address** and **Custom Domain Verification ID** to configure the domain. A typical domain configuration includes:
    * An **A Record** with a **Host** of `@` and a value of the IP address from the Azure portal.
    * A **TXT Record** with a **Host** of `asuid` and the value of the verification ID generated by Azure and provided by the Azure portal.
@@ -1096,33 +1270,6 @@ To configure an app, Azure App Service, and Azure Key Vault to host with a custo
 
    It can take a few days for domain registration changes to propagate across Internet domain name servers (DNS) after they're processed by your domain registrar. If domain records aren't updated within three business days, confirm the records are correctly set with the domain registrar and contact their customer support.
 1. In the **Custom domains** blade, the **SSL STATE** for the domain is marked `Not Secure`. Select the **Add binding** link. Select the site HTTPS certificate from the key vault for the custom domain binding.
-1. In Visual Studio, open the *Server* project's app settings file (`appsettings.json` or `appsettings.Production.json`). In the Identity Server configuration, add the following `Key` section. Specify the self-signed certificate **Subject** for the `Name` key. In the following example, the certificate's common name assigned in the key vault is `IdentityServerSigning`, which yields a **Subject** of `CN=IdentityServerSigning`:
-
-   ```json
-   "IdentityServer": {
-
-     ...
-
-     "Key": {
-       "Type": "Store",
-       "StoreName": "My",
-       "StoreLocation": "CurrentUser",
-       "Name": "CN=IdentityServerSigning"
-     }
-   },
-   ```
-
-1. In Visual Studio, create an Azure App Service [publish profile](xref:host-and-deploy/visual-studio-publish-profiles#publish-profiles) for the *Server* project. From the menu bar, select: **Build** > **Publish** > **New** > **Azure** > **Azure App Service** (Windows or Linux). When Visual Studio is connected to an Azure subscription, you can set the **View** of Azure resources by **Resource type**. Navigate within the **Web App** list to find the App Service for the app and select it. Select **Finish**.
-1. When Visual Studio returns to the **Publish** window, the key vault and SQL Server database service dependencies are automatically detected.
-
-   No configuration changes to the default settings are required for the key vault service.
-
-   For testing purposes, an app's local [SQLite](https://www.sqlite.org/index.html) database, which is configured by default by the Blazor template, can be deployed with the app without additional configuration. Configuring a different database for Identity Server in production is beyond the scope of this article. For more information, see the database resources in the following documentation sets:
-   * [App Service](/azure/app-service/)
-   * [Identity Server](https://identityserver4.readthedocs.io/en/latest/)
-
-1. Select the **Edit** link under the deployment profile name at the top of the window. Change the destination URL to the site's custom domain URL (for example, `https://www.contoso.com`). Save the settings.
-1. Publish the app. Visual Studio opens a browser window and requests the site at its custom domain.
 
 The Azure documentation contains additional detail on using Azure services and custom domains with TLS binding in App Service, including information on using CNAME records instead of A records. For more information, see the following resources:
 
@@ -1135,7 +1282,7 @@ We recommend using a new in-private or incognito browser window for each app tes
 
 When App Service configuration is changed in the Azure portal, the updates generally take effect quickly but aren't instant. Sometimes, you must wait a short period for an App Service to restart in order for a configuration change to take effect.
 
-If troubleshooting a certificate loading problem, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `My` > `CurrentUser` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
+If troubleshooting a certificate loading problem on Windows App Service, execute the following command in an Azure portal [Kudu](https://github.com/projectkudu/kudu/wiki/Accessing-the-kudu-service) PowerShell command shell. The command provides a list of certificates that the app can access from the `My` > `CurrentUser` certificate store. The output includes certificate subjects and thumbprints useful when debugging an app:
 
 ```powershell
 Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Subject, Thumbprint, EnhancedKeyUsageList


### PR DESCRIPTION
Fixes #23180

@niem94 ... Here's the direction that I'm headed **_thus far_** 🚧⛏️👷. I might ultimately decide not to go this way, but this shows one way to compose coverage for these features.

* Split token signing from custom domains. These are independent concepts.
* Place the new App Service setup in the two new token signing sections (... but I might decide to take all of the new App Service coverage bits out because other docs exist for it in our doc set and in the Azure docs already. That way, all of this IdS coverage can just focus on the token signing and custom domain config.)
* We'll keep the IdS app token signing configuration for Windows as a gesture in the `appsettings.json` file, where it uses the Windows cert store.
* Let's consider **NOT** using the more complicated Azure Key Vault client to load a cert, as I suggested in our discussion on the issue. Given that Barry 🎯 is ok with just grabbing the cert at the path on the server where it's placed by App Service was **_approved_** :+1:, I think we can just do that. However, I don't want to do it the way that you proposed with the word "**_Password_**" appearing in the config file 😨. It's **_conceptually_** something that we're trying to stop devs from considering generally 🐉. Therefore, the approach on the PR is to load it via code with `AddSigningCredential` from the path.
* I *might* need to get a tiny bit of coverage in here for `AddDeveloperSigningCredential`. I'll consider that later. It might be as simple as a cross-link to the API doc to raise awareness on it.

This is merely a DRAFT at this point. I'm sure that it needs work that will require me to walk the steps. Because we're focused on 6.0 docs at the moment and other high priority issues, I'll return to this as I get time here and there to wrap it up. I might be able to do so in the coming days prior to 6.0 RC1 coming out ... that's when I'll get really busy with 6.0 bits again.

In the meantime, you can look this over and see what you think about the approach thus far. If you have time to test the proposed Linux code with `AddSigningCredential` **_without the app settings file config_**, I hope you'll be able to report back that it works. If you don't have time, no worries ... that's what I'll be testing when I get back to this PR.

... and don't worry about any little text problems ... e.g., a misspelled word 🙈, a broken phrase 🙈, a missing period 🙈 ... things like that ... this has all just been typed right in on a first pass. There are bound to be little text problems at this early stage, and I'll get those little devils 😈 out later.