### PR TITLE
MS identity platform cross-links

### DIFF
--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -539,7 +539,12 @@ The <xref:Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationS
 
 ## Additional resources
 
-* [Microsoft identity platform documentation](/azure/active-directory/develop/)
+* Microsoft identity platform documentation
+  * [Overview](/azure/active-directory/develop/)
+  * [OAuth 2.0 and OpenID Connect protocols on the Microsoft identity platform](/azure/active-directory/develop/active-directory-v2-protocols)
+  * [Microsoft identity platform and OAuth 2.0 authorization code flow](/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+  * [Microsoft identity platform ID tokens](/azure/active-directory/develop/id-tokens)
+  * [Microsoft identity platform access tokens](/azure/active-directory/develop/access-tokens)
 * <xref:security/index>
 * <xref:security/authentication/windowsauth>
 * [Build a custom version of the Authentication.MSAL JavaScript library](xref:blazor/security/webassembly/additional-scenarios#build-a-custom-version-of-the-authenticationmsal-javascript-library)
@@ -1081,7 +1086,12 @@ The <xref:Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationS
 
 ## Additional resources
 
-* [Microsoft identity platform documentation](/azure/active-directory/develop/)
+* Microsoft identity platform documentation
+  * [Overview](/azure/active-directory/develop/)
+  * [OAuth 2.0 and OpenID Connect protocols on the Microsoft identity platform](/azure/active-directory/develop/active-directory-v2-protocols)
+  * [Microsoft identity platform and OAuth 2.0 authorization code flow](/azure/active-directory/develop/v2-oauth2-auth-code-flow)
+  * [Microsoft identity platform ID tokens](/azure/active-directory/develop/id-tokens)
+  * [Microsoft identity platform access tokens](/azure/active-directory/develop/access-tokens)
 * <xref:security/index>
 * <xref:security/authentication/windowsauth>
 * [Build a custom version of the Authentication.MSAL JavaScript library](xref:blazor/security/webassembly/additional-scenarios#build-a-custom-version-of-the-authenticationmsal-javascript-library)


### PR DESCRIPTION
Fixes #19807

Looking the issue over (and I'll consider this further on upcoming UE "user experience" updates on #19286), I'd like to improve cross-links to MS identity platform docs for the basics on OAuth 2.0, OIDC, auth code flow, and tokens.

> doc about the mapping between the registered default schemas and extension methods like AddAzureADBearer and AddAzureAD

API docs cover these, and the extension methods can be found in reference source. Some of the differences are point-in-time ... ADAL to MSAL and implicit grant to auth code. We try to avoid covering migration in the reference docs. Transitions are covered by MS security docs.

> JwtBearerOptions, OpenIdConnectOptions and CookiePolicyOptions. It would be also appreciated that those connections would be illustrated

These are documented in the ASP.NET Core security docs and API docs. If something (or some things) aren't clear or missing, it's best to open an issue from the relevant docs. I will take a fresh look at Blazor security docs on the UE passes, hopefully in the first half of 2022.