### PR TITLE
Update server.md

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -359,7 +359,7 @@ http {
 
     server {
         listen      80;
-        server_name example.com *.example.com
+        server_name example.com *.example.com;
         location / {
             proxy_pass         http://localhost:5000;
             proxy_http_version 1.1;


### PR DESCRIPTION
Code for "Linux with Nginx" was missing a semi colon after the server_name. Without it nginx gives the error "directive "server_name" is not terminated by ";".



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->