### PR TITLE
ServerOptionsSelectionCallback and TlsHandshakeCallbackOptions

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -377,7 +377,7 @@ webBuilder.ConfigureKestrel(serverOptions =>
 
 ### SNI with `TlsHandshakeCallbackOptions`
 
-Kestrel supports additional dynamic TLS configuraiton via the `TlsHandshakeCallbackOptions.OnConnection` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate, TLS configuration, and other server options. Default certificates and `ConfigureHttpsDefaults` are not used with this callback.
+Kestrel supports additional dynamic TLS configuration via the `TlsHandshakeCallbackOptions.OnConnection` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate, TLS configuration, and other server options. Default certificates and `ConfigureHttpsDefaults` are not used with this callback.
 
 ```csharp
 //using System.Security.Cryptography.X509Certificates;

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -330,6 +330,99 @@ webBuilder.ConfigureKestrel(serverOptions =>
 });
 ```
 
+### SNI with `ServerOptionsSelectionCallback`
+
+Kestrel supports additional dynamic TLS configuraiton via the `ServerOptionsSelectionCallback` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate and TLS configuration. Default certificates and `ConfigureHttpsDefaults` are not used with this callback.
+
+```csharp
+//using System.Security.Cryptography.X509Certificates;
+//using Microsoft.AspNetCore.Server.Kestrel.Https;
+
+webBuilder.ConfigureKestrel(serverOptions =>
+{
+    serverOptions.ListenAnyIP(5005, listenOptions =>
+    {
+        listenOptions.UseHttps(httpsOptions =>
+        {
+            var localhostCert = CertificateLoader.LoadFromStoreCert(
+                "localhost", "My", StoreLocation.CurrentUser,
+                allowInvalid: true);
+            var exampleCert = CertificateLoader.LoadFromStoreCert(
+                "example.com", "My", StoreLocation.CurrentUser,
+                allowInvalid: true);
+
+            listenOptions.UseHttps((stream, clientHelloInfo, state, cancellationToken) =>
+            {
+                if (string.Equals(clientHelloInfo.ServerName, "localhost", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                    {
+                        ServerCertificate = localhostCert,
+                        // Different TLS requirements for this host
+                        ClientCertificateRequired = true,
+                    });
+                }
+
+                return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                {
+                    ServerCertificate = exampleCert,
+                });
+            }, state: null);
+        });
+    });
+});
+```
+
+::: moniker range=">= aspnetcore-6.0"
+
+### SNI with `TlsHandshakeCallbackOptions`
+
+Kestrel supports additional dynamic TLS configuraiton via the `TlsHandshakeCallbackOptions.OnConnection` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate, TLS configuration, and other server options. Default certificates and `ConfigureHttpsDefaults` are not used with this callback.
+
+```csharp
+//using System.Security.Cryptography.X509Certificates;
+//using Microsoft.AspNetCore.Server.Kestrel.Https;
+
+webBuilder.ConfigureKestrel(serverOptions =>
+{
+    serverOptions.ListenAnyIP(5005, listenOptions =>
+    {
+        listenOptions.UseHttps(httpsOptions =>
+        {
+            var localhostCert = CertificateLoader.LoadFromStoreCert(
+                "localhost", "My", StoreLocation.CurrentUser,
+                allowInvalid: true);
+            var exampleCert = CertificateLoader.LoadFromStoreCert(
+                "example.com", "My", StoreLocation.CurrentUser,
+                allowInvalid: true);
+
+            listenOptions.UseHttps(new TlsHandshakeCallbackOptions()
+            {
+                OnConnection = context =>
+                {
+                    if (string.Equals(context.ClientHelloInfo.ServerName, "localhost", StringComparison.OrdinalIgnoreCase))
+                    {
+                        // Different TLS requirements for this host
+                        context.AllowDelayedClientCertificateNegotation = true;
+                        return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                        {
+                            ServerCertificate = localhostCert,
+                        });
+                    }
+
+                    return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                    {
+                        ServerCertificate = exampleCert,
+                    });
+                }
+            });
+        });
+    });
+});
+```
+
+::: moniker-end
+
 ### SNI in configuration
 
 Kestrel supports SNI defined in configuration. An endpoint can be configured with an `Sni` object that contains a mapping between host names and HTTPS options. The connection host name is matched to the options and they are used for that connection.


### PR DESCRIPTION
Fixes #26243 (5.0): ServerOptionsSelectionCallback 
Also adds (6.0): TlsHandshakeCallbackOptions

The overall document needs reorganizing, but at least this adds the new APIs.

***@Rick-Anderson EDIT:*** [Internal review URL - V6](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-6.0&branch=pr-en-us-23302#sni-with-servercertificateselector)