### PR TITLE
Move the creation of the QR code to a js file.

### DIFF
--- a/aspnetcore/security/authentication/identity-enable-qrcodes.md
+++ b/aspnetcore/security/authentication/identity-enable-qrcodes.md
@@ -52,7 +52,7 @@ These instructions use *qrcode.js* from the https://davidshimjs.github.io/qrcode
     @await Html.PartialAsync("_ValidationScriptsPartial")
 }
 ```
-* Create a new JavaScript file called `qr.js` in wwwroot/js and add the following code to generate the QR Code:
+* Create a new JavaScript file called *qr.js* in *wwwroot/js* and add the following code to generate the QR Code:
 
 ```javascript
 window.addEventListener("load", () => {
@@ -66,7 +66,8 @@ window.addEventListener("load", () => {
 });
 ```
 
-* Update the `Scripts` section to add a reference to the `qrcode.js` library you downloaded previously and also add the `qr.js` file with the call to generate the QR code. Based on our example it should look as follows:
+* Update the `Scripts` section to add a reference to the `qrcode.js` library previously downloaded.
+* Add the *qr.js* file with the call to generate the QR code:
 
 ```cshtml
 @section Scripts {

--- a/aspnetcore/security/authentication/identity-enable-qrcodes.md
+++ b/aspnetcore/security/authentication/identity-enable-qrcodes.md
@@ -52,22 +52,28 @@ These instructions use *qrcode.js* from the https://davidshimjs.github.io/qrcode
     @await Html.PartialAsync("_ValidationScriptsPartial")
 }
 ```
+* Create a new JavaScript file called `qr.js` in wwwroot/js and add the following code to generate the QR Code:
 
-* Update the `Scripts` section to add a reference to the `qrcodejs` library you added and a call to generate the QR Code. It should look as follows:
+```javascript
+window.addEventListener("load", () => {
+    const uri = document.getElementById("qrCodeData").getAttribute('data-url');
+    new QRCode(document.getElementById("qrCode"),
+        {
+            text: uri,
+            width: 150,
+            height: 150
+        });
+});
+```
+
+* Update the `Scripts` section to add a reference to the `qrcode.js` library you downloaded previously and also add the `qr.js` file with the call to generate the QR code. Based on our example it should look as follows:
 
 ```cshtml
 @section Scripts {
     @await Html.PartialAsync("_ValidationScriptsPartial")
 
     <script type="text/javascript" src="~/lib/qrcode.js"></script>
-    <script type="text/javascript">
-        new QRCode(document.getElementById("qrCode"),
-            {
-                text: "@Html.Raw(Model.AuthenticatorUri)",
-                width: 150,
-                height: 150
-            });
-    </script>
+    <script type="text/javascript" src="~/js/qs.js"></script>
 }
 ```
 


### PR DESCRIPTION
In-line JavaScript is insecure and breaks script-src 'unsafe-inline' in Content Security Policy.

Note: I think the part about locating the Scripts section in EnableAuthenticator.cshtml should probably go after bit I've added about creating the js file (qr.js), and before updating the scripts section. I haven't moved it as I wasn't sure how the "moniker" directives worked and didn't want to break anything. (my first ever documentation proposal)



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->