### PR TITLE
Fixed '@' symbol work definition

### DIFF
--- a/aspnetcore/tutorials/razor-pages/page.md
+++ b/aspnetcore/tutorials/razor-pages/page.md
@@ -44,7 +44,7 @@ Examine the *Pages/Movies/Index.cshtml* Razor Page:
 
 [!code-cshtml[](razor-pages-start/snapshot_sample3/RazorPagesMovie30/Pages/Movies/Index.cshtml)]
 
-Razor can transition from HTML into C# or into Razor-specific markup. When an `@` symbol is followed by a [Razor reserved keyword](xref:mvc/views/razor#razor-reserved-keywords), it transitions into Razor-specific markup, otherwise it transitions into C#.
+Razor can transition from HTML into C# or into Razor-specific markup. When an `@` symbol is followed by a [Razor reserved keyword](xref:mvc/views/razor#razor-reserved-keywords), it transitions into Razor-specific markup, otherwise it transitions into HTML.
 
 ### The @page directive
 


### PR DESCRIPTION
`@` symbol is followed by a Razor reserved keyword, it transitions into Razor-specific markup, otherwise it transitions into HTML. --NOT '...into C#."



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->