### PR TITLE
JS file collocation with Razor components

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -252,7 +252,7 @@ The distinction between using the `Link` component in a child component and plac
 * Can be modified by application state. A hard-coded `<link>` HTML tag can't be modified by application state.
 * Is removed from the HTML `<head>` when the parent component is no longer rendered.
 
-## Create an RCL with static assets
+## Create an RCL with static assets in the `wwwroot` folder
 
 An RCL's static assets are available to any app that consumes the library.
 
@@ -310,6 +310,12 @@ Rendered `Jeep` component:
 ![Jeep component](~/blazor/components/class-libraries/_static/jeep-component.png)
 
 For more information, see <xref:razor-pages/ui-class#create-an-rcl-with-static-assets>.
+
+## Create an RCL with static assets collocated with components
+
+[!INCLUDE[](~/includes/js-collocation.md)]
+
+For more information on RCLs, see <xref:razor-pages/ui-class>.
 
 ## Supply components and static assets to multiple hosted Blazor apps
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -311,7 +311,7 @@ Rendered `Jeep` component:
 
 For more information, see <xref:razor-pages/ui-class#create-an-rcl-with-static-assets>.
 
-## Create an RCL with static assets collocated with components
+## Create an RCL with JavaScript files collocated with components
 
 [!INCLUDE[](~/includes/js-collocation.md)]
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -315,8 +315,6 @@ For more information, see <xref:razor-pages/ui-class#create-an-rcl-with-static-a
 
 [!INCLUDE[](~/includes/js-collocation.md)]
 
-For more information on RCLs, see <xref:razor-pages/ui-class>.
-
 ## Supply components and static assets to multiple hosted Blazor apps
 
 For more information, see <xref:blazor/host-and-deploy/webassembly#static-assets-and-class-libraries-for-multiple-blazor-webassembly-apps>.

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -40,8 +40,8 @@ Load JavaScript (JS) code using any of the following approaches:
 
 * [Load a script in `<head>` markup](#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](#load-a-script-in-body-markup)
-* [Load a script from an external JavaScript file (`.js`) collocated with a component](#load-a-script-from-an-external-js-file-js-collocated-with-a-component)
-* [Load a script from an external JavaScript file (`.js`)](#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`) collocated with a component](#load-a-script-from-an-external-javascript-file-js-collocated-with-a-component)
+* [Load a script from an external JavaScript file (`.js`)](#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](#inject-a-script-after-blazor-starts)
 
 > [!WARNING]

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -40,7 +40,8 @@ Load JavaScript (JS) code using any of the following approaches:
 
 * [Load a script in `<head>` markup](#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](#load-a-script-in-body-markup)
-* [Load a script from an external JS file (`.js`)](#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`) collocated with a component](#load-a-script-from-an-external-js-file-js-collocated-with-a-component)
+* [Load a script from an external JavaScript file (`.js`)](#load-a-script-from-an-external-js-file-js)
 * [Inject a script after Blazor starts](#inject-a-script-after-blazor-starts)
 
 > [!WARNING]
@@ -53,7 +54,7 @@ Load JavaScript (JS) code using any of the following approaches:
 
 *The approach in this section isn't generally recommended.*
 
-Place the script  (`<script>...</script>`) in the `<head>` element markup of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
+Place the JavaScript (JS) tags (`<script>...</script>`) in the `<head>` element markup of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <head>
@@ -74,7 +75,7 @@ Loading JS from the `<head>` isn't the best approach for the following reasons:
 
 ### Load a script in `<body>` markup
 
-Place the script  (`<script>...</script>`) inside the closing `</body>` element markup of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
+Place the JavaScript (JS) tags (`<script>...</script>`) inside the closing `</body>` element markup of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
 <body>
@@ -91,9 +92,36 @@ Place the script  (`<script>...</script>`) inside the closing `</body>` element 
 
 The `{webassembly|server}` placeholder in the preceding markup is either `webassembly` for a Blazor WebAssembly app (`blazor.webassembly.js`) or `server` for a Blazor Server app (`blazor.server.js`).
 
-### Load a script from an external JS file (`.js`)
+### Load a script from an external JavaScript file (`.js`) collocated with a component
 
-Place the script  (`<script>...</script>`) with a script `src` path inside the closing `</body>` tag after the Blazor script reference.
+Collocate JavaScript (JS) files with Razor components using the `.razor.js` filename extension convention. Collocation of script files is a convenient way to organize JS code specific to components. Collocated JS files are publicly addressable using the path to the file in the project.
+
+[JS module](#javascript-isolation-in-javascript-modules) examples:
+
+* `Pages/{COMPONENT}.razor.js` for a scripts file in the app's `Pages` folder, where the `{COMPONENT}` placeholder is the name of the component.
+
+  In the following example, scripts are loaded for the `Index` component (`Pages/Index.razor`):
+   
+  ```csharp
+  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
+      "./Pages/Index.razor.js");
+  ```
+
+* `_content/{PACKAGE ID}/Pages/{COMPONENT}.razor.js` for scripts provided by a [Razor class library (RCL)](xref:blazor/components/class-libraries). The `{PACKAGE ID}` placeholder is the RCL's package identifier, and the `{COMPONENT}` placeholder is the name of the component.
+
+  In the following example, the RCL's package identifier is `AppJS`, and the scripts are loaded for the `Index` component (`Pages/Index.razor`):
+  
+  ```csharp
+  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
+      "_content/AppJS/Pages/Index.cshtml.js");
+  ```
+  
+> [!NOTE]
+> Collocation of JS is also supported for pages of Razor Pages apps and views of MVC apps using the `.cshtml.js` file extension convention. For more information, see XXXXXXXXXXXX.
+
+### Load a script from an external JavaScript file (`.js`)
+
+Place the JavaScript (JS) tags (`<script>...</script>`) with a script source (`src`) path inside the closing `</body>` tag after the Blazor script reference.
 
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -96,10 +96,7 @@ The `{webassembly|server}` placeholder in the preceding markup is either `webass
 
 [!INCLUDE[](~/includes/js-collocation.md)]
 
-For more information on RCLs, see the following articles:
-
-* <xref:razor-pages/ui-class>
-* <xref:blazor/components/class-libraries>
+For more information on RCLs, see <xref:blazor/components/class-libraries>.
 
 ### Load a script from an external JavaScript file (`.js`)
 

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -96,6 +96,11 @@ The `{webassembly|server}` placeholder in the preceding markup is either `webass
 
 [!INCLUDE[](~/includes/js-collocation.md)]
 
+For more information on RCLs, see the following articles:
+
+* <xref:razor-pages/ui-class>
+* <xref:blazor/components/class-libraries>
+
 ### Load a script from an external JavaScript file (`.js`)
 
 Place the JavaScript (JS) tags (`<script>...</script>`) with a script source (`src`) path inside the closing `</body>` tag after the Blazor script reference.

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -94,30 +94,7 @@ The `{webassembly|server}` placeholder in the preceding markup is either `webass
 
 ### Load a script from an external JavaScript file (`.js`) collocated with a component
 
-Collocate JavaScript (JS) files with Razor components using the `.razor.js` filename extension convention. Collocation of script files is a convenient way to organize JS code specific to components. Collocated JS files are publicly addressable using the path to the file in the project.
-
-[JS module](#javascript-isolation-in-javascript-modules) examples:
-
-* `Pages/{COMPONENT}.razor.js` for a scripts file in the app's `Pages` folder, where the `{COMPONENT}` placeholder is the name of the component.
-
-  In the following example, scripts are loaded for the `Index` component (`Pages/Index.razor`):
-   
-  ```csharp
-  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
-      "./Pages/Index.razor.js");
-  ```
-
-* `_content/{PACKAGE ID}/Pages/{COMPONENT}.razor.js` for scripts provided by a [Razor class library (RCL)](xref:blazor/components/class-libraries). The `{PACKAGE ID}` placeholder is the RCL's package identifier, and the `{COMPONENT}` placeholder is the name of the component.
-
-  In the following example, the RCL's package identifier is `AppJS`, and the scripts are loaded for the `Index` component (`Pages/Index.razor`):
-  
-  ```csharp
-  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
-      "_content/AppJS/Pages/Index.cshtml.js");
-  ```
-  
-> [!NOTE]
-> Collocation of JS is also supported for pages of Razor Pages apps and views of MVC apps using the `.cshtml.js` file extension convention. For more information, see XXXXXXXXXXXX.
+[!INCLUDE[](~/includes/js-collocation.md)]
 
 ### Load a script from an external JavaScript file (`.js`)
 

--- a/aspnetcore/includes/js-collocation.md
+++ b/aspnetcore/includes/js-collocation.md
@@ -6,9 +6,9 @@ Collocation of JavaScript (JS) files in the same folder as pages, views, or Razo
 Collocate JS files using the following filename extension conventions:
 
 * Pages of Razor Pages apps and views of MVC apps: `.cshtml.js`. Examples:
-  * `Pages/Contact.cshtml.js` for the app's `Contact` page at `Pages/Contact.cshtml`.
-  * `Views/Home/Contact.cshtml.js` for the app's `Contact` view at `Views/Home/Contact.cshtml`.
-* Razor components of Blazor apps: `.razor.js`. Example: `Pages/Index.razor.js` for the app's `Index` component at `Pages/Index.razor`.
+  * `Pages/Contact.cshtml.js` for the `Contact` page of a Razor Pages app at `Pages/Contact.cshtml`.
+  * `Views/Home/Contact.cshtml.js` for the `Contact` view of an MVC app at `Views/Home/Contact.cshtml`.
+* Razor components of Blazor apps: `.razor.js`. Example: `Pages/Index.razor.js` for the `Index` component at `Pages/Index.razor`.
 
 Collocated JS files are publicly addressable using the path to the file in the project:
 
@@ -32,7 +32,7 @@ Collocated JS files are publicly addressable using the path to the file in the p
 
   `_content/{PACKAGE ID}/{PATH}/{PAGE, VIEW, OR COMPONENT}.{EXTENSION}.js`
 
-  * The `{PACKAGE ID}` placeholder is the RCL's package identifier.
+  * The `{PACKAGE ID}` placeholder is the RCL's package identifier (or library name for a class library referenced by the app).
   * The `{PATH}` placeholder is the path to the page, view, or component.
   * The `{PAGE, VIEW, OR COMPONENT}` placeholder is the page, view, or component.
   * The `{EXTENSION}` placeholder matches the extension of page, view, or component, either `razor` or `cshtml`.

--- a/aspnetcore/includes/js-collocation.md
+++ b/aspnetcore/includes/js-collocation.md
@@ -14,11 +14,11 @@ Collocated JS files are publicly addressable using the path to the file in the p
 
 * Pages, views, and components from a collocated scripts file in the app:
 
-  `{PATH}/{PAGE, VIEW, OR COMPONENT}.{EXTENSION}.js`
+  `{PATH}/{PAGE, VIEW, OR COMPONENT}.{EXTENSION}`
   
   * The `{PATH}` placeholder is the path to the page, view, or component.
   * The `{PAGE, VIEW, OR COMPONENT}` placeholder is the page, view, or component.
-  * The `{EXTENSION}` placeholder matches the extension of the page, view, or component, either `razor` or `cshtml`.
+  * The `{EXTENSION}` placeholder matches the extension of the page, view, or component, either `razor` or `cshtml`, followed by `.js`.
   
   In the following example from a Razor Pages app, the script is collocated in the `Pages` folder with the `Contact` page (`Pages/Contact.cshtml`):
 
@@ -30,12 +30,12 @@ Collocated JS files are publicly addressable using the path to the file in the p
 
 * For scripts provided by a Razor class library (RCL):
 
-  `_content/{PACKAGE ID}/{PATH}/{PAGE, VIEW, OR COMPONENT}.{EXTENSION}.js`
+  `_content/{PACKAGE ID}/{PATH}/{PAGE, VIEW, OR COMPONENT}.{EXTENSION}`
 
   * The `{PACKAGE ID}` placeholder is the RCL's package identifier (or library name for a class library referenced by the app).
   * The `{PATH}` placeholder is the path to the page, view, or component. If a Razor component is located at the root of the RCL, the path segment isn't included.
   * The `{PAGE, VIEW, OR COMPONENT}` placeholder is the page, view, or component.
-  * The `{EXTENSION}` placeholder matches the extension of page, view, or component, either `razor` or `cshtml`.
+  * The `{EXTENSION}` placeholder matches the extension of page, view, or component, either `razor` or `cshtml`, followed by `.js`.
 
   In the following Blazor app example:
   

--- a/aspnetcore/includes/js-collocation.md
+++ b/aspnetcore/includes/js-collocation.md
@@ -1,53 +1,50 @@
 ---
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
-Collocation of script files in the same folder as pages, views, or Razor components is a convenient way to organize JS code specific to components. Collocated JS files are publicly addressable using the path to the file in the project.
+Collocation of JavaScript (JS) files in the same folder as pages, views, or Razor components is a convenient way to organize scripts in an app.
 
-Collocate JavaScript (JS) files using the following filename extension conventions:
+Collocate JS files using the following filename extension conventions:
 
-* Pages of Razor Pages apps: `.cshtml.js`
-* Views of MVC apps: `.cshtml.js`
-* Razor components of Blazor apps: `.razor.js`
+* Pages of Razor Pages apps and views of MVC apps: `.cshtml.js`. Examples:
+  * `Pages/Contact.cshtml.js` for the app's `Contact` page at `Pages/Contact.cshtml`.
+  * `Views/Home/Contact.cshtml.js` for the app's `Contact` view at `Views/Home/Contact.cshtml`.
+* Razor components of Blazor apps: `.razor.js`. Example: `Pages/Index.razor.js` for the app's `Index` component at `Pages/Index.razor`.
 
-[JS module](#javascript-isolation-in-javascript-modules) examples:
+Collocated JS files are publicly addressable using the path to the file in the project:
 
-* `{Pages|Views}/{PAGE, VIEW, OR COMPONENT NAME}.{cshtml|razor}.js` for script files.
+* Pages, views, and components from a collocated scripts file in the app:
 
-  * The `{Pages|Views}` placeholder is either `Pages` for the pages folder of a Razor Pages/Blazor app or `Views` for the views folder of an MVC app.
-  * The `{PAGE, VIEW, OR COMPONENT NAME}` placeholder is the name of the page, view, or component.
-  * The `{cshtml|razor}` placeholder is either `cshtml` for pages and views or `razor` for a component.
-
-  In the following example, scripts are loaded for the `Index` component (`Pages/Index.razor`) of a Blazor app:
-
-  ```csharp
-  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
-      "./Pages/Index.razor.js");
-  ```
+  `{PATH}/{PAGE, VIEW, OR COMPONENT}.{EXTENSION}.js`
   
-  In the following example, scripts are loaded for the `Contact` view (`Views/Contact.cshtml`) of an MVC app:
+  * The `{PATH}` placeholder is the path to the page, view, or component.
+  * The `{PAGE, VIEW, OR COMPONENT}` placeholder is the page, view, or component.
+  * The `{EXTENSION}` placeholder matches the extension of page, view, or component, either `razor` or `cshtml`.
+  
+  In the following example from a Razor Pages app, the script is collocated in the `Pages` folder with the `Contact` page (`Pages/Contact.cshtml`):
 
-  ```csharp
-  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
-      "./Views/Contact.cshtml.js");
+  ```razor
+  @section Scripts {
+    <script src="~/Pages/Contact.cshtml.js"></script>
+  }
   ```
 
-* `_content/{PACKAGE ID}/{Pages|Views}/{PAGE, VIEW, OR COMPONENT NAME}.{cshtml|razor}.js` for scripts provided by a [Razor class library (RCL)](xref:blazor/components/class-libraries).
+* For scripts provided by a Razor class library (RCL):
+
+  `_content/{PACKAGE ID}/{PATH}/{PAGE, VIEW, OR COMPONENT}.{EXTENSION}.js`
 
   * The `{PACKAGE ID}` placeholder is the RCL's package identifier.
-  * The `{Pages|Views}` placeholder is either `Pages` for the pages folder of a Razor Pages/Blazor app or `Views` for the views folder of an MVC app.
-  * The `{PAGE, VIEW, OR COMPONENT NAME}` placeholder is the name of the page, view, or component.
-  * The `{cshtml|razor}` placeholder is either `cshtml` for pages and views or `razor` for a component.
+  * The `{PATH}` placeholder is the path to the page, view, or component.
+  * The `{PAGE, VIEW, OR COMPONENT}` placeholder is the page, view, or component.
+  * The `{EXTENSION}` placeholder matches the extension of page, view, or component, either `razor` or `cshtml`.
 
-  In the following example, the RCL's package identifier is `AppJS`, and the scripts are loaded for the `Index` component (`Pages/Index.razor`) of a Blazor app:
+  In the following Blazor app example, the RCL's package identifier is `AppJS`, and a module's scripts are loaded for the `Index` component (`Pages/Index.razor`):
 
   ```csharp
   var module = await JS.InvokeAsync<IJSObjectReference>("import", 
       "_content/AppJS/Pages/Index.razor.js");
   ```
   
-  In the following example, the RCL's package identifier is `AppJS`, and the scripts are loaded for the `Contact` view (`Views/Contact.cshtml`) of an MVC app:
-
-  ```csharp
-  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
-      "_content/AppJS/Views/Contact.cshtml.js");
-  ```
+  For more information on RCLs, see the following articles:
+  
+  * <xref:razor-pages/ui-class>
+  * <xref:blazor/components/class-libraries>

--- a/aspnetcore/includes/js-collocation.md
+++ b/aspnetcore/includes/js-collocation.md
@@ -1,0 +1,53 @@
+---
+no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
+---
+Collocation of script files in the same folder as pages, views, or Razor components is a convenient way to organize JS code specific to components. Collocated JS files are publicly addressable using the path to the file in the project.
+
+Collocate JavaScript (JS) files using the following filename extension conventions:
+
+* Pages of Razor Pages apps: `.cshtml.js`
+* Views of MVC apps: `.cshtml.js`
+* Razor components of Blazor apps: `.razor.js`
+
+[JS module](#javascript-isolation-in-javascript-modules) examples:
+
+* `{Pages|Views}/{PAGE, VIEW, OR COMPONENT NAME}.{cshtml|razor}.js` for script files.
+
+  * The `{Pages|Views}` placeholder is either `Pages` for the pages folder of a Razor Pages/Blazor app or `Views` for the views folder of an MVC app.
+  * The `{PAGE, VIEW, OR COMPONENT NAME}` placeholder is the name of the page, view, or component.
+  * The `{cshtml|razor}` placeholder is either `cshtml` for pages and views or `razor` for a component.
+
+  In the following example, scripts are loaded for the `Index` component (`Pages/Index.razor`) of a Blazor app:
+
+  ```csharp
+  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
+      "./Pages/Index.razor.js");
+  ```
+  
+  In the following example, scripts are loaded for the `Contact` view (`Views/Contact.cshtml`) of an MVC app:
+
+  ```csharp
+  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
+      "./Views/Contact.cshtml.js");
+  ```
+
+* `_content/{PACKAGE ID}/{Pages|Views}/{PAGE, VIEW, OR COMPONENT NAME}.{cshtml|razor}.js` for scripts provided by a [Razor class library (RCL)](xref:blazor/components/class-libraries).
+
+  * The `{PACKAGE ID}` placeholder is the RCL's package identifier.
+  * The `{Pages|Views}` placeholder is either `Pages` for the pages folder of a Razor Pages/Blazor app or `Views` for the views folder of an MVC app.
+  * The `{PAGE, VIEW, OR COMPONENT NAME}` placeholder is the name of the page, view, or component.
+  * The `{cshtml|razor}` placeholder is either `cshtml` for pages and views or `razor` for a component.
+
+  In the following example, the RCL's package identifier is `AppJS`, and the scripts are loaded for the `Index` component (`Pages/Index.razor`) of a Blazor app:
+
+  ```csharp
+  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
+      "_content/AppJS/Pages/Index.razor.js");
+  ```
+  
+  In the following example, the RCL's package identifier is `AppJS`, and the scripts are loaded for the `Contact` view (`Views/Contact.cshtml`) of an MVC app:
+
+  ```csharp
+  var module = await JS.InvokeAsync<IJSObjectReference>("import", 
+      "_content/AppJS/Views/Contact.cshtml.js");
+  ```

--- a/aspnetcore/includes/js-collocation.md
+++ b/aspnetcore/includes/js-collocation.md
@@ -1,7 +1,7 @@
 ---
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
-Collocation of JavaScript (JS) files for pages, views, or Razor components is a convenient way to organize scripts in an app.
+Collocation of JavaScript (JS) files for pages, views, and Razor components is a convenient way to organize scripts in an app.
 
 Collocate JS files using the following filename extension conventions:
 
@@ -18,7 +18,7 @@ Collocated JS files are publicly addressable using the path to the file in the p
   
   * The `{PATH}` placeholder is the path to the page, view, or component.
   * The `{PAGE, VIEW, OR COMPONENT}` placeholder is the page, view, or component.
-  * The `{EXTENSION}` placeholder matches the extension of page, view, or component, either `razor` or `cshtml`.
+  * The `{EXTENSION}` placeholder matches the extension of the page, view, or component, either `razor` or `cshtml`.
   
   In the following example from a Razor Pages app, the script is collocated in the `Pages` folder with the `Contact` page (`Pages/Contact.cshtml`):
 

--- a/aspnetcore/includes/js-collocation.md
+++ b/aspnetcore/includes/js-collocation.md
@@ -1,7 +1,7 @@
 ---
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
-Collocation of JavaScript (JS) files in the same folder as pages, views, or Razor components is a convenient way to organize scripts in an app.
+Collocation of JavaScript (JS) files for pages, views, or Razor components is a convenient way to organize scripts in an app.
 
 Collocate JS files using the following filename extension conventions:
 
@@ -33,11 +33,15 @@ Collocated JS files are publicly addressable using the path to the file in the p
   `_content/{PACKAGE ID}/{PATH}/{PAGE, VIEW, OR COMPONENT}.{EXTENSION}.js`
 
   * The `{PACKAGE ID}` placeholder is the RCL's package identifier (or library name for a class library referenced by the app).
-  * The `{PATH}` placeholder is the path to the page, view, or component.
+  * The `{PATH}` placeholder is the path to the page, view, or component. If a Razor component is located at the root of the RCL, the path segment isn't included.
   * The `{PAGE, VIEW, OR COMPONENT}` placeholder is the page, view, or component.
   * The `{EXTENSION}` placeholder matches the extension of page, view, or component, either `razor` or `cshtml`.
 
-  In the following Blazor app example, the RCL's package identifier is `AppJS`, and a module's scripts are loaded for the `Index` component (`Pages/Index.razor`):
+  In the following Blazor app example:
+  
+  * The RCL's package identifier is `AppJS`.
+  * A module's scripts are loaded for the `Index` component (`Index.razor`).
+  * The `Index` component is in the `Pages` folder of the RCL.
 
   ```csharp
   var module = await JS.InvokeAsync<IJSObjectReference>("import", 

--- a/aspnetcore/includes/js-collocation.md
+++ b/aspnetcore/includes/js-collocation.md
@@ -43,8 +43,3 @@ Collocated JS files are publicly addressable using the path to the file in the p
   var module = await JS.InvokeAsync<IJSObjectReference>("import", 
       "_content/AppJS/Pages/Index.razor.js");
   ```
-  
-  For more information on RCLs, see the following articles:
-  
-  * <xref:razor-pages/ui-class>
-  * <xref:blazor/components/class-libraries>


### PR DESCRIPTION
Fixes #23299

* https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-rc-1/#collocate-javascript-files-with-pages-views-and-components
* Probably should be covered in a few spots because ...
  * This feature works with script files collocated with pages/views/components in the app and from RCLs.
  * There's separate general RCL coverage for RP/MVC and Blazor.

I think the best way to go is via an INCLUDES file that can be placed in a few strategic spots ... as long as such a file covers all of the scenarios (app model and script locations).

Notes on the INCLUDES file:

* I'm only going to work this into the Blazor topics on this PR. The RP/MVC topics need a little work ... e.g., they're like 2.0-era (literally 2.0, not 2.1) and don't use whole-topic versioning ... and I'm not sure *exactly* where the best spots for coverage are, but I imagine they will be similar ... e.g., in the RP and MVC *Overview* (`index.md`) files and the RP/MVC RCL topic (`ui-class.md`).
* I prefer not to include the heading for a few reasons: I want to change that text on a per-topic basis. Also, I can't know 100% that the heading level will always be 2nd level, either in Blazor topics or elsewhere in the overall ToC.
* I prefer not to version the content because you know how we can run into moniker ranges within moniker ranges errors doing that sometimes. That's certainly the case for Blazor ... the files where this is used are on *whole-topic versioning*, so this file will break that if it includes versioned content.
* I considered a few different approaches with and without significant use of placeholders, but the use placeholders (as seen on the current PR) seems to be the best (quicker anyway 🏃) way to cover these scenarios. The approaches are called out cleanly I think. I doubt devs will have a problem with this.

I recommend opening a separate issue to address this feature for RP/MVC. This PR will be merged, so the INCLUDES file will be present for the doc author and can then be touched up for RP/MVC scenarios as needed. If the doc author decides that a different INCLUDES file makes more sense, ping me 👂 on the PR because I'd like to move the INCLUDES file of this PR into the Blazor ToC's `includes` folder and update the content for Blazor-only scenarios.