### PR TITLE
Add link to SQL Server backplane for SignalR

### DIFF
--- a/aspnetcore/signalr/scale.md
+++ b/aspnetcore/signalr/scale.md
@@ -191,6 +191,7 @@ For more information about ASP.NET Core with Nginx see the following article:
 * [NCache](https://www.alachisoft.com/ncache/asp-net-core-signalr.html)
 * [Orleans](https://github.com/OrleansContrib/SignalR.Orleans)
 * [Rebus](https://github.com/rebus-org/Rebus.SignalR)
+* [SQL Server](https://github.com/IntelliTect/IntelliTect.AspNetCore.SignalR.SqlServer)
 
 ## Next steps
 


### PR DESCRIPTION
Adding a link to the SqlServer backplane that I've created. https://github.com/IntelliTect/IntelliTect.AspNetCore.SignalR.SqlServer