### PR TITLE
Update Long Polling content

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -364,12 +364,14 @@ endpoints.MapBlazorHub(configureOptions: options =>
 });
 ```
 
-Add the following script to the `Shared/_Layout.cshtml` file immediately inside the closing `</body>` tag. WebSockets (`1`) and Long Polling (`4`) are the supported `HTTPTransportTypes`. The following example:
+Add the following script to the `Pages/_Layout.cshtml` file immediately inside the closing `</body>` tag. WebSockets (`1`) and Long Polling (`4`) are the supported `HTTPTransportTypes`. The following example:
 
+* Adds the `autostart="false"` attribute to the Blazor script tag.
 * Specifies support for both WebSockets and Long Polling transports (`1 | 4`).
 * Defaults to the WebSockets transport when a WebSockets connection can be established.
 
 ```html
+<script src="_framework/blazor.server.js" autostart="false"></script>
 <script>
   (function start() {
     Blazor.start({

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -364,14 +364,18 @@ endpoints.MapBlazorHub(configureOptions: options =>
 });
 ```
 
+Locate the Blazor script tag in the `Pages/_Layout.cshtml` file. Add the `autostart="false"` attribute to the tag:
+
+```html
+<script src="_framework/blazor.server.js" autostart="false"></script>
+```
+
 Add the following script to the `Pages/_Layout.cshtml` file immediately inside the closing `</body>` tag. WebSockets (`1`) and Long Polling (`4`) are the supported `HTTPTransportTypes`. The following example:
 
-* Adds the `autostart="false"` attribute to the Blazor script tag.
 * Specifies support for both WebSockets and Long Polling transports (`1 | 4`).
 * Defaults to the WebSockets transport when a WebSockets connection can be established.
 
 ```html
-<script src="_framework/blazor.server.js" autostart="false"></script>
 <script>
   (function start() {
     Blazor.start({


### PR DESCRIPTION
btw -- I add the API doc cross-links (e.g., `HTTPTransportTypes`) after GA. They aren't available yet to cross-link.