### PR TITLE
Improve [Required] attribute description

### DIFF
--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -466,7 +466,7 @@ To find out which parameters are passed to `String.Format` for a particular attr
 
 ## [Required] attribute
 
-By default, the validation system treats non-nullable parameters or properties as if they had a `[Required]` attribute. [Value types](/dotnet/csharp/language-reference/keywords/value-types) such as `decimal` and `int` are non-nullable.
+By default, the validation system treats non-nullable parameters or properties as if they had a `[Required(AllowEmptyStrings = true)]` attribute. [Value types](/dotnet/csharp/language-reference/keywords/value-types) such as `decimal` and `int` are non-nullable.
 
 ### [Required] validation on the server
 
@@ -488,7 +488,7 @@ Non-nullable types and strings are handled differently on the client compared to
 * A value is considered present only if input is entered for it. Therefore, client-side validation handles non-nullable types the same as nullable types.
 * Whitespace in a string field is considered valid input by the jQuery Validation [required](https://jqueryvalidation.org/required-method/) method. Server-side validation considers a required string field invalid if only whitespace is entered.
 
-As noted earlier, non-nullable types are treated as though they had a `[Required]` attribute. That means you get client-side validation even if you don't apply the `[Required]` attribute. But if you don't use the attribute, you get a default error message. To specify a custom error message, use the attribute.
+As noted earlier, non-nullable types are treated as though they had a `[Required(AllowEmptyStrings = true)]` attribute. That means you get client-side validation even if you don't apply the `[Required(AllowEmptyStrings = true)]` attribute. But if you don't use the attribute, you get a default error message. To specify a custom error message, use the attribute.
 
 ## [Remote] attribute
 


### PR DESCRIPTION

Fixes #23034 by making it clear to the end-user that the `[Required]` attribute used for non-nullable context is not the default one, but one that only checks for null values.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->