### PR TITLE
Linkfix: ASP.NET (2021-09)

### DIFF
--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -241,7 +241,7 @@ For more information on template options, see the following resources:
 
 .NET Hot Reload applies code changes, including changes to stylesheets, to a running app without restarting the app and without losing app state.
 
-Hot Reload is activated using the [`dotnet watch`](/aspnet/core/tutorials/dotnet-watch) command:
+Hot Reload is activated using the [`dotnet watch`](../tutorials/dotnet-watch.md) command:
 
 ```dotnetcli
 dotnet watch

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -241,7 +241,7 @@ For more information on template options, see the following resources:
 
 .NET Hot Reload applies code changes, including changes to stylesheets, to a running app without restarting the app and without losing app state.
 
-Hot Reload is activated using the [`dotnet watch`](../tutorials/dotnet-watch.md) command:
+Hot Reload is activated using the [`dotnet watch`](xref:tutorials/dotnet-watch) command:
 
 ```dotnetcli
 dotnet watch

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -556,7 +556,7 @@ webBuilder.ConfigureKestrel(serverOptions =>
 
 The default value is `ClientCertificateMode.NoCertificate` where Kestrel will not request or require a certificate from the client.
 
-See [Certificate Authentication](../../../security/authentication/certauth.md) for more details.
+For more information, see <xref:security/authentication/certauth>.
 
 ## Connection logging
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -556,7 +556,7 @@ webBuilder.ConfigureKestrel(serverOptions =>
 
 The default value is `ClientCertificateMode.NoCertificate` where Kestrel will not request or require a certificate from the client.
 
-See [Certificate Authenticaiton](/aspnet/core/security/authentication/certauth) for more details.
+See [Certificate Authentication](../../../security/authentication/certauth.md) for more details.
 
 ## Connection logging
 


### PR DESCRIPTION
This PR is the result of running a Link Repair script on the included content. This script is primarily being run to clean up links to function correctly in Air Gapped Clouds (AGC). Here's a breakdown of what the script that generated the changes in this PR fixes:

- docs.microsoft.com Fully Qualified Domain Name (FQDN) Links to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- azure.microsoft.com/documentation/articles that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
- All known flavors of MSDN/TechNet domains (we know of 8 or 9 now) that reflect to Docs to either Relative (if in same Repo/DocSet/ContentSet) and Site Relative if not
  - This also includes cleanup of the appended query string for MSDN (redirectedfrom=MSDN).
- Fixes articles that are redirected in `.openpublishing.redirection.json` and updates the link to the current final location (this has a lot of customer usability fixes).

Please note the [Contributor Guide: Links](https://review.docs.microsoft.com/en-us/help/contribute/links-how-to?branch=master) has been updated with the following link-type preference order:

```
By order of preference, links hosted on Docs should be Relative if they are in the same repository and docset. If they are in a different docset, even if in the same repository, they should be Site Relative. Links to content hosted on Docs shouldn't use a complete URL, otherwise known as Fully Qualified Domain Names (FQDN). Using a complete URL from Docs to other content on Docs will cause that link to be non-functional in air-gap environments.
```
