### PR TITLE
Cross-link certificate use patterns for App Service

### DIFF
--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -262,13 +262,12 @@ See the [host and deploy documentation](xref:host-and-deploy/proxy-load-balancer
 
 ### Use certificate authentication in Azure Web Apps
 
-No forwarding configuration is required for Azure. This is already setup in the certificate forwarding middleware.
+No forwarding configuration is required for Azure. Forwarding configuration is set up by the Certificate Forwarding Middleware.
 
 > [!NOTE]
-> This requires that the CertificateForwardingMiddleware is present.
+> Certificate Forwarding Middleware is required for this scenario.
 
-Add "WEBSITE_LOAD_USER_PROFILE=1" to the application setting when hosting on a Windows instance, and the App Service plan needs to be on a Basic or above.
-
+For more information, see [Use a TLS/SSL certificate in your code in Azure App Service (Azure documentation)](/azure/app-service/configure-ssl-certificate-in-code).
 
 ### Use certificate authentication in custom web proxies
 

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -267,6 +267,9 @@ No forwarding configuration is required for Azure. This is already setup in the 
 > [!NOTE]
 > This requires that the CertificateForwardingMiddleware is present.
 
+Add "WEBSITE_LOAD_USER_PROFILE=1" to the application setting when hosting on a Windows instance, and the App Service plan needs to be on a Basic or above.
+
+
 ### Use certificate authentication in custom web proxies
 
 The `AddCertificateForwarding` method is used to specify:


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #63530

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->
Fixes #63530

There has some extra setup needed for Azure Web Apps, the validation will fail with the "The system cannot find the file specified" error if they're not supplied.