### PR TITLE
Feature/https linux updates

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -563,6 +563,28 @@ Close any browser instances open. Open a new browser window to app.
 
 See [HTTPS Error using IIS Express (dotnet/AspNetCore #16892)](https://github.com/dotnet/AspNetCore/issues/16892) for troubleshooting certificate issues with Visual Studio.
 
+### Linux - certificate not trusted
+
+Check that the certificate you are configuring for trust is the user HTTPS developer certificate that will be used by the dotnet Kestrel server.
+
+You can check the current user default HTTPS developer certificate (used by Kestrel) at the following location; the filename will be the SHA1 thumbprint. If you clear this file (via `dotnet dev-certs https --clean`) then it will be regenerated when needed, but with a different thumbprint.
+
+```
+ls -la ~/.dotnet/corefx/cryptography/x509stores/my
+```
+
+Check the thumbprint of the exported certificate (being trusted) matches:
+
+```
+openssl x509 -noout -fingerprint -sha1 -inform pem -in /usr/local/share/ca-certificates/aspnet/https.crt
+```
+
+If it does not match, you either have an old certificate, or may have exported a developer certificate for the root user, and will need to export the correct certificate again. You can check the root user certificate at:
+
+```
+ls -la /root/.dotnet/corefx/cryptography/x509stores/my
+```
+
 ### IIS Express SSL certificate used with Visual Studio
 
 To fix problems with the IIS Express certificate, select **Repair** from the Visual Studio installer. For more information, see [this GitHub issue](https://github.com/dotnet/aspnetcore/issues/16892).

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -411,7 +411,11 @@ Establishing trust is distribution and browser specific. The following sections 
     sudo update-ca-certificates
     ```
 
-This first ensure the current user's developer certificate is created, and then exports it with elevated permissions needed for the `ca-certificates` folder, but using the current user's environment.
+The preceding commands:
+
+* Ensure the current user's developer certificate is created.
+* Exports the certificate with elevated permissions needed for the `ca-certificates` folder, using the current user's environment.
+* Removing the `-E`  flag exports the root user certificate, generating it if necessary. Each newly generated certificate has a different thumbprint. When running as root, `sudo`  and  `-E` are not needed.
 
 Without `-E` it would export the root user certificate (generating it if necessary), which has a different thumbprint. If you are running as root, then you won't need `sudo` (or the `-E`).
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -458,17 +458,19 @@ For chromium browsers on Linux:
 
 * Create a JSON file at `/usr/lib/firefox/distribution/policies.json` with the following contents:
 
-  ```json
-  {
-      "policies": {
-          "Certificates": {
-              "Install": [
-                  "/usr/local/share/ca-certificates/aspnet/https.crt"
-              ]
-          }
-      }
-  }
-  ```
+```sh
+cat <<EOF | sudo tee /usr/lib/firefox/distribution/policies.json
+{
+    "policies": {
+        "Certificates": {
+            "Install": [
+                "/usr/local/share/ca-certificates/aspnet/https.crt"
+            ]
+        }
+    }
+}
+EOF
+```
   
 See [Configure trust of HTTPS certificate using Firefox browser](#trust-ff-ba) in this document for an alternative way to configure the policy file using the browser.
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -417,7 +417,6 @@ The preceding commands:
 * Exports the certificate with elevated permissions needed for the `ca-certificates` folder, using the current user's environment.
 * Removing the `-E`  flag exports the root user certificate, generating it if necessary. Each newly generated certificate has a different thumbprint. When running as root, `sudo`  and  `-E` are not needed.
 
-Without `-E` it would export the root user certificate (generating it if necessary), which has a different thumbprint. If you are running as root, then you won't need `sudo` (or the `-E`).
 
 The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -396,23 +396,28 @@ For more information, see [Setting Up Certificate Authorities (CAs) in Firefox](
 
 See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/6199).
 
-## Ubuntu trust the certificate for service-to-service communication
+## Trust HTTPS certificate on Linux
+
+Establishing trust is distribution and browser specific. The following sections provide instructions for some popular distributions and the Chromium browsers (Edge and Chrome) and for Firefox.
+
+### Ubuntu trust the certificate for service-to-service communication
 
 1. Install [OpenSSL](https://www.openssl.org/) 1.1.1h or later. See your distribution for instructions on how to update OpenSSL.
 1. Run the following commands:
 
     ```cli
-    sudo dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+    dotnet dev-certs https
+    sudo -E dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
     sudo update-ca-certificates
     ```
+
+This first ensure the current user's developer certificate is created, and then exports it with elevated permissions needed for the `ca-certificates` folder, but using the current user's environment.
+
+Without `-E` it would export the root user certificate (generating it if necessary), which has a different thumbprint. If you are running as root, then you won't need `sudo` (or the `-E`).
 
 The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
 
 <a name="ssl-linux"></a>
-
-## Trust HTTPS certificate on Linux
-
-Establishing trust is browser specific. The following sections provide instructions for the Chromium browsers Edge and Chrome and for Firefox.
 
 ### Trust HTTPS certificate on Linux using Edge or Chrome
 
@@ -423,10 +428,11 @@ For chromium browsers on Linux:
   * Export the certificate with the following command:
   
     ```cli
-    dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+    dotnet dev-certs https
+    sudo -E dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
     ```
 
-    The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs). **You may need elevated permissions to export the certificate to the `ca-certificates` folder.**
+    The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
 
   * Run the following commands:
   
@@ -444,7 +450,8 @@ For chromium browsers on Linux:
 * Export the certificate with the following command:
 
   ```vstscli
-  dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
+  dotnet dev-certs https
+  sudo -E dotnet dev-certs https -ep /usr/local/share/ca-certificates/aspnet/https.crt --format PEM
   ```
 
   The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -576,13 +576,19 @@ Check the current user default HTTPS developer Kestrel certificate at the follow
 ls -la ~/.dotnet/corefx/cryptography/x509stores/my
 ```
 
-Check the thumbprint of the exported certificate (being trusted) matches:
+The HTTPS developer Kestrel certificate file is the SHA1 thumbprint. When the file is deleted via `dotnet dev-certs https --clean`, it's regenerated when needed with a different thumbprint.
+Check the thumbprint of the exported certificate matches with the following command:
 
 ```
 openssl x509 -noout -fingerprint -sha1 -inform pem -in /usr/local/share/ca-certificates/aspnet/https.crt
 ```
 
-If it does not match, you either have an old certificate, or may have exported a developer certificate for the root user, and will need to export the correct certificate again. You can check the root user certificate at:
+If the certificate doesn't match, it could be one of the following:
+
+* An old certificate.
+* An exported a developer certificate for the root user. For this case, export the  certificate.
+
+The root user certificate can be checked at:
 
 ```
 ls -la /root/.dotnet/corefx/cryptography/x509stores/my

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -570,7 +570,7 @@ See [HTTPS Error using IIS Express (dotnet/AspNetCore #16892)](https://github.co
 
 Check that the certificate being configured for trust is the user HTTPS developer certificate that will be used by the Kestrel server.
 
-You can check the current user default HTTPS developer certificate (used by Kestrel) at the following location; the filename will be the SHA1 thumbprint. If you clear this file (via `dotnet dev-certs https --clean`) then it will be regenerated when needed, but with a different thumbprint.
+Check the current user default HTTPS developer Kestrel certificate at the following location:
 
 ```
 ls -la ~/.dotnet/corefx/cryptography/x509stores/my

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -568,7 +568,7 @@ See [HTTPS Error using IIS Express (dotnet/AspNetCore #16892)](https://github.co
 
 ### Linux certificate not trusted
 
-Check that the certificate you are configuring for trust is the user HTTPS developer certificate that will be used by the dotnet Kestrel server.
+Check that the certificate being configured for trust is the user HTTPS developer certificate that will be used by the Kestrel server.
 
 You can check the current user default HTTPS developer certificate (used by Kestrel) at the following location; the filename will be the SHA1 thumbprint. If you clear this file (via `dotnet dev-certs https --clean`) then it will be regenerated when needed, but with a different thumbprint.
 

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -566,7 +566,7 @@ Close any browser instances open. Open a new browser window to app.
 
 See [HTTPS Error using IIS Express (dotnet/AspNetCore #16892)](https://github.com/dotnet/AspNetCore/issues/16892) for troubleshooting certificate issues with Visual Studio.
 
-### Linux - certificate not trusted
+### Linux certificate not trusted
 
 Check that the certificate you are configuring for trust is the user HTTPS developer certificate that will be used by the dotnet Kestrel server.
 


### PR DESCRIPTION
Fixes #23378

Provide consistent instructions for exporting the Linux certificate that both has the needed permissions (sudo), and will use the current user's environment developer certificate (-E), that will work for the common scenario of a non-root user.

Also provide troubleshooting details for Linux, to see the thumbprint of both the Kestrel default certificate and the exported certificate being trusted. If they are not the same, then something went wrong, and the trust won't work.

Note there are many ways to configure/user Linux, e.g. as root, or as a user with permissions to add certificates, so the exact steps needed will vary. The most common way to use Linux as a developer is probably as a non-root user, but with sudo permissions, so instructions are based on that scenario.

The troubleshooting section provides details of where the certificates are found, and how to compare their thumbprints, so that a user can work out what the problem is, or adjust as necessary (e.g. if they need to use the root user certificate).

I also added a slight efficiency improvement to the Firefox instructions to provide a command line that will directly create the needed JSON file.

Note: Changes are separate commits, so you could cherry pick if you only want to include some of them.