### PR TITLE
[RC2] Revert Long Polling updates (2)

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -350,43 +350,6 @@ When a circuit ends because a user has disconnected and the framework is cleanin
 
 We recommend using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-service) for Blazor Server apps hosted in Microsoft Azure. The service works in conjunction with the app's Blazor Hub for scaling up a Blazor Server app to a large number of concurrent SignalR connections. In addition, the SignalR Service's global reach and high-performance data centers significantly aid in reducing latency due to geography. For prerendering support with the Azure SignalR Service, configure the app to use *sticky sessions*. For more information, see <xref:blazor/host-and-deploy/server>.
 
-## Long Polling
-
-In earlier versions of ASP.NET Core, Long Polling was enabled as a fallback transport for situations in which the WebSockets transport wasn't available. If an app must use Long Polling, make the following changes:
-
-In the app's `Startup.cs` file, replace `endpoints.MapBlazorHub()` with the following code:
-
-```csharp
-endpoints.MapBlazorHub(configureOptions: options => 
-{ 
-    options.Transports = 
-        HttpTransportType.WebSockets | HttpTransportType.LongPolling;
-});
-```
-
-Locate the Blazor script tag in the `Pages/_Layout.cshtml` file. Add the `autostart="false"` attribute to the tag:
-
-```html
-<script src="_framework/blazor.server.js" autostart="false"></script>
-```
-
-Add the following script to the `Pages/_Layout.cshtml` file immediately inside the closing `</body>` tag. WebSockets (`1`) and Long Polling (`4`) are the supported `HTTPTransportTypes`. The following example:
-
-* Specifies support for both WebSockets and Long Polling transports (`1 | 4`).
-* Defaults to the WebSockets transport when a WebSockets connection can be established.
-
-```html
-<script>
-  (function start() {
-    Blazor.start({
-      configureSignalR: builder => builder.withUrl('_blazor', 1 | 4)
-    });
-  })()
-</script>
-```
-
-For more information, see [Disable Long Polling Fallback Transport for Blazor Server (ASP.NET Announcements)](https://github.com/aspnet/Announcements/issues/470).
-
 ## Additional resources
 
 * <xref:signalr/introduction>


### PR DESCRIPTION
Fixes #23456

✋ **HOLD FOR 6.0 RC2 RELEASE** ✋

This 2nd PR for the issue removes the main content in the Fundamentals SignalR topic. The 1st PR at https://github.com/dotnet/AspNetCore.Docs/pull/23464 removed the content in two secondary spots. The 1st PR was merged to avoid blocking future PRs to those topics because work is on-going to update topics for minimal APIs.