### PR TITLE
v6Update: MVC Getting Started - Adding Model: Startup.cs move to Program.cs

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model.md
@@ -72,6 +72,7 @@ In the PMC, run the following command:
 
 ```powershell
 Install-Package Microsoft.EntityFrameworkCore.Design -IncludePrerelease
+Install-Package Microsoft.EntityFrameworkCore.SqlServer -IncludePrerelease
 ```
 
 The preceding commands add:


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-6.0&branch=pr-en-us-23473&tabs=visual-studio)

Fixes #23475 

Updated to reflect .NET 6.0 and VS 2022 preview changes:

- References to Startup.cs code moved to Program.cs in .NET 6 
- Install-Package Microsoft.EntityFrameworkCore.SqlServer -IncludePrerelease     (Required for the current preview release as an additional step.)


 