### PR TITLE
doc update for anchor tag helper

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -64,7 +64,7 @@ The [asp-route-{value}](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper
 
 Consider the following controller action:
 
-[!code-csharp[](samples/TagHelpersBuiltIn/Controllers/BuiltInTagController.cs?name=snippet_AnchorTagHelperAction)]
+[!code-csharp[](samples/TagHelpersBuiltIn/Controllers/SpeakerController.cs?name=snippet_SpeakerDetailAction)]
 
 With a default route template defined in *Startup.Configure*:
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Controllers/SpeakerController.cs
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/samples/TagHelpersBuiltIn/Controllers/SpeakerController.cs
@@ -7,6 +7,7 @@
 
     public class SpeakerController : Controller
     {
+        #region snippet_SpeakerDetailAction
         private List<Speaker> Speakers =
             new List<Speaker>
             {
@@ -18,6 +19,7 @@
         [Route("Speaker/{id:int}")]
         public IActionResult Detail(int id) =>
             View(Speakers.FirstOrDefault(a => a.SpeakerId == id));
+        #endregion
 
         [Route("/Speaker/Evaluations", 
                Name = "speakerevals")]


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/23474

@Rick-Anderson the `BuiltInTagController.cs` seems unused. I'm keeping it as it is. Let me know if I should remove it. 🙂 