### PR TITLE
Fix broken href

### DIFF
--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -143,7 +143,7 @@ By default, apps created using the PWA template option have support for running 
 > Development support would interfere with the usual development cycle of making changes and testing them. Therefore, offline support is only enabled for *published* apps. 
 
 > [!WARNING]
-> If you intend to distribute an offline-enabled PWA, there are [several important warnings and caveats](#caveats-for-offline-pwas). These scenarios are inherent to offline PWAs and not specific to Blazor. Be sure to read and understand these caveats before making assumptions about how your offline-enabled app will work.
+> If you intend to distribute an offline-enabled PWA, there are [several important warnings and caveats](#caveats-for-offline-pwas-1). These scenarios are inherent to offline PWAs and not specific to Blazor. Be sure to read and understand these caveats before making assumptions about how your offline-enabled app will work.
 
 To see how offline support works:
 


### PR DESCRIPTION
It seems that chapter hrefs are suffixed with `-1` for some reason.