### PR TITLE
Blazor WASM native deps support

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -57,14 +57,12 @@ Runtime relinking is performed automatically when you publish an app. The size r
 
 Blazor WebAssembly apps can use native dependencies built to run on WebAssembly. You can statically link native dependencies into the .NET WebAssembly runtime using the .NET WebAssembly build tools, the same tools used to [ahead-of-time (AOT) compile](#ahead-of-time-aot-compilation) a Blazor app to WebAssembly or to [relink the runtime to remove unused features](#runtime-relinking).
 
-To install the .NET WebAssembly build tools, use either of the following approaches:
+The .NET WebAssembly build tools are based on [Emscripten](https://emscripten.org/), a compiler toolchain for the web platform. To install the .NET WebAssembly build tools, use either of the following approaches:
 
 * Select the optional component in the Visual Studio installer.
 * Run `dotnet workload install wasm-tools` from an administrative command prompt.
 
-The .NET WebAssembly build tools are based on [Emscripten](https://emscripten.org/), a compiler toolchain for the web platform.
-
-Add native dependencies to a Blazor WebAssembly app by adding `NativeFileReference` items in the app's project file. When the project is built, each `NativeFileReference` is passed to Emscripten by the .NET WebAssembly build tools so that they are compiled and linked into the runtime. Next, p/invoke into the native code from the app's .NET code.
+Add native dependencies to a Blazor WebAssembly app by adding `NativeFileReference` items in the app's project file. When the project is built, each `NativeFileReference` is passed to Emscripten by the .NET WebAssembly build tools so that they are compiled and linked into the runtime. Next, [`p/invoke`](/dotnet/standard/native-interop/pinvoke) into the native code from the app's .NET code.
 
 Generally, any portable native code can be used as a native dependency with Blazor WebAssembly. You can add native dependencies to C/C++ code or code previously compiled using Emscripten:
 
@@ -99,12 +97,12 @@ Add a simple native C function to a Blazor WebAssembly app:
    </ItemGroup>
    ```
 
-1. In the app's `Pages/Index.razor` file, add a <xref:System.Runtime.InteropServices.DllImportAttribute> for the fact function in the generated `Test` library:
+1. In a Razor component (`.razor`), add a <xref:System.Runtime.InteropServices.DllImportAttribute> for the `fact` function in the generated `Test` library and call the `fact` method from .NET code in the component:
 
    ```razor
    @using System.Runtime.InteropServices
 
-   ...
+   <p>@fact(3)</p>
 
    @code {
        [DllImport("Test")]
@@ -112,20 +110,14 @@ Add a simple native C function to a Blazor WebAssembly app:
    }
    ```
 
-1. Call the `fact` method from .NET code.
-
-   ```razor
-   <p>@fact(3)</p>
-   ```
-
-When you build the app with the .NET WebAssembly build tools installed, the native C code is compiled and linked into `dotnet.wasm`. Compiling and linking may take a few minutes. After the app is built, run the app to see the rendered factorial value.
+When you build the app with the .NET WebAssembly build tools installed, the native C code is compiled and linked into the .NET WebAssembly runtime (`dotnet.wasm`). Compiling and linking may take a few minutes. After the app is built, run the app to see the rendered factorial value.
 
 > [!NOTE]
 > During the 6.0 preview release period, you may receive a build error on subsequent builds saying that the output assembly is being used by another process. This is a known issue that will be addressed for the .NET 6 general release. To workaround the issue, rebuild the project a second time.
 
 ### Use libraries
 
-NuGet packages can contain native dependencies for use on WebAssembly. These libraries and their native functionality can then be used from any Blazor WebAssembly app. The files for the native dependencies should be built for WebAssembly and packaged in the `browser-wasm` [architecture-specific folder](/nuget/create-packages/supporting-multiple-target-frameworks#architecture-specific-folders). WebAssembly-specific dependencies aren't referenced automatically and must be referenced manually as a `NativeFileReference`. Package authors can choose to add the native references by including a `.props` file in the package with the references.
+NuGet packages can contain native dependencies for use on WebAssembly. These libraries and their native functionality are then available to any Blazor WebAssembly app. The files for the native dependencies should be built for WebAssembly and packaged in the `browser-wasm` [architecture-specific folder](/nuget/create-packages/supporting-multiple-target-frameworks#architecture-specific-folders). WebAssembly-specific dependencies aren't referenced automatically and must be referenced manually as `NativeFileReference`s. Package authors can choose to add the native references by including a `.props` file in the package with the references.
 
 [SkiaSharp](https://github.com/mono/SkiaSharp) is a cross-platform 2D graphics library for .NET based on the native [Skia graphics library](https://skia.org/), and it now has preview support for Blazor WebAssembly.
 
@@ -146,9 +138,9 @@ To use SkiaSharp in a Blazor WebAssembly app:
 1. Add a `SKCanvasView` component to the app with the following:
 
    * `SkiaSharp` and `SkiaSharp.Views.Blazor` namespaces.
-   * Logic to draw in the `SKCanvasView` component.
+   * Logic to draw in the SkiaSharp Canvas View component (`SKCanvasView`).
 
-   `Pages/NativeDependencyExample.razor`
+   `Pages/NativeDependencyExample.razor`:
 
    ```razor
    @page "/native-dependency-example"


### PR DESCRIPTION
Fixes #23522

Based on the content in the [blog post](https://devblogs.microsoft.com/aspnet/asp-net-core-updates-in-net-6-rc-2/#native-dependencies-support-for-blazor-webassembly-apps).

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?view=aspnetcore-3.1&branch=pr-en-us-23530#native-dependencies-support)
