### PR TITLE
Update introduction.md

### DIFF
--- a/aspnetcore/signalr/introduction.md
+++ b/aspnetcore/signalr/introduction.md
@@ -37,7 +37,7 @@ The source is hosted in a [SignalR repository on GitHub](https://github.com/dotn
 
 SignalR supports the following techniques for handling real-time communication (in order of graceful fallback):
 
-* [WebSocket](https://tools.ietf.org/html/rfc7118)
+* [WebSockets](xref:fundamentals/websockets)
 * Server-Sent Events
 * Long Polling
 


### PR DESCRIPTION
According to rfc7118, it should be 'WebSocket'(without ending 's') instead of 'WebSockets'



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->