### PR TITLE
Remove outdated Channel 9 links

### DIFF
--- a/aspnetcore/client-side/libman/index.md
+++ b/aspnetcore/client-side/libman/index.md
@@ -22,8 +22,6 @@ LibMan offers the following benefits:
 * Additional tooling, such as [Node.js](https://nodejs.org), [npm](https://www.npmjs.com), and [WebPack](https://webpack.js.org), isn't necessary to acquire a subset of files in a library.
 * Files can be placed in a specific location without resorting to build tasks or manual file copying.
 
-For more information about LibMan's benefits, watch [Modern front-end web development in Visual Studio 2017: LibMan segment](https://channel9.msdn.com/Events/Build/2017/B8073#time=43m34s).
-
 LibMan isn't a package management system. If you're already using a package manager, such as npm or [yarn](https://yarnpkg.com), continue doing so. LibMan wasn't developed to replace those tools.
 
 ## Additional resources

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -334,8 +334,6 @@ If you need to transform *web.config* on publish (for example, set environment v
 ## Additional resources
 
 * [App Service overview](/azure/app-service/app-service-web-overview)
-* [Azure App Service: The Best Place to Host your .NET Apps (55-minute overview video)](https://channel9.msdn.com/events/dotnetConf/2017/T222)
-* [Azure Friday: Azure App Service Diagnostic and Troubleshooting Experience (12-minute video)](https://channel9.msdn.com/Shows/Azure-Friday/Azure-App-Service-Diagnostic-and-Troubleshooting-Experience)
 * [Azure App Service diagnostics overview](/azure/app-service/app-service-diagnostics)
 * <xref:host-and-deploy/web-farm>
 

--- a/aspnetcore/performance/diagnostic-tools.md
+++ b/aspnetcore/performance/diagnostic-tools.md
@@ -48,7 +48,7 @@ For more information on code-based monitoring, see [Application Insights for ASP
 
 [PerfView](https://github.com/Microsoft/perfview) is a performance analysis tool created by the .NET team specifically for diagnosing .NET performance issues. PerfView allows analysis of CPU usage, memory and GC behavior, performance events, and wall clock time.
 
-You can learn more about PerfView and how to get started with [PerfView video tutorials](https://channel9.msdn.com/Series/PerfView-Tutorial) or by reading the user's guide available in the tool or [on GitHub](https://github.com/Microsoft/perfview).
+For more about PerfView, see the user's guide available in the tool or [on GitHub](https://github.com/Microsoft/perfview).
 
 ## Windows Performance Toolkit
 

--- a/aspnetcore/release-notes/aspnetcore-5.0.md
+++ b/aspnetcore/release-notes/aspnetcore-5.0.md
@@ -386,8 +386,6 @@ endpoints.MapGet("/weather/{city:alpha}", async context =>
 });
 ```
 
-For more information on the new JSON extension methods and route to code, see [this .NET show](https://channel9.msdn.com/Shows/On-NET/ASPNET-Core-Series-Route-to-Code).
-
 ### System.Diagnostics.Activity
 
 The default format for <xref:System.Diagnostics.Activity?displayProperty=fullName> now defaults to the W3C format. This makes distributed tracing support in ASP.NET Core interoperable with more frameworks by default.

--- a/aspnetcore/security/authentication/azure-active-directory/index.md
+++ b/aspnetcore/security/authentication/azure-active-directory/index.md
@@ -23,6 +23,4 @@ These tutorials and samples demonstrate authentication in ASP.NET Core using Mic
 
 ## Samples
 
-* [Enable your ASP.NET Core app to sign-in users and call web APIs using Azure AD V2](/samples/azure-samples/active-directory-aspnetcore-webapp-openidconnect-v2/enable-webapp-signin/): 
-  * See [this associated video](https://channel9.msdn.com/Events/Build/2018/THR5001)
-
+* [Enable your ASP.NET Core app to sign-in users and call web APIs using Azure AD V2](/samples/azure-samples/active-directory-aspnetcore-webapp-openidconnect-v2/enable-webapp-signin/)

--- a/aspnetcore/security/key-vault-configuration.md
+++ b/aspnetcore/security/key-vault-configuration.md
@@ -363,7 +363,6 @@ When the app fails to load configuration using the provider, an error message is
 * [How to generate and transfer HSM-protected keys for Azure Key Vault](/azure/key-vault/key-vault-hsm-protected-keys)
 * [Quickstart: Set and retrieve a secret from Azure Key Vault by using a .NET web app](/azure/key-vault/quick-create-net)
 * [Tutorial: How to use Azure Key Vault with Azure Windows Virtual Machine in .NET](/azure/key-vault/tutorial-net-windows-virtual-machine)
-* [Secretless apps with .NET and Azure Key Vault](https://channel9.msdn.com/Shows/On-NET/Secretless-apps-with-NET-and-Azure-Key-Vault)
 
 ::: moniker-end
 

--- a/aspnetcore/test/troubleshoot-azure-iis.md
+++ b/aspnetcore/test/troubleshoot-azure-iis.md
@@ -563,7 +563,6 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 * [Troubleshoot slow web app performance issues in Azure App Service](/azure/app-service/app-service-web-troubleshoot-performance-degradation)
 * [Application performance FAQs for Web Apps in Azure](/azure/app-service/app-service-web-availability-performance-application-issues-faq)
 * [Azure Web App sandbox (App Service runtime execution limitations)](https://github.com/projectkudu/kudu/wiki/Azure-Web-App-sandbox)
-* [Azure Friday: Azure App Service Diagnostic and Troubleshooting Experience (12-minute video)](https://channel9.msdn.com/Shows/Azure-Friday/Azure-App-Service-Diagnostic-and-Troubleshooting-Experience)
 
 ### Visual Studio documentation
 
@@ -1056,7 +1055,6 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 * [Troubleshoot slow web app performance issues in Azure App Service](/azure/app-service/app-service-web-troubleshoot-performance-degradation)
 * [Application performance FAQs for Web Apps in Azure](/azure/app-service/app-service-web-availability-performance-application-issues-faq)
 * [Azure Web App sandbox (App Service runtime execution limitations)](https://github.com/projectkudu/kudu/wiki/Azure-Web-App-sandbox)
-* [Azure Friday: Azure App Service Diagnostic and Troubleshooting Experience (12-minute video)](https://channel9.msdn.com/Shows/Azure-Friday/Azure-App-Service-Diagnostic-and-Troubleshooting-Experience)
 
 ### Visual Studio documentation
 
@@ -1487,7 +1485,6 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 * [Troubleshoot slow web app performance issues in Azure App Service](/azure/app-service/app-service-web-troubleshoot-performance-degradation)
 * [Application performance FAQs for Web Apps in Azure](/azure/app-service/app-service-web-availability-performance-application-issues-faq)
 * [Azure Web App sandbox (App Service runtime execution limitations)](https://github.com/projectkudu/kudu/wiki/Azure-Web-App-sandbox)
-* [Azure Friday: Azure App Service Diagnostic and Troubleshooting Experience (12-minute video)](https://channel9.msdn.com/Shows/Azure-Friday/Azure-App-Service-Diagnostic-and-Troubleshooting-Experience)
 
 ### Visual Studio documentation
 


### PR DESCRIPTION
Fixes #23533 

Removed Channel 9 links from the following 7 topics.

Internal review, links to edited sections:
[Client-side library acquisition in ASP.NET Core with LibMan](https://review.docs.microsoft.com/en-us/aspnet/core/client-side/libman/?view=aspnetcore-5.0&branch=pr-en-us-23557#libman-use-cases)
[Deploy ASP.NET Core apps to Azure App Service](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/azure-apps/?view=aspnetcore-5.0&branch=pr-en-us-23557&tabs=visual-studio)
[Performance Diagnostic Tools](https://review.docs.microsoft.com/en-us/aspnet/core/performance/diagnostic-tools?view=aspnetcore-5.0&branch=pr-en-us-23557)
[Release Mptes](https://review.docs.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-5.0?view=aspnetcore-5.0&branch=pr-en-us-23557#json-extension-methods-for-httprequest-and-httpresponse)
[Azure Active Directory](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/azure-active-directory/?view=aspnetcore-5.0&branch=pr-en-us-23557#samples)
[Key Vault Configuration](https://review.docs.microsoft.com/en-us/aspnet/core/security/key-vault-configuration?view=aspnetcore-5.0&branch=pr-en-us-23557#additional-resources)
[Troubleshoot Azure IIS](https://review.docs.microsoft.com/en-us/aspnet/core/test/troubleshoot-azure-iis?view=aspnetcore-5.0&branch=pr-en-us-23557#azure-documentation)

