### PR TITLE
Blazor WASM debugging profile

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -470,7 +470,7 @@ To debug a Blazor WebAssembly app in Visual Studio:
    > When debugging with a Chromium-based browser, such as Google Chrome or Microsoft Edge, a new browser window is opened with a separate profile for the debugging session instead of opening a tab in an existing browser window with the user's profile. If debugging with the user's profile is a requirement, adopt **one** of the following approaches:
    >
    > * Close all open browser instances before pressing <kbd>F5</kbd> to start debugging.
-   > * Configure Visual Studio to launch the browser with the user's profile. For more information on this approach, see [Blazor WASM Debugging in VS launches Edge with a separate user data directory (dotnet/aspnetcore #20915)](https://github.com/dotnet/aspnetcore/issues/20915).
+   > * Configure Visual Studio to launch the browser with the user's profile. For more information on this approach, see [Blazor WASM Debugging in VS launches Edge with a separate user data directory (dotnet/aspnetcore #20915)](https://github.com/dotnet/aspnetcore/issues/20915#issuecomment-614933322).
 
    > [!NOTE]
    > **Start Without Debugging** (<kbd>Ctrl</kbd>+<kbd>F5</kbd>) isn't supported. When the app is run in Debug configuration, debugging overhead always results in a small performance reduction.
@@ -899,7 +899,7 @@ To debug a Blazor WebAssembly app in Visual Studio:
    > When debugging with a Chromium-based browser, such as Google Chrome or Microsoft Edge, a new browser window is opened with a separate profile for the debugging session instead of opening a tab in an existing browser window with the user's profile. If debugging with the user's profile is a requirement, adopt **one** of the following approaches:
    >
    > * Close all open browser instances before pressing <kbd>F5</kbd> to start debugging.
-   > * Configure Visual Studio to launch the browser with the user's profile. For more information on this approach, see [Blazor WASM Debugging in VS launches Edge with a separate user data directory (dotnet/aspnetcore #20915)](https://github.com/dotnet/aspnetcore/issues/20915).
+   > * Configure Visual Studio to launch the browser with the user's profile. For more information on this approach, see [Blazor WASM Debugging in VS launches Edge with a separate user data directory (dotnet/aspnetcore #20915)](https://github.com/dotnet/aspnetcore/issues/20915#issuecomment-614933322).
 
    > [!NOTE]
    > **Start Without Debugging** (<kbd>Ctrl</kbd>+<kbd>F5</kbd>) isn't supported. When the app is run in Debug configuration, debugging overhead always results in a small performance reduction.


### PR DESCRIPTION
Fixes #23561

Thanks @anurse! ... and 👋 ... and plz let me know ur feedback on this (at least temporary) coverage. Very minor point: Since I go with a cross-link to the PU issue for details, you could make the title of the PU issue use "a Chromium-based browser" instead of "Edge" ... it would be a little better that way if Safia decides that we only ever need to cross-link the PU issue here and never host specific doc guidance on this (i.e., the steps for setting up the custom browser launch) :point_down:.

Safia, there are some scattered bits of guidance in VS docs for setting up VS for running with a profile, but nothing as specific and helpful as the PU issue. For now, I think we should direct readers there for the detailed steps. We could eventually carry the guidance in the topic.

* Do you agree with cross-linking the PU issue for now?
* Would you like the topic to eventually ... later ... *much later* 🏃😅, i.e., middle of next year ... would you like the topic carry the exact guidance and drop the PU issue cross-link? If so, I'll open a follow-up issue of low priority for it after we merge this.
* On a specific point here: Is it actually named `dev-profile`? ... or instead of saying ...

  > ... opened with a separate profile (`dev-profile`) for the debugging session ...

  ... should that read ...

  > ... opened with a separate developer profile for the debugging session ...