### PR TITLE
Browser Profile Minor Update

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -86,7 +86,7 @@ To debug a Blazor WebAssembly app in Visual Studio:
 1. With the **`Server`** project selected in **Solution Explorer**, press <kbd>F5</kbd> to run the app in the debugger.
 
    > [!NOTE]
-   > When debugging with a Chromium-based browser, such as Google Chrome or Microsoft Edge, a new browser window may be opened with a separate profile for the debugging session instead of opening a tab in an existing browser window with the user's profile. If debugging with the user's profile is a requirement, adopt **one** of the following approaches:
+   > When debugging with a Chromium-based browser, such as Google Chrome or Microsoft Edge, a new browser window might open with a separate profile for the debugging session instead of opening a tab in an existing browser window with the user's profile. If debugging with the user's profile is a requirement, adopt **one** of the following approaches:
    >
    > * Close all open browser instances before pressing <kbd>F5</kbd> to start debugging.
    > * Configure Visual Studio to launch the browser with the user's profile. For more information on this approach, see [Blazor WASM Debugging in VS launches Edge with a separate user data directory (dotnet/aspnetcore #20915)](https://github.com/dotnet/aspnetcore/issues/20915#issuecomment-614933322).
@@ -467,7 +467,7 @@ To debug a Blazor WebAssembly app in Visual Studio:
 1. With the **`Server`** project selected in **Solution Explorer**, press <kbd>F5</kbd> to run the app in the debugger.
 
    > [!NOTE]
-   > When debugging with a Chromium-based browser, such as Google Chrome or Microsoft Edge, a new browser window may be opened with a separate profile for the debugging session instead of opening a tab in an existing browser window with the user's profile. If debugging with the user's profile is a requirement, adopt **one** of the following approaches:
+   > When debugging with a Chromium-based browser, such as Google Chrome or Microsoft Edge, a new browser window might open with a separate profile for the debugging session instead of opening a tab in an existing browser window with the user's profile. If debugging with the user's profile is a requirement, adopt **one** of the following approaches:
    >
    > * Close all open browser instances before pressing <kbd>F5</kbd> to start debugging.
    > * Configure Visual Studio to launch the browser with the user's profile. For more information on this approach, see [Blazor WASM Debugging in VS launches Edge with a separate user data directory (dotnet/aspnetcore #20915)](https://github.com/dotnet/aspnetcore/issues/20915#issuecomment-614933322).
@@ -896,7 +896,7 @@ To debug a Blazor WebAssembly app in Visual Studio:
 1. With the **`Server`** project selected in **Solution Explorer**, press <kbd>F5</kbd> to run the app in the debugger.
 
    > [!NOTE]
-   > When debugging with a Chromium-based browser, such as Google Chrome or Microsoft Edge, a new browser window may be opened with a separate profile for the debugging session instead of opening a tab in an existing browser window with the user's profile. If debugging with the user's profile is a requirement, adopt **one** of the following approaches:
+   > When debugging with a Chromium-based browser, such as Google Chrome or Microsoft Edge, a new browser window might open with a separate profile for the debugging session instead of opening a tab in an existing browser window with the user's profile. If debugging with the user's profile is a requirement, adopt **one** of the following approaches:
    >
    > * Close all open browser instances before pressing <kbd>F5</kbd> to start debugging.
    > * Configure Visual Studio to launch the browser with the user's profile. For more information on this approach, see [Blazor WASM Debugging in VS launches Edge with a separate user data directory (dotnet/aspnetcore #20915)](https://github.com/dotnet/aspnetcore/issues/20915#issuecomment-614933322).


### PR DESCRIPTION
Changing it to `may be` opened in a new profile as for whatever reason, it uses my default profile when I try it out. However I've definitely seen it open a new "developer profile" in the past.

Extension to: https://github.com/dotnet/AspNetCore.Docs/pull/23564