### PR TITLE
Blazor 6.0 migration guidance

### DIFF
--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -129,7 +129,7 @@ For more details on the new hosting model, see the [Frequently asked questions](
 * The endpoint routing middleware wraps the entire middleware pipeline, therefore there's no need to have explicit calls to `UseEndpoints` to register routes. `UseRouting` can still be used to specify where route matching happens but `UseRouting` doesn't need to be explicitly called.
 * The [pipeline](xref:fundamentals/middleware/index) is created before any <xref:Microsoft.AspNetCore.Hosting.IStartupFilter> runs, therefore exceptions caused while building the pipeline aren't visible to the `IStartupFilter` call chain.
 * Some tools, such as EF migrations, use [`Program.CreateHostBuilder`](xref:fundamentals/host/generic-host) to access the app's `IServiceProvider` to execute custom logic in the context of the app. These tools have been updated to use a new technique to execute custom logic in the context of the app. [Entity Framework Migrations](/ef/core/managing-schemas/migrations/) is an example of a tool that uses `Program.CreateHostBuilder`in this way. We're working to make sure tools are updated to use the new model.
-* It's ***not*** possible to [change any host settings such as app name, environment, or the content root](xref:migration/50-to-60-samples#ccr) after the creation of the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder>. See [Customize `IHostBuilder` or `IWebHostBuilder`](xref:migration/50-to-60-samples#cii) for detailed instructions on changing host settings. The following highlighted APIs throw an exception:
+* It's ***not*** possible to [change any host settings such as app name, environment, or the content root](xref:migration/50-to-60-samples#ccr) after the creation of the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder>. For detailed instructions on changing host settings, see [Customize `IHostBuilder` or `IWebHostBuilder`](xref:migration/50-to-60-samples#cii). The following highlighted APIs throw an exception:
 
 <!-- sample without try/catch 
   [!code-csharp[](50-to-60/samples/WebThrowEx/Program.cs?name=snippet1&highlight=5-14)]
@@ -157,43 +157,42 @@ The existing .NET ecosystem built extensibility around <xref:Microsoft.Extension
 
 We expect library authors to continue targeting `IHostBuilder`, `IWebHostBuilder`, `IApplicationBuilder`, and `IEndpointRouteBuilder` when building ASP.NET Core specific components. This ensures that your middleware, route handler, or other extensibility points continue to work across different hosting models.
 
-<h2 id="faq">Frequently asked questions (FAQ) </h2>
+<h2 id="faq">Frequently asked questions (FAQ)</h2>
 
-### Is the new minimal hosting model less capable
+* **Is the new minimal hosting model less capable?**
 
-No. The new hosting model is functionally equivalent for 98% of scenarios supported by `IHostBuilder` and the `IWebHostBuilder`. There are some advanced scenarios that require specific workarounds on `IHostBuilder`, but we expect those to be extremely rare.
+  No. The new hosting model is functionally equivalent for 98% of scenarios supported by `IHostBuilder` and the `IWebHostBuilder`. There are some advanced scenarios that require specific workarounds on `IHostBuilder`, but we expect those to be extremely rare.
 
-### Is the generic hosting model deprecated
+* **Is the generic hosting model deprecated?**
 
-No. The generic hosting model is an alternative model that is supported indefinitely. The generic host underpins the new hosting model and is still the primary way to host worker-based applications.
+  No. The generic hosting model is an alternative model that is supported indefinitely. The generic host underpins the new hosting model and is still the primary way to host worker-based applications.
 
-### Do I have to migrate to the new hosting model
+* **Do I have to migrate to the new hosting model?**
 
-No. The new hosting model is the preferred way to host new apps using .NET 6 and later, but you aren't forced to change the project layout in existing apps. This means apps can upgrade from .NET 5 to .NET 6 by changing the target framework in the project file from `net5.0` to `net6.0`. See [Update the target framework](#tf) in this document. However, we recommend apps migrate to the new hosting model to take advantage of new features only available to the new hosting model.
+  No. The new hosting model is the preferred way to host new apps using .NET 6 and later, but you aren't forced to change the project layout in existing apps. This means apps can upgrade from .NET 5 to .NET 6 by changing the target framework in the project file from `net5.0` to `net6.0`. For more information, see the [Update the target framework](#tf) section in this article. However, we recommend apps migrate to the new hosting model to take advantage of new features only available to the new hosting model.
 
-### Do I have to use top-level statements
+* **Do I have to use top-level statements?**
 
-No.
-The new project templates all use [top-level statements](/dotnet/csharp/fundamentals/program-structure/top-level-statements), but the new hosting APIs can be used in any .NET 6 app to host a webserver or web app.
+  No. The new project templates all use [top-level statements](/dotnet/csharp/fundamentals/program-structure/top-level-statements), but the new hosting APIs can be used in any .NET 6 app to host a webserver or web app.
 
-### Where do I put state that was stored as fields in my `Program` or `Startup` class
+* **Where do I put state that was stored as fields in my `Program` or `Startup` class?**
 
-We strongly recommend using [dependency injection](xref:fundamentals/dependency-injection) (DI) to flow state in ASP.NET Core apps.
+  We strongly recommend using [dependency injection](xref:fundamentals/dependency-injection) (DI) to flow state in ASP.NET Core apps.
 
-There are two approaches to storing state outside of DI:
+  There are two approaches to storing state outside of DI:
 
-* Store the state in another class. Storing in a class assumes a static state that can be accessed from anywhere in the app.
-* Use the `Program` class generated by top level statements to store state. Using `Program` to store state is the semantic approach:
+  * Store the state in another class. Storing in a class assumes a static state that can be accessed from anywhere in the app.
+  * Use the `Program` class generated by top level statements to store state. Using `Program` to store state is the semantic approach:
 
-  [!code-csharp[](50-to-60/samples/WebThrowEx/Program.cs?name=snippetE)]
+    [!code-csharp[](50-to-60/samples/WebThrowEx/Program.cs?name=snippetE)]
 
-### What if I was using a custom dependency injection container
+* **What if I was using a custom dependency injection container?**
 
-Custom DI containers are supported. See [Custom dependency injection (DI) container](xref:migration/50-to-60-samples#cdi) for an example.
+  Custom DI containers are supported. For an example, see [Custom dependency injection (DI) container](xref:migration/50-to-60-samples#cdi).
 
-### Does `WebApplicationFactory` and `TestServer` still work
+* **Do `WebApplicationFactory` and `TestServer` still work?**
 
-`WebApplicationFactory<TEntryPoint>` is the way to test the new hosting model. See [Test with `WebApplicationFactory` or `TestServer`](xref:migration/50-to-60-samples#twa) for an example.
+  Yes. `WebApplicationFactory<TEntryPoint>` is the way to test the new hosting model. For an example, see [Test with `WebApplicationFactory` or `TestServer`](xref:migration/50-to-60-samples#twa).
 
 ## Blazor
 
@@ -260,17 +259,20 @@ public DbSet<Key> Keys { get; set; }
 
 ## Codes samples migrated to ASP.NET Core 6.0
 
-See <xref:migration/50-to-60-samples>
+<xref:migration/50-to-60-samples>
 
 ## Review breaking changes
 
-For breaking changes from .NET 5.0 to .NET 6.0, see [Breaking changes for migration from version 5.0 to 6.0](/dotnet/core/compatibility/6.0). ASP.NET Core and Entity Framework Core are also included in the list. Additional information is available at the [Announcements GitHub repository (aspnet/Announcements, `6.0.0` label)](https://github.com/aspnet/Announcements/issues?q=is%3Aissue+label%3A6.0.0+is%3Aopen).
+See the following resources:
+
+* [Breaking changes for migration from version 5.0 to 6.0](/dotnet/core/compatibility/6.0): Includes ASP.NET Core and Entity Framework Core.
+* [Announcements GitHub repository (aspnet/Announcements, `6.0.0` label)](https://github.com/aspnet/Announcements/issues?q=is%3Aissue+label%3A6.0.0+is%3Aopen): Includes breaking and non-breaking information.
 
 ## Nullable reference types (NRTs) and .NET compiler null-state static analysis
 
-ASP.NET Core project templates embrace the use of nullable reference types (NRTs) and the .NET compiler's null-state static analysis. These features were released with C# 8 and are enabled by default for apps generated using ASP.NET Core 6.0 (C# 10) or later.
+ASP.NET Core project templates use nullable reference types (NRTs), and the .NET compiler performs null-state static analysis. These features were released with C# 8 and are enabled by default for apps generated using ASP.NET Core 6.0 (C# 10) or later.
 
-The .NET compiler's null-state static analysis warnings can either be ignored or serve as a guide for updating a documentation example or sample app locally. Null-state static analysis can be disabled by [setting `Nullable` to `disable`](/dotnet/csharp/language-reference/builtin-types/nullable-reference-types#setting-the-nullable-context) in the app's project file, which we only recommend for documentation examples and sample apps if the compiler warnings are distracting while learning about .NET. **_We don't recommended disabling null-state checking in production projects._**
+The .NET compiler's null-state static analysis warnings can either serve as a guide for updating a documentation example or sample app locally or be ignored. Null-state static analysis can be disabled by [setting `Nullable` to `disable`](/dotnet/csharp/language-reference/builtin-types/nullable-reference-types#setting-the-nullable-context) in the app's project file, which we only recommend for documentation examples and sample apps if the compiler warnings are distracting while learning about .NET. **_We don't recommended disabling null-state checking in production projects._**
 
 For more information on NRTs, the MSBuild `Nullable` property, and updating apps (including `#pragma` guidance), see the following resources in the C# documentation:
 


### PR DESCRIPTION
Fixes #23603
Addresses #22045

Artak ... TFM+packages per the current guidance at the top of the topic and it all ✨ **_Just Works!_**&trade; ✨.

I add a tidbit on how we recommend moving components+code to a new project to get ALL 6.0 features.

... and a handful of general updates to the whole topic ... mostly code-fencing to avoid loc on filenames and API.