### PR TITLE
Remove [Required] from todoDTO app

### DIFF
--- a/aspnetcore/tutorials/min-web-api/samples/6.x/todoDTO/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/6.x/todoDTO/Program.cs
@@ -1,5 +1,4 @@
 #region snippet_all
-using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -66,7 +65,6 @@ app.Run();
 public class Todo
 {
     public int Id { get; set; }
-    [Required]
     public string? Name { get; set; }
     public bool IsComplete { get; set; }
     public string? Secret { get; set; }
@@ -76,7 +74,6 @@ public class Todo
 #region snippet_DTO
 public class TodoItemDTO
 {
-    public long Id { get; set; }
     public string? Name { get; set; }
     public bool IsComplete { get; set; }
 


### PR DESCRIPTION
`[Required]` isn't supported directly by minimal APIs (https://github.com/dotnet/aspnetcore/issues/30666) or indirectly by System.Text.Json (https://github.com/dotnet/runtime/issues/29861).

`TodoItemDTO.Id` was unused.