### PR TITLE
Fix empty RP tutorial pages

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -297,7 +297,7 @@ The next tutorial explains the files created by scaffolding.
 
 ::: moniker-end
 
-::: moniker range=">= aspnetcore-3.0 < aspnetcore-5.0"
+::: moniker range="< aspnetcore-5.0"
 
 <!-- In the next update on the CLI version, let the scaffolder do the same work the VS driven scaffolder does. That is, create the DB context, etc -->
 

--- a/aspnetcore/tutorials/razor-pages/page.md
+++ b/aspnetcore/tutorials/razor-pages/page.md
@@ -15,7 +15,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 This tutorial examines the Razor Pages created by scaffolding in the [previous tutorial](xref:tutorials/razor-pages/model).
 
-::: moniker range=">= aspnetcore-3.0 < aspnetcore-6.0"
+::: moniker range="< aspnetcore-6.0"
 
 ## The Create, Delete, Details, and Edit pages
 
@@ -206,7 +206,7 @@ For more information on Tag Helpers such as `<form method="post">`, see [Tag Hel
 
 ::: moniker-end
 
-::: moniker range=">=  aspnetcore-6.0"
+::: moniker range=">= aspnetcore-6.0"
 <!-- Make a copy of the current project at tutorials/razor-pages/razor-pages-start/snapshot_v6 -->
 ## The Create, Delete, Details, and Edit pages
 

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start.md
@@ -162,7 +162,7 @@ If you run into a problem you can't resolve, compare your code to the completed 
 
 ::: moniker-end
 
-::: moniker range=">= aspnetcore-3.0 < aspnetcore-5.0"
+::: moniker range="< aspnetcore-5.0"
 
 This is the first tutorial of a series that teaches the basics of building an ASP.NET Core Razor Pages web app.
 

--- a/aspnetcore/tutorials/razor-pages/sql.md
+++ b/aspnetcore/tutorials/razor-pages/sql.md
@@ -166,7 +166,7 @@ The app shows the seeded data:
 
 ::: moniker-end
 
-::: moniker range="< aspnetcore-5.0 >= aspnetcore-3.0"
+::: moniker range="< aspnetcore-5.0"
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie30) ([how to download](xref:index#how-to-download-a-sample)).
 


### PR DESCRIPTION
Fixes #23682.

For consistency with the other pages, I've changed the relevant monikers to show content for all versions rather than excluding the lower versions. I concluded that this is the quickest/easiest approach for now, but we can come back and use a topic-level `monikerRange` later.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->