### PR TITLE
Version-agnostic App component

### DIFF
--- a/aspnetcore/blazor/security/includes/app-component.md
+++ b/aspnetcore/blazor/security/includes/app-component.md
@@ -7,32 +7,9 @@ The `App` component (`App.razor`) is similar to the `App` component found in Bla
 * The <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView> component makes sure that the current user is authorized to access a given page or otherwise renders the `RedirectToLogin` component.
 * The `RedirectToLogin` component manages redirecting unauthorized users to the login page.
 
-```razor
-<CascadingAuthenticationState>
-    <Router AppAssembly="@typeof(Program).Assembly">
-        <Found Context="routeData">
-            <AuthorizeRouteView RouteData="@routeData" 
-                DefaultLayout="@typeof(MainLayout)">
-                <NotAuthorized>
-                    @if (!context.User.Identity.IsAuthenticated)
-                    {
-                        <RedirectToLogin />
-                    }
-                    else
-                    {
-                        <p>
-                            You are not authorized to access 
-                            this resource.
-                        </p>
-                    }
-                </NotAuthorized>
-            </AuthorizeRouteView>
-        </Found>
-        <NotFound>
-            <LayoutView Layout="@typeof(MainLayout)">
-                <p>Sorry, there's nothing at this address.</p>
-            </LayoutView>
-        </NotFound>
-    </Router>
-</CascadingAuthenticationState>
-```
+Due to changes in the framework across releases of ASP.NET Core, Razor markup for the `App` component (`App.razor`) isn't shown in this section. To inspect the markup of the component for a given release, use ***either*** of the following approaches:
+
+* Create an app provisioned for authentication from the default Blazor WebAssembly project template for the version of ASP.NET Core that you intend to use. Inspect the `App` component (`App.razor`) in the generated app.
+* Inspect the `App` component (`App.razor`) in [reference source](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/App.razor).
+
+  [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]


### PR DESCRIPTION
Fixes #23696

Thanks @johndhunter! :rocket: ... This will be the best way to go for now. I'll revisit when I reach the security node on UE passes in 2022 and perhaps make it so that versioned code is loaded. The problem with doing that now is that:

* It's a change that will require similar work in other areas. I might even decide in the end to use this "see the ref source" approach for everything. The framework churn is challenging to keep up with, and that's a guaranteed winner for churn **_as long as the dev selects the right release in the PU repo (per the INCLUDE here)._**
* Or, we might be dropping this coverage entirely in 2022 in favor of the Azure docs coverage. If so, then we don't want to spend a lot of time making changes to this at this time. That's a waste of ⏱️ ... thus a waste of 💰 ... if it comes to pass that all of this gets dropped here.