### PR TITLE
Correct an error in the use of `MapWhen`

### DIFF
--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -55,7 +55,7 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 
   ```csharp
   app.MapWhen(ctx => !ctx.Request.Path
-        .StartsWithSegments("_framework/blazor.server.js"),
+      .StartsWithSegments("_framework/blazor.server.js"),
           subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
 
@@ -105,7 +105,7 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 
   ```csharp
   app.MapWhen(ctx => !ctx.Request.Path
-        .StartsWithSegments("_framework/blazor.server.js"),
+      .StartsWithSegments("_framework/blazor.server.js"),
           subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
 
@@ -155,7 +155,7 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 
   ```csharp
   app.MapWhen(ctx => !ctx.Request.Path
-        .StartsWithSegments("_framework/blazor.server.js"),
+      .StartsWithSegments("_framework/blazor.server.js"),
           subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -55,8 +55,8 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 
   ```csharp
   app.MapWhen(ctx => !ctx.Request.Path
-      .StartsWithSegments("_framework/blazor.server.js", 
-          subApp => subApp.UseStaticFiles(new StaticFileOptions(){ ... })));
+        .StartsWithSegments("_framework/blazor.server.js"),
+          subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
 
 ::: moniker-end
@@ -105,8 +105,8 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 
   ```csharp
   app.MapWhen(ctx => !ctx.Request.Path
-      .StartsWithSegments("_framework/blazor.server.js", 
-          subApp => subApp.UseStaticFiles(new StaticFileOptions(){ ... })));
+        .StartsWithSegments("_framework/blazor.server.js"),
+          subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
 
 ::: moniker-end
@@ -155,8 +155,8 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 
   ```csharp
   app.MapWhen(ctx => !ctx.Request.Path
-      .StartsWithSegments("_framework/blazor.server.js", 
-          subApp => subApp.UseStaticFiles(new StaticFileOptions(){ ... })));
+        .StartsWithSegments("_framework/blazor.server.js"),
+          subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
 
 ::: moniker-end


### PR DESCRIPTION
Move the branch configuration from the `StartsWithSegments` method to the `MapWhen` method.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->