### PR TITLE
Blazor static files guidance improvements

### DIFF
--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -183,7 +183,7 @@ Use the wildcard (`*`) operator to share scope identifiers across multiple files
 
 ### Change base path for static web assets
 
-The `scoped.styles.css` file is generated at the root of the app. In the project file, use the `StaticWebAssetBasePath` property to change the default path. The following example places the `scoped.styles.css` file, and the rest of the app's assets, at the `_content` path:
+The `scoped.styles.css` file is generated at the root of the app. In the project file, use the [`<StaticWebAssetBasePath>` property](xref:blazor/fundamentals/static-files#static-web-asset-base-path) to change the default path. The following example places the `scoped.styles.css` file, and the rest of the app's assets, at the `_content` path:
 
 ```xml
 <PropertyGroup>
@@ -398,7 +398,7 @@ Use the wildcard (`*`) operator to share scope identifiers across multiple files
 
 ### Change base path for static web assets
 
-The `scoped.styles.css` file is generated at the root of the app. In the project file, use the `StaticWebAssetBasePath` property to change the default path. The following example places the `scoped.styles.css` file, and the rest of the app's assets, at the `_content` path:
+The `scoped.styles.css` file is generated at the root of the app. In the project file, use the [`<StaticWebAssetBasePath>` property](xref:blazor/fundamentals/static-files#static-web-asset-base-path) to change the default path. The following example places the `scoped.styles.css` file, and the rest of the app's assets, at the `_content` path:
 
 ```xml
 <PropertyGroup>

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -13,7 +13,55 @@ uid: blazor/fundamentals/static-files
 
 ::: moniker range=">= aspnetcore-6.0"
 
-*This article applies to Blazor Server.*
+This article describes the configuration for serving static files in Blazor apps.
+
+## Static File Middleware
+
+*This section applies to Blazor Server apps and the `**Server**` app of a hosted Blazor WebAssembly solution.*
+
+Configure Static File Middleware to serve static assets to clients by calling <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> in the app's request processing pipeline. For more information, see <xref:fundamentals/static-files>.
+
+## Static web asset base path
+
+*This section applies to standalone Blazor WebAssembly apps and hosted Blazor WebAssembly solutions.*
+
+By default, publishing a Blazor WebAssembly app places the app's static assets, including Blazor framework files (`_framework` folder assets), at the root path (`/`) in published output. The `<StaticWebAssetBasePath>` property specified in the project file (`.csproj`) sets the base path to a non-root path:
+
+```xml
+<PropertyGroup>
+  <StaticWebAssetBasePath>{PATH}</StaticWebAssetBasePath>
+</PropertyGroup>
+```
+
+In the preceding example, the `{PATH}` placeholder is the path.
+
+The `<StaticWebAssetBasePath>` property is most commonly used to control the paths to published static assets of multiple Blazor WebAssembly apps in a single hosted deployment. For more information, see <xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps>. The property is also effective in standalone Blazor WebAssembly apps.
+
+Without setting the `<StaticWebAssetBasePath>` property, the client app of a hosted solution or a standalone app is published at the following paths:
+
+* In the **`Server`** project of a hosted Blazor WebAssembly solution: `/BlazorHostedSample/Server/bin/Release/{TFM}/publish/wwwroot/`
+* In a standalone Blazor WebAssembly app: `/BlazorStandaloneSample/bin/Release/{TFM}/publish/wwwroot/`
+
+In the preceding examples, the `{TFM}` placeholder is the [Target Framework Moniker (TFM)](/dotnet/standard/frameworks) (for example, `net6.0`).
+
+If the `<StaticWebAssetBasePath>` property in the **`Client`** project of a hosted Blazor WebAssembly app or in a standalone Blazor WebAssembly app sets the published static asset path to `app1`, the root path to the app in published output is `/app1`.
+
+In the **`Client`** app's project file (`.csproj`) or the standalone Blazor WebAssembly app's project file (`.csproj`):
+
+```xml
+<PropertyGroup>
+  <StaticWebAssetBasePath>app1</StaticWebAssetBasePath>
+</PropertyGroup>
+```
+
+In published output:
+
+* Path to the client app in the **`Server`** project of a hosted Blazor WebAssembly solution: `/BlazorHostedSample/Server/bin/Release/{TFM}/publish/wwwroot/app1/`
+* Path to a standalone Blazor WebAssembly app: `/BlazorStandaloneSample/bin/Release/{TFM}/publish/wwwroot/app1/`
+
+In the preceding examples, the `{TFM}` placeholder is the [Target Framework Moniker (TFM)](/dotnet/standard/frameworks) (for example, `net6.0`).
+
+## Blazor Server file mappings and static file options
 
 To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider> or configure other <xref:Microsoft.AspNetCore.Builder.StaticFileOptions>, use **one** of the following approaches. In the following examples, the `{EXTENSION}` placeholder is the file extension, and the `{CONTENT TYPE}` placeholder is the content type.
 
@@ -59,11 +107,64 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
           subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
 
+## Additional resources
+
+* [App base path](xref:blazor/host-and-deploy/index#app-base-path)
+* [Hosted deployment with multiple Blazor WebAssembly apps](xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps)
+
 ::: moniker-end
 
 ::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-*This article applies to Blazor Server.*
+This article describes the configuration for serving static files in Blazor apps.
+
+## Static File Middleware
+
+*This section applies to Blazor Server apps and the `**Server**` app of a hosted Blazor WebAssembly solution.*
+
+Configure Static File Middleware to serve static assets to clients by calling <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> in the app's request processing pipeline. For more information, see <xref:fundamentals/static-files>.
+
+## Static web asset base path
+
+*This section applies to standalone Blazor WebAssembly apps and hosted Blazor WebAssembly solutions.*
+
+By default, publishing a Blazor WebAssembly app places the app's static assets, including Blazor framework files (`_framework` folder assets), at the root path (`/`) in published output. The `<StaticWebAssetBasePath>` property specified in the project file (`.csproj`) sets the base path to a non-root path:
+
+```xml
+<PropertyGroup>
+  <StaticWebAssetBasePath>{PATH}</StaticWebAssetBasePath>
+</PropertyGroup>
+```
+
+In the preceding example, the `{PATH}` placeholder is the path.
+
+The `<StaticWebAssetBasePath>` property is most commonly used to control the paths to published static assets of multiple Blazor WebAssembly apps in a single hosted deployment. For more information, see <xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps>. The property is also effective in standalone Blazor WebAssembly apps.
+
+Without setting the `<StaticWebAssetBasePath>` property, the client app of a hosted solution or a standalone app is published at the following paths:
+
+* In the **`Server`** project of a hosted Blazor WebAssembly solution: `/BlazorHostedSample/Server/bin/Release/{TFM}/publish/wwwroot/`
+* In a standalone Blazor WebAssembly app: `/BlazorStandaloneSample/bin/Release/{TFM}/publish/wwwroot/`
+
+In the preceding examples, the `{TFM}` placeholder is the [Target Framework Moniker (TFM)](/dotnet/standard/frameworks) (for example, `net6.0`).
+
+If the `<StaticWebAssetBasePath>` property in the **`Client`** project of a hosted Blazor WebAssembly app or in a standalone Blazor WebAssembly app sets the published static asset path to `app1`, the root path to the app in published output is `/app1`.
+
+In the **`Client`** app's project file (`.csproj`) or the standalone Blazor WebAssembly app's project file (`.csproj`):
+
+```xml
+<PropertyGroup>
+  <StaticWebAssetBasePath>app1</StaticWebAssetBasePath>
+</PropertyGroup>
+```
+
+In published output:
+
+* Path to the client app in the **`Server`** project of a hosted Blazor WebAssembly solution: `/BlazorHostedSample/Server/bin/Release/{TFM}/publish/wwwroot/app1/`
+* Path to a standalone Blazor WebAssembly app: `/BlazorStandaloneSample/bin/Release/{TFM}/publish/wwwroot/app1/`
+
+In the preceding examples, the `{TFM}` placeholder is the [Target Framework Moniker (TFM)](/dotnet/standard/frameworks) (for example, `net6.0`).
+
+## Blazor Server file mappings and static file options
 
 To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider> or configure other <xref:Microsoft.AspNetCore.Builder.StaticFileOptions>, use **one** of the following approaches. In the following examples, the `{EXTENSION}` placeholder is the file extension, and the `{CONTENT TYPE}` placeholder is the content type.
 
@@ -108,12 +209,70 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
       .StartsWithSegments("_framework/blazor.server.js"),
           subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
+
+## Additional resources
+
+* [App base path](xref:blazor/host-and-deploy/index#app-base-path)
+* [Hosted deployment with multiple Blazor WebAssembly apps](xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps)
 
 ::: moniker-end
 
 ::: moniker range="< aspnetcore-5.0"
 
-*This article applies to Blazor Server.*
+This article describes the configuration for serving static files in Blazor apps.
+
+## Static File Middleware
+
+Configure Static File Middleware to serve static assets to clients by calling <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> in the app's request processing pipeline. Multiple calls to <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> is supported when static files exist at multiple locations:
+
+```csharp
+app.UseStaticFiles();
+app.UseStaticFiles("/static");
+```
+
+For more information, see <xref:fundamentals/static-files>.
+
+## Static web asset base path
+
+*This section applies to standalone Blazor WebAssembly apps and hosted Blazor WebAssembly solutions.*
+
+By default, publishing a Blazor WebAssembly app places the app's static assets, including Blazor framework files (`_framework` folder assets), at the root path (`/`) in published output. The `<StaticWebAssetBasePath>` property specified in the project file (`.csproj`) sets the base path to a non-root path:
+
+```xml
+<PropertyGroup>
+  <StaticWebAssetBasePath>{PATH}</StaticWebAssetBasePath>
+</PropertyGroup>
+```
+
+In the preceding example, the `{PATH}` placeholder is the path.
+
+The `<StaticWebAssetBasePath>` property is most commonly used to control the paths to published static assets of multiple Blazor WebAssembly apps in a single hosted deployment. For more information, see <xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps>. The property is also effective in standalone Blazor WebAssembly apps.
+
+Without setting the `<StaticWebAssetBasePath>` property, the client app of a hosted solution or a standalone app is published at the following paths:
+
+* In the **`Server`** project of a hosted Blazor WebAssembly solution: `/BlazorHostedSample/Server/bin/Release/{TFM}/publish/wwwroot/`
+* In a standalone Blazor WebAssembly app: `/BlazorStandaloneSample/bin/Release/{TFM}/publish/wwwroot/`
+
+In the preceding examples, the `{TFM}` placeholder is the [Target Framework Moniker (TFM)](/dotnet/standard/frameworks) (for example, `net6.0`).
+
+If the `<StaticWebAssetBasePath>` property in the **`Client`** project of a hosted Blazor WebAssembly app or in a standalone Blazor WebAssembly app sets the published static asset path to `app1`, the root path to the app in published output is `/app1`.
+
+In the **`Client`** app's project file (`.csproj`) or the standalone Blazor WebAssembly app's project file (`.csproj`):
+
+```xml
+<PropertyGroup>
+  <StaticWebAssetBasePath>app1</StaticWebAssetBasePath>
+</PropertyGroup>
+```
+
+In published output:
+
+* Path to the client app in the **`Server`** project of a hosted Blazor WebAssembly solution: `/BlazorHostedSample/Server/bin/Release/{TFM}/publish/wwwroot/app1/`
+* Path to a standalone Blazor WebAssembly app: `/BlazorStandaloneSample/bin/Release/{TFM}/publish/wwwroot/app1/`
+
+In the preceding examples, the `{TFM}` placeholder is the [Target Framework Moniker (TFM)](/dotnet/standard/frameworks) (for example, `net6.0`).
+
+## Blazor Server file mappings and static file options
 
 To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider> or configure other <xref:Microsoft.AspNetCore.Builder.StaticFileOptions>, use **one** of the following approaches. In the following examples, the `{EXTENSION}` placeholder is the file extension, and the `{CONTENT TYPE}` placeholder is the content type.
 
@@ -158,5 +317,10 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
       .StartsWithSegments("_framework/blazor.server.js"),
           subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
+
+## Additional resources
+
+* [App base path](xref:blazor/host-and-deploy/index#app-base-path)
+* [Hosted deployment with multiple Blazor WebAssembly apps](xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps)
 
 ::: moniker-end

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -293,7 +293,7 @@ In the following example:
 
 Use an existing hosted Blazor solution or create a new solution from the Blazor Hosted project template:
 
-* In the client app's project file, add a `<StaticWebAssetBasePath>` property to the `<PropertyGroup>` with a value of `FirstApp` to set the base path for the project's static assets:
+* In the client app's project file, add a [`<StaticWebAssetBasePath>` property](xref:blazor/fundamentals/static-files#static-web-asset-base-path) to the `<PropertyGroup>` with a value of `FirstApp` to set the base path for the project's static assets:
 
   ```xml
   <PropertyGroup>
@@ -357,15 +357,15 @@ Use an existing hosted Blazor solution or create a new solution from the Blazor 
 
 * In the server app's `Program.cs` file, remove the following lines, which appear after the call to <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A>:
 
-  ```csharp
-  app.UseBlazorFrameworkFiles();
-  app.UseStaticFiles();
+  ```diff
+  -app.UseBlazorFrameworkFiles();
+  -app.UseStaticFiles();
 
-  app.UseRouting();
+  -app.UseRouting();
 
-  app.MapRazorPages();
-  app.MapControllers();
-  app.MapFallbackToFile("index.html");
+  -app.MapRazorPages();
+  -app.MapControllers();
+  -app.MapFallbackToFile("index.html");
   ```
 
   Add middleware that maps requests to the client apps. The following example configures the middleware to run when:
@@ -428,6 +428,15 @@ Use an existing hosted Blazor solution or create a new solution from the Blazor 
       });
   });
   ```
+
+  For more information on <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A>, see <xref:blazor/fundamentals/static-files#static-file-middleware>.
+
+  For more information on `UseBlazorFrameworkFiles` and `MapFallbackToFile`, see the following resources:
+
+  * <xref:Microsoft.AspNetCore.Builder.ComponentsWebAssemblyApplicationBuilderExtensions.UseBlazorFrameworkFiles%2A?displayProperty=fullName> ([reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs))
+  * <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A?displayProperty=fullName> ([reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs))
+
+  [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 * In the server app's weather forecast controller (`Controllers/WeatherForecastController.cs`), replace the existing route (`[Route("[controller]")]`) to `WeatherForecastController` with the following routes:
 
@@ -1095,7 +1104,7 @@ In the following example:
 
 Use an existing hosted Blazor solution or create a new solution from the Blazor Hosted project template:
 
-* In the client app's project file, add a `<StaticWebAssetBasePath>` property to the `<PropertyGroup>` with a value of `FirstApp` to set the base path for the project's static assets:
+* In the client app's project file, add a [`<StaticWebAssetBasePath>` property](xref:blazor/fundamentals/static-files#static-web-asset-base-path) to the `<PropertyGroup>` with a value of `FirstApp` to set the base path for the project's static assets:
 
   ```xml
   <PropertyGroup>
@@ -1159,18 +1168,18 @@ Use an existing hosted Blazor solution or create a new solution from the Blazor 
 
 * In the server app's `Startup.Configure` method (`Startup.cs`), remove the following lines, which appear after the call to <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A>:
 
-  ```csharp
-  app.UseBlazorFrameworkFiles();
-  app.UseStaticFiles();
+  ```diff
+  -app.UseBlazorFrameworkFiles();
+  -app.UseStaticFiles();
 
-  app.UseRouting();
+  -app.UseRouting();
 
-  app.UseEndpoints(endpoints =>
-  {
-      endpoints.MapRazorPages();
-      endpoints.MapControllers();
-      endpoints.MapFallbackToFile("index.html");
-  });
+  -app.UseEndpoints(endpoints =>
+  -{
+  -    endpoints.MapRazorPages();
+  -    endpoints.MapControllers();
+  -    endpoints.MapFallbackToFile("index.html");
+  -});
   ```
 
   Add middleware that maps requests to the client apps. The following example configures the middleware to run when:
@@ -1233,6 +1242,15 @@ Use an existing hosted Blazor solution or create a new solution from the Blazor 
       });
   });
   ```
+
+  For more information on <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A>, see <xref:blazor/fundamentals/static-files#static-file-middleware>.
+
+  For more information on `UseBlazorFrameworkFiles` and `MapFallbackToFile`, see the following resources:
+
+  * <xref:Microsoft.AspNetCore.Builder.ComponentsWebAssemblyApplicationBuilderExtensions.UseBlazorFrameworkFiles%2A?displayProperty=fullName> ([reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs))
+  * <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A?displayProperty=fullName> ([reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs))
+
+  [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 * In the server app's weather forecast controller (`Controllers/WeatherForecastController.cs`), replace the existing route (`[Route("[controller]")]`) to `WeatherForecastController` with the following routes:
 
@@ -1900,7 +1918,7 @@ In the following example:
 
 Use an existing hosted Blazor solution or create a new solution from the Blazor Hosted project template:
 
-* In the client app's project file, add a `<StaticWebAssetBasePath>` property to the `<PropertyGroup>` with a value of `FirstApp` to set the base path for the project's static assets:
+* In the client app's project file, add a [`<StaticWebAssetBasePath>` property](xref:blazor/fundamentals/static-files#static-web-asset-base-path) to the `<PropertyGroup>` with a value of `FirstApp` to set the base path for the project's static assets:
 
   ```xml
   <PropertyGroup>
@@ -1964,18 +1982,18 @@ Use an existing hosted Blazor solution or create a new solution from the Blazor 
 
 * In the server app's `Startup.Configure` method (`Startup.cs`), remove the following lines, which appear after the call to <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A>:
 
-  ```csharp
-  app.UseBlazorFrameworkFiles();
-  app.UseStaticFiles();
+  ```diff
+  -app.UseBlazorFrameworkFiles();
+  -app.UseStaticFiles();
 
-  app.UseRouting();
+  -app.UseRouting();
 
-  app.UseEndpoints(endpoints =>
-  {
-      endpoints.MapRazorPages();
-      endpoints.MapControllers();
-      endpoints.MapFallbackToFile("index.html");
-  });
+  -app.UseEndpoints(endpoints =>
+  -{
+  -    endpoints.MapRazorPages();
+  -    endpoints.MapControllers();
+  -    endpoints.MapFallbackToFile("index.html");
+  -});
   ```
 
   Add middleware that maps requests to the client apps. The following example configures the middleware to run when:
@@ -2038,6 +2056,15 @@ Use an existing hosted Blazor solution or create a new solution from the Blazor 
       });
   });
   ```
+
+  For more information on <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A>, see <xref:blazor/fundamentals/static-files#static-file-middleware>.
+
+  For more information on `UseBlazorFrameworkFiles` and `MapFallbackToFile`, see the following resources:
+
+  * <xref:Microsoft.AspNetCore.Builder.ComponentsWebAssemblyApplicationBuilderExtensions.UseBlazorFrameworkFiles%2A?displayProperty=fullName> ([reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/Server/src/ComponentsWebAssemblyApplicationBuilderExtensions.cs))
+  * <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A?displayProperty=fullName> ([reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Middleware/StaticFiles/src/StaticFilesEndpointRouteBuilderExtensions.cs))
+
+  [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 * In the server app's weather forecast controller (`Controllers/WeatherForecastController.cs`), replace the existing route (`[Route("[controller]")]`) to `WeatherForecastController` with the following routes:
 


### PR DESCRIPTION
Fixes #23729

* Static file topic organization.
* Static File Middleware callout and cross-link to main doc set for details.
* `<StaticWebAssetBasePath>` property description and examples.
* Cross-links relevant scenarios, including API docs and ref source.
* Nit improvements to hosted multiple WASM app scenario.