### PR TITLE
.NET 6 update enforce HTTPS /4

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -48,9 +48,9 @@ We recommend that production ASP.NET Core web apps use:
 
 ### UseHttpsRedirection
 
-The following code calls `UseHttpsRedirection` in the `Startup` class:
+The following code calls <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A> in the *Program.cs* file:
 
-[!code-csharp[](enforcing-ssl/sample-snapshot/3.x/Startup.cs?name=snippet1&highlight=14)]
+[!code-csharp[](enforcing-ssl/sample-snapshot/6.x/Program.cs?highlight=13)]
 
 The preceding highlighted code:
 

--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program.cs
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program.cs
@@ -1,0 +1,22 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();

--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program2.cs
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program2.cs
@@ -1,0 +1,39 @@
+using System.Net;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+builder.Services.AddHsts(options =>
+{
+    options.Preload = true;
+    options.IncludeSubDomains = true;
+    options.MaxAge = TimeSpan.FromDays(60);
+    options.ExcludedHosts.Add("example.com");
+    options.ExcludedHosts.Add("www.example.com");
+});
+
+builder.Services.AddHttpsRedirection(options =>
+{
+    options.RedirectStatusCode = (int)HttpStatusCode.TemporaryRedirect;
+    options.HttpsPort = 5001;
+});
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();

--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program3.cs
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program3.cs
@@ -1,0 +1,34 @@
+using System.Net;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+if (builder.Environment.IsDevelopment())
+{
+    builder.Services.AddHttpsRedirection(options =>
+    {
+        options.RedirectStatusCode = (int)HttpStatusCode.PermanentRedirect;
+        options.HttpsPort = 443;
+    });
+}
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();

--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/appsettings.json
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "https_port": 443,
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes #23761
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-6.0&branch=pr-en-us-23773&tabs=visual-studio)