### PR TITLE
Blazor updates for What's New 6.0

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-6.0.md
+++ b/aspnetcore/release-notes/aspnetcore-6.0.md
@@ -192,7 +192,7 @@ Binding supports multiple option selection with `<input>` elements. For more inf
 
 ### Head (`<head>`) content control
 
-Razor components can modify the HTML `<head>` element content of a page, including setting the page's title (`<title>` element) and modifying metadata (`<meta>` elements). For more information, see <xref:blazor/components/control-head-content?view=aspnetcore-6.0>.
+Razor components can modify the HTML `<head>` element content of a page, including setting the page's title (`<title>` element) and modifying metadata (`<meta>` elements). For more information, see [Control `<head>` content in ASP.NET Core Blazor apps](xref:blazor/components/control-head-content?view=aspnetcore-6.0).
 
 ### Generate Angular and React components
 
@@ -232,7 +232,7 @@ Collocate JavaScript files for pages, views, and Razor components as a convenien
 
 ### JavaScript initializers
 
-JavaScript initializers execute logic before and after a Blazor app loads. For more information, see <xref:blazor/js-interop/index?view=aspnetcore-6.0# javascript-initializers>.
+JavaScript initializers execute logic before and after a Blazor app loads. For more information, see <xref:blazor/js-interop/index?view=aspnetcore-6.0#javascript-initializers>.
 
 ### Streaming JavaScript interop
 


### PR DESCRIPTION
Addresses #22852

cc: @Rick-Anderson @serpent5 @wadepickett 

Just a few nits at the moment. I'll have a few more updates on Monday morning for the Error Handling topic. The heading in the topic will change to match what's here, so the link here will ✨ *Just Work!*&trade; ✨ when my Monday morning update goes live. As for the rest of the MIA Blazor stuff, that's still being worked out internally. I'll flesh out the commented-out bits as soon as I have guidance from DR on the final Blazor coverage.

Side-note on the `view` qs param: It only works when non-6.0 docs load if that "preserve view" param is also supplied. I don't recall the exact param at the moment. I think all of the `view=aspnetcore-6.0` links should get it here. It's a confusing UE if we don't add that param to these links 😵. 