### PR TITLE
Blazor platforms update for 3.1

### DIFF
--- a/aspnetcore/blazor/supported-platforms.md
+++ b/aspnetcore/blazor/supported-platforms.md
@@ -53,16 +53,31 @@ Blazor WebAssembly and Blazor Server are supported in the browsers shown in the 
 
 ::: moniker range="< aspnetcore-5.0"
 
-Blazor WebAssembly and Blazor Server are supported in the browsers shown in the following table.
+## Blazor WebAssembly
+
+| Browser                          | Version               |
+| -------------------------------- | --------------------- |
+| Apple Safari, including iOS      | Current&dagger;       |
+| Google Chrome, including Android | Current&dagger;       |
+| Microsoft Edge                   | Current&dagger;       |
+| Microsoft Internet Explorer      | Not Supported&Dagger; |
+| Mozilla Firefox                  | Current&dagger;       |  
+
+&dagger;*Current* refers to the latest version of the browser.  
+&Dagger;Microsoft Internet Explorer doesn't support [WebAssembly](https://webassembly.org).
+
+## Blazor Server
 
 | Browser                          | Version         |
 | -------------------------------- | --------------- |
 | Apple Safari, including iOS      | Current&dagger; |
 | Google Chrome, including Android | Current&dagger; |
 | Microsoft Edge                   | Current&dagger; |
-| Mozilla Firefox                  | Current&dagger; |  
+| Microsoft Internet Explorer      | 11&Dagger;      |
+| Mozilla Firefox                  | Current&dagger; |
 
 &dagger;*Current* refers to the latest version of the browser.  
+&Dagger;Additional polyfills are required. For example, promises can be added via a [`Polyfill.io`](https://polyfill.io/v3/) bundle.
 
 ## Additional resources
 


### PR DESCRIPTION
Fixes #23784

Thanks @anranruye! :rocket: ... Part of the doc wasn't updated properly on a recent round of updates when I was trying to implement a new type of doc content versioning (*that didn't work out* 😢). This PR restores the original 3.1 content before that failed attempt took place. Thanks for your report on this.