### PR TITLE
v6 vs2022 update for prereq include

### DIFF
--- a/aspnetcore/includes/net-prereqs-vs-6.0.md
+++ b/aspnetcore/includes/net-prereqs-vs-6.0.md
@@ -1,4 +1,4 @@
 ---
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ---
-* [Visual Studio 2022 latest preview](https://visualstudio.microsoft.com/vs/preview/#download-preview) with the **ASP.NET and web development** workload.
+* [Visual Studio 2022](https://visualstudio.microsoft.com/vs/#download) with the **ASP.NET and web development** workload.


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/migration/50-to-60?view=aspnetcore-6.0&branch=pr-en-us-23794&tabs=visual-studio)

Updated the v6 prereq include to point to VS 2022 rather than preview.

Contributes towards #23771.  Doing this item in a separate PR to get it live quickly since it is used in several topics.