### PR TITLE
Persist component state updates

### DIFF
--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -730,11 +730,11 @@ For more information, see <xref:blazor/components/index#namespaces>.
 
 ::: zone-end
 
-## Preserve prerendered state
+## Persist prerendered state
 
-Without preserving prerendered state, state used during prerendering is lost and must be recreated when the app is fully loaded. If any state is setup asynchronously, the UI may flicker as the prerendered UI is replaced with temporary placeholders and then fully rendered again.
+Without persisting prerendered state, state used during prerendering is lost and must be recreated when the app is fully loaded. If any state is setup asynchronously, the UI may flicker as the prerendered UI is replaced with temporary placeholders and then fully rendered again.
 
-To solve these problems, Blazor supports persisting state in a prerendered page using the [Preserve Component State Tag Helper](xref:mvc/views/tag-helpers/builtin-th/preserve-component-state-tag-helper) (`<preserve-component-state />`). Add the `<preserve-component-state />` tag inside the closing `</body>` tag.
+To solve these problems, Blazor supports persisting state in a prerendered page using the [Persist Component State Tag Helper](xref:mvc/views/tag-helpers/builtin-th/persist-component-state-tag-helper) (`<persist-component-state />`). Add the `<persist-component-state />` tag inside the closing `</body>` tag.
 
 `Pages/_Layout.cshtml`:
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/persist-component-state.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/persist-component-state.md
@@ -1,16 +1,16 @@
 ---
-title: Preserve Component State Tag Helper in ASP.NET Core
+title: Persist Component State Tag Helper in ASP.NET Core
 author: guardrex
 ms.author: riande
-description: Learn how to use the ASP.NET Core Preserve Component State Tag Helper to preserve state when prerendering components.
+description: Learn how to use the ASP.NET Core Persist Component State Tag Helper to persist state when prerendering components.
 monikerRange: '>= aspnetcore-6.0'
 ms.custom: mvc
 ms.date: 07/16/2021
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
-uid: mvc/views/tag-helpers/builtin-th/preserve-component-state-tag-helper
+uid: mvc/views/tag-helpers/builtin-th/persist-component-state-tag-helper
 zone_pivot_groups: blazor-hosting-models
 ---
-# Preserve Component State Tag Helper in ASP.NET Core
+# Persist Component State Tag Helper in ASP.NET Core
 
 ## Prerequisites
 
@@ -19,9 +19,9 @@ Follow the guidance in the *Configuration* section for either:
 * [Blazor WebAssembly](xref:blazor/components/prerendering-and-integration?pivots=webassembly)
 * [Blazor Server](xref:blazor/components/prerendering-and-integration?pivots=server)
 
-## Preserve Component State Tag Helper
+## Persist Component State Tag Helper
 
-To preserve state for prerendered components, use the Preserve Component State Tag Helper (`<persist-component-state />`). Add the `<preserve-component-state />` tag inside the closing `</body>` tag of the `_Host` page in an app that prerenders components:
+To persist state for prerendered components, use the Persist Component State Tag Helper (`<persist-component-state />`). Add the `<persist-component-state />` tag inside the closing `</body>` tag of the `_Host` page in an app that prerenders components:
 
 ::: zone pivot="webassembly"
 
@@ -94,7 +94,7 @@ In the following example:
 }
 ```
 
-For more information and a complete example, see <xref:blazor/components/prerendering-and-integration#preserve-prerendered-state>.
+For more information and a complete example, see <xref:blazor/components/prerendering-and-integration#persist-prerendered-state>.
 
 ## Additional resources
 

--- a/aspnetcore/release-notes/aspnetcore-6.0.md
+++ b/aspnetcore/release-notes/aspnetcore-6.0.md
@@ -162,7 +162,7 @@ Blazor WebAssembly supports ahead-of-time (AOT) compilation, where you can compi
 
 ### Persist prerendering state
 
-Blazor supports persisting state in a prerendered page so that the state doesn't need to be recreated when the app is fully loaded. For more information, see <xref:blazor/components/prerendering-and-integration?view=aspnetcore-6.0&pivots=server#preserve-prerendered-state>.
+Blazor supports persisting state in a prerendered page so that the state doesn't need to be recreated when the app is fully loaded. For more information, see <xref:blazor/components/prerendering-and-integration?view=aspnetcore-6.0&pivots=server#persist-prerendered-state>.
 
 ### Error boundaries
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -540,8 +540,8 @@
               uid: mvc/views/tag-helpers/builtin-th/link-tag-helper
             - name: Partial
               uid: mvc/views/tag-helpers/builtin-th/partial-tag-helper
-            - name: Preserve Component State
-              uid: mvc/views/tag-helpers/builtin-th/preserve-component-state-tag-helper
+            - name: Persist Component State
+              uid: mvc/views/tag-helpers/builtin-th/persist-component-state-tag-helper
             - name: Script
               uid: mvc/views/tag-helpers/builtin-th/script-tag-helper
             - name: Select

--- a/aspnetcore/whats-new/21-07.md
+++ b/aspnetcore/whats-new/21-07.md
@@ -28,7 +28,7 @@ Welcome to what's new in the ASP.NET Core docs from July 1, 2021 through July 31
 
 ### New articles
 
-- <xref:mvc/views/tag-helpers/builtin-th/preserve-component-state-tag-helper> - Blazor preserve state during prerendering
+- <xref:mvc/views/tag-helpers/builtin-th/persist-component-state-tag-helper> - Blazor preserve state during prerendering
 
 ### Updated articles
 


### PR DESCRIPTION
Fixes #23810

Thanks @JulienM28! :rocket:

cc: @shirhatti ... I was too literal copying DR's blog post on this from ...

https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-net-6-preview-2/#preserve-prerendered-state-in-blazor-apps

... and the coverage ended up mangling the name (and markup) of the Tag Helper. This PR should fix things up. It will break the link to the TH doc, and the section in the Blazor *Prerendering and integration* topic gets a new name. If you cross-linked in the blog post to ...

https://docs.microsoft.com/aspnet/core/blazor/components/prerendering-and-integration?view=aspnetcore-6.0&pivots=server#preserve-prerendered-state

... change that to ...

https://docs.microsoft.com/aspnet/core/blazor/components/prerendering-and-integration?view=aspnetcore-6.0&pivots=server#persist-prerendered-state

The TH doc goes from ...

https://docs.microsoft.com/aspnet/core/mvc/views/tag-helpers/built-in/preserve-component-state?view=aspnetcore-6.0&pivots=server

... to ...

https://docs.microsoft.com/aspnet/core/mvc/views/tag-helpers/built-in/persist-component-state?view=aspnetcore-6.0&pivots=server


I'll be merging to live here shortly, so those links will be good within a few hours this morning ... say by 10am CST (8am PST).