### PR TITLE
Configure xrefService in docxfx.json

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -74,6 +74,9 @@
     "markdownEngineName": "markdig",
     "groups": {
       "group1": { "dest": "group1-dest", "moniker_range": ">= aspnetcore-1.0" }
-    }
+    },
+    "xrefservice": [
+      "https://xref.docs.microsoft.com/query?uid={uid}"
+    ]
   }
 }


### PR DESCRIPTION
cc @Rick-Anderson, @guardrex, @wadepickett.

This should mean we no longer need to provide the `--xrefService` argument for DocFx. I'm just running it through the build-system to make sure I haven't missed anything. Please let me know if you see any issues before I consider merging.