### PR TITLE
Blazor CSS isolation updates

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -170,7 +170,13 @@ Alternatively, add a [`@using`](xref:mvc/views/razor#using) directive and use th
 <Component1 />
 ```
 
-For library components that use [CSS isolation](xref:blazor/components/css-isolation), the component styles are automatically made available to the consuming app. There's no need to link the library's individual component stylesheets in the app that consumes the library. For the preceding examples, `Component1`'s stylesheet (`Component1.razor.css`) is included automatically.
+For library components that use [CSS isolation](xref:blazor/components/css-isolation), the component styles are automatically made available to the consuming app. There's no need to manually link or import the library's individual component stylesheets or it's bundled CSS file in the app that consumes the library. The app uses CSS imports to reference the RCL's bundled styles. The bundled styles aren't published as a static web asset of the app that consumes the library. For a class library named `ClassLib` and a Blazor app with a `BlazorSample.styles.css` stylesheet, the RCL's stylesheet is imported at the top of the app's stylesheet automatically at build time:
+  
+```css
+@import '_content/ClassLib/ClassLib.bundle.scp.css';
+```
+
+For the preceding examples, `Component1`'s stylesheet (`Component1.razor.css`) is included automatically.
 
 `Component1.razor.css` in the `ComponentLibrary` RCL:
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -170,7 +170,7 @@ Alternatively, add a [`@using`](xref:mvc/views/razor#using) directive and use th
 <Component1 />
 ```
 
-For library components that use [CSS isolation](xref:blazor/components/css-isolation), the component styles are automatically made available to the consuming app. There's no need to manually link or import the library's individual component stylesheets or it's bundled CSS file in the app that consumes the library. The app uses CSS imports to reference the RCL's bundled styles. The bundled styles aren't published as a static web asset of the app that consumes the library. For a class library named `ClassLib` and a Blazor app with a `BlazorSample.styles.css` stylesheet, the RCL's stylesheet is imported at the top of the app's stylesheet automatically at build time:
+For library components that use [CSS isolation](xref:blazor/components/css-isolation), the component styles are automatically made available to the consuming app. There's no need to manually link or import the library's individual component stylesheets or its bundled CSS file in the app that consumes the library. The app uses CSS imports to reference the RCL's bundled styles. The bundled styles aren't published as a static web asset of the app that consumes the library. For a class library named `ClassLib` and a Blazor app with a `BlazorSample.styles.css` stylesheet, the RCL's stylesheet is imported at the top of the app's stylesheet automatically at build time:
   
 ```css
 @import '_content/ClassLib/ClassLib.bundle.scp.css';
@@ -527,7 +527,13 @@ Alternatively, add a [`@using`](xref:mvc/views/razor#using) directive and use th
 <Component1 />
 ```
 
-For library components that use [CSS isolation](xref:blazor/components/css-isolation), the component styles are automatically made available to the consuming app. There's no need to link the library's individual component stylesheets in the app that consumes the library. For the preceding examples, `Component1`'s stylesheet (`Component1.razor.css`) is included automatically.
+For library components that use [CSS isolation](xref:blazor/components/css-isolation), the component styles are automatically made available to the consuming app. There's no need to manually link or import the library's individual component stylesheets or its bundled CSS file in the app that consumes the library. The app uses CSS imports to reference the RCL's bundled styles. The bundled styles aren't published as a static web asset of the app that consumes the library. For a class library named `ClassLib` and a Blazor app with a `BlazorSample.styles.css` stylesheet, the RCL's stylesheet is imported at the top of the app's stylesheet automatically at build time:
+  
+```css
+@import '_content/ClassLib/ClassLib.bundle.scp.css';
+```
+
+For the preceding examples, `Component1`'s stylesheet (`Component1.razor.css`) is included automatically.
 
 `Component1.razor.css` in the `ComponentLibrary` RCL:
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -176,7 +176,7 @@ For library components that use [CSS isolation](xref:blazor/components/css-isola
 @import '_content/ClassLib/ClassLib.bundle.scp.css';
 ```
 
-For the preceding examples, `Component1`'s stylesheet (`Component1.razor.css`) is included automatically.
+For the preceding examples, `Component1`'s stylesheet (`Component1.razor.css`) is bundled automatically.
 
 `Component1.razor.css` in the `ComponentLibrary` RCL:
 
@@ -533,7 +533,7 @@ For library components that use [CSS isolation](xref:blazor/components/css-isola
 @import '_content/ClassLib/ClassLib.bundle.scp.css';
 ```
 
-For the preceding examples, `Component1`'s stylesheet (`Component1.razor.css`) is included automatically.
+For the preceding examples, `Component1`'s stylesheet (`Component1.razor.css`) is bundled automatically.
 
 `Component1.razor.css` in the `ComponentLibrary` RCL:
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -77,7 +77,11 @@ h1[b-3xxtam6d07] {
 }
 ```
 
-At build time, a project bundle is created with the convention `{STATIC WEB ASSETS BASE PATH}/Project.lib.scp.css`, where the placeholder `{STATIC WEB ASSETS BASE PATH}` is the static web assets base path.
+At build time, a project bundle is created with the convention `obj/{CONFIGURATION}/{TARGET FRAMEWORK}/scopedcss/projectbundle/{ASSEMBLY NAME}.bundle.scp.css`, where the placeholders are:
+
+* `{CONFIGURATION}`: The app's build configuration (for example, `Debug`, `Release`).
+* `{TARGET FRAMEWORK}`: The target framework (for example, `net6.0`).
+* `{ASSEMBLY NAME}`: The app's assembly name (for example, `BlazorSample`).
 
 If other projects are utilized, such as NuGet packages or [Razor class libraries](xref:blazor/components/class-libraries), the bundled file:
 
@@ -203,21 +207,7 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 
 ## Razor class library (RCL) support
 
-When a [Razor class library (RCL)](xref:razor-pages/ui-class) provides isolated styles, the `<link>` tag's `href` attribute points to `{STATIC WEB ASSET BASE PATH}/{PACKAGE ID}.bundle.scp.css`, where the placeholders are:
-
-* `{STATIC WEB ASSET BASE PATH}`: The static web asset base path.
-* `{PACKAGE ID}`: The library's [package ID](/nuget/create-packages/creating-a-package-msbuild#set-properties). The package ID defaults to the project's assembly name if `<PackageId>` isn't specified in the project file.
-
-In the following example:
-
-* The static web asset base path is `_content/ClassLib`.
-* The class library's assembly name is `ClassLib`.
-
-`wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
-
-```html
-<link href="_content/ClassLib/ClassLib.bundle.scp.css" rel="stylesheet">
-```
+Isolated styles for components in a [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled and linked for the consuming app.
 
 For more information on RCLs, see the following articles:
 
@@ -292,7 +282,11 @@ h1[b-3xxtam6d07] {
 }
 ```
 
-At build time, a project bundle is created with the convention `{STATIC WEB ASSETS BASE PATH}/Project.lib.scp.css`, where the placeholder `{STATIC WEB ASSETS BASE PATH}` is the static web assets base path.
+At build time, a project bundle is created with the convention `obj/{CONFIGURATION}/{TARGET FRAMEWORK}/scopedcss/projectbundle/{ASSEMBLY NAME}.bundle.scp.css`, where the placeholders are:
+
+* `{CONFIGURATION}`: The app's build configuration (for example, `Debug`, `Release`).
+* `{TARGET FRAMEWORK}`: The target framework (for example, `net6.0`).
+* `{ASSEMBLY NAME}`: The app's assembly name (for example, `BlazorSample`).
 
 If other projects are utilized, such as NuGet packages or [Razor class libraries](xref:blazor/components/class-libraries), the bundled file:
 
@@ -418,21 +412,7 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 
 ## Razor class library (RCL) support
 
-When a [Razor class library (RCL)](xref:razor-pages/ui-class) provides isolated styles, the `<link>` tag's `href` attribute points to `{STATIC WEB ASSET BASE PATH}/{PACKAGE ID}.bundle.scp.css`, where the placeholders are:
-
-* `{STATIC WEB ASSET BASE PATH}`: The static web asset base path.
-* `{PACKAGE ID}`: The class library's [package ID](/nuget/create-packages/creating-a-package-msbuild#set-properties). The package ID defaults to the project's assembly name if `<PackageId>` isn't specified in the library's project file.
-
-In the following example:
-
-* The static web asset base path is `_content/ClassLib`.
-* The class library's package ID is `ClassLib`.
-
-`wwwroot/index.html` (Blazor WebAssembly) or `Pages_Host.cshtml` (Blazor Server):
-
-```html
-<link href="_content/ClassLib/ClassLib.bundle.scp.css" rel="stylesheet">
-```
+Isolated styles for components in a [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled and linked for the consuming app.
 
 For more information on RCLs, see the following articles:
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -202,10 +202,15 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 
 ## Razor class library (RCL) support
 
-Isolated styles for components in a NuGet package or [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled. The bundled file:
+Isolated styles for components in a NuGet package or [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled:
 
-* References the styles using CSS imports.
-* Isn't published as a static web asset of the app that consumes the styles.
+* The app uses CSS imports to reference the RCL's bundled styles. For a class library named `ClassLib` and a Blazor app with a `BlazorSample.styles.css` stylesheet, the RCL's stylesheet is imported at the top of the app's stylesheet:
+  
+  ```css
+  @import '_content/ClassLib/ClassLib.bundle.scp.css';
+  ```
+
+* The RCL's bundled styles aren't published as a static web asset of the app that consumes the styles.
 
 For more information on RCLs, see the following articles:
 
@@ -405,10 +410,15 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 
 ## Razor class library (RCL) support
 
-Isolated styles for components in a NuGet package or [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled. The bundled file:
+Isolated styles for components in a NuGet package or [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled:
 
-* References the styles using CSS imports.
-* Isn't published as a static web asset of the app that consumes the styles.
+* The app uses CSS imports to reference the RCL's bundled styles. For a class library named `ClassLib` and a Blazor app with a `BlazorSample.styles.css` stylesheet, the RCL's stylesheet is imported at the top of the app's stylesheet:
+  
+  ```css
+  @import '_content/ClassLib/ClassLib.bundle.scp.css';
+  ```
+
+* The RCL's bundled styles aren't published as a static web asset of the app that consumes the styles.
 
 For more information on RCLs, see the following articles:
 

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -1,6 +1,6 @@
 ---
 title: ASP.NET Core Blazor CSS isolation
-author: daveabrock
+author: guardrex
 description: Learn how CSS isolation allows you to scope CSS to your components, which can simplify your CSS and avoid collisions with other components or libraries.
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -83,11 +83,6 @@ At build time, a project bundle is created with the convention `obj/{CONFIGURATI
 * `{TARGET FRAMEWORK}`: The target framework (for example, `net6.0`).
 * `{ASSEMBLY NAME}`: The app's assembly name (for example, `BlazorSample`).
 
-If other projects are utilized, such as NuGet packages or [Razor class libraries](xref:blazor/components/class-libraries), the bundled file:
-
-* References the styles using CSS imports.
-* Isn't published as a static web asset of the app that consumes the styles.
-
 ## Child component support
 
 By default, CSS isolation only applies to the component you associate with the format `{COMPONENT NAME}.razor.css`, where the placeholder `{COMPONENT NAME}` is usually the component name. To apply changes to a child component, use the `::deep` combinator to any descendant elements in the parent component's `.razor.css` file. The `::deep` combinator selects elements that are *descendants* of an element's generated scope identifier. 
@@ -207,7 +202,10 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 
 ## Razor class library (RCL) support
 
-Isolated styles for components in a [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled and linked for the consuming app.
+Isolated styles for components in a NuGet package or [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled. The bundled file:
+
+* References the styles using CSS imports.
+* Isn't published as a static web asset of the app that consumes the styles.
 
 For more information on RCLs, see the following articles:
 
@@ -287,11 +285,6 @@ At build time, a project bundle is created with the convention `obj/{CONFIGURATI
 * `{CONFIGURATION}`: The app's build configuration (for example, `Debug`, `Release`).
 * `{TARGET FRAMEWORK}`: The target framework (for example, `net6.0`).
 * `{ASSEMBLY NAME}`: The app's assembly name (for example, `BlazorSample`).
-
-If other projects are utilized, such as NuGet packages or [Razor class libraries](xref:blazor/components/class-libraries), the bundled file:
-
-* References the styles using CSS imports.
-* Isn't published as a static web asset of the app that consumes the styles.
 
 ## Child component support
 
@@ -412,7 +405,10 @@ To opt out of how Blazor publishes and loads scoped files at runtime, use the `D
 
 ## Razor class library (RCL) support
 
-Isolated styles for components in a [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled and linked for the consuming app.
+Isolated styles for components in a NuGet package or [Razor class library (RCL)](xref:razor-pages/ui-class) are automatically bundled. The bundled file:
+
+* References the styles using CSS imports.
+* Isn't published as a static web asset of the app that consumes the styles.
 
 For more information on RCLs, see the following articles:
 


### PR DESCRIPTION
Fixes  #23849

Thanks @liangpeihui! :rocket:

Javier, you approved the RCL section at https://github.com/dotnet/AspNetCore.Docs/pull/20539. Looks like we need some additional detail on it:

* Updates seek to clarify the RCL scenario in both this topic and in the RCL topic. I took @liangpeihui's suggestion to expand the remark in the CSS Isolation topic that the bundled file "references the styles using CSS imports" remark to include more detail (and an example) on the CSS import statement. The RCL topic is also updated on this PR with these expanded remarks.
* The updated *build time* remark now points to the `obj` path for the bundle file. This is a bit detailed for docs to cover, but the updated path seems to be where the file is in the project and updates how it's named. I guess we're keeping this for full disclosure and just in case a dev wants to understand where/how this feature works.

cc: @daveabrock 