### PR TITLE
Make the migration samples not exclude the LTS train, 3.1 folks aren't excluded

### DIFF
--- a/aspnetcore/migration/50-to-60-samples.md
+++ b/aspnetcore/migration/50-to-60-samples.md
@@ -1,7 +1,7 @@
 ---
-title: Code samples migrated from ASP.NET Core 5.0 to the the new minimal hosting model in 6.0
+title: Code samples migrated to the the new minimal hosting model in 6.0
 author: rick-anderson
-description:  Shows how to migrate ASP.NET Core 5.0 samples to the the new minimal hosting model in 6.0
+description:  Shows how to migrate ASP.NET Core samples to the the new minimal hosting model in 6.0
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.date: 10/22/2021
@@ -9,13 +9,13 @@ no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cook
 uid: migration/50-to-60-samples
 ---
 
-# Code samples migrated from ASP.NET Core 5.0 to the the new minimal hosting model in 6.0
+# Code samples migrated to the the new minimal hosting model in ASP.NET Core 6.0
 
 <!-- 
 This content from https://gist.github.com/davidfowl/0e0372c3c1d895c3ce195ba983b1e03d#differences-in-the-hosting-model
  -->
 
-This article provides samples of code migrated from ASP.NET Core 5.0 to ASP.NET Core 6.0. ASP.NET Core 6.0 uses a new minimal hosting model. For more information, see [New hosting model](xref:migration/50-to-60#nhm)
+This article provides samples of code migrated to ASP.NET Core 6.0. ASP.NET Core 6.0 uses a new minimal hosting model. For more information, see [New hosting model](xref:migration/50-to-60#nhm)
 
 ## Middleware
 

--- a/aspnetcore/migration/50-to-60-samples.md
+++ b/aspnetcore/migration/50-to-60-samples.md
@@ -1,7 +1,7 @@
 ---
-title: Code samples migrated to the the new minimal hosting model in 6.0
+title: Code samples migrated to the new minimal hosting model in 6.0
 author: rick-anderson
-description:  Shows how to migrate ASP.NET Core samples to the the new minimal hosting model in 6.0
+description: Learn how to migrate ASP.NET Core samples to the the new minimal hosting model in 6.0.
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.date: 10/22/2021
@@ -9,13 +9,13 @@ no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cook
 uid: migration/50-to-60-samples
 ---
 
-# Code samples migrated to the the new minimal hosting model in ASP.NET Core 6.0
+# Code samples migrated to the new minimal hosting model in ASP.NET Core 6.0
 
 <!-- 
 This content from https://gist.github.com/davidfowl/0e0372c3c1d895c3ce195ba983b1e03d#differences-in-the-hosting-model
  -->
 
-This article provides samples of code migrated to ASP.NET Core 6.0. ASP.NET Core 6.0 uses a new minimal hosting model. For more information, see [New hosting model](xref:migration/50-to-60#nhm)
+This article provides samples of code migrated to ASP.NET Core 6.0. ASP.NET Core 6.0 uses a new minimal hosting model. For more information, see [New hosting model](xref:migration/50-to-60#nhm).
 
 ## Middleware
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -1405,7 +1405,7 @@
     - name: 5.0 to 6.0
       displayName: migrate, migration
       uid: migration/50-to-60
-    - name: 3.1,5.0 Code to 6.0
+    - name: 3.1/5.0 Code to 6.0
       displayName: migrate, migration
       uid: migration/50-to-60-samples
     - name: 3.1 to 5.0

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -1405,7 +1405,7 @@
     - name: 5.0 to 6.0
       displayName: migrate, migration
       uid: migration/50-to-60
-    - name: 5.0 Code to 6.0
+    - name: 3.1,5.0 Code to 6.0
       displayName: migrate, migration
       uid: migration/50-to-60-samples
     - name: 3.1 to 5.0


### PR DESCRIPTION
While I work on the 3.1 to 6.0 migration guide, let's not rule out the 3.1 folks to look at these samples, most of which apply to 3.1 for folks that want to make the big jump to the new minimal hosting model.