### PR TITLE
Update Blazor custom web.config guidance

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -17,6 +17,9 @@ uid: blazor/host-and-deploy/index
 
 Apps are published for deployment in Release configuration.
 
+> [!NOTE]
+> Publish hosted Blazor WebAssembly solutions from the **`Server`** project.
+
 # [Visual Studio](#tab/visual-studio)
 
 1. Select **Build** > **Publish {APPLICATION}** from the navigation bar.

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -393,7 +393,7 @@ When a Blazor project is published, a `web.config` file is created with the foll
 To use a custom `web.config` file:
 
 1. Place the custom `web.config` file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder.
-1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project.
+1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project. For more information, see <xref:blazor/host-and-deploy/index>.
 
 #### Install the URL Rewrite Module
 
@@ -1212,7 +1212,7 @@ To use a custom `web.config` file:
    </PropertyGroup>
    ```
 
-1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project.
+1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project. For more information, see <xref:blazor/host-and-deploy/index>.
 
 #### Install the URL Rewrite Module
 
@@ -2031,7 +2031,7 @@ To use a custom `web.config` file:
    </PropertyGroup>
    ```
 
-1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project.
+1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project. For more information, see <xref:blazor/host-and-deploy/index>.
 
 #### Install the URL Rewrite Module
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -390,13 +390,18 @@ When a Blazor project is published, a `web.config` file is created with the foll
   
 #### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
+To use a custom `web.config` file:
 
-```xml
-<PropertyGroup>
-  <PublishIISAssets>true</PublishIISAssets>
-</PropertyGroup>
-```
+1. Place the custom `web.config` file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder.
+1. Set the `<PublishIISAssets>` property to `true` in the project file (`.csproj`). For a hosted Blazor WebAssembly solution, set the property in the **`Server`** project's project file.
+
+   ```xml
+   <PropertyGroup>
+     <PublishIISAssets>true</PublishIISAssets>
+   </PropertyGroup>
+   ```
+
+1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project.
 
 #### Install the URL Rewrite Module
 
@@ -1204,13 +1209,18 @@ When a Blazor project is published, a `web.config` file is created with the foll
   
 #### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
+To use a custom `web.config` file:
 
-```xml
-<PropertyGroup>
-  <PublishIISAssets>true</PublishIISAssets>
-</PropertyGroup>
-```
+1. Place the custom `web.config` file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder.
+1. Set the `<PublishIISAssets>` property to `true` in the project file (`.csproj`). For a hosted Blazor WebAssembly solution, set the property in the **`Server`** project's project file.
+
+   ```xml
+   <PropertyGroup>
+     <PublishIISAssets>true</PublishIISAssets>
+   </PropertyGroup>
+   ```
+
+1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project.
 
 #### Install the URL Rewrite Module
 
@@ -2018,13 +2028,18 @@ When a Blazor project is published, a `web.config` file is created with the foll
   
 #### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
+To use a custom `web.config` file:
 
-```xml
-<PropertyGroup>
-  <PublishIISAssets>true</PublishIISAssets>
-</PropertyGroup>
-```
+1. Place the custom `web.config` file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder.
+1. Set the `<PublishIISAssets>` property to `true` in the project file (`.csproj`). For a hosted Blazor WebAssembly solution, set the property in the **`Server`** project's project file.
+
+   ```xml
+   <PropertyGroup>
+     <PublishIISAssets>true</PublishIISAssets>
+   </PropertyGroup>
+   ```
+
+1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project.
 
 #### Install the URL Rewrite Module
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -390,7 +390,7 @@ When a Blazor project is published, a `web.config` file is created with the foll
   
 #### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom file in the root folder of the project. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
+To use a custom `web.config` file, place the custom file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
 
 ```xml
 <PropertyGroup>
@@ -1204,7 +1204,7 @@ When a Blazor project is published, a `web.config` file is created with the foll
   
 #### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom file in the root folder of the project. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
+To use a custom `web.config` file, place the custom file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
 
 ```xml
 <PropertyGroup>
@@ -2018,7 +2018,7 @@ When a Blazor project is published, a `web.config` file is created with the foll
   
 #### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom file in the root folder of the project. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
+To use a custom `web.config` file, place the custom file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
 
 ```xml
 <PropertyGroup>

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -388,9 +388,9 @@ When a Blazor project is published, a `web.config` file is created with the foll
   * Serve the sub-directory where the app's static assets reside (`wwwroot/{PATH REQUESTED}`).
   * Create SPA fallback routing so that requests for non-file assets are redirected to the app's default document in its static assets folder (`wwwroot/index.html`).
   
-#### Use a custom web.config
+#### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom `web.config` file at the root of the project folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the app's project file and publish the project:
+To use a custom `web.config` file, place the custom file in the root folder of the project. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
 
 ```xml
 <PropertyGroup>
@@ -1202,9 +1202,9 @@ When a Blazor project is published, a `web.config` file is created with the foll
   * Serve the sub-directory where the app's static assets reside (`wwwroot/{PATH REQUESTED}`).
   * Create SPA fallback routing so that requests for non-file assets are redirected to the app's default document in its static assets folder (`wwwroot/index.html`).
   
-#### Use a custom web.config
+#### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom `web.config` file at the root of the project folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the app's project file and publish the project:
+To use a custom `web.config` file, place the custom file in the root folder of the project. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
 
 ```xml
 <PropertyGroup>
@@ -2016,9 +2016,9 @@ When a Blazor project is published, a `web.config` file is created with the foll
   * Serve the sub-directory where the app's static assets reside (`wwwroot/{PATH REQUESTED}`).
   * Create SPA fallback routing so that requests for non-file assets are redirected to the app's default document in its static assets folder (`wwwroot/index.html`).
   
-#### Use a custom web.config
+#### Use a custom `web.config`
 
-To use a custom `web.config` file, place the custom `web.config` file at the root of the project folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the app's project file and publish the project:
+To use a custom `web.config` file, place the custom file in the root folder of the project. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder. Configure the project to publish IIS-specific assets using `PublishIISAssets` in the project file (`.csproj`) and publish the project:
 
 ```xml
 <PropertyGroup>

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -393,14 +393,6 @@ When a Blazor project is published, a `web.config` file is created with the foll
 To use a custom `web.config` file:
 
 1. Place the custom `web.config` file in the project's root folder. For a hosted Blazor WebAssembly solution, place the file in the **`Server`** project's folder.
-1. Set the `<PublishIISAssets>` property to `true` in the project file (`.csproj`). For a hosted Blazor WebAssembly solution, set the property in the **`Server`** project's project file.
-
-   ```xml
-   <PropertyGroup>
-     <PublishIISAssets>true</PublishIISAssets>
-   </PropertyGroup>
-   ```
-
 1. Publish the project. For a hosted Blazor WebAssembly solution, publish the solution from the **`Server`** project.
 
 #### Install the URL Rewrite Module


### PR DESCRIPTION
Fixes #23911

Thanks @dotnetshadow! :rocket:

* Looks like we can drop the property for 6.0 or later based on local testing.
* Let's make this guidance about publishing from the **`Server`** project for hosted WASM more prominent with a callout in the *Host and Deploy* overview NOTE.