### PR TITLE
bool is true or false

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -257,7 +257,7 @@ To set this value, use the environment variable or configure `HostOptions`. The 
 By [default](xref:fundamentals/configuration/index#default), *appsettings.json* and *appsettings.{Environment}.json* are reloaded when the file changes. To disable this reload behavior in ASP.NET Core 5.0 or later, set the `hostBuilder:reloadConfigOnChange` key to `false`.
 
 **Key**: `hostBuilder:reloadConfigOnChange`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true` or `false`)  
 **Default**: `true`  
 **Command-line argument**: `hostBuilder:reloadConfigOnChange`  
 **Environment variable**: `<PREFIX_>hostBuilder:reloadConfigOnChange`
@@ -286,7 +286,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 When `false`, errors during startup result in the host exiting. When `true`, the host captures exceptions during startup and attempts to start the server.
 
 **Key**: `captureStartupErrors`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true` or `false`)  
 **Default**: Defaults to `false` unless the app runs with Kestrel behind IIS, where the default is `true`.  
 **Environment variable**: `<PREFIX_>CAPTURESTARTUPERRORS`
 
@@ -301,7 +301,7 @@ webBuilder.CaptureStartupErrors(true);
 When enabled, or when the environment is `Development`, the app captures detailed errors.
 
 **Key**: `detailedErrors`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true` or `false`)  
 **Default**: `false`  
 **Environment variable**: `<PREFIX_>_DETAILEDERRORS`
 


### PR DESCRIPTION
> Wystąpił wyjątek: CLR/System.InvalidOperationException
> Wystąpił nieobsługiwany wyjątek typu „System.InvalidOperationException” w Microsoft.Extensions.Configuration.Binder.dll: > 'Failed to convert configuration value at 'hostBuilder:reloadConfigOnChange' to type 'System.Boolean'.'
> Znaleziono wewnętrzne wyjątki. Zobacz $exception w oknie zmiennych, aby uzyskać więcej szczegółów.
> 	Najbardziej wewnętrzny wyjątek 	 System.FormatException : String '1' was not recognized as a valid Boolean.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->