### PR TITLE
Update bool value entries for host config

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -191,7 +191,7 @@ The [IHostEnvironment.ApplicationName](xref:Microsoft.Extensions.Hosting.IHostEn
 **Key**: `applicationName`  
 **Type**: `string`  
 **Default**: The name of the assembly that contains the app's entry point.  
-**Environment variable**: `<PREFIX_>APPLICATIONNAME`
+**Environment variable**: `{PREFIX_}APPLICATIONNAME`
 
 To set this value, use the environment variable. 
 
@@ -202,7 +202,7 @@ The [IHostEnvironment.ContentRootPath](xref:Microsoft.Extensions.Hosting.IHostEn
 **Key**: `contentRoot`  
 **Type**: `string`  
 **Default**: The folder where the app assembly resides.  
-**Environment variable**: `<PREFIX_>CONTENTROOT`
+**Environment variable**: `{PREFIX_}CONTENTROOT`
 
 To set this value, use the environment variable or call `UseContentRoot` on `IHostBuilder`:
 
@@ -224,7 +224,7 @@ The [IHostEnvironment.EnvironmentName](xref:Microsoft.Extensions.Hosting.IHostEn
 **Key**: `environment`  
 **Type**: `string`  
 **Default**: `Production`  
-**Environment variable**: `<PREFIX_>ENVIRONMENT`
+**Environment variable**: `{PREFIX_}ENVIRONMENT`
 
 To set this value, use the environment variable or call `UseEnvironment` on `IHostBuilder`:
 
@@ -246,7 +246,7 @@ If the timeout period expires before all of the hosted services stop, any remain
 **Key**: `shutdownTimeoutSeconds`  
 **Type**: `int`  
 **Default**: 5 seconds  
-**Environment variable**: `<PREFIX_>SHUTDOWNTIMEOUTSECONDS`
+**Environment variable**: `{PREFIX_}SHUTDOWNTIMEOUTSECONDS`
 
 To set this value, use the environment variable or configure `HostOptions`. The following example sets the timeout to 20 seconds:
 
@@ -260,7 +260,7 @@ By [default](xref:fundamentals/configuration/index#default), *appsettings.json* 
 **Type**: `bool` (`true` or `false`)  
 **Default**: `true`  
 **Command-line argument**: `hostBuilder:reloadConfigOnChange`  
-**Environment variable**: `<PREFIX_>hostBuilder:reloadConfigOnChange`
+**Environment variable**: `{PREFIX_}hostBuilder:reloadConfigOnChange`
 
 > [!WARNING]
 > The colon (`:`) separator doesn't work with environment variable hierarchical keys on all platforms. For more information, see [Environment variables](xref:fundamentals/configuration/index#environment-variables).
@@ -288,7 +288,7 @@ When `false`, errors during startup result in the host exiting. When `true`, the
 **Key**: `captureStartupErrors`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: Defaults to `false` unless the app runs with Kestrel behind IIS, where the default is `true`.  
-**Environment variable**: `<PREFIX_>CAPTURESTARTUPERRORS`
+**Environment variable**: `{PREFIX_}CAPTURESTARTUPERRORS`
 
 To set this value, use configuration or call `CaptureStartupErrors`:
 
@@ -303,7 +303,7 @@ When enabled, or when the environment is `Development`, the app captures detaile
 **Key**: `detailedErrors`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
-**Environment variable**: `<PREFIX_>_DETAILEDERRORS`
+**Environment variable**: `{PREFIX_}DETAILEDERRORS`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -318,7 +318,7 @@ A semicolon-delimited string of hosting startup assemblies to load on startup. A
 **Key**: `hostingStartupAssemblies`  
 **Type**: `string`  
 **Default**: Empty string  
-**Environment variable**: `<PREFIX_>_HOSTINGSTARTUPASSEMBLIES`
+**Environment variable**: `{PREFIX_}HOSTINGSTARTUPASSEMBLIES`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -333,7 +333,7 @@ A semicolon-delimited string of hosting startup assemblies to exclude on startup
 **Key**: `hostingStartupExcludeAssemblies`  
 **Type**: `string`  
 **Default**: Empty string  
-**Environment variable**: `<PREFIX_>_HOSTINGSTARTUPEXCLUDEASSEMBLIES`
+**Environment variable**: `{PREFIX_}HOSTINGSTARTUPEXCLUDEASSEMBLIES`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -348,7 +348,7 @@ The HTTPS redirect port. Used in [enforcing HTTPS](xref:security/enforcing-ssl).
 **Key**: `https_port`  
 **Type**: `string`  
 **Default**: A default value isn't set.  
-**Environment variable**: `<PREFIX_>HTTPS_PORT`
+**Environment variable**: `{PREFIX_}HTTPS_PORT`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -363,7 +363,7 @@ Indicates whether the host should listen on the URLs configured with the `IWebHo
 **Key**: `preferHostingUrls`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `true`  
-**Environment variable**: `<PREFIX_>_PREFERHOSTINGURLS`
+**Environment variable**: `{PREFIX_}PREFERHOSTINGURLS`
 
 To set this value, use the environment variable or call `PreferHostingUrls`:
 
@@ -378,7 +378,7 @@ Prevents the automatic loading of hosting startup assemblies, including hosting 
 **Key**: `preventHostingStartup`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
-**Environment variable**: `<PREFIX_>_PREVENTHOSTINGSTARTUP`
+**Environment variable**: `{PREFIX_}PREVENTHOSTINGSTARTUP`
 
 To set this value, use the environment variable or call `UseSetting` :
 
@@ -393,7 +393,7 @@ The assembly to search for the `Startup` class.
 **Key**: `startupAssembly`  
 **Type**: `string`  
 **Default**: The app's assembly  
-**Environment variable**: `<PREFIX_>STARTUPASSEMBLY`
+**Environment variable**: `{PREFIX_}STARTUPASSEMBLY`
 
 To set this value, use the environment variable or call `UseStartup`. `UseStartup` can take an assembly name (`string`) or a type (`TStartup`). If multiple `UseStartup` methods are called, the last one takes precedence.
 
@@ -412,7 +412,7 @@ When enabled, suppresses hosting startup status messages.
 **Key**: `suppressStatusMessages`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
-**Environment variable**: `<PREFIX_>_SUPPRESSSTATUSMESSAGES`
+**Environment variable**: `{PREFIX_}SUPPRESSSTATUSMESSAGES`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -427,7 +427,7 @@ A semicolon-delimited list of IP addresses or host addresses with ports and prot
 **Key**: `urls`  
 **Type**: `string`  
 **Default**: `http://localhost:5000` and `https://localhost:5001`  
-**Environment variable**: `<PREFIX_>URLS`
+**Environment variable**: `{PREFIX_}URLS`
 
 To set this value, use the environment variable or call `UseUrls`:
 
@@ -444,7 +444,7 @@ The [IWebHostEnvironment.WebRootPath](xref:Microsoft.AspNetCore.Hosting.IWebHost
 **Key**: `webroot`  
 **Type**: `string`  
 **Default**: The default is `wwwroot`. The path to *{content root}/wwwroot* must exist.  
-**Environment variable**: `<PREFIX_>WEBROOT`
+**Environment variable**: `{PREFIX_}WEBROOT`
 
 To set this value, use the environment variable or call `UseWebRoot` on `IWebHostBuilder`:
 
@@ -709,7 +709,7 @@ The [IHostEnvironment.ApplicationName](xref:Microsoft.Extensions.Hosting.IHostEn
 **Key**: `applicationName`  
 **Type**: `string`  
 **Default**: The name of the assembly that contains the app's entry point.  
-**Environment variable**: `<PREFIX_>APPLICATIONNAME`
+**Environment variable**: `{PREFIX_}APPLICATIONNAME`
 
 To set this value, use the environment variable. 
 
@@ -720,7 +720,7 @@ The [IHostEnvironment.ContentRootPath](xref:Microsoft.Extensions.Hosting.IHostEn
 **Key**: `contentRoot`  
 **Type**: `string`  
 **Default**: The folder where the app assembly resides.  
-**Environment variable**: `<PREFIX_>CONTENTROOT`
+**Environment variable**: `{PREFIX_}CONTENTROOT`
 
 To set this value, use the environment variable or call `UseContentRoot` on `IHostBuilder`:
 
@@ -742,7 +742,7 @@ The [IHostEnvironment.EnvironmentName](xref:Microsoft.Extensions.Hosting.IHostEn
 **Key**: `environment`  
 **Type**: `string`  
 **Default**: `Production`  
-**Environment variable**: `<PREFIX_>ENVIRONMENT`
+**Environment variable**: `{PREFIX_}ENVIRONMENT`
 
 To set this value, use the environment variable or call `UseEnvironment` on `IHostBuilder`:
 
@@ -764,7 +764,7 @@ If the timeout period expires before all of the hosted services stop, any remain
 **Key**: `shutdownTimeoutSeconds`  
 **Type**: `int`  
 **Default**: 5 seconds  
-**Environment variable**: `<PREFIX_>SHUTDOWNTIMEOUTSECONDS`
+**Environment variable**: `{PREFIX_}SHUTDOWNTIMEOUTSECONDS`
 
 To set this value, use the environment variable or configure `HostOptions`. The following example sets the timeout to 20 seconds:
 
@@ -793,7 +793,7 @@ When `false`, errors during startup result in the host exiting. When `true`, the
 **Key**: `captureStartupErrors`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: Defaults to `false` unless the app runs with Kestrel behind IIS, where the default is `true`.  
-**Environment variable**: `<PREFIX_>CAPTURESTARTUPERRORS`
+**Environment variable**: `{PREFIX_}CAPTURESTARTUPERRORS`
 
 To set this value, use configuration or call `CaptureStartupErrors`:
 
@@ -808,7 +808,7 @@ When enabled, or when the environment is `Development`, the app captures detaile
 **Key**: `detailedErrors`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
-**Environment variable**: `<PREFIX_>_DETAILEDERRORS`
+**Environment variable**: `{PREFIX_}DETAILEDERRORS`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -823,7 +823,7 @@ A semicolon-delimited string of hosting startup assemblies to load on startup. A
 **Key**: `hostingStartupAssemblies`  
 **Type**: `string`  
 **Default**: Empty string  
-**Environment variable**: `<PREFIX_>_HOSTINGSTARTUPASSEMBLIES`
+**Environment variable**: `{PREFIX_}HOSTINGSTARTUPASSEMBLIES`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -838,7 +838,7 @@ A semicolon-delimited string of hosting startup assemblies to exclude on startup
 **Key**: `hostingStartupExcludeAssemblies`  
 **Type**: `string`  
 **Default**: Empty string  
-**Environment variable**: `<PREFIX_>_HOSTINGSTARTUPEXCLUDEASSEMBLIES`
+**Environment variable**: `{PREFIX_}HOSTINGSTARTUPEXCLUDEASSEMBLIES`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -853,7 +853,7 @@ The HTTPS redirect port. Used in [enforcing HTTPS](xref:security/enforcing-ssl).
 **Key**: `https_port`  
 **Type**: `string`  
 **Default**: A default value isn't set.  
-**Environment variable**: `<PREFIX_>HTTPS_PORT`
+**Environment variable**: `{PREFIX_}HTTPS_PORT`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -868,7 +868,7 @@ Indicates whether the host should listen on the URLs configured with the `IWebHo
 **Key**: `preferHostingUrls`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `true`  
-**Environment variable**: `<PREFIX_>_PREFERHOSTINGURLS`
+**Environment variable**: `{PREFIX_}PREFERHOSTINGURLS`
 
 To set this value, use the environment variable or call `PreferHostingUrls`:
 
@@ -883,7 +883,7 @@ Prevents the automatic loading of hosting startup assemblies, including hosting 
 **Key**: `preventHostingStartup`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
-**Environment variable**: `<PREFIX_>_PREVENTHOSTINGSTARTUP`
+**Environment variable**: `{PREFIX_}PREVENTHOSTINGSTARTUP`
 
 To set this value, use the environment variable or call `UseSetting` :
 
@@ -898,7 +898,7 @@ The assembly to search for the `Startup` class.
 **Key**: `startupAssembly`  
 **Type**: `string`  
 **Default**: The app's assembly  
-**Environment variable**: `<PREFIX_>STARTUPASSEMBLY`
+**Environment variable**: `{PREFIX_}STARTUPASSEMBLY`
 
 To set this value, use the environment variable or call `UseStartup`. `UseStartup` can take an assembly name (`string`) or a type (`TStartup`). If multiple `UseStartup` methods are called, the last one takes precedence.
 
@@ -917,7 +917,7 @@ When enabled, suppresses hosting startup status messages.
 **Key**: `suppressStatusMessages`  
 **Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
-**Environment variable**: `<PREFIX_>_SUPPRESSSTATUSMESSAGES`
+**Environment variable**: `{PREFIX_}SUPPRESSSTATUSMESSAGES`
 
 To set this value, use configuration or call `UseSetting`:
 
@@ -932,7 +932,7 @@ A semicolon-delimited list of IP addresses or host addresses with ports and prot
 **Key**: `urls`  
 **Type**: `string`  
 **Default**: `http://localhost:5000` and `https://localhost:5001`  
-**Environment variable**: `<PREFIX_>URLS`
+**Environment variable**: `{PREFIX_}URLS`
 
 To set this value, use the environment variable or call `UseUrls`:
 
@@ -949,7 +949,7 @@ The [IWebHostEnvironment.WebRootPath](xref:Microsoft.AspNetCore.Hosting.IWebHost
 **Key**: `webroot`  
 **Type**: `string`  
 **Default**: The default is `wwwroot`. The path to *{content root}/wwwroot* must exist.  
-**Environment variable**: `<PREFIX_>WEBROOT`
+**Environment variable**: `{PREFIX_}WEBROOT`
 
 To set this value, use the environment variable or call `UseWebRoot` on `IWebHostBuilder`:
 

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -176,11 +176,11 @@ App configuration is created by calling <xref:Microsoft.Extensions.Hosting.HostB
 
 The configuration created by `ConfigureAppConfiguration` is available at [HostBuilderContext.Configuration](xref:Microsoft.Extensions.Hosting.HostBuilderContext.Configuration*) for subsequent operations and as a service from DI. The host configuration is also added to the app configuration.
 
-For more information, see [Configuration in ASP.NET Core](xref:fundamentals/configuration/index).
+For more information, see <xref:fundamentals/configuration/index>.
 
 ## Settings for all app types
 
-This section lists host settings that apply to both HTTP and non-HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following list of settings as the `{PREFIX_}` placeholder. For more information, see the [Default builder settings](#default-builder-settings) section.
+This section lists host settings that apply to both HTTP and non-HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following list of settings as the `{PREFIX_}` placeholder. For more information, see the [Default builder settings](#default-builder-settings) section and [Configuration: Environment variables](xref:fundamentals/configuration/index#environment-variables).
 
 <!-- In the following sections, two spaces at end of line are used to force line breaks in the rendered page. -->
 

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -180,7 +180,7 @@ For more information, see [Configuration in ASP.NET Core](xref:fundamentals/conf
 
 ## Settings for all app types
 
-This section lists host settings that apply to both HTTP and non-HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix. For more information, see the [Default builder settings](#default-builder-settings) section.
+This section lists host settings that apply to both HTTP and non-HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following configuration for the `{PREFIX_}` placeholder. For more information, see the [Default builder settings](#default-builder-settings) section.
 
 <!-- In the following sections, two spaces at end of line are used to force line breaks in the rendered page. -->
 

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -267,7 +267,7 @@ By [default](xref:fundamentals/configuration/index#default), *appsettings.json* 
 
 ## Settings for web apps
 
-Some host settings apply only to HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix.
+Some host settings apply only to HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following configuration for the `{PREFIX_}` placeholder.
 
 Extension methods on `IWebHostBuilder` are available for these settings. Code samples that show how to call the extension methods assume `webBuilder` is an instance of `IWebHostBuilder`, as in the following example:
 
@@ -698,7 +698,7 @@ For more information, see [Configuration in ASP.NET Core](xref:fundamentals/conf
 
 ## Settings for all app types
 
-This section lists host settings that apply to both HTTP and non-HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix.
+This section lists host settings that apply to both HTTP and non-HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following configuration for the `{PREFIX_}` placeholder.
 
 <!-- In the following sections, two spaces at end of line are used to force line breaks in the rendered page. -->
 

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -257,7 +257,7 @@ To set this value, use the environment variable or configure `HostOptions`. The 
 By [default](xref:fundamentals/configuration/index#default), *appsettings.json* and *appsettings.{Environment}.json* are reloaded when the file changes. To disable this reload behavior in ASP.NET Core 5.0 or later, set the `hostBuilder:reloadConfigOnChange` key to `false`.
 
 **Key**: `hostBuilder:reloadConfigOnChange`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true` or `false`)  
 **Default**: `true`  
 **Command-line argument**: `hostBuilder:reloadConfigOnChange`  
 **Environment variable**: `<PREFIX_>hostBuilder:reloadConfigOnChange`
@@ -286,7 +286,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 When `false`, errors during startup result in the host exiting. When `true`, the host captures exceptions during startup and attempts to start the server.
 
 **Key**: `captureStartupErrors`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: Defaults to `false` unless the app runs with Kestrel behind IIS, where the default is `true`.  
 **Environment variable**: `<PREFIX_>CAPTURESTARTUPERRORS`
 
@@ -301,7 +301,7 @@ webBuilder.CaptureStartupErrors(true);
 When enabled, or when the environment is `Development`, the app captures detailed errors.
 
 **Key**: `detailedErrors`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
 **Environment variable**: `<PREFIX_>_DETAILEDERRORS`
 
@@ -361,7 +361,7 @@ webBuilder.UseSetting("https_port", "8080");
 Indicates whether the host should listen on the URLs configured with the `IWebHostBuilder` instead of those URLs configured with the `IServer` implementation.
 
 **Key**: `preferHostingUrls`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `true`  
 **Environment variable**: `<PREFIX_>_PREFERHOSTINGURLS`
 
@@ -376,7 +376,7 @@ webBuilder.PreferHostingUrls(false);
 Prevents the automatic loading of hosting startup assemblies, including hosting startup assemblies configured by the app's assembly. For more information, see <xref:fundamentals/configuration/platform-specific-configuration>.
 
 **Key**: `preventHostingStartup`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
 **Environment variable**: `<PREFIX_>_PREVENTHOSTINGSTARTUP`
 
@@ -403,6 +403,21 @@ webBuilder.UseStartup("StartupAssemblyName");
 
 ```csharp
 webBuilder.UseStartup<Startup>();
+```
+
+### SuppressStatusMessages
+
+When enabled, suppresses hosting startup status messages.
+
+**Key**: `suppressStatusMessages`  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
+**Default**: `false`  
+**Environment variable**: `<PREFIX_>_SUPPRESSSTATUSMESSAGES`
+
+To set this value, use configuration or call `UseSetting`:
+
+```csharp
+webBuilder.UseSetting(WebHostDefaults.SuppressStatusMessagesKey, "true");
 ```
 
 ### URLs
@@ -776,7 +791,7 @@ public static IHostBuilder CreateHostBuilder(string[] args) =>
 When `false`, errors during startup result in the host exiting. When `true`, the host captures exceptions during startup and attempts to start the server.
 
 **Key**: `captureStartupErrors`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: Defaults to `false` unless the app runs with Kestrel behind IIS, where the default is `true`.  
 **Environment variable**: `<PREFIX_>CAPTURESTARTUPERRORS`
 
@@ -791,7 +806,7 @@ webBuilder.CaptureStartupErrors(true);
 When enabled, or when the environment is `Development`, the app captures detailed errors.
 
 **Key**: `detailedErrors`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
 **Environment variable**: `<PREFIX_>_DETAILEDERRORS`
 
@@ -851,7 +866,7 @@ webBuilder.UseSetting("https_port", "8080");
 Indicates whether the host should listen on the URLs configured with the `IWebHostBuilder` instead of those URLs configured with the `IServer` implementation.
 
 **Key**: `preferHostingUrls`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `true`  
 **Environment variable**: `<PREFIX_>_PREFERHOSTINGURLS`
 
@@ -866,7 +881,7 @@ webBuilder.PreferHostingUrls(false);
 Prevents the automatic loading of hosting startup assemblies, including hosting startup assemblies configured by the app's assembly. For more information, see <xref:fundamentals/configuration/platform-specific-configuration>.
 
 **Key**: `preventHostingStartup`  
-**Type**: `bool` (`true` or `1`)  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
 **Default**: `false`  
 **Environment variable**: `<PREFIX_>_PREVENTHOSTINGSTARTUP`
 
@@ -893,6 +908,21 @@ webBuilder.UseStartup("StartupAssemblyName");
 
 ```csharp
 webBuilder.UseStartup<Startup>();
+```
+
+### SuppressStatusMessages
+
+When enabled, suppresses hosting startup status messages.
+
+**Key**: `suppressStatusMessages`  
+**Type**: `bool` (`true`/`1` or `false`/`0`)  
+**Default**: `false`  
+**Environment variable**: `<PREFIX_>_SUPPRESSSTATUSMESSAGES`
+
+To set this value, use configuration or call `UseSetting`:
+
+```csharp
+webBuilder.UseSetting(WebHostDefaults.SuppressStatusMessagesKey, "true");
 ```
 
 ### URLs

--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -180,7 +180,7 @@ For more information, see [Configuration in ASP.NET Core](xref:fundamentals/conf
 
 ## Settings for all app types
 
-This section lists host settings that apply to both HTTP and non-HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following configuration for the `{PREFIX_}` placeholder. For more information, see the [Default builder settings](#default-builder-settings) section.
+This section lists host settings that apply to both HTTP and non-HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following list of settings as the `{PREFIX_}` placeholder. For more information, see the [Default builder settings](#default-builder-settings) section.
 
 <!-- In the following sections, two spaces at end of line are used to force line breaks in the rendered page. -->
 
@@ -267,7 +267,7 @@ By [default](xref:fundamentals/configuration/index#default), *appsettings.json* 
 
 ## Settings for web apps
 
-Some host settings apply only to HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following configuration for the `{PREFIX_}` placeholder.
+Some host settings apply only to HTTP workloads. By default, environment variables used to configure these settings can have a `DOTNET_` or `ASPNETCORE_` prefix, which appear in the following list of settings as the `{PREFIX_}` placeholder.
 
 Extension methods on `IWebHostBuilder` are available for these settings. Code samples that show how to call the extension methods assume `webBuilder` is an instance of `IWebHostBuilder`, as in the following example:
 


### PR DESCRIPTION
Fixes #23984

Thanks @yecril71pl! :rocket:

From identifying the `ParseBool`-calling options in `WebHostOptions` and given that `ParseBool` is a `true`/`1` **string** for `true` (**bool**) and `false`/`0`/anything **string** for `false` (**bool**), this PR sets the potential and recommended&dagger; values.

&dagger;Recommended in the sense that a nonsensical/nonstandard value is interpreted as `false`. We don't need to call it out, but ...

```csharp
webBuilder.UseSetting(WebHostDefaults.DetailedErrorsKey, 
    "Spare me the details, man! It's FRIDAY for crying out loud! 🎉🍻");
```

😆 Technically, that's ok. Then, it would reach code review, and you'd have to go find a new dev role. 🙈

* https://github.com/dotnet/aspnetcore/blob/main/src/Hosting/Abstractions/src/WebHostDefaults.cs
* https://github.com/dotnet/aspnetcore/blob/main/src/Hosting/Hosting/src/Internal/WebHostOptions.cs#L21-L29
* https://github.com/dotnet/aspnetcore/blob/main/src/Hosting/Hosting/src/Internal/WebHostUtilities.cs#L11-L15
* There's only a test for one key AFAICT ... I guess just to check that `ParseBool` is working ok. https://github.com/dotnet/aspnetcore/blob/a450cb69b5e4549f5515cdb057a68771f56cefd7/src/Hosting/Hosting/test/WebHostConfigurationsTests.cs#L47-L56

Also, it looks like we missed one back in the day, `SuppressStatusMessagesKey`. It's added here. The 2.x bits use a different format for options. I think we can let that go unchanged here ... and it's going away soon enough.

Kirk, I don't think we need PU review given that these are mostly nit-level updates to the descriptions and the clarity of the framework API. However, if you feel we should ping, I'll call for PU review as well. :ear:

... and btw ... not going for the 6.0 updates here. I need to get back to Blazor-ish things, and the whole topic is going to need more work on that set of updates.

