### PR TITLE
Change service name to match code examples

### DIFF
--- a/aspnetcore/grpc/client.md
+++ b/aspnetcore/grpc/client.md
@@ -17,7 +17,7 @@ A .NET gRPC client library is available in the [Grpc.Net.Client](https://www.nug
 
 ## Configure gRPC client
 
-gRPC clients are concrete client types that are [generated from *\*.proto* files](xref:grpc/basics#generated-c-assets). The concrete gRPC client has methods that translate to the gRPC service in the *\*.proto* file. For example, a service called `Greeter` generates a `GreeterClient` type with methods to call the service.
+gRPC clients are concrete client types that are [generated from *\*.proto* files](xref:grpc/basics#generated-c-assets). The concrete gRPC client has methods that translate to the gRPC service in the *\*.proto* file. For example, a service called `Greet` generates a `GreeterClient` type with methods to call the service.
 
 A gRPC client is created from a channel. Start by using `GrpcChannel.ForAddress` to create a channel, and then use the channel to create a gRPC client:
 


### PR DESCRIPTION
Fixes #24002

Thanks @felinepunch! :rocket: ... If we change the service name in this one sentence, then it will match all of the code examples down the doc. This seems to be the quickest way to resolve the issue. James will let us know if that's going to be a problem.