### PR TITLE
A controller is an instantiable public class

### DIFF
--- a/aspnetcore/mvc/controllers/actions.md
+++ b/aspnetcore/mvc/controllers/actions.md
@@ -22,7 +22,7 @@ By convention, controller classes:
 * Reside in the project's root-level *Controllers* folder.
 * Inherit from `Microsoft.AspNetCore.Mvc.Controller`.
 
-A controller is an instantiable public class in which at least one of the following conditions is true:
+A controller is an instantiable class, usually [public](/dotnet/csharp/language-reference/keywords/public), in which at least one of the following conditions is true:
 
 * The class name is suffixed with `Controller`.
 * The class inherits from a class whose name is suffixed with `Controller`.

--- a/aspnetcore/mvc/controllers/actions.md
+++ b/aspnetcore/mvc/controllers/actions.md
@@ -22,7 +22,7 @@ By convention, controller classes:
 * Reside in the project's root-level *Controllers* folder.
 * Inherit from `Microsoft.AspNetCore.Mvc.Controller`.
 
-A controller is an instantiable class in which at least one of the following conditions is true:
+A controller is an instantiable public class in which at least one of the following conditions is true:
 
 * The class name is suffixed with `Controller`.
 * The class inherits from a class whose name is suffixed with `Controller`.


### PR DESCRIPTION
I understand that from the library POV a non-public class is non-instantiable.  However, when I look at my code, I can instantiate the controller class all right, so I cannot see the problem.  Also, there is no warning from the library when a controller class is non-public, so there is no way to discover the problem at run time.  I hope this small amendment will do no harm.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->