### PR TITLE
Reference to FormTagHelper API docs

### DIFF
--- a/aspnetcore/mvc/views/working-with-forms.md
+++ b/aspnetcore/mvc/views/working-with-forms.md
@@ -20,7 +20,7 @@ In many cases, HTML Helpers provide an alternative approach to a specific Tag He
 
 ## The Form Tag Helper
 
-The [Form](https://www.w3.org/TR/html401/interact/forms.html) Tag Helper:
+The [Form Tag Helper](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.formtaghelper):
 
 * Generates the HTML [\<FORM>](https://www.w3.org/TR/html401/interact/forms.html) `action` attribute value for a MVC controller action or named route
 

--- a/aspnetcore/mvc/views/working-with-forms.md
+++ b/aspnetcore/mvc/views/working-with-forms.md
@@ -20,7 +20,7 @@ In many cases, HTML Helpers provide an alternative approach to a specific Tag He
 
 ## The Form Tag Helper
 
-The [Form Tag Helper](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.formtaghelper):
+The [Form Tag Helper](xref:Microsoft.AspNetCore.Mvc.TagHelpers.FormTagHelper):
 
 * Generates the HTML [\<FORM>](https://www.w3.org/TR/html401/interact/forms.html) `action` attribute value for a MVC controller action or named route
 


### PR DESCRIPTION
The page already has a link to the `<form />` html tag. Users reading this document are probably more interested in the API docs, I know I am.