### PR TITLE
Blazor Identity scaffolding

### DIFF
--- a/aspnetcore/includes/scaffold-identity/id-scaffold-dlg-auth.md
+++ b/aspnetcore/includes/scaffold-identity/id-scaffold-dlg-auth.md
@@ -8,7 +8,7 @@ Run the Identity scaffolder:
 # [Visual Studio](#tab/visual-studio)
 
 * From **Solution Explorer**, right-click on the project > **Add** > **New Scaffolded Item**.
-* From the left pane of the **Add Scaffold** dialog, select **Identity** > **Add**.
+* From the left pane of the **Add New Scaffolded Item** dialog, select **Identity**. Select **Identity** in the center pane. Select the **Add** button.
 * In the **Add Identity** dialog, select the options you want.
   * Select your existing layout page so your layout file isn't overwritten with incorrect markup. When an existing `_Layout.cshtml` file is selected, it is **not** overwritten. For example:
     * `~/Pages/Shared/_Layout.cshtml` for Razor Pages or Blazor Server projects with existing Razor Pages infrastructure.

--- a/aspnetcore/includes/scaffold-identity/id-scaffold-dlg-auth.md
+++ b/aspnetcore/includes/scaffold-identity/id-scaffold-dlg-auth.md
@@ -10,9 +10,9 @@ Run the Identity scaffolder:
 * From **Solution Explorer**, right-click on the project > **Add** > **New Scaffolded Item**.
 * From the left pane of the **Add Scaffold** dialog, select **Identity** > **Add**.
 * In the **Add Identity** dialog, select the options you want.
-  * Select your existing layout page so your layout file isn't overwritten with incorrect markup. When an existing *\_Layout.cshtml* file is selected, it is **not** overwritten. For example:
-    * `~/Pages/Shared/_Layout.cshtml` for Razor Pages or Blazor Server projects with existing Razor Pages infrastructure
-    * `~/Views/Shared/_Layout.cshtml` for MVC projects or Blazor Server projects with existing MVC infrastructure
+  * Select your existing layout page so your layout file isn't overwritten with incorrect markup. When an existing `_Layout.cshtml` file is selected, it is **not** overwritten. For example:
+    * `~/Pages/Shared/_Layout.cshtml` for Razor Pages or Blazor Server projects with existing Razor Pages infrastructure.
+    * `~/Views/Shared/_Layout.cshtml` for MVC projects or Blazor Server projects with existing MVC infrastructure.
 * To use your existing data context, select at least one file to override. You must select at least one file to add your data context.
   * Select your data context class.
   * Select **Add**.

--- a/aspnetcore/security/authentication/scaffold-identity.md
+++ b/aspnetcore/security/authentication/scaffold-identity.md
@@ -146,11 +146,11 @@ dotnet aspnet-codegenerator identity -dc MvcAuth.Data.ApplicationDbContext  --fi
 
 [!INCLUDE[](~/includes/scaffold-identity/id-scaffold-dlg-auth.md)]
 
-## Scaffold Identity into a Blazor Server project without existing authorization
+## Scaffold Identity into a Blazor Server project
 
-[!INCLUDE[](~/includes/scaffold-identity/id-scaffold-dlg.md)]
+[!INCLUDE[](~/includes/scaffold-identity/install-pkg.md)]
 
-Identity is configured in *Areas/Identity/IdentityHostingStartup.cs*. For more information, see [IHostingStartup](xref:fundamentals/configuration/platform-specific-configuration).
+[!INCLUDE[](~/includes/scaffold-identity/id-scaffold-dlg-auth.md)]
 
 ### Migrations
 
@@ -165,7 +165,7 @@ Tokens can be passed to components:
 
 For more information, see <xref:blazor/security/server/additional-scenarios#pass-tokens-to-a-blazor-server-app>.
 
-In the *Pages/_Host.cshtml* file, establish the token after adding it to the `InitialApplicationState` and `TokenProvider` classes:
+In the `Pages/_Host.cshtml` file, establish the token after adding it to the `InitialApplicationState` and `TokenProvider` classes:
 
 ```csharp
 @inject Microsoft.AspNetCore.Antiforgery.IAntiforgery Xsrf
@@ -180,7 +180,7 @@ var tokens = new InitialApplicationState
 };
 ```
 
-Update the `App` component (*App.razor*) to assign the `InitialState.XsrfToken`:
+Update the `App` component (`App.razor`) to assign the `InitialState.XsrfToken`:
 
 ```csharp
 @inject TokenProvider TokenProvider
@@ -192,23 +192,17 @@ TokenProvider.XsrfToken = InitialState.XsrfToken;
 
 The `TokenProvider` service demonstrated in the topic is used in the `LoginDisplay` component in the following [Layout and authentication flow changes](#layout-and-authentication-flow-changes) section.
 
-### Enable authentication
+### Register the token provider service
 
-In the `Startup` class:
+If using a [token provider service](xref:blazor/security/server/additional-scenarios#pass-tokens-to-a-blazor-server-app), register the service in `Program.cs`:
 
-* Confirm that Razor Pages services are added in `Startup.ConfigureServices`.
-* If using the [TokenProvider](xref:blazor/security/server/additional-scenarios#pass-tokens-to-a-blazor-server-app), register the service.
-* Call `UseDatabaseErrorPage` on the application builder in `Startup.Configure` for the Development environment.
-* Call `UseAuthentication` and `UseAuthorization` after `UseRouting`.
-* Add an endpoint for Razor Pages.
-
-[!code-csharp[](scaffold-identity/3.1sample/StartupBlazor.cs?highlight=3,6,14,27-28,32)]
-
-[!INCLUDE[](~/includes/scaffold-identity/hsts.md)]
+```csharp
+builder.Services.AddScoped<TokenProvider>();
+```
 
 ### Layout and authentication flow changes
 
-Add a `RedirectToLogin` component (*RedirectToLogin.razor*) to the app's *Shared* folder in the project root:
+Add a `RedirectToLogin` component (`RedirectToLogin.razor`) to the app's `Shared` folder in the project root:
 
 ```razor
 @inject NavigationManager Navigation
@@ -221,7 +215,7 @@ Add a `RedirectToLogin` component (*RedirectToLogin.razor*) to the app's *Shared
 }
 ```
 
-Add a `LoginDisplay` component (*LoginDisplay.razor*) to the app's *Shared* folder. The [TokenProvider service](xref:blazor/security/server/additional-scenarios#pass-tokens-to-a-blazor-server-app) provides the XSRF token for the HTML form that POSTs to Identity's logout endpoint:
+Add a `LoginDisplay` component (`LoginDisplay.razor`) to the app's `Shared` folder. A [token provider service](xref:blazor/security/server/additional-scenarios#pass-tokens-to-a-blazor-server-app), `TokenProvider` in the following example, provides the XSRF token for the HTML form that POSTs to Identity's logout endpoint:
 
 ```razor
 @using Microsoft.AspNetCore.Components.Authorization
@@ -246,7 +240,7 @@ Add a `LoginDisplay` component (*LoginDisplay.razor*) to the app's *Shared* fold
 </AuthorizeView>
 ```
 
-In the `MainLayout` component (*Shared/MainLayout.razor*), add the `LoginDisplay` component to the top-row `<div>` element's content:
+In the `MainLayout` component (`Shared/MainLayout.razor`), add the `LoginDisplay` component to the top-row `<div>` element's content:
 
 ```razor
 <div class="top-row px-4 auth">
@@ -270,11 +264,11 @@ The Identity pages layout and styles can be modified to produce pages that use t
 > [!NOTE]
 > The example in this section is merely a starting point for customization. Additional work is likely required for the best user experience.
 
-Create a new `NavMenu_IdentityLayout` component (*Shared/NavMenu_IdentityLayout.razor*). For the markup and code of the component, use the same content of the app's `NavMenu` component (*Shared/NavMenu.razor*). Strip out any `NavLink`s to components that can't be reached anonymously because automatic redirects in the `RedirectToLogin` component fail for components requiring authentication or authorization.
+Create a new `NavMenu_IdentityLayout` component (`Shared/NavMenu_IdentityLayout.razor`). For the markup and code of the component, use the same content of the app's `NavMenu` component (`Shared/NavMenu.razor`). Strip out any `NavLink`s to components that can't be reached anonymously because automatic redirects in the `RedirectToLogin` component fail for components requiring authentication or authorization.
 
-In the *Pages/Shared/Layout.cshtml* file, make the following changes:
+In the `Pages/Shared/Layout.cshtml` file, make the following changes:
 
-* Add Razor directives to the top of the file to use Tag Helpers and the app's components in the *Shared* folder:
+* Add Razor directives to the top of the file to use Tag Helpers and the app's components in the `Shared` folder:
 
   ```cshtml
   @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
@@ -327,12 +321,6 @@ In the *Pages/Shared/Layout.cshtml* file, make the following changes:
   @RenderSection("Scripts", required: false)
   <script src="_framework/blazor.server.js"></script>
   ```
-
-## Scaffold Identity into a Blazor Server project with authorization
-
-[!INCLUDE[](~/includes/scaffold-identity/id-scaffold-dlg-auth.md)]
-<!-- Remove this, no longer true -->
-Some Identity options are configured in *Areas/Identity/IdentityHostingStartup.cs*. For more information, see [IHostingStartup](xref:fundamentals/configuration/platform-specific-configuration).
 
 ## Standalone or hosted Blazor WebAssembly apps
 


### PR DESCRIPTION
Fixes #23993

Rick ... I'll number these so that you can easily respond to each .......

1. Let's eliminate the unnecessary division between existing/new scaffolding Blazor Server section ... for now anyway until I perform additional testing+validation. It's the same dialog, and we weren't describing anything in particular about apps that already have Identity in place and just need to add some Identity pages via the scaffolder.

1. Let's eliminate the `Program.cs` (formerly `Startup.cs`) aspect for Blazor Server. It doesn't seem helpful because the scaffolder adds the required services (it did here in testing), and there's nothing to add for an Identity-enabled Blazor Server app that's scaffolding in pages for custom dev markup/code. It simplifies the coverage, thus cuts maintenance release-to-release. I'll know more with additional local testing+validation, which I'll do here before taking this off of DRAFT.

1. On the issue, I suggest a replacement for "From **Solution Explorer**, right-click on the project > **Add** > **New Scaffolded Item**." in the INCLUDE at `includes/scaffold-identity/id-scaffold-dlg-auth.md` ...

   > From the left pane of the \*\*Add New Scaffolded Item\*\* dialog, select \*\*Identity\*\*. Select \*\*Identity\*\* in the center pane. Select the \*\*Add\*\* button.

   I haven't made that ☝️ update yet. Should I make that change?

1. WRT `Install-Package Microsoft.VisualStudio.Web.CodeGeneration.Design` in the Package Manager Console for VS (before the INCLUDE about running the scaffolder). It wasn't required using VS here. VS did that automatically ✨ after I told it to scaffold the app. Scaffolding gave me ...

   ```xml
   <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
   ```

   Should I change the INCLUDE for VS in `includes/scaffold-identity/install-pkg.md` to say something like 'confirm the presence of the package in the Package Manager UI ... if not present, then run the command or use the UI to add the package'? If so tho, then the INCLUDE for adding that package would go **_after_** the INCLUDE for `includes/scaffold-identity/id-scaffold-dlg-auth.md` because that scaffolding step adds the package without developer intervention AFAICT.

   I might not understand the 6.0 churn on this aspect. The INCLUDE looks like it may have been added for 6.0 coverage to deal with a *gotcha* of some sort that cropped up with 6.0 apps (i.e., scaffolding for some reason doesn't add the package and the dev ends up with a broken app if they don't manually add the package), but I can't see for a garden variety scaffold that it's required yet. I'm :ear: for more info on it.

1. I don't address anything for moniker ranges. These seem to nest versioning to between the topic and the INCLUDE, and that has (in the past) led to a 💥 on the build. **UPDATE**: Ok ... well ... it didn't 💥. I'm concerned 😨 about it tho. I'd certainly check the built topic at ...

   https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/scaffold-identity?view=aspnetcore-3.1&branch=pr-en-us-24018

   ... and I'll check the live doc to make sure that all is well after nesting like this if we proceed.