### PR TITLE
Fix typo: implemenation => implementation

### DIFF
--- a/aspnetcore/migration/50-to-60-samples/samples/Web6Samples/Program.cs
+++ b/aspnetcore/migration/50-to-60-samples/samples/Web6Samples/Program.cs
@@ -95,7 +95,7 @@ app.Run();
 #region snippet_whb
 var builder = WebApplication.CreateBuilder(args);
 
-// Change the HTTP server implemenation to be HTTP.sys based.
+// Change the HTTP server implementation to be HTTP.sys based.
 // Windows only.
 builder.WebHost.UseHttpSys();
 


### PR DESCRIPTION
Fixes typo: `implemenation` => `implementation`