### PR TITLE
Layout and prerendered head content

### DIFF
--- a/aspnetcore/blazor/components/control-head-content.md
+++ b/aspnetcore/blazor/components/control-head-content.md
@@ -48,6 +48,10 @@ The following example sets the page's title and description using Razor.
 }
 ```
 
+## Control head content during prerendering
+
+When [components are prerendered in a Blazor app](xref:blazor/components/prerendering-and-integration), the use of a layout page (`_Layout.cshtml`) is required to control head (`<head>`) content with the <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components. The reason for this requirement is that components that control head content must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.**
+
 ## `HeadOutlet` component
 
 The <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component renders content provided by <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components.

--- a/aspnetcore/blazor/components/control-head-content.md
+++ b/aspnetcore/blazor/components/control-head-content.md
@@ -56,13 +56,13 @@ When [Razor components are prerendered](xref:blazor/components/prerendering-and-
 
 If the shared `_Layout.cshtml` file doesn't have a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component, add it to the `<head>` elements.
 
-In a **required**, shared `_Layout.cshtml` file of a Blazor Server app:
+In a **required**, shared `_Layout.cshtml` file of a Blazor Server app or Razor Pages/MVC app that embeds components into pages or views:
 
 ```cshtml
 <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 ```
 
-In a **required**, shared `_Layout.cshtml` file of a prerendered Blazor WebAssembly app:
+In a **required**, shared `_Layout.cshtml` file of a prerendered hosted Blazor WebAssembly app:
 
 ```cshtml
 <component type="typeof(HeadOutlet)" render-mode="WebAssemblyPrerendered" />

--- a/aspnetcore/blazor/components/control-head-content.md
+++ b/aspnetcore/blazor/components/control-head-content.md
@@ -52,7 +52,7 @@ The following example sets the page's title and description using Razor.
 
 *This section applies to prerendered Blazor WebAssembly apps and Blazor Server apps.*
 
-When [components are prerendered in a Blazor app](xref:blazor/components/prerendering-and-integration), the use of a layout page (`_Layout.cshtml`) is required to control head (`<head>`) content with the <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components. The reason for this requirement is that components that control head content must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.**
+When [Razor components are prerendered](xref:blazor/components/prerendering-and-integration), the use of a layout page (`_Layout.cshtml`) is required to control head (`<head>`) content with the <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components. The reason for this requirement is that components that control head content must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.**
 
 If the shared `_Layout.cshtml` file doesn't have a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component, add it to the `<head>` elements.
 

--- a/aspnetcore/blazor/components/control-head-content.md
+++ b/aspnetcore/blazor/components/control-head-content.md
@@ -50,7 +50,23 @@ The following example sets the page's title and description using Razor.
 
 ## Control head content during prerendering
 
+*This section applies to prerendered Blazor WebAssembly apps and Blazor Server apps.*
+
 When [components are prerendered in a Blazor app](xref:blazor/components/prerendering-and-integration), the use of a layout page (`_Layout.cshtml`) is required to control head (`<head>`) content with the <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components. The reason for this requirement is that components that control head content must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.**
+
+If the shared `_Layout.cshtml` file doesn't have a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component, add it to the `<head>` elements.
+
+In a shared `_Layout.cshtml` file of a Blazor Server app:
+
+```cshtml
+<component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+```
+
+In a shared `_Layout.cshtml` file of a prerendered Blazor WebAssembly app:
+
+```cshtml
+<component type="typeof(HeadOutlet)" render-mode="WebAssemblyPrerendered" />
+```
 
 ## `HeadOutlet` component
 

--- a/aspnetcore/blazor/components/control-head-content.md
+++ b/aspnetcore/blazor/components/control-head-content.md
@@ -56,13 +56,13 @@ When [Razor components are prerendered](xref:blazor/components/prerendering-and-
 
 If the shared `_Layout.cshtml` file doesn't have a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component, add it to the `<head>` elements.
 
-In a shared `_Layout.cshtml` file of a Blazor Server app:
+In a **required**, shared `_Layout.cshtml` file of a Blazor Server app:
 
 ```cshtml
 <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 ```
 
-In a shared `_Layout.cshtml` file of a prerendered Blazor WebAssembly app:
+In a **required**, shared `_Layout.cshtml` file of a prerendered Blazor WebAssembly app:
 
 ```cshtml
 <component type="typeof(HeadOutlet)" render-mode="WebAssemblyPrerendered" />

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -43,7 +43,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
 1. Add `_Host.cshtml` and `_Layout.cshtml` files to the **`Server`** project's `Pages` folder. You can obtain the files from a project created from the Blazor Server template using Visual Studio or using the .NET CLI with the `dotnet new blazorserver -o BlazorServer` command in a command shell (the `-o BlazorServer` option creates a folder for the project). After placing the files into the **`Server`** project's `Pages` folder, make the following changes to the files.
 
    > [!IMPORTANT]
-   > The use of a layout page (`_Layout.cshtml`) is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+   > The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). For more information, see <xref:blazor/components/control-head-content#control-head-content-during-prerendering>.
 
    Make the following changes to the `_Layout.cshtml` file:
 
@@ -170,7 +170,7 @@ MVC:
 * `Views/_ViewStart.cshtml`
 
 > [!IMPORTANT]
-> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). For more information, see <xref:blazor/components/control-head-content#control-head-content-during-prerendering>.
 
 The preceding files can be obtained by generating an app from the ASP.NET Core project templates using:
 
@@ -388,7 +388,7 @@ After [configuring the project](#configuration), use the guidance in the followi
 Use the following guidance to integrate Razor components into pages and views of an existing Razor Pages or MVC app.
 
 > [!IMPORTANT]
-> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). For more information, see <xref:blazor/components/control-head-content#control-head-content-during-prerendering>.
 
 1. In the project's layout file:
 
@@ -542,13 +542,7 @@ To support routable Razor components in Razor Pages apps:
    In this scenario, components use the shared `_Layout.cshtml` file for their layout.
   
    > [!IMPORTANT]
-   > The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
-   >
-   > If the shared `_Layout.cshtml` file doesn't have the Tag Helper, add it to the `<head>` elements:
-   >
-   > ```cshtml
-   > <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
-   > ```
+   > The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). For more information, see <xref:blazor/components/control-head-content#control-head-content-during-prerendering>.
   
    <xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode> configures whether the `App` component:
 
@@ -633,13 +627,7 @@ To support routable Razor components in MVC apps:
    Components use the shared `_Layout.cshtml` file for their layout.
      
    > [!IMPORTANT]
-   > The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
-   >
-   > If the shared `_Layout.cshtml` file doesn't have the Tag Helper, add it to the `<head>` elements:
-   >
-   > ```cshtml
-   > <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
-   > ```
+   > The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). For more information, see <xref:blazor/components/control-head-content#control-head-content-during-prerendering>.
 
    <xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode> configures whether the `App` component:
 
@@ -725,13 +713,7 @@ The following Razor page renders a `Counter` component:
 For more information, see <xref:mvc/views/tag-helpers/builtin-th/component-tag-helper>.
      
 > [!IMPORTANT]
-> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
->
-> If the shared `_Layout.cshtml` file doesn't have the Tag Helper, add it to the `<head>` elements:
->
-> ```cshtml
-> <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
-> ```
+> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). For more information, see <xref:blazor/components/control-head-content#control-head-content-during-prerendering>.
 
 ### Render noninteractive components
 
@@ -757,13 +739,7 @@ In the following Razor page, the `Counter` component is statically rendered with
 For more information, see <xref:mvc/views/tag-helpers/builtin-th/component-tag-helper>.
      
 > [!IMPORTANT]
-> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
->
-> If the shared `_Layout.cshtml` file doesn't have the Tag Helper, add it to the `<head>` elements:
->
-> ```cshtml
-> <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
-> ```
+> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). For more information, see <xref:blazor/components/control-head-content#control-head-content-during-prerendering>.
 
 ## Component namespaces
 

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -40,7 +40,12 @@ To set up prerendering for a hosted Blazor WebAssembly app:
    - builder.RootComponents.Add<HeadOutlet>("head::after");
    ```
 
-1. Add `_Host.cshtml` and `_Layout.cshtml` files to the **`Server`** project's `Pages` folder. You can obtain the files from a project created from the Blazor Server template using Visual Studio or using the .NET CLI with the `dotnet new blazorserver -o BlazorServer` command in a command shell (the `-o BlazorServer` option creates a folder for the project). After placing the files into the **`Server`** project's `Pages` folder:
+1. Add `_Host.cshtml` and `_Layout.cshtml` files to the **`Server`** project's `Pages` folder. You can obtain the files from a project created from the Blazor Server template using Visual Studio or using the .NET CLI with the `dotnet new blazorserver -o BlazorServer` command in a command shell (the `-o BlazorServer` option creates a folder for the project). After placing the files into the **`Server`** project's `Pages` folder, make the following changes to the files.
+
+   > [!IMPORTANT]
+   > The use of a layout page (`_Layout.cshtml`) is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other `<head>` elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+
+The use of a layout page (`_Layout.cshtml`) is required to 
 
    Make the following changes to the `_Layout.cshtml` file:
 

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -209,7 +209,7 @@ Update the imported layout file (`_Layout.cshtml`) to include the **`Client`** p
     <link rel="stylesheet" href="~/css/site.css" />
 +   <link href="css/app.css" rel="stylesheet" />
 +   <link href="BlazorHosted.Client.styles.css" rel="stylesheet" />
-+   <component type="typeof(HeadOutlet)" render-mode="WebAssemblyPrerendered" />
++   <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
 ```
 

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -43,9 +43,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
 1. Add `_Host.cshtml` and `_Layout.cshtml` files to the **`Server`** project's `Pages` folder. You can obtain the files from a project created from the Blazor Server template using Visual Studio or using the .NET CLI with the `dotnet new blazorserver -o BlazorServer` command in a command shell (the `-o BlazorServer` option creates a folder for the project). After placing the files into the **`Server`** project's `Pages` folder, make the following changes to the files.
 
    > [!IMPORTANT]
-   > The use of a layout page (`_Layout.cshtml`) is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other `<head>` elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
-
-The use of a layout page (`_Layout.cshtml`) is required to 
+   > The use of a layout page (`_Layout.cshtml`) is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
 
    Make the following changes to the `_Layout.cshtml` file:
 
@@ -171,6 +169,9 @@ MVC:
 * `Views/_ViewImports.cshtml`
 * `Views/_ViewStart.cshtml`
 
+> [!IMPORTANT]
+> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+
 The preceding files can be obtained by generating an app from the ASP.NET Core project templates using:
 
 * Visual Studio's new project creation tools.
@@ -208,6 +209,7 @@ Update the imported layout file (`_Layout.cshtml`) to include the **`Client`** p
     <link rel="stylesheet" href="~/css/site.css" />
 +   <link href="css/app.css" rel="stylesheet" />
 +   <link href="BlazorHosted.Client.styles.css" rel="stylesheet" />
++   <component type="typeof(HeadOutlet)" render-mode="WebAssemblyPrerendered" />
 </head>
 ```
 
@@ -383,17 +385,23 @@ After [configuring the project](#configuration), use the guidance in the followi
 
 ## Configuration
 
-An existing Razor Pages or MVC app can integrate Razor components into pages and views:
+Use the following guidance to integrate Razor components into pages and views of an existing Razor Pages or MVC app.
+
+> [!IMPORTANT]
+> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
 
 1. In the project's layout file:
 
-   * Add the following `<base>` tag to the `<head>` element in `Pages/Shared/_Layout.cshtml` (Razor Pages) or `Views/Shared/_Layout.cshtml` (MVC):
+   * Add the following `<base>` tag and <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component Tag Helper to the `<head>` element in `Pages/Shared/_Layout.cshtml` (Razor Pages) or `Views/Shared/_Layout.cshtml` (MVC):
 
      ```html
      <base href="~/" />
+     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
      ```
 
      The `href` value (the *app base path*) in the preceding example assumes that the app resides at the root URL path (`/`). If the app is a sub-application, follow the guidance in the *App base path* section of the <xref:blazor/host-and-deploy/index#app-base-path> article.
+  
+     The <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is used to render head (`<head>`) content for page titles (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component) set by Razor components. For more information, see <xref:blazor/components/control-head-content>.
 
    * Add a `<script>` tag for the `blazor.server.js` script immediately before the `Scripts` render section (`@await RenderSectionAsync(...)`) in the app's layout.
 
@@ -532,7 +540,16 @@ To support routable Razor components in Razor Pages apps:
    ```
 
    In this scenario, components use the shared `_Layout.cshtml` file for their layout.
-
+  
+   > [!IMPORTANT]
+   > The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+   >
+   > If the shared `_Layout.cshtml` file doesn't have the Tag Helper, add it to the `<head>` elements:
+   >
+   > ```cshtml
+   > <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+   > ```
+  
    <xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode> configures whether the `App` component:
 
    * Is prerendered into the page.
@@ -614,6 +631,15 @@ To support routable Razor components in MVC apps:
    ```
 
    Components use the shared `_Layout.cshtml` file for their layout.
+     
+   > [!IMPORTANT]
+   > The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+   >
+   > If the shared `_Layout.cshtml` file doesn't have the Tag Helper, add it to the `<head>` elements:
+   >
+   > ```cshtml
+   > <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+   > ```
 
    <xref:Microsoft.AspNetCore.Mvc.Rendering.RenderMode> configures whether the `App` component:
 
@@ -697,6 +723,15 @@ The following Razor page renders a `Counter` component:
 ```
 
 For more information, see <xref:mvc/views/tag-helpers/builtin-th/component-tag-helper>.
+     
+> [!IMPORTANT]
+> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+>
+> If the shared `_Layout.cshtml` file doesn't have the Tag Helper, add it to the `<head>` elements:
+>
+> ```cshtml
+> <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+> ```
 
 ### Render noninteractive components
 
@@ -720,6 +755,15 @@ In the following Razor page, the `Counter` component is statically rendered with
 ```
 
 For more information, see <xref:mvc/views/tag-helpers/builtin-th/component-tag-helper>.
+     
+> [!IMPORTANT]
+> The use of a layout page (`_Layout.cshtml`) with a [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) for a <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component is required to [control head (`<head>`) content](xref:blazor/components/control-head-content), such as the page's title (<xref:Microsoft.AspNetCore.Components.Web.PageTitle> component) and other head elements (<xref:Microsoft.AspNetCore.Components.Web.HeadContent> component). The reason for this requirement is that components that use <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components must be rendered before the layout with the <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component. **This order of rendering is required to control head content.** For more information on controlling head content, see <xref:blazor/components/control-head-content>.
+>
+> If the shared `_Layout.cshtml` file doesn't have the Tag Helper, add it to the `<head>` elements:
+>
+> ```cshtml
+> <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
+> ```
 
 ## Component namespaces
 


### PR DESCRIPTION
Fixes #24034

Internal Review Topics:

* [*Control \<head> Content* article (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components/control-head-content?view=aspnetcore-6.0&branch=pr-en-us-24035#control-head-content-during-prerendering)
* [*Prerendering and Integration* article (the NOTE with cross-link is in multiple sections)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/components/prerendering-and-integration?view=aspnetcore-3.1&branch=pr-en-us-24035)

I recommend **_very careful review_** 😨. These overlapping cases and permutations of scenarios are tricky to describe.

I assume that a RP/MVC app that's integrating Razor components into pages and views from a hosted WASM app **_can have the component set \<head> content_**. That might be incorrect ... or it might be fine and work but such a rare edge case that we don't want to call it out (i.e., the page/view would always set head content). 🤔 I think if it will work that it's a possibility ... I can see someone doing it ... not so much for the page title ... more so for controlling head content with the `HeadContent` component. **Important** ❓  **on it** (if I didn't just make up a feature that doesn't exist 🙈): Is the `render-mode` correct for the added TH at Line 212?

I started in the first few commits to have a larger IMPORTANT NOTE in each section of the *Prerendering and Integration* topic. It was a bulky NOTE to repeat over and over, and I realized that the new section added to the *Control \<head> Content* article is a better spot to place the complete guidance, including example Tag Helpers for the `HeadOutlet` component and the reason for the requirement (i.e., render ordering). Then, I cross-link from the various sections in the *Prerendering and Integration* topic to that section. That lightened the NOTE considerably.

Side-note here on diff line highlighting in *Prerendering and Integration* topic: GitHub thinks that any line with a plus sign (`+`) as the first character should be highlighted green, so there are lines in at least one code example for a diff code language (`diff`) that places green highlights for **_no changed lines_** 😈 that just happen to have plus signs on them. If you expand the diff in that area, you'll see that those highlights are false positives for GH diff changes.