### PR TITLE
Update Index.cshtml.cs

### DIFF
--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/snapshot_sample6/Pages/Movies/Index.cshtml.cs
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/snapshot_sample6/Pages/Movies/Index.cshtml.cs
@@ -26,8 +26,8 @@ namespace RazorPagesMovie.Pages.Movies
             Movie = await _context.Movie.ToListAsync();
         }
     }
-#pragma warning disable CS8618
-#pragma warning disable CS8604
+#pragma warning restore CS8618
+#pragma warning restore CS8604
 }
 #endregion
 #endregion


### PR DESCRIPTION
I think that the warning should be restored after the class instead of being disabled again.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->