### PR TITLE
Update Handle Web API Errors to 6.0

### DIFF
--- a/aspnetcore/web-api/handle-errors.md
+++ b/aspnetcore/web-api/handle-errors.md
@@ -91,7 +91,7 @@ The preceding `HandleError` action sends an [RFC 7807](https://tools.ietf.org/ht
 > [!WARNING]
 > Don't mark the error handler action method with HTTP method attributes, such as `HttpGet`. Explicit verbs prevent some requests from reaching the action method. Allow anonymous access to the method if unauthenticated users should see the error.
 
-Exception Handling Middleware can also provide more detailed content-negotiated output in the Development environment. To produce a consistent payload format across all environments:
+Exception Handling Middleware can also be used in the Development environment to produce a consistent payload format across all environments:
 
 1. In *Program.cs*, register environment-specific Exception Handling Middleware instances:
 
@@ -102,7 +102,7 @@ Exception Handling Middleware can also provide more detailed content-negotiated 
     * A route of `/error-development` in the Development environment.
     * A route of `/error` in non-Development environments.
     
-<a name="pd"></a>
+    <a name="pd"></a>
 1. Add controller actions for both the Development and non-Development routes:
 
     :::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Controllers/ErrorsController.cs" id="snippet_ConsistentEnvironments":::

--- a/aspnetcore/web-api/handle-errors.md
+++ b/aspnetcore/web-api/handle-errors.md
@@ -127,7 +127,7 @@ The contents of the response can be modified from outside of the controller usin
 
 ## Validation failure error response
 
-For web API controllers, MVC responds with a <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> response type when model validation fails. MVC uses the results of <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.InvalidModelStateResponseFactory> to construct the error response for a validation failure. The following example replaces the factory in *Program.cs* to add support for formatting responses as XML:
+For web API controllers, MVC responds with a <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> response type when model validation fails. MVC uses the results of <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.InvalidModelStateResponseFactory> to construct the error response for a validation failure. The following example replaces the default factory with an implementation that also supports formatting responses as XML, in *Program.cs*:
 
 :::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs" id="snippet_ConfigureInvalidModelStateResponseFactory":::
 
@@ -152,7 +152,7 @@ To customize the problem details response, register a custom implementation of <
 
 :::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs" id="snippet_ReplaceProblemDetailsFactory":::
 
-### Use ApiBehaviorOptions.ClientErrorMapping
+### Use `ApiBehaviorOptions.ClientErrorMapping`
 
 Use the <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.ClientErrorMapping%2A> property to configure the contents of the `ProblemDetails` response. For example, the following code in *Program.cs* updates the <xref:Microsoft.AspNetCore.Mvc.ClientErrorData.Link%2A> property for 404 responses:
 

--- a/aspnetcore/web-api/handle-errors.md
+++ b/aspnetcore/web-api/handle-errors.md
@@ -109,31 +109,31 @@ Exception Handling Middleware can also be used in the Development environment to
 
 ## Use exceptions to modify the response
 
-The contents of the response can be modified from outside of the controller. In ASP.NET 4.x Web API, one way to do this was using the <xref:System.Web.Http.HttpResponseException> type. ASP.NET Core doesn't include an equivalent type. Support for `HttpResponseException` can be added with the following steps:
+The contents of the response can be modified from outside of the controller using a custom exception and an action filter:
 
 1. Create a well-known exception type named `HttpResponseException`:
 
-    :::code language="csharp" source="handle-errors/samples/3.x/Exceptions/HttpResponseException.cs" id="snippet_HttpResponseException":::
+    :::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Snippets/HttpResponseException.cs" id="snippet_Class":::
 
 1. Create an action filter named `HttpResponseExceptionFilter`:
 
-    :::code language="csharp" source="handle-errors/samples/3.x/Filters/HttpResponseExceptionFilter.cs" id="snippet_HttpResponseExceptionFilter":::
+    :::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Snippets/HttpResponseExceptionFilter.cs" id="snippet_Class":::
 
     The preceding filter specifies an `Order` of the maximum integer value minus 10. This `Order` allows other filters to run at the end of the pipeline.
 
-1. In `Startup.ConfigureServices`, add the action filter to the filters collection:
+1. In *Program.cs*, add the action filter to the filters collection:
 
-    :::code language="csharp" source="handle-errors/samples/3.x/Startup.cs" id="snippet_AddExceptionFilter":::
+    :::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs" id="snippet_AddHttpResponseExceptionFilter":::
 
 ## Validation failure error response
 
-For web API controllers, MVC responds with a <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> response type when model validation fails. MVC uses the results of <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.InvalidModelStateResponseFactory> to construct the error response for a validation failure. The following example uses the factory to change the default response type to <xref:Microsoft.AspNetCore.Mvc.SerializableError> in `Startup.ConfigureServices`:
+For web API controllers, MVC responds with a <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails> response type when model validation fails. MVC uses the results of <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.InvalidModelStateResponseFactory> to construct the error response for a validation failure. The following example replaces the factory in *Program.cs* to add support for formatting responses as XML:
 
-:::code language="csharp" source="handle-errors/samples/3.x/Startup.cs" id="snippet_DisableProblemDetailsInvalidModelStateResponseFactory" highlight="4-13":::
+:::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs" id="snippet_ConfigureInvalidModelStateResponseFactory":::
 
 ## Client error response
 
-An *error result* is defined as a result with an HTTP status code of 400 or higher. For web API controllers, MVC transforms an error result to a result with <xref:Microsoft.AspNetCore.Mvc.ProblemDetails>.
+An *error result* is defined as a result with an HTTP status code of 400 or higher. For web API controllers, MVC transforms an error result to a produce a <xref:Microsoft.AspNetCore.Mvc.ProblemDetails>.
 
 The error response can be configured in one of the following ways:
 
@@ -148,27 +148,21 @@ MVC uses <xref:Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory?dis
 * Validation failure error responses
 * <xref:Microsoft.AspNetCore.Mvc.ControllerBase.Problem%2A?displayProperty=nameWithType> and <xref:Microsoft.AspNetCore.Mvc.ControllerBase.ValidationProblem%2A?displayProperty=nameWithType>
 
-To customize the problem details response, register a custom implementation of <xref:Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory> in `Startup.ConfigureServices`:
+To customize the problem details response, register a custom implementation of <xref:Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory> in *Program.cs*:
 
-```csharp
-public void ConfigureServices(IServiceCollection serviceCollection)
-{
-    services.AddControllers();
-    services.AddTransient<ProblemDetailsFactory, CustomProblemDetailsFactory>();
-}
-```
+:::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs" id="snippet_ReplaceProblemDetailsFactory":::
 
 ### Use ApiBehaviorOptions.ClientErrorMapping
 
-Use the <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.ClientErrorMapping%2A> property to configure the contents of the `ProblemDetails` response. For example, the following code in `Startup.ConfigureServices` updates the `type` property for 404 responses:
+Use the <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.ClientErrorMapping%2A> property to configure the contents of the `ProblemDetails` response. For example, the following code in *Program.cs* updates the <xref:Microsoft.AspNetCore.Mvc.ClientErrorData.Link%2A> property for 404 responses:
 
-:::code language="csharp" source="index/samples/3.x/Startup.cs" id="snippet_ConfigureApiBehaviorOptions" highlight="8-9":::
+:::code language="csharp" source="handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs" id="snippet_ClientErrorMapping":::
 
 ## Custom Middleware to handle exceptions
 
 The defaults in the exception handling middleware work well for most apps. For apps that require specialized exception handling, consider [customizing the exception handling middleware](xref:fundamentals/error-handling#exception-handler-lambda).
 
-### Producing a ProblemDetails payload for exceptions
+### Produce a ProblemDetails payload for exceptions
 
 ASP.NET Core doesn't produce a standardized error payload when an unhandled exception occurs. For scenarios where it's desirable to return a standardized [ProblemDetails response](https://datatracker.ietf.org/doc/html/rfc7807) to the client, the [ProblemDetails middleware](https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails/) can be used to map exceptions and 404 responses to a [ProblemDetails](xref:web-api/handle-errors#pd) payload. The exception handling middleware can also be used to return a <xref:Microsoft.AspNetCore.Mvc.ProblemDetails> payload for unhandled exceptions.
 

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Controllers/ErrorsController.cs
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Controllers/ErrorsController.cs
@@ -30,7 +30,6 @@ public class ErrorsController : ControllerBase
             detail: exceptionHandlerFeature.Error.StackTrace,
             title: exceptionHandlerFeature.Error.Message);
     }
-    // </snippet_ConsistentEnvironments>
 
     // <snippet_HandleError>
     [Route("/error")]

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Controllers/ErrorsController.cs
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Controllers/ErrorsController.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HandleErrorsSample.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ErrorsController : ControllerBase
+{
+    // <snippet_Throw>
+    [HttpGet("Throw")]
+    public IActionResult Throw() =>
+        throw new Exception("Sample exception.");
+    // </snippet_Throw>
+
+    // <snippet_ConsistentEnvironments>
+    [Route("/error-development")]
+    public IActionResult HandleErrorDevelopment(
+        [FromServices] IHostEnvironment hostEnvironment)
+    {
+        if (!hostEnvironment.IsDevelopment())
+        {
+            return NotFound();
+        }
+
+        var exceptionHandlerFeature =
+            HttpContext.Features.Get<IExceptionHandlerFeature>()!;
+
+        return Problem(
+            detail: exceptionHandlerFeature.Error.StackTrace,
+            title: exceptionHandlerFeature.Error.Message);
+    }
+    // </snippet_ConsistentEnvironments>
+
+    // <snippet_HandleError>
+    [Route("/error")]
+    public IActionResult HandleError() =>
+        Problem();
+    // </snippet_HandleError>
+    // </snippet_ConsistentEnvironments>
+}

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/HandleErrorsSample.csproj
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/HandleErrorsSample.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Program.cs
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Program.cs
@@ -1,0 +1,20 @@
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+
+// <snippet_Middleware>
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/error");
+}
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();
+// </snippet_Middleware>

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/HttpResponseException.cs
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/HttpResponseException.cs
@@ -1,0 +1,13 @@
+﻿namespace HandleErrorsSample.Snippets;
+
+// <snippet_Class>
+public class HttpResponseException : Exception
+{
+    public HttpResponseException(int statusCode, object? value = null) =>
+        (StatusCode, Value) = (statusCode, value);
+
+    public int StatusCode { get; }
+
+    public object? Value { get; }
+}
+// </snippet_Class>

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/HttpResponseExceptionFilter.cs
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/HttpResponseExceptionFilter.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace HandleErrorsSample.Snippets;
+
+// <snippet_Class>
+public class HttpResponseExceptionFilter : IActionFilter, IOrderedFilter
+{
+    public int Order => int.MaxValue - 10;
+
+    public void OnActionExecuting(ActionExecutingContext context) { }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context.Exception is HttpResponseException httpResponseException)
+        {
+            context.Result = new ObjectResult(httpResponseException.Value)
+            {
+                StatusCode = httpResponseException.StatusCode
+            };
+
+            context.ExceptionHandled = true;
+        }
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs
@@ -1,0 +1,18 @@
+﻿namespace HandleErrorsSample.Snippets;
+
+public static class Program
+{
+    public static void ConsistentEnvironments(WebApplication app)
+    {
+        // <snippet_ConsistentEnvironments>
+        if (app.Environment.IsDevelopment())
+        {
+            app.UseExceptionHandler("/error-development");
+        }
+        else
+        {
+            app.UseExceptionHandler("/error");
+        }
+        // </snippet_ConsistentEnvironments>
+    }
+}

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/Program.cs
@@ -1,4 +1,8 @@
-﻿namespace HandleErrorsSample.Snippets;
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace HandleErrorsSample.Snippets;
 
 public static class Program
 {
@@ -14,5 +18,56 @@ public static class Program
             app.UseExceptionHandler("/error");
         }
         // </snippet_ConsistentEnvironments>
+    }
+
+    public static void AddHttpResponseExceptionFilter(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHttpResponseExceptionFilter>
+        builder.Services.AddControllers(options =>
+        {
+            options.Filters.Add<HttpResponseExceptionFilter>();
+        });
+        // </snippet_AddHttpResponseExceptionFilter>
+    }
+
+    public static void ConfigureInvalidModelStateResponseFactory(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureInvalidModelStateResponseFactory>
+        builder.Services.AddControllers()
+            .ConfigureApiBehaviorOptions(options =>
+            {
+                options.InvalidModelStateResponseFactory = context =>
+                    new BadRequestObjectResult(context.ModelState)
+                    {
+                        ContentTypes =
+                        {
+                            // using static System.Net.Mime.MediaTypeNames;
+                            Application.Json,
+                            Application.Xml
+                        }
+                    };
+            })
+            .AddXmlSerializerFormatters();
+        // </snippet_ConfigureInvalidModelStateResponseFactory>
+    }
+
+    public static void ReplaceProblemDetailsFactory(WebApplicationBuilder builder)
+    {
+        // <snippet_ReplaceProblemDetailsFactory>
+        builder.Services.AddControllers();
+        builder.Services.AddTransient<ProblemDetailsFactory, SampleProblemDetailsFactory>();
+        // </snippet_ReplaceProblemDetailsFactory>
+    }
+
+    public static void ClientErrorMapping(WebApplicationBuilder builder)
+    {
+        // <snippet_ClientErrorMapping>
+        builder.Services.AddControllers()
+            .ConfigureApiBehaviorOptions(options =>
+            {
+                options.ClientErrorMapping[StatusCodes.Status404NotFound].Link =
+                    "https://httpstatuses.com/404";
+            });
+        // </snippet_ClientErrorMapping>
     }
 }

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/SampleProblemDetailsFactory.cs
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/Snippets/SampleProblemDetailsFactory.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace HandleErrorsSample.Snippets;
+
+public class SampleProblemDetailsFactory : ProblemDetailsFactory
+{
+    public override ProblemDetails CreateProblemDetails(
+        HttpContext httpContext, int? statusCode = null, string? title = null,
+        string? type = null, string? detail = null, string? instance = null)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override ValidationProblemDetails CreateValidationProblemDetails(
+        HttpContext httpContext, ModelStateDictionary modelStateDictionary,
+        int? statusCode = null, string? title = null, string? type = null,
+        string? detail = null, string? instance = null)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/appsettings.Development.json
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/appsettings.json
+++ b/aspnetcore/web-api/handle-errors/samples/6.x/HandleErrorsSample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes #23537.

[Internal Preview URL](https://review.docs.microsoft.com/en-us/aspnet/core/web-api/handle-errors?view=aspnetcore-6.0&branch=pr-en-us-24066).