### PR TITLE
Resource authorization

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,11 @@
         "TypeScript",
         "XML",
         "YAML"
-    ]
+    ],
+    "markdownlint.config": {
+        "MD028": false,
+        "MD025": {
+            "front_matter_title": ""
+        }
+    }
 }

--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -420,6 +420,80 @@ If neither <xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute.Roles> no
 * Authenticated (signed-in) users as authorized.
 * Unauthenticated (signed-out) users as unauthorized.
 
+## Resource authorization
+
+To authorize users for resources, pass the request's route data to the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Resource> parameter of <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView>.
+
+In the <xref:Microsoft.AspNetCore.Components.Routing.Router.Found?displayProperty=nameWithType> content for a requested route in the `App` component (`App.razor`):
+
+```razor
+<AuthorizeRouteView Resource="@routeData" RouteData="@routeData" 
+    DefaultLayout="@typeof(MainLayout)" />
+```
+
+For more information on how authorization state data is passed and used in procedural logic, see the [Expose the authentication state as a cascading parameter](#expose-the-authentication-state-as-a-cascading-parameter) section.
+
+When the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView> receives the route data for the resource, authorization policies have access to <xref:Microsoft.AspNetCore.Components.RouteData.PageType?displayProperty=nameWithType> and <xref:Microsoft.AspNetCore.Components.RouteData.RouteValues?displayProperty=nameWithType> that permit custom logic to make authorization decisions.
+
+In the following example, an `EditUser` policy is created in <xref:Microsoft.AspNetCore.Authorization.AuthorizationOptions> for the app's authorization service configuration (<xref:Microsoft.Extensions.DependencyInjection.AuthorizationServiceCollectionExtensions.AddAuthorizationCore%2A>) with the following logic:
+
+* Determine if a route value exists with a key of `id`. If the key exists, the route value is stored in `value`.
+* In a variable named `id`, store `value` as a string or set an empty string value (`string.Empty`).
+* If `id` isn't an empty string, assert that the policy is satisfied (return `true`) if the string's value starts with `EMP`. Otherwise, assert that the policy fails (return `false`).
+
+In either `Program.cs` or `Startup.cs` (depending on the hosting model and framework version):
+
+* Add namespaces for <xref:Microsoft.AspNetCore.Components?displayProperty=fullName> and <xref:System.Linq?displayProperty=fullName>:
+
+  ```csharp
+  using Microsoft.AspNetCore.Components;
+  using System.Linq;
+  ```
+
+* Add the policy:
+
+  ```csharp
+  options.AddPolicy("EditUser", policy =>
+      policy.RequireAssertion(context =>
+      {
+          if (context.Resource is RouteData rd)
+          {
+              var routeValue = rd.RouteValues.TryGetValue("id", out var value);
+              var id = Convert.ToString(value, 
+                  System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+
+              if (!string.IsNullOrEmpty(id))
+              {
+                  return id.StartsWith("EMP", StringComparison.InvariantCulture);
+              }
+          }
+
+          return false;
+      })
+  );
+  ```
+
+The preceding example is an oversimplified authorization policy, merely used to demonstrate the concept with a working example. For more information on creating and configuring authorization policies, see <xref:security/authorization/policies>.
+
+In the following `EditUser` component, the resource at `/users/{id}/edit` has a route parameter for the user's identifier (`{id}`). The component uses the preceding `EditUser` authorization policy to determine if the route value for `id` starts with `EMP`. If `id` starts with `EMP`, the policy succeeds and access to the component is authorized. If `id` starts with a value other than `EMP` or if `id` is an empty string, the policy fails, and the component doesn't load.
+
+`Pages/EditUser.razor`:
+
+```razor
+@page "/users/{id}/edit"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Policy = "EditUser")]
+
+<h1>Edit User</h1>
+
+<p>The 'EditUser' policy is satisfied! <code>Id</code> starts with 'EMP'.</p>
+
+@code {
+    [Parameter]
+    public string Id { get; set; }
+}
+```
+
 ## Customize unauthorized content with the Router component
 
 The <xref:Microsoft.AspNetCore.Components.Routing.Router> component, in conjunction with the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView> component, allows the app to specify custom content if:
@@ -962,6 +1036,80 @@ If neither <xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute.Roles> no
 
 * Authenticated (signed-in) users as authorized.
 * Unauthenticated (signed-out) users as unauthorized.
+
+## Resource authorization
+
+To authorize users for resources, pass the request's route data to the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Resource> parameter of <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView>.
+
+In the <xref:Microsoft.AspNetCore.Components.Routing.Router.Found?displayProperty=nameWithType> content for a requested route in the `App` component (`App.razor`):
+
+```razor
+<AuthorizeRouteView Resource="@routeData" RouteData="@routeData" 
+    DefaultLayout="@typeof(MainLayout)" />
+```
+
+For more information on how authorization state data is passed and used in procedural logic, see the [Expose the authentication state as a cascading parameter](#expose-the-authentication-state-as-a-cascading-parameter) section.
+
+When the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView> receives the route data for the resource, authorization policies have access to <xref:Microsoft.AspNetCore.Components.RouteData.PageType?displayProperty=nameWithType> and <xref:Microsoft.AspNetCore.Components.RouteData.RouteValues?displayProperty=nameWithType> that permit custom logic to make authorization decisions.
+
+In the following example, an `EditUser` policy is created in <xref:Microsoft.AspNetCore.Authorization.AuthorizationOptions> for the app's authorization service configuration (<xref:Microsoft.Extensions.DependencyInjection.AuthorizationServiceCollectionExtensions.AddAuthorizationCore%2A>) with the following logic:
+
+* Determine if a route value exists with a key of `id`. If the key exists, the route value is stored in `value`.
+* In a variable named `id`, store `value` as a string or set an empty string value (`string.Empty`).
+* If `id` isn't an empty string, assert that the policy is satisfied (return `true`) if the string's value starts with `EMP`. Otherwise, assert that the policy fails (return `false`).
+
+In either `Program.cs` or `Startup.cs` (depending on the hosting model and framework version):
+
+* Add namespaces for <xref:Microsoft.AspNetCore.Components?displayProperty=fullName> and <xref:System.Linq?displayProperty=fullName>:
+
+  ```csharp
+  using Microsoft.AspNetCore.Components;
+  using System.Linq;
+  ```
+
+* Add the policy:
+
+  ```csharp
+  options.AddPolicy("EditUser", policy =>
+      policy.RequireAssertion(context =>
+      {
+          if (context.Resource is RouteData rd)
+          {
+              var routeValue = rd.RouteValues.TryGetValue("id", out var value);
+              var id = Convert.ToString(value, 
+                  System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+
+              if (!string.IsNullOrEmpty(id))
+              {
+                  return id.StartsWith("EMP", StringComparison.InvariantCulture);
+              }
+          }
+
+          return false;
+      })
+  );
+  ```
+
+The preceding example is an oversimplified authorization policy, merely used to demonstrate the concept with a working example. For more information on creating and configuring authorization policies, see <xref:security/authorization/policies>.
+
+In the following `EditUser` component, the resource at `/users/{id}/edit` has a route parameter for the user's identifier (`{id}`). The component uses the preceding `EditUser` authorization policy to determine if the route value for `id` starts with `EMP`. If `id` starts with `EMP`, the policy succeeds and access to the component is authorized. If `id` starts with a value other than `EMP` or if `id` is an empty string, the policy fails, and the component doesn't load.
+
+`Pages/EditUser.razor`:
+
+```razor
+@page "/users/{id}/edit"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize(Policy = "EditUser")]
+
+<h1>Edit User</h1>
+
+<p>The 'EditUser' policy is satisfied! <code>Id</code> starts with 'EMP'.</p>
+
+@code {
+    [Parameter]
+    public string Id { get; set; }
+}
+```
 
 ## Customize unauthorized content with the Router component
 


### PR DESCRIPTION
Fixes #24052

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/security/index?view=aspnetcore-3.1&branch=pr-en-us-24113#resource-authorization)

Javier ... Best if you put an 👁️ on this. I've hacked up a simple, fully-working example.

**UPDATE (12/1)**: Javier ... I'm going ahead with this. I'll take community feedback on it. 

Delta from [your recommendation](https://github.com/dotnet/aspnetcore/issues/33958#issuecomment-977910725) for `Resource="@(routeData)"`. Seems like `Resource="@routeData"` works, so that's what's on the PR. I'm 👂 if I made a mistake there 🙈.

Setting this up only for 5.0 or later, as [`Resource`](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.components.authorization.authorizerouteview.resource) apparently landed for 5.0.

cc: @optimizasean ... I like the example direction that you pitched on the PU issue, but I simplify that approach here for a basic, fully-working demo. It merely checks the first three letters of `{id}` instead of having another claim to check. That should be enough to get devs headed in the right direction. I cross-link to the ASP.NET Core Security Policy Auth doc for more info on policy configuration.