### PR TITLE
Update google-logins.md's codes to meet .net 6 update

### DIFF
--- a/aspnetcore/security/authentication/social/google-logins.md
+++ b/aspnetcore/security/authentication/social/google-logins.md
@@ -45,9 +45,33 @@ You can manage your API credentials and usage in the [API Console](https://conso
 
 ## Configure Google authentication
 
-Add the Google service to `Startup.ConfigureServices`:
+Add the Google service to `Program.cs` builder:
 
-[!code-csharp[](~/security/authentication/social/social-code/3.x/StartupGoogle3x.cs?highlight=11-19)]
+     var builder = WebApplication.CreateBuilder(args);
+
+     // Add services to the container.
+     var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+     builder.Services.AddDbContext<ApplicationDbContext>(options =>
+         options.UseSqlServer(connectionString));
+     builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+
+     builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
+         .AddEntityFrameworkStores<ApplicationDbContext>();
+
+     builder.Services.AddAuthentication()
+         .AddGoogle(options =>
+         {
+             IConfigurationSection googleAuthNSection =
+                 builder.Configuration.GetSection("Authentication:Google");
+
+             options.ClientId = googleAuthNSection["ClientId"];
+             options.ClientSecret = googleAuthNSection["ClientSecret"];
+         });
+
+     builder.Services.AddControllersWithViews();
+
+     var app = builder.Build();
+
 
 [!INCLUDE [default settings configuration](includes/default-settings2-2.md)]
 


### PR DESCRIPTION
The codes which inside the Configure Google authentication is old for the .net 5.0, but for dotnet 6.0, we should modify it at the Program.cs's builder object.

Also we faced some issue when developer try to follow this article to enable google authentication in asp.net core 6.0.

Issue:
https://stackoverflow.com/questions/69969293/asp-net-core-mvc-add-oauth-missing-startup-cs-owin

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->