### PR TITLE
add link to code analysis to middleware /3

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -28,7 +28,7 @@ Request delegates are configured using <xref:Microsoft.AspNetCore.Builder.RunExt
 
 ## Middleware code analysis
 
-ASP.NET Core includes many compiler platform analyzers inspect application code for code quality. For more information, see <xref:diagnostics/code-analysis>
+ASP.NET Core includes many compiler platform analyzers that inspect application code for quality. For more information, see <xref:diagnostics/code-analysis>
 
 ## Create a middleware pipeline with `WebApplication`
 

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -26,6 +26,10 @@ Request delegates are configured using <xref:Microsoft.AspNetCore.Builder.RunExt
 
 <xref:migration/http-modules> explains the difference between request pipelines in ASP.NET Core and ASP.NET 4.x and provides additional middleware samples.
 
+## Middleware code analysis
+
+ASP.NET Core includes many compiler platform analyzers inspect application code for code quality. For more information, see <xref:diagnostics/code-analysis>
+
 ## Create a middleware pipeline with `WebApplication`
 
 The ASP.NET Core request pipeline consists of a sequence of request delegates, called one after the other. The following diagram demonstrates the concept. The thread of execution follows the black arrows.


### PR DESCRIPTION
Fixes #23527
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-6.0&branch=pr-en-us-24164#middleware-code-analysis)