### PR TITLE
Progress For Blazor File Upload

### DIFF
--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -361,6 +361,23 @@ public class FilesaveController : ControllerBase
 
 In the preceding code, <xref:System.IO.Path.GetRandomFileName%2A> is called to generate a secure filename. Never trust the filename provided by the browser, as an attacker may choose an existing filename that overwrites an existing file or send a path that attempts to write outside of the app.
 
+::: zone pivot="server"
+
+## Upload files with progress
+
+The following example demonstrates how to upload files in a Blazor Server app with upload progress displayed to the user.
+
+`Pages/FileUpload3.razor`:
+
+[!code-razor[](~/blazor/samples/6.0/BlazorSample_Server/Pages/file-uploads/FileUpload3.razor)]
+
+For more information, see the following API resources:
+
+* <xref:System.IO.FileStream>: Provides a <xref:System.IO.Stream> for a file, supporting both synchronous and asynchronous read and write operations.
+* <xref:System.IO.FileStream.Read%2A>: The preceding `FileUpload3` component example is based on the approach in the *Examples* section of this API document. The main difference between the example in the API document and the `FileUpload3` component is that the component reads the stream asychronously with <xref:System.IO.FileStream.ReadAsync%2A?displayProperty=nameWithType>. Reading a stream sychronously with <xref:System.IO.FileStream.Read%2A> isn't supported in Razor components.
+
+::: zone-end
+
 ## File streams
 
 ::: zone pivot="webassembly"
@@ -728,6 +745,23 @@ public class FilesaveController : ControllerBase
     }
 }
 ```
+
+::: zone pivot="server"
+
+## Upload files with progress
+
+The following example demonstrates how to upload files in a Blazor Server app with upload progress displayed to the user.
+
+`Pages/FileUpload3.razor`:
+
+[!code-razor[](~/blazor/samples/5.0/BlazorSample_Server/Pages/file-uploads/FileUpload3.razor)]
+
+For more information, see the following API resources:
+
+* <xref:System.IO.FileStream>: Provides a <xref:System.IO.Stream> for a file, supporting both synchronous and asynchronous read and write operations.
+* <xref:System.IO.FileStream.Read%2A>: The preceding `FileUpload3` component example is based on the approach in the *Examples* section of this API document. The main difference between the example in the API document and the `FileUpload3` component is that the component reads the stream asychronously with <xref:System.IO.FileStream.ReadAsync%2A?displayProperty=nameWithType>. Reading a stream sychronously with <xref:System.IO.FileStream.Read%2A> isn't supported in Razor components.
+
+::: zone-end
 
 ## File streams
 

--- a/aspnetcore/blazor/samples/5.0/BlazorSample_Server/Pages/file-uploads/FileUpload3.razor
+++ b/aspnetcore/blazor/samples/5.0/BlazorSample_Server/Pages/file-uploads/FileUpload3.razor
@@ -1,0 +1,114 @@
+@page "/file-upload-3"
+@using System 
+@using System.IO
+@using Microsoft.AspNetCore.Hosting
+@using Microsoft.Extensions.Logging
+@inject ILogger<FileUpload3> Logger
+@inject IWebHostEnvironment Environment
+
+<h3>Upload Files</h3>
+
+<p>
+    <label>
+        Max file size:
+        <input type="number" @bind="maxFileSize" />
+    </label>
+</p>
+
+<p>
+    <label>
+        Max allowed files:
+        <input type="number" @bind="maxAllowedFiles" />
+    </label>
+</p>
+
+<p>
+    <label>
+        Upload up to @maxAllowedFiles of up to @maxFileSize bytes:
+        <InputFile OnChange="@LoadFiles" multiple />
+    </label>
+</p>
+
+@if (isLoading)
+{
+    <p>Progress: @string.Format("{0:P0}", progressPercent)</p>
+}
+else
+{
+    <ul>
+        @foreach (var file in loadedFiles)
+        {
+            <li>
+                <ul>
+                    <li>Name: @file.Name</li>
+                    <li>Last modified: @file.LastModified.ToString()</li>
+                    <li>Size (bytes): @file.Size</li>
+                    <li>Content type: @file.ContentType</li>
+                </ul>
+            </li>
+        }
+    </ul>
+}
+
+@code {
+    private List<IBrowserFile> loadedFiles = new();
+    private long maxFileSize = 1024 * 1024 * 16;
+    private int maxAllowedFiles = 3;
+    private bool isLoading;
+    private decimal progressPercent = 0.0M;
+
+    private async Task LoadFiles(InputFileChangeEventArgs e)
+    {
+        isLoading = true;
+        loadedFiles.Clear();
+
+        foreach (var file in e.GetMultipleFiles(maxAllowedFiles))
+        {
+            try
+            {
+                var trustedFileNameForFileStorage = Path.GetRandomFileName();
+                var path = Path.Combine(Environment.ContentRootPath,
+                        Environment.EnvironmentName, "unsafe_uploads",
+                        trustedFileNameForFileStorage);
+
+                await using FileStream writeStream = new(path, FileMode.Create);
+                using var readStream = file.OpenReadStream(maxFileSize);
+
+                var bytes = new byte[readStream.Length];
+                var bytesToRead = (int)readStream.Length;
+                var bytesRead = 0;
+
+                while (bytesToRead > 0)
+                {
+                    var n = await readStream.ReadAsync(bytes, bytesRead, 
+                        bytesToRead);
+
+                    if (n == 0)
+                    {
+                        break;
+                    }
+
+                    bytesRead += n;
+                    bytesToRead -= n;
+
+                    progressPercent = Decimal.Divide(bytesRead, file.Size);
+
+                    StateHasChanged();
+                }
+                
+                bytesToRead = bytes.Length;
+
+                writeStream.Write(bytes, 0, bytesToRead);                
+
+                loadedFiles.Add(file);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("File: {Filename} Error: {Error}", 
+                    file.Name, ex.Message);
+            }
+        }
+
+        isLoading = false;
+    }
+}

--- a/aspnetcore/blazor/samples/6.0/BlazorSample_Server/Pages/file-uploads/FileUpload3.razor
+++ b/aspnetcore/blazor/samples/6.0/BlazorSample_Server/Pages/file-uploads/FileUpload3.razor
@@ -1,0 +1,114 @@
+@page "/file-upload-3"
+@using System 
+@using System.IO
+@using Microsoft.AspNetCore.Hosting
+@using Microsoft.Extensions.Logging
+@inject ILogger<FileUpload3> Logger
+@inject IWebHostEnvironment Environment
+
+<h3>Upload Files</h3>
+
+<p>
+    <label>
+        Max file size:
+        <input type="number" @bind="maxFileSize" />
+    </label>
+</p>
+
+<p>
+    <label>
+        Max allowed files:
+        <input type="number" @bind="maxAllowedFiles" />
+    </label>
+</p>
+
+<p>
+    <label>
+        Upload up to @maxAllowedFiles of up to @maxFileSize bytes:
+        <InputFile OnChange="@LoadFiles" multiple />
+    </label>
+</p>
+
+@if (isLoading)
+{
+    <p>Progress: @string.Format("{0:P0}", progressPercent)</p>
+}
+else
+{
+    <ul>
+        @foreach (var file in loadedFiles)
+        {
+            <li>
+                <ul>
+                    <li>Name: @file.Name</li>
+                    <li>Last modified: @file.LastModified.ToString()</li>
+                    <li>Size (bytes): @file.Size</li>
+                    <li>Content type: @file.ContentType</li>
+                </ul>
+            </li>
+        }
+    </ul>
+}
+
+@code {
+    private List<IBrowserFile> loadedFiles = new();
+    private long maxFileSize = 1024 * 1024 * 16;
+    private int maxAllowedFiles = 3;
+    private bool isLoading;
+    private decimal progressPercent = 0.0M;
+
+    private async Task LoadFiles(InputFileChangeEventArgs e)
+    {
+        isLoading = true;
+        loadedFiles.Clear();
+
+        foreach (var file in e.GetMultipleFiles(maxAllowedFiles))
+        {
+            try
+            {
+                var trustedFileNameForFileStorage = Path.GetRandomFileName();
+                var path = Path.Combine(Environment.ContentRootPath,
+                        Environment.EnvironmentName, "unsafe_uploads",
+                        trustedFileNameForFileStorage);
+
+                await using FileStream writeStream = new(path, FileMode.Create);
+                using var readStream = file.OpenReadStream(maxFileSize);
+
+                var bytes = new byte[readStream.Length];
+                var bytesToRead = (int)readStream.Length;
+                var bytesRead = 0;
+
+                while (bytesToRead > 0)
+                {
+                    var n = await readStream.ReadAsync(bytes, bytesRead, 
+                        bytesToRead);
+
+                    if (n == 0)
+                    {
+                        break;
+                    }
+
+                    bytesRead += n;
+                    bytesToRead -= n;
+
+                    progressPercent = Decimal.Divide(bytesRead, file.Size);
+
+                    StateHasChanged();
+                }
+                
+                bytesToRead = bytes.Length;
+
+                writeStream.Write(bytes, 0, bytesToRead);                
+
+                loadedFiles.Add(file);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError("File: {Filename} Error: {Error}", 
+                    file.Name, ex.Message);
+            }
+        }
+
+        isLoading = false;
+    }
+}


### PR DESCRIPTION
Fixes #23717

/[Internal Review Topic (links to section)]()

When I first dropped in the example code provided by the reader on the PU issue, the runtime wasn't too pleased with it tossing a nasty 💥 *offset/length/byte count* bug 😈.

I went over to our `FileStream` API doc, and I found a different approach that ✨ **_Just Works!_**&trade; ✨ almost OOB with a minor change to read the stream asynchronously. Therefore, I base this on that approach.