### PR TITLE
Add GitHub Workflow for Merge to Live

### DIFF
--- a/.github/workflows/merge-live.yml
+++ b/.github/workflows/merge-live.yml
@@ -1,0 +1,11 @@
+name: Merge to Live
+on:
+  workflow_dispatch
+jobs:
+  default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: gh pr create --base live --head main --title "Merge to Live" --body "[AUTOMATED]"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds a manual GitHub Actions workflow to create a PR that merges from main to live.

I've [tested this in a fork](https://github.com/serpent5/dotnet-AspNetCore.Docs/actions/runs/1531727795), where it [works well](https://github.com/serpent5/dotnet-AspNetCore.Docs/pull/3), so I'd like to bring it in here. I've deliberately kept this as simple as it can be for now, with scope for more automation, etc, going forward.