### PR TITLE
Add permissions for merge-live GitHub Workflow

### DIFF
--- a/.github/workflows/merge-live.yml
+++ b/.github/workflows/merge-live.yml
@@ -1,4 +1,7 @@
 name: Merge to Live
+permissions:
+  contents: read
+  pull-requests: write
 on:
   workflow_dispatch
 jobs:


### PR DESCRIPTION
This repo is more restrictive than the fork I created, so we need to add explicit permissions for writing PRs.