### PR TITLE
Cosmetic rename of Blazor Routing topic

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1,7 +1,7 @@
 ---
-title: ASP.NET Core Blazor routing
+title: ASP.NET Core Blazor routing and navigation
 author: guardrex
-description: Learn how to manage request routing in apps and how to use the NavLink component in Blazor apps for navigation.
+description: Learn how to manage request routing in Blazor apps and how to use the Navigation Manager and NavLink component for navigation.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
@@ -9,7 +9,7 @@ ms.date: 11/09/2021
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: blazor/fundamentals/routing
 ---
-# ASP.NET Core Blazor routing
+# ASP.NET Core Blazor routing and navigation
 
 ::: moniker range=">= aspnetcore-6.0"
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -335,7 +335,7 @@
         uid: blazor/project-structure
       - name: Fundamentals
         items:
-          - name: Routing
+          - name: Routing and navigation
             uid: blazor/fundamentals/routing
           - name: Configuration
             uid: blazor/fundamentals/configuration


### PR DESCRIPTION
Fixes #24185

We'll decide later if we want to update the filename and UID to match. It's actually more likely that we'll split out the Navigation Manager and NavLink component bits into a *Navigation* topic to appear immediately after the *Routing* topic ... and then the *Routing* topic will get its old name back. Therefore, the update on this PR is merely cosmetic for the time being (title and ToC entry text).