### PR TITLE
Anchor: What if asp-page does not exist

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -284,6 +284,8 @@ The generated HTML:
 <a href="/Attendee?attendeeid=10">View Attendee</a>
 ```
 
+If the referenced page does not exist, a link to the main page will be generated.  No warning will be produced.
+
 ### asp-page-handler
 
 The [asp-page-handler](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.PageHandler*) attribute is used with Razor Pages. It's intended for linking to specific page handlers.

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -284,7 +284,7 @@ The generated HTML:
 <a href="/Attendee?attendeeid=10">View Attendee</a>
 ```
 
-If the referenced page does not exist, a link to the main page will be generated.  No warning will be produced.
+If the referenced page doesn't exist, a link to the main page is generated. No warning is indicated.
 
 ### asp-page-handler
 


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Explain that if the [page referenced by an anchor](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper.page) does not exist, a link to the main page will be generated.  No warning will be produced.