### PR TITLE
Check for existing PRs before merge-to-live

### DIFF
--- a/.github/workflows/merge-live.yml
+++ b/.github/workflows/merge-live.yml
@@ -9,6 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: |
+          numOpenPullRequests="$(gh pr list --author app/github-actions --search "base:live" --json id --jq ". | length")"
+
+          if [ "$numOpenPullRequests" -ne "0" ]; then
+            echo "::error::An open pull-request already exists.";
+            exit 1;
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: gh pr create --base live --head main --title "Merge to Live" --body "[AUTOMATED]"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When the merge-to-live workflow runs, we don't want it to open a new PR if one already exists. This change fails the workflow if a there's an open PR that:

- Targets the `live` branch.
- Is authored by `github-actions`.

This isn't likely to happen, as we won't leave these PRs open for long, but I think it's a worthy addition to protect us against multiple PRs.