### PR TITLE
Fixes wrong environment name

### DIFF
--- a/aspnetcore/fundamentals/environments/6.0sample/EnvironmentsSample/Properties/launchSettings.json
+++ b/aspnetcore/fundamentals/environments/6.0sample/EnvironmentsSample/Properties/launchSettings.json
@@ -34,7 +34,7 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:7152;http://localhost:5105",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Production"
       }
     },
     "IIS Express": {


### PR DESCRIPTION
Fixes wrong environment name in multi environment launch settings documentation sample.
The launch profile is named `EnvironmentsSample-Production` so i guess the environment should also be `Production` and not `Development`