### PR TITLE
Update Health Checks to 6.0

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -389,26 +389,6 @@ In the sample app's `LivenessProbeStartup` example, the `StartupHostedService` r
 >
 > [`AspNetCore.Diagnostics.HealthChecks`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) isn't maintained or supported by Microsoft.
 
-## Restrict health checks with MapWhen
-
-Use <xref:Microsoft.AspNetCore.Builder.MapWhenExtensions.MapWhen%2A> to conditionally branch the request pipeline for health check endpoints.
-
-In the following example, `MapWhen` branches the request pipeline to activate Health Checks Middleware if a GET request is received for the `api/healthz` endpoint:
-
-```csharp
-app.MapWhen(
-    context => context.Request.Method == HttpMethod.Get.Method && 
-        context.Request.Path.StartsWith("/api/healthz"),
-    builder => builder.UseHealthChecks());
-
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapRazorPages();
-});
-```
-
-For more information, see <xref:fundamentals/middleware/index#branch-the-middleware-pipeline>.
-
 :::moniker-end
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -17,7 +17,7 @@ By [Glenn Condron](https://github.com/glennc)
 
 ASP.NET Core offers Health Checks Middleware and libraries for reporting the health of app infrastructure components.
 
-Health checks are exposed by an app as HTTP endpoints. Health check endpoints can be configured for a variety of real-time monitoring scenarios:
+Health checks are exposed by an app as HTTP endpoints. Health check endpoints can be configured for various real-time monitoring scenarios:
 
 * Health probes can be used by container orchestrators and load balancers to check an app's status. For example, a container orchestrator may respond to a failing health check by halting a rolling deployment or restarting a container. A load balancer might react to an unhealthy app by routing traffic away from the failing instance to a healthy instance.
 * Use of memory, disk, and other physical server resources can be monitored for healthy status.
@@ -73,7 +73,7 @@ The <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckEx
 
 :::code language="csharp" source="health-checks/samples/6.x/HealthChecksSample/Snippets/Program.cs" id="snippet_AddHealthChecksDelegate":::
 
-Call <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddTypeActivatedCheck%2A> to pass arguments to a health check implementation. In the following example,a type-activated health check accepts an integer and a string in its constructor:
+Call <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddTypeActivatedCheck%2A> to pass arguments to a health check implementation. In the following example, a type-activated health check accepts an integer and a string in its constructor:
 
 :::code language="csharp" source="health-checks/samples/6.x/HealthChecksSample/HealthChecks/SampleHealthCheckWithArgs.cs" id="snippet_Class" highlight="6":::
 
@@ -180,7 +180,7 @@ By default:
 * The `DbContextHealthCheck` calls EF Core's `CanConnectAsync` method. You can customize what operation is run when checking health using `AddDbContextCheck` method overloads.
 * The name of the health check is the name of the `TContext` type.
 
-The following examples registers a `DbContext` and an associated `DbContextHealthCheck`:
+The following example registers a `DbContext` and an associated `DbContextHealthCheck`:
 
 :::code language="csharp" source="health-checks/samples/6.x/HealthChecksSample/Snippets/Program.cs" id="snippet_AddHealthChecksDbContext":::
 
@@ -245,29 +245,27 @@ To distribute a health check as a library:
 
 1. Write a health check that implements the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck> interface as a standalone class. The class can rely on [dependency injection (DI)](xref:fundamentals/dependency-injection), type activation, and [named options](xref:fundamentals/configuration/options) to access configuration data.
 
-   In the health checks logic of `CheckHealthAsync`, `arg1` and `arg2` are used in the method to run the probe's health check logic.
-
-1. Write an extension method with parameters that the consuming app calls in its `Startup.Configure` method. In the following example, assume the following health check method signature:
+1. Write an extension method with parameters that the consuming app calls in its *Program.cs* method. Consider the following example health check, which accepts `arg1` and `arg2` as constructor parameters:
 
    :::code language="csharp" source="health-checks/samples/6.x/HealthChecksSample/HealthChecks/SampleHealthCheckWithArgs.cs" id="snippet_ctor":::
 
-   The preceding signature indicates that the `ExampleHealthCheck` requires additional data to process the health check probe logic. The data is provided to the delegate used to create the health check instance when the health check is registered with an extension method. In the following example, the caller specifies optional:
+   The preceding signature indicates that the health check requires custom data to process the health check probe logic. The data is provided to the delegate used to create the health check instance when the health check is registered with an extension method. In the following example, the caller specifies:
 
-   * health check name (`name`). If `null`, `example_health_check` is used.
-   * string data point for the health check (`data1`).
-   * integer data point for the health check (`data2`). If `null`, `1` is used.
-   * failure status (<xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>). The default is `null`. If `null`, <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType> is reported for a failure status.
-   * tags (`IEnumerable<string>`).
+   * `arg1`: An integer data point for the health check.
+   * `arg2`: A string argument for the health check.
+   * `name`: An optional health check name. If `null`, a default value is used.
+   * `failureStatus`: An optional <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>, which is reported for a failure status. If `null`, <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType> is used.
+   * `tags`: An `IEnumerable<string>` collection of tags.
 
    :::code language="csharp" source="health-checks/samples/6.x/HealthChecksSample/Extensions/SampleHealthCheckBuilderExtensions.cs" id="snippet_Class":::
 
 ## Health Check Publisher
 
-When an <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> is added to the service container, the health check system periodically executes your health checks and calls <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher.PublishAsync%2A> with the result. This is useful in a push-based health monitoring system scenario that expects each process to call the monitoring system periodically in order to determine health.
+When an <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> is added to the service container, the health check system periodically executes your health checks and calls <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher.PublishAsync%2A> with the result. This process is useful in a push-based health monitoring system scenario that expects each process to call the monitoring system periodically to determine health.
 
 <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions> allow you to set the:
 
-* <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Delay>: The initial delay applied after the app starts before executing <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> instances. The delay is applied once at startup and doesn't apply to subsequent iterations. The default value is five seconds.
+* <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Delay>: The initial delay applied after the app starts before executing <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> instances. The delay is applied once at startup and doesn't apply to later iterations. The default value is five seconds.
 * <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Period>: The period of <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> execution. The default value is 30 seconds.
 * <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Predicate>: If <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Predicate> is `null` (default), the health check publisher service runs all registered health checks. To run a subset of health checks, provide a function that filters the set of checks. The predicate is evaluated each period.
 * <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions.Timeout>: The timeout for executing the health checks for all <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> instances. Use <xref:System.Threading.Timeout.InfiniteTimeSpan> to execute without a timeout. The default value is 30 seconds.
@@ -297,7 +295,7 @@ The following example registers a health check publisher as a singleton and conf
 
 ASP.NET Core offers Health Checks Middleware and libraries for reporting the health of app infrastructure components.
 
-Health checks are exposed by an app as HTTP endpoints. Health check endpoints can be configured for a variety of real-time monitoring scenarios:
+Health checks are exposed by an app as HTTP endpoints. Health check endpoints can be configured for various real-time monitoring scenarios:
 
 * Health probes can be used by container orchestrators and load balancers to check an app's status. For example, a container orchestrator may respond to a failing health check by halting a rolling deployment or restarting a container. A load balancer might react to an unhealthy app by routing traffic away from the failing instance to a healthy instance.
 * Use of memory, disk, and other physical server resources can be monitored for healthy status.
@@ -1069,7 +1067,7 @@ For more information, see <xref:fundamentals/middleware/index#branch-the-middlew
 
 ASP.NET Core offers Health Checks Middleware and libraries for reporting the health of app infrastructure components.
 
-Health checks are exposed by an app as HTTP endpoints. Health check endpoints can be configured for a variety of real-time monitoring scenarios:
+Health checks are exposed by an app as HTTP endpoints. Health check endpoints can be configured for various real-time monitoring scenarios:
 
 * Health probes can be used by container orchestrators and load balancers to check an app's status. For example, a container orchestrator may respond to a failing health check by halting a rolling deployment or restarting a container. A load balancer might react to an unhealthy app by routing traffic away from the failing instance to a healthy instance.
 * Use of memory, disk, and other physical server resources can be monitored for healthy status.

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -29,7 +29,7 @@ Health checks are typically used with an external monitoring service or containe
 
 For many apps, a basic health probe configuration that reports the app's availability to process requests (*liveness*) is sufficient to discover the status of the app.
 
-The basic configuration registers health check services and calls the Health Checks Middleware to respond at a URL endpoint with a health response. By default, no specific health checks are registered to test any particular dependency or subsystem. The app is considered healthy if it can respond at the health endpoint URL. The default response writer writes the status (<xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>) as a plaintext response back to the client, indicating either a <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy?displayProperty=nameWithType>, <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded?displayProperty=nameWithType>, or <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType> status.
+The basic configuration registers health check services and calls the Health Checks Middleware to respond at a URL endpoint with a health response. By default, no specific health checks are registered to test any particular dependency or subsystem. The app is considered healthy if it can respond at the health endpoint URL. The default response writer writes <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus> as a plaintext response to the client. The `HealthStatus` is <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Healthy?displayProperty=nameWithType>, <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Degraded?displayProperty=nameWithType>, or <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType>.
 
 Register health check services with <xref:Microsoft.Extensions.DependencyInjection.HealthCheckServiceCollectionExtensions.AddHealthChecks%2A> in *Program.cs*. Create a health check endpoint by calling <xref:Microsoft.AspNetCore.Builder.HealthCheckEndpointRouteBuilderExtensions.MapHealthChecks%2A>.
 
@@ -47,7 +47,7 @@ HEALTHCHECK CMD curl --fail http://localhost:5000/healthz || exit
 
 ## Create health checks
 
-Health checks are created by implementing the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck> interface. The <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck.CheckHealthAsync%2A> method returns a <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> that indicates the health as `Healthy`, `Degraded`, or `Unhealthy`. The result is written as a plaintext response with a configurable status code (configuration is described in the [Health check options](#health-check-options) section). <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> can also return optional key-value pairs.
+Health checks are created by implementing the <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck> interface. The <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheck.CheckHealthAsync%2A> method returns a <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> that indicates the health as `Healthy`, `Degraded`, or `Unhealthy`. The result is written as a plaintext response with a configurable status code. Configuration is described in the [Health check options](#health-check-options) section. <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckResult> can also return optional key-value pairs.
 
 The following example demonstrates the layout of a health check: 
 
@@ -65,7 +65,7 @@ To register a health check service, call <xref:Microsoft.Extensions.DependencyIn
 
 The <xref:Microsoft.Extensions.DependencyInjection.HealthChecksBuilderAddCheckExtensions.AddCheck%2A> overload shown in the following example sets the failure status (<xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>) to report when the health check reports a failure. If the failure status is set to `null` (default), <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType> is reported. This overload is a useful scenario for library authors, where the failure status indicated by the library is enforced by the app when a health check failure occurs if the health check implementation honors the setting.
 
-*Tags* can be used to filter health checks (described further in the [Filter health checks](#filter-health-checks) section).
+*Tags* can be used to filter health checks. Tags are described in the [Filter health checks](#filter-health-checks) section.
 
 :::code language="csharp" source="health-checks/samples/6.x/HealthChecksSample/Snippets/Program.cs" id="snippet_AddHealthChecksExtended":::
 
@@ -101,7 +101,7 @@ For more information, see [Host matching in routes with RequireHost](xref:fundam
 
 ### Require authorization
 
-Call `RequireAuthorization` to run Authorization Middleware on the health check request endpoint. A `RequireAuthorization` overload accepts one or more authorization policies. If a policy isn't provided, the default authorization policy is used:
+Call <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization%2A> to run Authorization Middleware on the health check request endpoint. A `RequireAuthorization` overload accepts one or more authorization policies. If a policy isn't provided, the default authorization policy is used:
 
 :::code language="csharp" source="health-checks/samples/6.x/HealthChecksSample/Snippets/Program.cs" id="snippet_MapHealthChecksRequireAuthorization":::
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -255,7 +255,7 @@ To distribute a health check as a library:
    * `arg2`: A string argument for the health check.
    * `name`: An optional health check name. If `null`, a default value is used.
    * `failureStatus`: An optional <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus>, which is reported for a failure status. If `null`, <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType> is used.
-   * `tags`: An `IEnumerable<string>` collection of tags.
+   * `tags`: An optional `IEnumerable<string>` collection of tags.
 
    :::code language="csharp" source="health-checks/samples/6.x/HealthChecksSample/Extensions/SampleHealthCheckBuilderExtensions.cs" id="snippet_Class":::
 

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Extensions/SampleHealthCheckBuilderExtensions.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Extensions/SampleHealthCheckBuilderExtensions.cs
@@ -1,0 +1,27 @@
+using HealthChecksSample.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecksSample.Extensions;
+
+// <snippet_Class>
+public static class SampleHealthCheckBuilderExtensions
+{
+    private const string DefaultName = "Sample";
+
+    public static IHealthChecksBuilder AddSampleHealthCheck(
+        this IHealthChecksBuilder healthChecksBuilder,
+        int arg1,
+        string arg2,
+        string? name = null,
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = default)
+    {
+        return healthChecksBuilder.Add(
+            new HealthCheckRegistration(
+                name ?? DefaultName,
+                _ => new SampleHealthCheckWithArgs(arg1, arg2),
+                failureStatus,
+                tags));
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthCheckPublishers/SampleHealthCheckPublisher.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthCheckPublishers/SampleHealthCheckPublisher.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecksSample.HealthCheckPublishers;
+
+// <snippet_Class>
+public class SampleHealthCheckPublisher : IHealthCheckPublisher
+{
+    public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
+    {
+        if (report.Status == HealthStatus.Healthy)
+        {
+            // ...
+        }
+        else
+        {
+            // ...
+        }
+
+        return Task.CompletedTask;
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthChecks/SampleHealthCheck.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthChecks/SampleHealthCheck.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecksSample.HealthChecks;
+
+// <snippet_Class>
+public class SampleHealthCheck : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        var isHealthy = true;
+
+        // ...
+
+        if (isHealthy)
+        {
+            return Task.FromResult(
+                HealthCheckResult.Healthy("A healthy result."));
+        }
+
+        return Task.FromResult(
+            new HealthCheckResult(
+                context.Registration.FailureStatus, "An unhealthy result."));
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthChecks/SampleHealthCheckWithArgs.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthChecks/SampleHealthCheckWithArgs.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecksSample.HealthChecks;
+
+// <snippet_Class>
+public class SampleHealthCheckWithArgs : IHealthCheck
+{
+    private readonly int _arg1;
+    private readonly string _arg2;
+
+    // <snippet_ctor>
+    public SampleHealthCheckWithArgs(int arg1, string arg2)
+        => (_arg1, _arg2) = (arg1, arg2);
+    // </snippet_ctor>
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        // ...
+
+        return Task.FromResult(HealthCheckResult.Healthy("A healthy result."));
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthChecks/StartupHealthCheck.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthChecks/StartupHealthCheck.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecksSample.HealthChecks;
+
+// <snippet_Class>
+public class StartupHealthCheck : IHealthCheck
+{
+    private volatile bool _isReady;
+
+    public bool StartupCompleted
+    {
+        get => _isReady;
+        set => _isReady = value;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        if (StartupCompleted)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy("The startup task has completed."));
+        }
+
+        return Task.FromResult(HealthCheckResult.Unhealthy("That startup task is still running."));
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthChecksSample.csproj
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/HealthChecksSample.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.1-rc2.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Program.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Services/StartupBackgroundService.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Services/StartupBackgroundService.cs
@@ -1,0 +1,21 @@
+using HealthChecksSample.HealthChecks;
+
+namespace HealthChecksSample.Services;
+
+// <snippet_Class>
+public class StartupBackgroundService : BackgroundService
+{
+    private readonly StartupHealthCheck _healthCheck;
+
+    public StartupBackgroundService(StartupHealthCheck healthCheck)
+        => _healthCheck = healthCheck;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Simulate the effect of a long-running task.
+        await Task.Delay(TimeSpan.FromSeconds(15), stoppingToken);
+
+        _healthCheck.StartupCompleted = true;
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Snippets/Program.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Snippets/Program.cs
@@ -95,31 +95,12 @@ public static class Program
         // </snippet_MapHealthChecksRequireAuthorization>
     }
 
-    public static void AddHealthChecksFilterTags(WebApplicationBuilder builder)
-    {
-        // <snippet_AddHealthChecksFilterTags>
-        builder.Services.AddHealthChecks()
-            .AddCheck(
-                "Check_1",
-                () => HealthCheckResult.Healthy("Check_1 is healthy."),
-                tags: new[] { "tag_1" })
-            .AddCheck(
-                "Check_2",
-                () => HealthCheckResult.Healthy("Check_2 is unhealthy."),
-                tags: new[] { "tag_1" })
-            .AddCheck(
-                "Check_2",
-                () => HealthCheckResult.Healthy("Check_3 is healthy."),
-                tags: new[] { "tag_2" });
-        // </snippet_AddHealthChecksFilterTags>
-    }
-
     public static void MapHealthChecksFilterTags(WebApplication app)
     {
         // <snippet_MapHealthChecksFilterTags>
         app.MapHealthChecks("/healthz", new HealthCheckOptions
         {
-            Predicate = healthCheck => healthCheck.Tags.Contains("tag_1")
+            Predicate = healthCheck => healthCheck.Tags.Contains("sample")
         });
         // </snippet_MapHealthChecksFilterTags>
     }

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Snippets/Program.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Snippets/Program.cs
@@ -1,0 +1,267 @@
+using System.Text;
+using System.Text.Json;
+using HealthChecksSample.HealthCheckPublishers;
+using HealthChecksSample.HealthChecks;
+using HealthChecksSample.Services;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace HealthChecksSample.Snippets;
+
+public static class Program
+{
+    public static void MapHealthChecksComplete(string[] args)
+    {
+        // <snippet_MapHealthChecksComplete>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddHealthChecks();
+
+        var app = builder.Build();
+
+        app.MapHealthChecks("/healthz");
+
+        app.Run();
+        // </snippet_MapHealthChecksComplete>
+    }
+
+    public static void AddHealthChecks(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHealthChecks>
+        builder.Services.AddHealthChecks()
+            .AddCheck<SampleHealthCheck>("Sample");
+        // </snippet_AddHealthChecks>
+    }
+    public static void AddHealthChecksExtended(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHealthChecksExtended>
+        builder.Services.AddHealthChecks()
+            .AddCheck<SampleHealthCheck>(
+                "Sample",
+                failureStatus: HealthStatus.Degraded,
+                tags: new[] { "sample" });
+        // </snippet_AddHealthChecksExtended>
+    }
+
+    public static void AddHealthChecksDelegate(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHealthChecksDelegate>
+        builder.Services.AddHealthChecks()
+            .AddCheck("Sample", () => HealthCheckResult.Healthy("A healthy result."));
+        // </snippet_AddHealthChecksDelegate>
+    }
+
+    public static void AddHealthChecksTypeActivated(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHealthChecksTypeActivated>
+        builder.Services.AddHealthChecks()
+            .AddTypeActivatedCheck<SampleHealthCheckWithArgs>(
+                "Sample",
+                failureStatus: HealthStatus.Degraded,
+                tags: new[] { "sample" },
+                args: new object[] { 1, "Arg" });
+        // </snippet_AddHealthChecksTypeActivated>
+    }
+
+    public static void MapHealthChecks(WebApplication app)
+    {
+        // <snippet_MapHealthChecks>
+        app.MapHealthChecks("/healthz");
+        // </snippet_MapHealthChecks>
+    }
+
+    public static void MapHealthChecksRequireHost(WebApplication app)
+    {
+        // <snippet_MapHealthChecksRequireHost>
+        app.MapHealthChecks("/healthz")
+            .RequireHost("www.contoso.com:5001");
+        // </snippet_MapHealthChecksRequireHost>
+    }
+
+    public static void MapHealthChecksRequireHostPort(WebApplication app)
+    {
+        // <snippet_MapHealthChecksRequireHostPort>
+        app.MapHealthChecks("/healthz")
+            .RequireHost("*:5001");
+        // </snippet_MapHealthChecksRequireHostPort>
+    }
+
+    public static void MapHealthChecksRequireAuthorization(WebApplication app)
+    {
+        // <snippet_MapHealthChecksRequireAuthorization>
+        app.MapHealthChecks("/healthz")
+            .RequireAuthorization();
+        // </snippet_MapHealthChecksRequireAuthorization>
+    }
+
+    public static void AddHealthChecksFilterTags(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHealthChecksFilterTags>
+        builder.Services.AddHealthChecks()
+            .AddCheck(
+                "Check_1",
+                () => HealthCheckResult.Healthy("Check_1 is healthy."),
+                tags: new[] { "tag_1" })
+            .AddCheck(
+                "Check_2",
+                () => HealthCheckResult.Healthy("Check_2 is unhealthy."),
+                tags: new[] { "tag_1" })
+            .AddCheck(
+                "Check_2",
+                () => HealthCheckResult.Healthy("Check_3 is healthy."),
+                tags: new[] { "tag_2" });
+        // </snippet_AddHealthChecksFilterTags>
+    }
+
+    public static void MapHealthChecksFilterTags(WebApplication app)
+    {
+        // <snippet_MapHealthChecksFilterTags>
+        app.MapHealthChecks("/healthz", new HealthCheckOptions
+        {
+            Predicate = healthCheck => healthCheck.Tags.Contains("tag_1")
+        });
+        // </snippet_MapHealthChecksFilterTags>
+    }
+
+    public static void MapHealthChecksResultStatusCodes(WebApplication app)
+    {
+        // <snippet_MapHealthChecksResultStatusCodes>
+        app.MapHealthChecks("/healthz", new HealthCheckOptions
+        {
+            ResultStatusCodes =
+            {
+                [HealthStatus.Healthy] = StatusCodes.Status200OK,
+                [HealthStatus.Degraded] = StatusCodes.Status200OK,
+                [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+            }
+        });
+        // </snippet_MapHealthChecksResultStatusCodes>
+    }
+
+    public static void MapHealthChecksAllowCachingResponses(WebApplication app)
+    {
+        // <snippet_MapHealthChecksAllowCachingResponses>
+        app.MapHealthChecks("/healthz", new HealthCheckOptions
+        {
+            AllowCachingResponses = false
+        });
+        // </snippet_MapHealthChecksAllowCachingResponses>
+    }
+
+    public static void MapHealthChecksResponseWriter(WebApplication app)
+    {
+        // <snippet_MapHealthChecksResponseWriter>
+        app.MapHealthChecks("/healthz", new HealthCheckOptions
+        {
+            ResponseWriter = WriteResponse
+        });
+        // </snippet_MapHealthChecksResponseWriter>
+    }
+
+    public static void AddHealthChecksSqlServer(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHealthChecksSqlServer>
+        builder.Services.AddHealthChecks()
+            .AddSqlServer(
+                builder.Configuration.GetConnectionString("DefaultConnection"));
+        // </snippet_AddHealthChecksSqlServer>
+    }
+
+    public static void AddHealthChecksDbContext(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHealthChecksDbContext>
+        builder.Services.AddDbContext<SampleDbContext>(options =>
+            options.UseSqlServer(
+                builder.Configuration.GetConnectionString("DefaultConnection")));
+
+        builder.Services.AddHealthChecks()
+            .AddDbContextCheck<SampleDbContext>();
+        // </snippet_AddHealthChecksDbContext>
+    }
+
+    public static void AddHealthChecksReadinessLiveness(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHealthChecksReadinessLiveness>
+        builder.Services.AddHostedService<StartupBackgroundService>();
+        builder.Services.AddSingleton<StartupHealthCheck>();
+
+        builder.Services.AddHealthChecks()
+            .AddCheck<StartupHealthCheck>(
+                "Startup",
+                tags: new[] { "ready" });
+        // </snippet_AddHealthChecksReadinessLiveness>
+    }
+
+    public static void MapHealthChecksReadinessLiveness(WebApplication app)
+    {
+        // <snippet_MapHealthChecksReadinessLiveness>
+        app.MapHealthChecks("/healthz/ready", new HealthCheckOptions
+        {
+            Predicate = healthCheck => healthCheck.Tags.Contains("ready")
+        });
+
+        app.MapHealthChecks("/healthz/live", new HealthCheckOptions
+        {
+            Predicate = _ => false
+        });
+        // </snippet_MapHealthChecksReadinessLiveness>
+    }
+
+    public static void HealthCheckPublisherOptionsService(WebApplicationBuilder builder)
+    {
+        // <snippet_HealthCheckPublisherOptionsService>
+        builder.Services.Configure<HealthCheckPublisherOptions>(options =>
+        {
+            options.Delay = TimeSpan.FromSeconds(2);
+            options.Predicate = healthCheck => healthCheck.Tags.Contains("sample");
+        });
+
+        builder.Services.AddSingleton<IHealthCheckPublisher, SampleHealthCheckPublisher>();
+        // </snippet_HealthCheckPublisherOptionsService>
+    }
+
+    // <snippet_WriteResponse>
+    private static Task WriteResponse(HttpContext context, HealthReport healthReport)
+    {
+        context.Response.ContentType = "application/json; charset=utf-8";
+
+        var options = new JsonWriterOptions { Indented = true };
+
+        using var memoryStream = new MemoryStream();
+        using (var jsonWriter = new Utf8JsonWriter(memoryStream, options))
+        {
+            jsonWriter.WriteStartObject();
+            jsonWriter.WriteString("status", healthReport.Status.ToString());
+            jsonWriter.WriteStartObject("results");
+
+            foreach (var healthReportEntry in healthReport.Entries)
+            {
+                jsonWriter.WriteStartObject(healthReportEntry.Key);
+                jsonWriter.WriteString("status",
+                    healthReportEntry.Value.Status.ToString());
+                jsonWriter.WriteString("description",
+                    healthReportEntry.Value.Description);
+                jsonWriter.WriteStartObject("data");
+
+                foreach (var item in healthReportEntry.Value.Data)
+                {
+                    jsonWriter.WritePropertyName(item.Key);
+
+                    JsonSerializer.Serialize(jsonWriter, item.Value,
+                        item.Value?.GetType() ?? typeof(object));
+                }
+
+                jsonWriter.WriteEndObject();
+                jsonWriter.WriteEndObject();
+            }
+
+            jsonWriter.WriteEndObject();
+            jsonWriter.WriteEndObject();
+        }
+
+        return context.Response.WriteAsync(
+            Encoding.UTF8.GetString(memoryStream.ToArray()));
+    }
+    // </snippet_WriteResponse>
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Snippets/SampleDbContext.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/Snippets/SampleDbContext.cs
@@ -1,0 +1,9 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace HealthChecksSample.Snippets;
+
+public class SampleDbContext : DbContext
+{
+    public SampleDbContext(DbContextOptions<SampleDbContext> dbContextOptions)
+        : base(dbContextOptions) { }
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/appsettings.Development.json
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/appsettings.json
+++ b/aspnetcore/host-and-deploy/health-checks/samples/6.x/HealthChecksSample/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\MSSQLLocalDB;Database=HealthChecksSample;Trusted_Connection=True;MultipleActiveResultSets=true;ConnectRetryCount=0"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes #24092.

[Internal Preview URL](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-6.0&branch=pr-en-us-24261).

Working notes on changes:

- Removed two sections:
  - [Metric-based probe with a custom response writer](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-6.0#metric-based-probe-with-a-custom-response-writer): I don't think this offers anything in the context of health checks that's not already covered elsewhere in the topic.
  - [Restrict health checks with MapWhen](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?view=aspnetcore-6.0#restrict-health-checks-with-mapwhen): This looks like it would have never compiled, so I don't think it's serving any value.
- Removed instructions to run different scenarios in the sample app.
- Combined *RequireHost* and *Filter by port*.
- Changed the hosted service implementation to extend `BackgroundService`.