### PR TITLE
fix instructions for referencing internal classes

### DIFF
--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -120,7 +120,7 @@ If the SUT's [environment](xref:fundamentals/environments) isn't set, the enviro
 
 ::: moniker range=">= aspnetcore-6.0"
 
-ASP.NET Core 6 introduced [`WebApplication`](/dotnet/api/microsoft.aspnetcore.builder.webapplication) which removed the need for a `Startup` class. To test with `WebApplicationFactory` without a `Startup` class, an ASP.NET Core 6 app needs to expose the implicitly defined `Program` class to the test project in **one** of the following ways:
+ASP.NET Core 6 introduced [`WebApplication`](/dotnet/api/microsoft.aspnetcore.builder.webapplication) which removed the need for a `Startup` class. To test with `WebApplicationFactory` without a `Startup` class, an ASP.NET Core 6 app needs to expose the implicitly defined `Program` class to the test project by doing the following:
 
 * Expose internal types from the web app to the test project. This can be done in the project file (`.csproj`):
   ```xml


### PR DESCRIPTION
In aspnetcore 6, both of the code snippets mentioned are needed in order to get the Program class imported in a test project.

Initially I only added the changes shown for `.csproj`, but after following along to the BasicTests example I still got this error when writing the constructor: `Inconsistent accessibility: parameter type 'WebApplicationFactory<Program>' is less accessible than method 'MyControllerTest.MyControllerTest(WebApplicationFactory<Program>)'`.

Adding the `public partial class Program { }` change fixed that error.


***EDIT by @Rick-Anderson*** [Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-6.0&branch=pr-en-us-24274#basic-tests-with-the-default-webapplicationfactory)