### PR TITLE
fix folder name error

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -80,9 +80,9 @@ At the end, you'll have a working chat app:
     * The checkbox **trust the authors of all files in the parent folder**
    * **Yes, I trust the authors** (because dotnet generated the files).
 
-   The `dotnet new` command creates a new Razor Pages project in the *RazorPagesMovie* folder.
+   The `dotnet new` command creates a new Razor Pages project in the *SignalRChat* folder.
 
-   The `code` command opens the *RazorPagesMovie* folder in the current instance of Visual Studio Code.
+   The `code` command opens the *SignalRChat* folder in the current instance of Visual Studio Code.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
@@ -368,6 +368,7 @@ The SignalR server library is included in the ASP.NET Core 3.1 shared framework.
   ```
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
+
 
   * In the **Terminal**, run the following command to install LibMan.
 


### PR DESCRIPTION
SignalRChat instead of RazorPagesMovie



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->