### PR TITLE
Schedule automatic runs of merge-live

### DIFF
--- a/.github/workflows/merge-live.yml
+++ b/.github/workflows/merge-live.yml
@@ -3,7 +3,9 @@ permissions:
   contents: read
   pull-requests: write
 on:
-  workflow_dispatch
+  schedule:
+    - cron: "0 8 * * 1-5"
+  workflow_dispatch:
 jobs:
   default:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-live.yml
+++ b/.github/workflows/merge-live.yml
@@ -4,7 +4,7 @@ permissions:
   pull-requests: write
 on:
   schedule:
-    - cron: "0 8 * * 1-5"
+    - cron: "0 8 * * *"
   workflow_dispatch:
 jobs:
   default:


### PR DESCRIPTION
Adds a scheduled trigger to open a merge-live PR [At 08:00 on every day-of-week from Monday through Friday](https://crontab.guru/#0_8_*_*_1-5). The time is UTC, so I think 8AM is a good starter, and I don't think it needs to run at weekends. We can still do it manually [here](https://github.com/dotnet/AspNetCore.Docs/actions/workflows/merge-live.yml):

![image](https://user-images.githubusercontent.com/6025110/145998821-e76bd23f-cbb2-4b4c-8217-aee1804ad77b.png)

Very much open to feedback on all of this. The next step is automated merge of the PR, but I have some investigation around status checks to do first.