### PR TITLE
Header control in Blazor apps

### DIFF
--- a/aspnetcore/blazor/components/control-head-content.md
+++ b/aspnetcore/blazor/components/control-head-content.md
@@ -78,9 +78,11 @@ In Blazor apps created from Blazor project templates, the `NotFound` component t
 
 ## Additional resources
 
+* [Control headers in C# code at startup](xref:blazor/fundamentals/startup#control-headers-in-c-code)
+
 Mozilla MDN Web Docs documentation:
 
 * [What's in the head? Metadata in HTML](https://developer.mozilla.org/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML)
-* [\<head>: The Document Metadata (Header) element](https://developer.mozilla.org/docs/Web/HTML/Element/head)
-* [\<title>: The Document Title element](https://developer.mozilla.org/docs/Web/HTML/Element/title)
-* [\<meta>: The metadata element](https://developer.mozilla.org/docs/Web/HTML/Element/meta)
+* [`<head>`: The Document Metadata (Header) element](https://developer.mozilla.org/docs/Web/HTML/Element/head)
+* [`<title>`: The Document Title element](https://developer.mozilla.org/docs/Web/HTML/Element/title)
+* [`<meta>`: The metadata element](https://developer.mozilla.org/docs/Web/HTML/Element/meta)

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -157,9 +157,9 @@ In the following examples, a [Content Security Policy (CSP)](https://developer.m
 
   The preceding example uses inline middleware, but you can also create a custom middleware class and call the middleware with an extension method in `Program.cs`. For more information, see <xref:fundamentals/middleware/write>.
 
-* In Blazor WebAssembly apps, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage. <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> is called after the status code and headers are set but before the body is written.
+* In hosted Blazor WebAssembly apps that aren't prerendered, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage.
 
-  In `Program.cs`:
+  In `Program.cs` of the **`Server`** project:
 
   ```csharp
   var staticFileOptions = new StaticFileOptions
@@ -335,9 +335,9 @@ In the following examples, a [Content Security Policy (CSP)](https://developer.m
 
   The preceding example uses inline middleware, but you can also create a custom middleware class and call the middleware with an extension method in `Startup.Configure`. For more information, see <xref:fundamentals/middleware/write>.
 
-* In Blazor WebAssembly apps, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage. <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> is called after the status code and headers are set but before the body is written.
+* In hosted Blazor WebAssembly apps that aren't prerendered, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage.
 
-  In `Program.cs`:
+  In `Startup.Configure` (`Startup.cs`) of the **`Server`** project:
 
   ```csharp
   var staticFileOptions = new StaticFileOptions
@@ -499,7 +499,7 @@ Control headers at startup in C# code using the following approaches.
 
 In the following examples, a [Content Security Policy (CSP)](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) is applied to the app via a CSP header. The `{POLICY STRING}` placeholder is the CSP policy string.
 
-* In Blazor Server and prerendered Blazor WebAssembly apps, use [ASP.NET Core Middleware](xref:fundamentals/middleware/index) to control the headers collection.
+* In Blazor Server, use [ASP.NET Core Middleware](xref:fundamentals/middleware/index) to control the headers collection.
 
   In `Startup.Configure` of `Startup.cs`:
 
@@ -513,9 +513,9 @@ In the following examples, a [Content Security Policy (CSP)](https://developer.m
 
   The preceding example uses inline middleware, but you can also create a custom middleware class and call the middleware with an extension method in `Program.cs`. For more information, see <xref:fundamentals/middleware/write>.
 
-* In Blazor WebAssembly apps, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage. <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> is called after the status code and headers are set but before the body is written.
+* In hosted Blazor WebAssembly apps, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage.
 
-  In `Program.cs`:
+  In `Startup.Configure` (`Startup.cs`) of the **`Server`** project:
 
   ```csharp
   var staticFileOptions = new StaticFileOptions

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -137,6 +137,47 @@ The `loadBootResource` function can also return:
 * `null`/`undefined`, which results in the default loading behavior.
 * A [`Response` promise](https://developer.mozilla.org/docs/Web/API/Response). For an example, see <xref:blazor/host-and-deploy/webassembly#compression>.
 
+## Control headers in C# code
+
+Control headers at startup in C# code using the following approaches.
+
+In the following examples, a [Content Security Policy (CSP)](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) is applied to the app via a CSP header. The `{POLICY STRING}` placeholder is the CSP policy string.
+
+* In Blazor Server and prerendered Blazor WebAssembly apps, use [ASP.NET Core Middleware](xref:fundamentals/middleware/index) to control the headers collection.
+
+  In `Program.cs`:
+
+  ```csharp
+  app.Use(async (context, next) =>
+  {
+      context.Response.Headers.Add("Content-Security-Policy", "{POLICY STRING}");
+      await next();
+  });
+  ```
+
+  The preceding example uses inline middleware, but you can also create a custom middleware class and call the middleware with an extension method in `Program.cs`. For more information, see <xref:fundamentals/middleware/write>.
+
+* In Blazor WebAssembly apps, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage. <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> is called after the status code and headers are set but before the body is written.
+
+  In `Program.cs`:
+
+  ```csharp
+  var staticFileOptions = new StaticFileOptions
+  {
+      OnPrepareResponse = context =>
+      {
+          context.Context.Response.Headers.Add("Content-Security-Policy", 
+              "{POLICY STRING}");
+      }
+  };
+
+  ...
+
+  app.MapFallbackToFile("index.html", staticFileOptions);
+  ```
+
+For more information on CSPs, see <xref:blazor/security/content-security-policy>.
+
 ## Additional resources
 
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)
@@ -274,6 +315,47 @@ The `loadBootResource` function can also return:
 * `null`/`undefined`, which results in the default loading behavior.
 * A [`Response` promise](https://developer.mozilla.org/docs/Web/API/Response). For an example, see <xref:blazor/host-and-deploy/webassembly#compression>.
 
+## Control headers in C# code
+
+Control headers at startup in C# code using the following approaches.
+
+In the following examples, a [Content Security Policy (CSP)](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) is applied to the app via a CSP header. The `{POLICY STRING}` placeholder is the CSP policy string.
+
+* In Blazor Server and prerendered Blazor WebAssembly apps, use [ASP.NET Core Middleware](xref:fundamentals/middleware/index) to control the headers collection.
+
+  In `Startup.Configure` of `Startup.cs`:
+
+  ```csharp
+  app.Use(async (context, next) =>
+  {
+      context.Response.Headers.Add("Content-Security-Policy", "{POLICY STRING}");
+      await next();
+  });
+  ```
+
+  The preceding example uses inline middleware, but you can also create a custom middleware class and call the middleware with an extension method in `Startup.Configure`. For more information, see <xref:fundamentals/middleware/write>.
+
+* In Blazor WebAssembly apps, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage. <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> is called after the status code and headers are set but before the body is written.
+
+  In `Program.cs`:
+
+  ```csharp
+  var staticFileOptions = new StaticFileOptions
+  {
+      OnPrepareResponse = context =>
+      {
+          context.Context.Response.Headers.Add("Content-Security-Policy", 
+              "{POLICY STRING}");
+      }
+  };
+
+  ...
+
+  app.MapFallbackToFile("index.html", staticFileOptions);
+  ```
+
+For more information on CSPs, see <xref:blazor/security/content-security-policy>.
+
 ## Additional resources
 
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)
@@ -410,6 +492,47 @@ The `loadBootResource` function can also return:
 
 * `null`/`undefined`, which results in the default loading behavior.
 * A [`Response` promise](https://developer.mozilla.org/docs/Web/API/Response). For an example, see <xref:blazor/host-and-deploy/webassembly#compression>.
+
+## Control headers in C# code
+
+Control headers at startup in C# code using the following approaches.
+
+In the following examples, a [Content Security Policy (CSP)](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) is applied to the app via a CSP header. The `{POLICY STRING}` placeholder is the CSP policy string.
+
+* In Blazor Server and prerendered Blazor WebAssembly apps, use [ASP.NET Core Middleware](xref:fundamentals/middleware/index) to control the headers collection.
+
+  In `Startup.Configure` of `Startup.cs`:
+
+  ```csharp
+  app.Use(async (context, next) =>
+  {
+      context.Response.Headers.Add("Content-Security-Policy", "{POLICY STRING}");
+      await next();
+  });
+  ```
+
+  The preceding example uses inline middleware, but you can also create a custom middleware class and call the middleware with an extension method in `Program.cs`. For more information, see <xref:fundamentals/middleware/write>.
+
+* In Blazor WebAssembly apps, pass <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> to <xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A> that specifies response headers at the <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> stage. <xref:Microsoft.AspNetCore.Builder.StaticFileOptions.OnPrepareResponse> is called after the status code and headers are set but before the body is written.
+
+  In `Program.cs`:
+
+  ```csharp
+  var staticFileOptions = new StaticFileOptions
+  {
+      OnPrepareResponse = context =>
+      {
+          context.Context.Response.Headers.Add("Content-Security-Policy", 
+              "{POLICY STRING}");
+      }
+  };
+
+  ...
+
+  app.MapFallbackToFile("index.html", staticFileOptions);
+  ```
+
+For more information on CSPs, see <xref:blazor/security/content-security-policy>.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -19,7 +19,7 @@ uid: blazor/security/content-security-policy
 * Actions taken by a page, specifying permitted URL targets of forms.
 * Plugins that can be loaded.
 
-To apply a CSP to an app, the developer specifies several CSP content security *directives* in one or more `Content-Security-Policy` headers or `<meta>` tags.
+To apply a CSP to an app, the developer specifies several CSP content security *directives* in one or more `Content-Security-Policy` headers or `<meta>` tags. For guidance on applying a CSP to an app in C# code at startup, see <xref:blazor/fundamentals/startup#control-headers-in-c-code>.
 
 Policies are evaluated by the browser while a page is loading. The browser inspects the page's sources and determines if they meet the requirements of the content security directives. When policy directives aren't met for a resource, the browser doesn't load the resource. For example, consider a policy that doesn't allow third-party scripts. When a page contains a `<script>` tag with a third-party origin in the `src` attribute, the browser prevents the script from loading.
 
@@ -153,6 +153,7 @@ Test and update an app's policy every release.
 
 ## Additional resources
 
+* [Apply a CSP in C# code at startup](xref:blazor/fundamentals/startup#control-headers-in-c-code)
 * [MDN web docs: Content-Security-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy)
 * [Content Security Policy Level 2](https://www.w3.org/TR/CSP2/)
 * [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)
@@ -167,7 +168,7 @@ Test and update an app's policy every release.
 * Actions taken by a page, specifying permitted URL targets of forms.
 * Plugins that can be loaded.
 
-To apply a CSP to an app, the developer specifies several CSP content security *directives* in one or more `Content-Security-Policy` headers or `<meta>` tags.
+To apply a CSP to an app, the developer specifies several CSP content security *directives* in one or more `Content-Security-Policy` headers or `<meta>` tags. For guidance on applying a CSP to an app in C# code at startup, see <xref:blazor/fundamentals/startup#control-headers-in-c-code>.
 
 Policies are evaluated by the browser while a page is loading. The browser inspects the page's sources and determines if they meet the requirements of the content security directives. When policy directives aren't met for a resource, the browser doesn't load the resource. For example, consider a policy that doesn't allow third-party scripts. When a page contains a `<script>` tag with a third-party origin in the `src` attribute, the browser prevents the script from loading.
 
@@ -304,6 +305,7 @@ Test and update an app's policy every release.
 
 ## Additional resources
 
+* [Apply a CSP in C# code at startup](xref:blazor/fundamentals/startup#control-headers-in-c-code)
 * [MDN web docs: Content-Security-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy)
 * [Content Security Policy Level 2](https://www.w3.org/TR/CSP2/)
 * [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)
@@ -318,7 +320,7 @@ Test and update an app's policy every release.
 * Actions taken by a page, specifying permitted URL targets of forms.
 * Plugins that can be loaded.
 
-To apply a CSP to an app, the developer specifies several CSP content security *directives* in one or more `Content-Security-Policy` headers or `<meta>` tags.
+To apply a CSP to an app, the developer specifies several CSP content security *directives* in one or more `Content-Security-Policy` headers or `<meta>` tags. For guidance on applying a CSP to an app in C# code at startup, see <xref:blazor/fundamentals/startup#control-headers-in-c-code>.
 
 Policies are evaluated by the browser while a page is loading. The browser inspects the page's sources and determines if they meet the requirements of the content security directives. When policy directives aren't met for a resource, the browser doesn't load the resource. For example, consider a policy that doesn't allow third-party scripts. When a page contains a `<script>` tag with a third-party origin in the `src` attribute, the browser prevents the script from loading.
 
@@ -458,6 +460,7 @@ Test and update an app's policy every release.
 
 ## Additional resources
 
+* [Apply a CSP in C# code at startup](xref:blazor/fundamentals/startup#control-headers-in-c-code)
 * [MDN web docs: Content-Security-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy)
 * [Content Security Policy Level 2](https://www.w3.org/TR/CSP2/)
 * [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)


### PR DESCRIPTION
Fixes  #24237

Thanks @christianAtSuddath :rocket: and @damienbod 🚀!

I think we'll go ahead with this and get it merged on Friday. I want to sleep on it 🛌💤 and make a few more updates on Friday morning.

@damienbod ... I'd ***very much*** like to just go with a ✨ **_'use middleware'_** ✨ bit of guidance 😄 for the Blazor Server/hosted WASM scenario. I don't want to get into the weeds on how far a dev might want to take that (a la what you cross-linked). It's really just middleware under-the-covers. I do have a remark here tho that they can create a class and use an extension method to call middleware and cross-link the appropriate doc in the main doc set. We can't link 3rd party for this. If the blog or the GH repo is something that you/Andrew want to surface, we recommend Awesome Blazor. We send devs there all the time ... in fact ... that reminds me ... I need to add that to my little saved GH reply on what we tell devs to use for community support. I'll add that now. **_Done!_** :+1: