### PR TITLE
Surface error for lack of sticky sessions

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -77,6 +77,11 @@ If a Blazor WebAssembly app that uses SignalR is configured to prerender on the 
 
 A Blazor Server app prerenders in response to the first client request, which creates UI state on the server. When the client attempts to create a SignalR connection, **the client must reconnect to the same server**. Blazor Server apps that use more than one backend server should implement *sticky sessions* for SignalR connections.
 
+> [!NOTE]
+> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm hosting scenario:
+>
+> > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
+
 ## Azure SignalR Service (Blazor Server)
 
 We recommend using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-service) for Blazor Server apps hosted in Microsoft Azure. The service works in conjunction with the app's Blazor Hub for scaling up a Blazor Server app to a large number of concurrent SignalR connections. In addition, the SignalR Service's global reach and high-performance data centers significantly aid in reducing latency due to geography.
@@ -387,6 +392,11 @@ If a Blazor WebAssembly app that uses SignalR is configured to prerender on the 
 
 A Blazor Server app prerenders in response to the first client request, which creates the UI state on the server. When the client attempts to create a SignalR connection, **the client must reconnect to the same server**. Blazor Server apps that use more than one backend server should implement *sticky sessions* for SignalR connections.
 
+> [!NOTE]
+> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm hosting scenario:
+>
+> > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
+
 ## Azure SignalR Service (Blazor Server)
 
 We recommend using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-service) for Blazor Server apps hosted in Microsoft Azure. The service works in conjunction with the app's Blazor Hub for scaling up a Blazor Server app to a large number of concurrent SignalR connections. In addition, the SignalR Service's global reach and high-performance data centers significantly aid in reducing latency due to geography.
@@ -693,6 +703,11 @@ For more information, see <xref:signalr/configuration#configure-additional-optio
 ## Use sticky sessions for webfarm hosting (Blazor Server)
 
 A Blazor Server app prerenders in response to the first client request, which creates the UI state on the server. When the client attempts to create a SignalR connection, **the client must reconnect to the same server**. Blazor Server apps that use more than one backend server should implement *sticky sessions* for SignalR connections. For more information, see <xref:blazor/host-and-deploy/server#configuration>.
+
+> [!NOTE]
+> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm hosting scenario:
+>
+> > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
 
 ## Azure SignalR Service (Blazor Server)
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -78,7 +78,7 @@ If a Blazor WebAssembly app that uses SignalR is configured to prerender on the 
 A Blazor Server app prerenders in response to the first client request, which creates UI state on the server. When the client attempts to create a SignalR connection, **the client must reconnect to the same server**. Blazor Server apps that use more than one backend server should implement *sticky sessions* for SignalR connections.
 
 > [!NOTE]
-> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm hosting scenario:
+> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm:
 >
 > > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
 
@@ -393,7 +393,7 @@ If a Blazor WebAssembly app that uses SignalR is configured to prerender on the 
 A Blazor Server app prerenders in response to the first client request, which creates the UI state on the server. When the client attempts to create a SignalR connection, **the client must reconnect to the same server**. Blazor Server apps that use more than one backend server should implement *sticky sessions* for SignalR connections.
 
 > [!NOTE]
-> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm hosting scenario:
+> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm:
 >
 > > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
 
@@ -705,7 +705,7 @@ For more information, see <xref:signalr/configuration#configure-additional-optio
 A Blazor Server app prerenders in response to the first client request, which creates the UI state on the server. When the client attempts to create a SignalR connection, **the client must reconnect to the same server**. Blazor Server apps that use more than one backend server should implement *sticky sessions* for SignalR connections. For more information, see <xref:blazor/host-and-deploy/server#configuration>.
 
 > [!NOTE]
-> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm hosting scenario:
+> The following error is thrown by an app that hasn't enabled sticky sessions in a webfarm:
 >
 > > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -83,6 +83,11 @@ To configure an app for the Azure SignalR Service, the app must support *sticky 
 
   * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__StickyServerMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
 
+> [!NOTE]
+> The following error is thrown by an app that hasn't enabled sticky sessions for Azure SignalR Service:
+>
+> > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
+
 ### Provision the Azure SignalR Service
 
 To provision the Azure SignalR Service for an app in Visual Studio:
@@ -278,6 +283,11 @@ To configure an app for the Azure SignalR Service, the app must support *sticky 
     ```
 
   * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__StickyServerMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
+
+> [!NOTE]
+> The following error is thrown by an app that hasn't enabled sticky sessions for Azure SignalR Service:
+>
+> > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
 
 ### Provision the Azure SignalR Service
 
@@ -499,6 +509,11 @@ To configure an app for the Azure SignalR Service, the app must support *sticky 
     ```
 
   * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__StickyServerMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
+
+> [!NOTE]
+> The following error is thrown by an app that hasn't enabled sticky sessions for Azure SignalR Service:
+>
+> > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
 
 ### Provision the Azure SignalR Service
 

--- a/aspnetcore/fundamentals/servers/kestrel/diagnostics.md
+++ b/aspnetcore/fundamentals/servers/kestrel/diagnostics.md
@@ -3,7 +3,7 @@ title: Logging and diagnostics in Kestrel
 author: shirhatti
 description: Learn how to gather diagnostics from Kestrel.
 monikerRange: '>= aspnetcore-6.0'
-ms.author: soshir
+ms.author: riande
 ms.date: 07/01/2021
 uid: fundamentals/servers/kestrel/diagnostics
 ---


### PR DESCRIPTION
Fixes #21939

cc: @Rick-Anderson ... For the Kestrel diagnostics doc (`fundamentals/servers/kestrel/diagnostics.md`), a build suggestion popped up ...

> Invalid value for 'ms.author', 'soshir' is not a valid Microsoft alias.

I change it here to `riande`.