### PR TITLE
Update Program.cs example for minimal-apis documentation

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/samples/todo/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/samples/todo/Program.cs
@@ -44,8 +44,8 @@ app.MapGet("/api/todoitems/{id}", async (int id, TodoDb db) =>
          is Todo todo
          ? Results.Ok(todo) 
          : Results.NotFound())
-   .Produces<Todo>(200)
-   .Produces(404);
+   .Produces<Todo>(StatusCodes.Status200OK)
+   .Produces(StatusCodes.Status404NotFound);
 #endregion
 
 app.MapGet("/api/todoitems", async (TodoDb db) =>


### PR DESCRIPTION
Utilize Microsoft.AspNetCore.Http.StatusCodes instead of integers for Produces() method of a endpoint mapping to utilize available convention within the AspNetCore framework.

Fixes #24360 
