### PR TITLE
GH repoman rules: Persist Component State TH doc

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -53,6 +53,14 @@ issues:
             - labels-add: ["Blazor"]
             - projects-add: [35]
             - labels-remove: [":watch: Not Triaged"]
+        - check:
+            - type: metadata-comment
+              name: content source
+              value: "(?i).*main\/aspnetcore\/mvc\/views\/tag-helpers\/built-in\/persist-component-state.md"
+          pass:
+            - labels-add: ["Blazor"]
+            - projects-add: [35]
+            - labels-remove: [":watch: Not Triaged"]
         
         # If the word appears anywhere in the file name path, add the label
         - check:


### PR DESCRIPTION
There's a new TH doc (Persist Component State TH) that can auto-map to me for ...

https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/mvc/views/tag-helpers/built-in/persist-component-state.md