### PR TITLE
Fix setx examples

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -212,13 +212,13 @@ Environment variable names reflect the structure of an *appsettings.json* file. 
 **environment variables**
 
 ```console
-setx SmtpServer=smtp.example.com
-setx Logging__0__Name=ToEmail
-setx Logging__0__Level=Critical
-setx Logging__0__Args__FromAddress=MySystem@example.com
-setx Logging__0__Args__ToAddress=SRE@example.com
-setx Logging__1__Name=ToConsole
-setx Logging__1__Level=Information
+setx SmtpServer smtp.example.com
+setx Logging__0__Name ToEmail
+setx Logging__0__Level Critical
+setx Logging__0__Args__FromAddress MySystem@example.com
+setx Logging__0__Args__ToAddress SRE@example.com
+setx Logging__1__Name ToConsole
+setx Logging__1__Level Information
 ```
 
 ### Environment variables set in generated launchSettings.json
@@ -1061,13 +1061,13 @@ Environment variable names reflect the structure of an *appsettings.json* file. 
 **environment variables**
 
 ```console
-setx SmtpServer=smtp.example.com
-setx Logging__0__Name=ToEmail
-setx Logging__0__Level=Critical
-setx Logging__0__Args__FromAddress=MySystem@example.com
-setx Logging__0__Args__ToAddress=SRE@example.com
-setx Logging__1__Name=ToConsole
-setx Logging__1__Level=Information
+setx SmtpServer smtp.example.com
+setx Logging__0__Name ToEmail
+setx Logging__0__Level Critical
+setx Logging__0__Args__FromAddress MySystem@example.com
+setx Logging__0__Args__ToAddress SRE@example.com
+setx Logging__1__Name ToConsole
+setx Logging__1__Level Information
 ```
 
 ### Environment variables set in generated launchSettings.json


### PR DESCRIPTION
setx command does not use equal operator for assignment. Attempting this will result in an error. Instead you simply use a space.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->