### PR TITLE
Update dotnet-aspnet-codegenerator version to 6.0.1

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -346,7 +346,7 @@ Run the following commands from the project folder, that is, the `TodoApi` folde
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design --prerelease
 dotnet add package Microsoft.EntityFrameworkCore.Design --prerelease
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer --prerelease
-dotnet tool install -g dotnet-aspnet-codegenerator --version 6.0.0-preview.7.21413.1
+dotnet tool install -g dotnet-aspnet-codegenerator --version 6.0.1
 dotnet aspnet-codegenerator controller -name TodoItemsController -async -api -m TodoItem -dc TodoContext -outDir Controllers
 ```
 


### PR DESCRIPTION
Update dotnet-aspnet-codegenerator version to stable 6.0.1

Fixes #24418 

dotnet-aspnet-codegenerator --version 6.0.0-preview.7.21413.1 causes issue when scaffolding. Using Latest stable version of dotnet-aspnet-codegenerator will fix the issue.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->