### PR TITLE
Fixes #24452 Minimal API webroot change sample

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/samples/WebMinAPIs/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/samples/WebMinAPIs/Program.cs
@@ -27,14 +27,14 @@ app.Run();
 #endregion
 #elif CHNGR
 #region snippet_chngr
-var builder = WebApplication.CreateBuilder(args);
-
-// Look for static files in webroot.
-builder.WebHost.UseWebRoot("webroot");
+var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+{
+    Args = args,
+    // Look for static files in webroot
+    WebRootPath = "webroot"
+});
 
 var app = builder.Build();
-
-app.MapGet("/", () => "Hello World!");
 
 app.Run();
 #endregion


### PR DESCRIPTION
Current code fails building because of breaking change in .NET 6. This changes the code sample to a correct .NET 6 variant. See #24452



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->