### PR TITLE
Add automatic 400 response logging code samples

### DIFF
--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -173,33 +173,7 @@ By default, [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet
 
 Here is an example of code to be used in `Startup.ConfigureServices` that adds logging and preserves the original behavior:
 
-```csharp
-services.AddControllers().ConfigureApiBehaviorOptions(options =>
-{
-    // If preserving of the original behavior is desired, get a reference to the delegate.
-    var builtInFactory = options.InvalidModelStateResponseFactory;
-
-    options.InvalidModelStateResponseFactory = context =>
-    {
-        // As an example, we will get an instance of ILogger with the category "Startup".
-        var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Startup>>();
-
-        // Log accordingly.
-
-        // By using the original delegate, we preserve the default behavior.
-        // Alternatively, you can take full control and simply construct the ValidationProblemDetails object yourself,
-        // or even use a custom object.
-        var result = builtInFactory(context);
-
-        // If accessing the returned ValidationProblemDetails object is required, get a reference to it.
-        var problemDetails = (ValidationProblemDetails)((ObjectResult)result).Value;
-
-        // Modify & Log accordingly.
-
-        return result;
-    };
-});
-```
+[!code-csharp[](index/samples/3.x/Startup.cs?name=snippet_AutomaticBadRequestLogging)]
 
 ### Disable automatic 400 response
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -167,7 +167,11 @@ To make automatic and custom responses consistent, call the <xref:Microsoft.AspN
 
 ### Log automatic 400 responses
 
-You can add logging by utilizing [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory). By default, [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory) uses [ProblemDetailsFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.infrastructure.problemdetailsfactory) to construct an instance of [ValidationProblemDetails](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.validationproblemdetails). Here is an example of code to be used in `Startup.ConfigureServices` that adds logging and preserves the original behavior:
+You can add logging by utilizing [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory).
+
+By default, [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory) uses [ProblemDetailsFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.infrastructure.problemdetailsfactory) to construct an instance of [ValidationProblemDetails](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.validationproblemdetails).
+
+Here is an example of code to be used in `Startup.ConfigureServices` that adds logging and preserves the original behavior:
 
 ```csharp
 services.AddControllers().ConfigureApiBehaviorOptions(options =>
@@ -510,7 +514,9 @@ To make automatic and custom responses consistent, call the <xref:Microsoft.AspN
 
 ### Log automatic 400 responses
 
-You can add logging by utilizing [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory). Here is an example of code to be used in `Startup.ConfigureServices` that adds logging on top of **any** already existing functionality that generates the response:
+You can add logging by utilizing [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory).
+
+Here is an example of code to be used in `Startup.ConfigureServices` that adds logging on top of **any** already existing functionality that generates the response:
 
 ```csharp
 services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -167,11 +167,9 @@ To make automatic and custom responses consistent, call the <xref:Microsoft.AspN
 
 ### Log automatic 400 responses
 
-You can add logging by utilizing [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory).
+To log automatic 400 responses, set the <xref:Microsoft.AspNetCore.Mvc.ApiBehaviorOptions.InvalidModelStateResponseFactory%2A> delegate property to perform custom processing in `Startup.ConfigureServices`. By default, `InvalidModelStateResponseFactory` uses <xref:Microsoft.AspNetCore.Mvc.Infrastructure.ProblemDetailsFactory> to create an instance of <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails>.
 
-By default, [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory) uses [ProblemDetailsFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.infrastructure.problemdetailsfactory) to construct an instance of [ValidationProblemDetails](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.validationproblemdetails).
-
-Here is an example of code to be used in `Startup.ConfigureServices` that adds logging and preserves the original behavior:
+The following example shows how to retrieve an instance of <xref:Microsoft.Extensions.Logging.ILogger%601> to log information about an automatic 400 response:
 
 [!code-csharp[](index/samples/3.x/Startup.cs?name=snippet_AutomaticBadRequestLogging)]
 

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -181,8 +181,8 @@ services.AddControllers().ConfigureApiBehaviorOptions(options =>
 
     options.InvalidModelStateResponseFactory = context =>
     {
-        // As an example, we will create a logger with the full name of the action method as the category.
-        var logger = GetLoggerInstance(context.HttpContext.RequestServices, context.ActionDescriptor.DisplayName);
+        // As an example, we will get an instance of ILogger with the category "Startup".
+        var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Startup>>();
 
         // Log accordingly.
 
@@ -191,41 +191,12 @@ services.AddControllers().ConfigureApiBehaviorOptions(options =>
         // or even use a custom object.
         var result = builtInFactory(context);
 
-        // Example of manually constructing a ValidationProblemDetails object:
-        // var problemDetails = new ValidationProblemDetails(context.ModelState)
-        //    {
-        //        Type = "https://tools.ietf.org/html/rfc7231#section-6.5.1",
-        //        Title = "One or more model validation errors occurred.",
-        //        Status = StatusCodes.Status400BadRequest,
-        //        Detail = "See the errors property for details.",
-        //        Instance = context.HttpContext.Request.Path,
-        //        Extensions =
-        //        {
-        //            ["traceId"] = Activity.Current?.Id ?? context.HttpContext?.TraceIdentifier
-        //        }
-        //    };
-
         // If accessing the returned ValidationProblemDetails object is required, get a reference to it.
         var problemDetails = (ValidationProblemDetails)((ObjectResult)result).Value;
 
         // Modify & Log accordingly.
 
         return result;
-
-        static ILogger GetLoggerInstance(IServiceProvider provider, string? category)
-        {
-            if (category is null)
-            {
-                // Get an instance of ILogger with the category "Startup".
-                return provider.GetRequiredService<ILogger<Startup>>();
-            }
-            else
-            {
-                // Alternatively, get an instance of ILoggerFactory and create a logger with a custom category.
-                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                return loggerFactory.CreateLogger(category);
-            }
-        }
     };
 });
 ```
@@ -514,45 +485,7 @@ To make automatic and custom responses consistent, call the <xref:Microsoft.AspN
 
 ### Log automatic 400 responses
 
-You can add logging by utilizing [InvalidModelStateResponseFactory](https://docs.microsoft.com/dotnet/api/microsoft.aspnetcore.mvc.apibehavioroptions.invalidmodelstateresponsefactory).
-
-Here is an example of code to be used in `Startup.ConfigureServices` that adds logging on top of **any** already existing functionality that generates the response:
-
-```csharp
-services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);
-
-services.PostConfigure<ApiBehaviorOptions>(options =>
-{
-    // If preserving of the existing functionality is desired, get a reference to the delegate.
-    var builtInFactory = options.InvalidModelStateResponseFactory;
-
-    options.InvalidModelStateResponseFactory = context =>
-    {
-        // As an example, we will create a logger with the full name of the action method as the category.
-        var logger = GetLoggerInstance(context.HttpContext.RequestServices, context.ActionDescriptor.DisplayName);
-
-        // Log accordingly.
-
-        // Use existing functionality - either one defined by us, or in this case the framework's.
-        return builtInFactory(context);
-
-        ILogger GetLoggerInstance(IServiceProvider provider, string category)
-        {
-            if (category is null)
-            {
-                // Get an instance of ILogger with the category "Startup".
-                return provider.GetRequiredService<ILogger<Startup>>();
-            }
-            else
-            {
-                // Alternatively, get an instance of ILoggerFactory and create a logger with a custom category.
-                var loggerFactory = provider.GetRequiredService<ILoggerFactory>();
-                return loggerFactory.CreateLogger(category);
-            }
-        }
-    };
-});
-```
+See [How to log automatic 400 responses on model validation errors (dotnet/AspNetCore.Docs#12157)](https://github.com/dotnet/AspNetCore.Docs/issues/12157).
 
 ### Disable automatic 400 response
 

--- a/aspnetcore/web-api/index/samples/3.x/Startup.cs
+++ b/aspnetcore/web-api/index/samples/3.x/Startup.cs
@@ -48,27 +48,19 @@ namespace WebApiSample
             services.AddControllers()
                 .ConfigureApiBehaviorOptions(options =>
                 {
-                    // If preserving of the original behavior is desired, get a reference to the delegate.
+                    // To preserve the default behavior, capture the original delegate to call later.
                     var builtInFactory = options.InvalidModelStateResponseFactory;
 
                     options.InvalidModelStateResponseFactory = context =>
                     {
-                        // As an example, we will get an instance of ILogger with the category "Startup".
                         var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<Startup>>();
 
-                        // Log accordingly.
+                        // Perform logging here.
+                        // ...
 
-                        // By using the original delegate, we preserve the default behavior.
-                        // Alternatively, you can take full control and simply construct the ValidationProblemDetails object yourself,
-                        // or even use a custom object.
-                        var result = builtInFactory(context);
-
-                        // If accessing the returned ValidationProblemDetails object is required, get a reference to it.
-                        var problemDetails = (ValidationProblemDetails)((ObjectResult)result).Value;
-
-                        // Modify & Log accordingly.
-
-                        return result;
+                        // Invoke the default behavior, which produces a ValidationProblemDetails response.
+                        // To produce a custom response, return a different implementation of IActionResult instead.
+                        return builtInFactory(context);
                     };
                 });
             #endregion


### PR DESCRIPTION
Add automatic 400 response logging code samples, instead of pointing the end-user to our issue tracking website, as proposed in https://github.com/dotnet/AspNetCore.Docs/issues/12157

[Internal Preview URL](https://review.docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-6.0&branch=pr-en-us-24463).

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->