### PR TITLE
Mono/WASM MSBuild property guidance

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/configure-linker.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-linker.md
@@ -74,7 +74,7 @@ Control linking on a per-assembly basis by providing an XML configuration file a
 </linker>
 ```
 
-For more information and examples, see [Data Formats (mono/linker GitHub repository)](https://github.com/mono/linker/blob/main/docs/data-formats.md).
+For more information and examples, see [Data Formats (dotnet/linker GitHub repository)](https://github.com/dotnet/linker/blob/main/docs/data-formats.md).
 
 ## Add an XML linker configuration file to a library
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -49,13 +49,16 @@ WebAssembly AOT compilation is only performed when the project is published. AOT
 
 The size of an AOT-compiled Blazor WebAssembly app is generally larger than the size of the app if compiled into .NET IL. Although the size difference depends on the app, most AOT-compiled apps are about twice the size of their IL-compiled versions. This means that using AOT compilation trades off load time performance for runtime performance. Whether this tradeoff is worth using AOT compilation depends on your app. Blazor WebAssembly apps that are CPU intensive generally benefit the most from AOT compilation.
 
+> [!NOTE]
+> For [Mono](https://github.com/mono/mono)/WebAssembly MSBuild properties and targets, see [`WasmApp.targets` (dotnet/runtime GitHub repository)](https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.targets). Official documentation for common MSBuild properties is planned per [Document blazor msbuild configuration options (dotnet/docs #27395)](https://github.com/dotnet/docs/issues/27395).
+
 ## Runtime relinking
 
 One of the largest parts of a Blazor WebAssembly app is the WebAssembly-based .NET runtime (`dotnet.wasm`) that the browser must download when the app is first accessed by a user's browser. Relinking the .NET WebAssembly runtime trims unused runtime code and thus improves download speed.
 
 Runtime relinking requires installation of the .NET WebAssembly build tools. For more information, see <xref:blazor/tooling#net-webassembly-build-tools>.
 
-With the .NET WebAssembly build tools installed, runtime relinking is performed automatically when an app is published. The size reduction is particularly dramatic when disabling globalization. For more information, see <xref:blazor/globalization-localization#invariant-globalization>.
+With the .NET WebAssembly build tools installed, runtime relinking is performed automatically when an app is **published** in the `Release` configuration. The size reduction is particularly dramatic when disabling globalization. For more information, see <xref:blazor/globalization-localization#invariant-globalization>.
 
 ## Customize how boot resources are loaded
 

--- a/aspnetcore/blazor/index.md
+++ b/aspnetcore/blazor/index.md
@@ -157,6 +157,7 @@ APIs that aren't applicable inside of a web browser (for example, accessing the 
 * <xref:tutorials/signalr-blazor>
 * <xref:blazor/js-interop/call-javascript-from-dotnet>
 * <xref:blazor/js-interop/call-dotnet-from-javascript>
+* [mono/mono GitHub repository](https://github.com/mono/mono)
 * [C# Guide](/dotnet/csharp/)
 * <xref:mvc/views/razor>
 * [HTML](https://www.w3.org/html/)

--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -41,7 +41,7 @@ Minimally, specify the following directives and sources for Blazor apps. Add add
   * Specify `self` to indicate that the app's origin, including the scheme and port number, is a valid source.
   * In a Blazor WebAssembly app:
     * Specify hashes to permit required scripts to load.
-    * Specify `unsafe-eval` to permit the Blazor WebAssembly mono runtime to function.
+    * Specify `unsafe-eval` to permit the Blazor WebAssembly Mono runtime to function.
   * In a Blazor Server app, specify hashes to permit required scripts to load.
 * [style-src](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src): Indicates valid sources for stylesheets.
   * Specify the `https://stackpath.bootstrapcdn.com/` host source for Bootstrap stylesheets.

--- a/aspnetcore/blazor/webassembly-native-dependencies.md
+++ b/aspnetcore/blazor/webassembly-native-dependencies.md
@@ -33,6 +33,9 @@ Generally, any portable native code can be used as a native dependency with Blaz
 
 Prebuilt dependencies typically must be built using the same version of Emscripten used to build the .NET WebAssembly runtime.
 
+> [!NOTE]
+> For [Mono](https://github.com/mono/mono)/WebAssembly MSBuild properties and targets, see [`WasmApp.targets` (dotnet/runtime GitHub repository)](https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.targets). Official documentation for common MSBuild properties is planned per [Document blazor msbuild configuration options (dotnet/docs #27395)](https://github.com/dotnet/docs/issues/27395).
+
 ## Use native code
 
 Add a simple native C function to a Blazor WebAssembly app:


### PR DESCRIPTION
Fixes #24443

@markarnolditpro ...

* It seems that runtime relinking is a **_publish-in-Release config_** gesture based on the size of compiled output in testing here. I've made a note on a tracking issue to confirm this with the PU ("product unit") later when they're all back from vacation. For now, I feel good enough about it to clarify it in the doc.
* This will cross-link the MSBuild properties and targets file *temporarily* until we get .NET Core doc set article updates. Also, it calls out the open issue to provide that coverage in order to ward off additional requests here. I think you're the third person to ask.
* I don't think we need to say anything specific at this time about `WasmBuildNative`. If you were to get that error regularly and could describe exact repro steps, it would be a good issue for the PU. As it stands, I'm sure it will get reported *by someone* if it's a regular occurrence.
* I found a few other NITs to touch-up along the way here.
* Thanks for your issue, @markarnolditpro! :rocket: ... and Happy New Year! 🥳