### PR TITLE
Additional Blazor files and folders

### DIFF
--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -51,6 +51,8 @@ The Blazor WebAssembly template creates the initial files and directory structur
   * The `App` component is the root component of the app. The `App` component is specified as the `div` DOM element with an `id` of `app` (`<div id="app">Loading...</div>` in `wwwroot/index.html`) to the root component collection (`builder.RootComponents.Add<App>("#app")`).
   * [Services](xref:blazor/fundamentals/dependency-injection) are added and configured (for example, `builder.Services.AddSingleton<IMyDependency, MyDependency>()`).
 
+Additional files and folders may appear in an app produced from a Blazor WebAssembly project template when additional options are configured. For example, generating an app with ASP.NET Core Identity includes additional assets for authentication and authorization features.
+
 ## Blazor Server
 
 Blazor Server project template: `blazorserver`
@@ -95,6 +97,8 @@ The Blazor Server template creates the initial files and directory structure for
   * Configures the app's request handling pipeline:
     * <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> is called to set up an endpoint for the real-time connection with the browser. The connection is created with [SignalR](xref:signalr/introduction), which is a framework for adding real-time web functionality to apps.
     * [`MapFallbackToPage("/_Host")`](xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A) is called to set up the root page of the app (`Pages/_Host.cshtml`) and enable navigation.
+
+Additional files and folders may appear in an app produced from a Blazor Server project template when additional options are configured. For example, generating an app with ASP.NET Core Identity includes additional assets for authentication and authorization features.
 
 ## Additional resources
 


### PR DESCRIPTION
Fixes #24426

Thanks for the issue, @AxelSamyn ... Let's do it this way, where we just say additional files and folders may appear from a project template based on the options selected. Let's merely use Identity as an example. The main purpose of the article's guidance is to call out the most important files and folders. It will be difficult to maintain a list of **_all_** files and folders given the churn.