### PR TITLE
Razor tutorial update for additional .NET 6.0 VS for Mac EF changes - 23414

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -238,6 +238,7 @@ In this section, the **Package Manager Console** (PMC) window is used to:
 * Run the following .NET CLI commands:
 
   ```dotnetcli
+  dotnet tool install --global dotnet-ef
   dotnet ef migrations add InitialCreate
   dotnet ef database update
   ```
@@ -247,15 +248,17 @@ In this section, the **Package Manager Console** (PMC) window is used to:
 
 ---
 
-For SQL Server, the preceding commands generate the following warning:
+The preceding commands do the following:
 
- > No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.
+* Generate a warning for SQL Server. Ignore the following warning, as it will be addressed in a later step:
 
-Ignore the warning, as it will be addressed in a later step.
+  > No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.
 
-The `migrations` command generates code to create the initial database schema. The schema is based on the model specified in `DbContext`. The `InitialCreate` argument is used to name the migrations. Any name can be used, but by convention a name is selected that describes the migration.
+* Install `dotnet ef` as a global tool.  For more information on the Entity Framework Core Tools, see [Get the Entity Framework Core tools](https://docs.microsoft.com/ef/core/get-started/overview/install#get-the-entity-framework-core-tools)
 
-The `update` command runs the `Up` method in migrations that have not been applied. In this case, `update` runs the `Up` method in the *Migrations/\<time-stamp>_InitialCreate.cs* file, which creates the database.
+* The `migrations` command generates code to create the initial database schema. The schema is based on the model specified in `DbContext`. The `InitialCreate` argument is used to name the migrations. Any name can be used, but by convention a name is selected that describes the migration.
+
+* The `update` command runs the `Up` method in migrations that have not been applied. In this case, `update` runs the `Up` method in the *Migrations/\<time-stamp>_InitialCreate.cs* file, which creates the database.
 
 ### Examine the context registered with dependency injection
 

--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -248,17 +248,17 @@ In this section, the **Package Manager Console** (PMC) window is used to:
 
 ---
 
-The preceding commands do the following:
+The preceding commands install [the Entity Framework Core tools](https://docs.microsoft.com/ef/core/get-started/overview/install#get-the-entity-framework-core-tools) and run the `migrations` command to generate code that creates the initial database schema.
 
-* Generate a warning for SQL Server. Ignore the following warning, as it will be addressed in a later step:
+You’ll see the following warning, which you will address in a later step:
 
-  > No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.
+> No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.
 
-* Install `dotnet ef` as a global tool.  For more information on the Entity Framework Core Tools, see [Get the Entity Framework Core tools](https://docs.microsoft.com/ef/core/get-started/overview/install#get-the-entity-framework-core-tools)
+The database schema is based on the model specified in `DbContext`. The `InitialCreate` argument is used to name the migration. Any name can be used, but by convention a name is selected that describes the migration.
 
-* The `migrations` command generates code to create the initial database schema. The schema is based on the model specified in `DbContext`. The `InitialCreate` argument is used to name the migrations. Any name can be used, but by convention a name is selected that describes the migration.
+The `migrations` command generates code to create the initial database schema. The schema is based on the model specified in `DbContext`. The `InitialCreate` argument is used to name the migrations. Any name can be used, but by convention a name is selected that describes the migration.
 
-* The `update` command runs the `Up` method in migrations that have not been applied. In this case, `update` runs the `Up` method in the *Migrations/\<time-stamp>_InitialCreate.cs* file, which creates the database.
+The `update` command runs the `Up` method in migrations that have not been applied. In this case, `update` runs the `Up` method in the *Migrations/\<time-stamp>_InitialCreate.cs* file, which creates the database.
 
 ### Examine the context registered with dependency injection
 

--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -250,7 +250,7 @@ In this section, the **Package Manager Console** (PMC) window is used to:
 
 The preceding commands install [the Entity Framework Core tools](https://docs.microsoft.com/ef/core/get-started/overview/install#get-the-entity-framework-core-tools) and run the `migrations` command to generate code that creates the initial database schema.
 
-You’ll see the following warning, which you will address in a later step:
+The following warning is displayed, which is addressed in a later step:
 
 > No type was specified for the decimal column 'Price' on entity type 'Movie'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'HasColumnType()'.
 

--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -3,7 +3,7 @@ title: Part 2, add a model
 author: rick-anderson
 description: Part 2 of tutorial series on Razor Pages. In this section, model classes are added.
 ms.author: riande
-ms.date: 1/2/2022
+ms.date: 1/7/2022
 monikerRange: '>= aspnetcore-3.1'
 ms.custom: contperf-fy21q2
 no-loc: [Home, Privacy, Index, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]


### PR DESCRIPTION
[Internal review - link to edited section](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-6.0&branch=pr-en-us-24532&tabs=visual-studio-mac#create-the-initial-database-schema-using-efs-migration-feature)

Summary changes:
VS for Mac 2022 Preview for .NET 6.0 has recently changed so EF CLI Tools are not included, but rather need to be added. Updated the Model topic to reflect this.

Fixes #23414