### PR TITLE
Update Certificate Authentication to 6.0

### DIFF
--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -36,7 +36,7 @@ If authentication fails, this handler returns a `403 (Forbidden)` response rathe
 
 Also add `app.UseAuthentication();` in *Program.cs*. Otherwise, the `HttpContext.User` will not be set to `ClaimsPrincipal` created from the certificate. For example:
 
-:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateUseAuthentication":::
+:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateUseAuthentication" highlight="3-6,10":::
 
 The preceding example demonstrates the default way to add certificate authentication. The handler constructs a user principal using the common certificate properties.
 
@@ -99,7 +99,7 @@ If you find the inbound certificate doesn't meet your extra validation, call `co
 
 For real functionality, you'll probably want to call a service registered in dependency injection that connects to a database or other type of user store. Access your service by using the context passed into your delegate. Consider the following example:
 
-:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateOnCertificateValidatedService":::
+:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateOnCertificateValidatedService" highlight="9-10,12":::
 
 Conceptually, the validation of the certificate is an authorization concern. Adding a check on, for example, an issuer or thumbprint in an authorization policy, rather than inside `OnCertificateValidated`, is perfectly acceptable.
 
@@ -154,7 +154,7 @@ If the app is reverse proxied by NGINX with the configuration `proxy_set_header 
 
 Add the middleware in *Program.cs*. `UseCertificateForwarding` is called before the calls to `UseAuthentication` and `UseAuthorization`:
 
-:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_UseCertificateForwarding":::
+:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_UseCertificateForwarding" highlight="3":::
 
 A separate class can be used to implement validation logic. Because the same self-signed certificate is used in this example, ensure that only your certificate can be used. Validate that the thumbprints of both the client certificate and the server certificate match, otherwise any certificate can be used and will be enough to authenticate. This would be used inside the `AddCertificate` method. You could also validate the subject or the issuer here if you're using intermediate or child certificates.
 
@@ -286,7 +286,7 @@ ASP.NET Core 5.0 and later versions support the ability to enable caching of val
 
 By default, certificate authentication disables caching. To enable caching, call `AddCertificateCache` in *Program.cs*:
 
-:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="AddCertificateCaching":::
+:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateCaching":::
 
 The default caching implementation stores results in memory. You can provide your own cache by implementing `ICertificateValidationCache` and registering it with dependency injection. For example, `services.AddSingleton<ICertificateValidationCache, YourCache>()`.
 

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -36,7 +36,7 @@ If authentication fails, this handler returns a `403 (Forbidden)` response rathe
 
 Also add `app.UseAuthentication();` in *Program.cs*. Otherwise, the `HttpContext.User` will not be set to `ClaimsPrincipal` created from the certificate. For example:
 
-:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateUseAuthentication" highlight="3-6,10":::
+:::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateUseAuthentication" highlight="3-5,9":::
 
 The preceding example demonstrates the default way to add certificate authentication. The handler constructs a user principal using the common certificate properties.
 

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -29,12 +29,15 @@ An alternative to certificate authentication in environments where proxies and l
 
 Acquire an HTTPS certificate, apply it, and [configure your server](#configure-your-server-to-require-certificates) to require certificates.
 
-In your web app, add a reference to the [Microsoft.AspNetCore.Authentication.Certificate](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Certificate) package. Then in *Program.cs*, call
-`builder.Services.AddAuthentication(CertificateAuthenticationDefaults.AuthenticationScheme).AddCertificate(...);` with your options, providing a delegate for `OnCertificateValidated` to do any supplementary validation on the client certificate sent with requests. Turn that information into a `ClaimsPrincipal` and set it on the `context.Principal` property.
+In the web app:
+
+* Add a reference to the [Microsoft.AspNetCore.Authentication.Certificate](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Certificate) NuGet package.
+* In *Program.cs*, call
+`builder.Services.AddAuthentication(CertificateAuthenticationDefaults.AuthenticationScheme).AddCertificate(...);`. Provide a delegate for `OnCertificateValidated` to do any supplementary validation on the client certificate sent with requests. Turn that information into a `ClaimsPrincipal` and set it on the `context.Principal` property.
 
 If authentication fails, this handler returns a `403 (Forbidden)` response rather a `401 (Unauthorized)`, as you might expect. The reasoning is that the authentication should happen during the initial TLS connection. By the time it reaches the handler, it's too late. There's no way to upgrade the connection from an anonymous connection to one with a certificate.
 
-Also add `app.UseAuthentication();` in *Program.cs*. Otherwise, the `HttpContext.User` will not be set to `ClaimsPrincipal` created from the certificate. For example:
+`UseAuthentication` is required to set `HttpContext.User` to a `ClaimsPrincipal` created from the certificate. For example:
 
 :::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateUseAuthentication" highlight="3-5,9":::
 
@@ -97,7 +100,7 @@ The handler has two events:
 
 If you find the inbound certificate doesn't meet your extra validation, call `context.Fail("failure reason")` with a failure reason.
 
-For real functionality, you'll probably want to call a service registered in dependency injection that connects to a database or other type of user store. Access your service by using the context passed into your delegate. Consider the following example:
+For better functionality, call a service registered in dependency injection that connects to a database or other type of user store. Access the service by using the context passed into the delegate. Consider the following example:
 
 :::code language="csharp" source="certauth/samples/6.x/CertAuthSample/Snippets/Program.cs" id="snippet_AddCertificateOnCertificateValidatedService" highlight="9-10,12":::
 

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/CertAuthSample.csproj
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/CertAuthSample.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="6.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Program.cs
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Program.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.Certificate;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
+
+// <snippet_ConfigureKestrelServerOptions>
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<KestrelServerOptions>(options =>
+{
+    options.ConfigureHttpsDefaults(options =>
+        options.ClientCertificateMode = ClientCertificateMode.RequireCertificate);
+});
+// </snippet_ConfigureKestrelServerOptions>
+
+builder.Services.AddAuthentication(
+        CertificateAuthenticationDefaults.AuthenticationScheme)
+    .AddCertificate()
+    .AddCertificateCache();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+
+app.MapGet("/", (ClaimsPrincipal claimsPrincipal) =>
+    string.Join(
+        Environment.NewLine,
+        claimsPrincipal.Claims.Select(x => $"{x.Type}: {x.Value}")));
+
+app.Run();

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/ICertificateValidationService.cs
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/ICertificateValidationService.cs
@@ -1,0 +1,8 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace CertAuthSample.Snippets;
+
+public interface ICertificateValidationService
+{
+    bool ValidateCertificate(X509Certificate2 clientCertificate);
+}

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/Program.cs
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/Program.cs
@@ -1,0 +1,173 @@
+using System.Net;
+using System.Security.Claims;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Authentication.Certificate;
+
+namespace CertAuthSample.Snippets;
+
+public static class Program
+{
+    public static void AddCertificateUseAuthentication(string[] args)
+    {
+        // <snippet_AddCertificateUseAuthentication>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddAuthentication(
+                CertificateAuthenticationDefaults.AuthenticationScheme)
+            .AddCertificate()
+            .AddCertificateCache();
+
+        var app = builder.Build();
+
+        app.UseAuthentication();
+
+        app.MapGet("/", () => "Hello World!");
+
+        app.Run();
+        // </snippet_AddCertificateUseAuthentication>
+    }
+
+    public static void AddCertificateOnCertificateValidated(WebApplicationBuilder builder)
+    {
+        // <snippet_AddCertificateOnCertificateValidated>
+        builder.Services.AddAuthentication(
+                CertificateAuthenticationDefaults.AuthenticationScheme)
+            .AddCertificate(options =>
+            {
+                options.Events = new CertificateAuthenticationEvents
+                {
+                    OnCertificateValidated = context =>
+                    {
+                        var claims = new[]
+                        {
+                            new Claim(
+                                ClaimTypes.NameIdentifier,
+                                context.ClientCertificate.Subject,
+                                ClaimValueTypes.String, context.Options.ClaimsIssuer),
+                            new Claim(
+                                ClaimTypes.Name,
+                                context.ClientCertificate.Subject,
+                                ClaimValueTypes.String, context.Options.ClaimsIssuer)
+                        };
+
+                        context.Principal = new ClaimsPrincipal(
+                            new ClaimsIdentity(claims, context.Scheme.Name));
+                        context.Success();
+
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+        // </snippet_AddCertificateOnCertificateValidated>
+    }
+
+    public static void AddCertificateOnCertificateValidatedService(WebApplicationBuilder builder)
+    {
+        // <snippet_AddCertificateOnCertificateValidatedService>
+        builder.Services.AddAuthentication(
+                CertificateAuthenticationDefaults.AuthenticationScheme)
+            .AddCertificate(options =>
+            {
+                options.Events = new CertificateAuthenticationEvents
+                {
+                    OnCertificateValidated = context =>
+                    {
+                        var validationService = context.HttpContext.RequestServices
+                            .GetRequiredService<ICertificateValidationService>();
+
+                        if (validationService.ValidateCertificate(context.ClientCertificate))
+                        {
+                            var claims = new[]
+                            {
+                                new Claim(
+                                    ClaimTypes.NameIdentifier,
+                                    context.ClientCertificate.Subject,
+                                    ClaimValueTypes.String, context.Options.ClaimsIssuer),
+                                new Claim(
+                                    ClaimTypes.Name,
+                                    context.ClientCertificate.Subject,
+                                    ClaimValueTypes.String, context.Options.ClaimsIssuer)
+                            };
+
+                            context.Principal = new ClaimsPrincipal(
+                                new ClaimsIdentity(claims, context.Scheme.Name));
+                            context.Success();
+                        }
+
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+        // </snippet_AddCertificateOnCertificateValidatedService>
+    }
+
+    public static void AddCertificateForwarding(WebApplicationBuilder builder)
+    {
+        // <snippet_AddCertificateForwarding>
+        builder.Services.AddCertificateForwarding(options =>
+        {
+            options.CertificateHeader = "X-SSL-CERT";
+
+            options.HeaderConverter = headerValue =>
+            {
+                X509Certificate2? clientCertificate = null;
+
+                if (!string.IsNullOrWhiteSpace(headerValue))
+                {
+                    clientCertificate = new X509Certificate2(StringToByteArray(headerValue));
+                }
+
+                return clientCertificate!;
+
+                static byte[] StringToByteArray(string hex)
+                {
+                    var numberChars = hex.Length;
+                    var bytes = new byte[numberChars / 2];
+
+                    for (int i = 0; i < numberChars; i += 2)
+                    {
+                        bytes[i / 2] = Convert.ToByte(hex.Substring(i, 2), 16);
+                    }
+
+                    return bytes;
+                }
+            };
+        });
+        // </snippet_AddCertificateForwarding>
+    }
+
+    public static void AddCertificateForwardingUrlEncoded(WebApplicationBuilder builder)
+    {
+        // <snippet_AddCertificateForwardingUrlEncoded>
+        builder.Services.AddCertificateForwarding(options =>
+        {
+            options.CertificateHeader = "ssl-client-cert";
+
+            options.HeaderConverter = (headerValue) =>
+            {
+                X509Certificate2? clientCertificate = null;
+
+                if (!string.IsNullOrWhiteSpace(headerValue))
+                {
+                    clientCertificate = X509Certificate2.CreateFromPem(
+                        WebUtility.UrlDecode(headerValue));
+                }
+
+                return clientCertificate!;
+            };
+        });
+        // </snippet_AddCertificateForwardingUrlEncoded>
+    }
+
+    public static void UseCertificateForwarding(WebApplicationBuilder builder)
+    {
+        // <snippet_UseCertificateForwarding>
+        var app = builder.Build();
+
+        app.UseCertificateForwarding();
+
+        app.UseAuthentication();
+        app.UseAuthorization();
+        // </snippet_UseCertificateForwarding>
+    }
+}

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/Program.cs
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/Program.cs
@@ -14,8 +14,7 @@ public static class Program
 
         builder.Services.AddAuthentication(
                 CertificateAuthenticationDefaults.AuthenticationScheme)
-            .AddCertificate()
-            .AddCertificateCache();
+            .AddCertificate();
 
         var app = builder.Build();
 
@@ -169,5 +168,32 @@ public static class Program
         app.UseAuthentication();
         app.UseAuthorization();
         // </snippet_UseCertificateForwarding>
+    }
+
+    public static void AddHttplient(WebApplicationBuilder builder)
+    {
+        // <snippet_AddHttpClient>
+        var clientCertificateHandler = new HttpClientHandler();
+
+        clientCertificateHandler.ClientCertificates.Add(
+            new X509Certificate2(Path.Combine("/path/to/pfx"), "1234"));
+
+        builder.Services.AddHttpClient("namedClient")
+            .ConfigurePrimaryHttpMessageHandler(() => clientCertificateHandler);
+        // </snippet_AddHttpClient>
+    }
+
+    public static void AddCertificateCaching(WebApplicationBuilder builder)
+    {
+        // <snippet_AddCertificateCaching>
+        builder.Services.AddAuthentication(
+                CertificateAuthenticationDefaults.AuthenticationScheme)
+            .AddCertificate()
+            .AddCertificateCache(options =>
+            {
+                options.CacheSize = 1024;
+                options.CacheEntryExpiration = TimeSpan.FromMinutes(2);
+            });
+        // </snippet_AddCertificateCaching>
     }
 }

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/SampleCertificateThumbprintsValidationService.cs
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/SampleCertificateThumbprintsValidationService.cs
@@ -1,0 +1,16 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace CertAuthSample.Snippets;
+
+public class SampleCertificateThumbprintsValidationService : ICertificateValidationService
+{
+    private readonly string[] validThumbprints = new[]
+    {
+        "141594A0AE38CBBECED7AF680F7945CD51D8F28A",
+        "0C89639E4E2998A93E423F919B36D4009A0F9991",
+        "BA9BF91ED35538A01375EFC212A2F46104B33A44"
+    };
+
+    public bool ValidateCertificate(X509Certificate2 clientCertificate)
+        => validThumbprints.Contains(clientCertificate.Thumbprint);
+}

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/SampleCertificateValidationService.cs
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/SampleCertificateValidationService.cs
@@ -1,0 +1,16 @@
+using System.Security.Cryptography.X509Certificates;
+
+namespace CertAuthSample.Snippets;
+
+public class SampleCertificateValidationService : ICertificateValidationService
+{
+    public bool ValidateCertificate(X509Certificate2 clientCertificate)
+    {
+        // Don't hardcode passwords in production code.
+        // Use a certificate thumbprint or Azure Key Vault.
+        var expectedCertificate = new X509Certificate2(
+            Path.Combine("/path/to/pfx"), "1234");
+
+        return clientCertificate.Thumbprint == expectedCertificate.Thumbprint;
+    }
+}

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/SampleHttpService.cs
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/Snippets/SampleHttpService.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+
+namespace CertAuthSample.Snippets;
+
+// <snippet_Class>
+public class SampleHttpService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public SampleHttpService(IHttpClientFactory httpClientFactory)
+        => _httpClientFactory = httpClientFactory;
+
+    public async Task<JsonDocument> GetAsync()
+    {
+        var httpClient = _httpClientFactory.CreateClient("namedClient");
+        var httpResponseMessage = await httpClient.GetAsync("https://example.com");
+
+        if (httpResponseMessage.IsSuccessStatusCode)
+        {
+            return JsonDocument.Parse(
+                await httpResponseMessage.Content.ReadAsStringAsync());
+        }
+
+        throw new ApplicationException($"Status code: {httpResponseMessage.StatusCode}");
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/appsettings.Development.json
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/appsettings.json
+++ b/aspnetcore/security/authentication/certauth/samples/6.x/CertAuthSample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes #23229.

[Internal Preview URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/authentication/certauth?view=aspnetcore-6.0&branch=pr-en-us-24550).

I've created a 6.0 sample project and moved all inline code into there. I've left the content alone as much as I can, changing only references to `Startup` and updating the code for 6.0. I've also dropped the first section that discusses using `HttpClient` directly, as I think the section that follows covers the same details without having to worry about the lifetime of `HttpClient` et al.