### PR TITLE
Blazor file download updates

### DIFF
--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -106,7 +106,7 @@ function triggerFileDownload(fileName, url) {
 }
 ```
 
-The call to `contentStreamReference.arrayBuffer` loads the entire file into client memory. For file downloads over 250 MB, we recommend downloading the file from a URL instead:
+In the preceding example, the call to `contentStreamReference.arrayBuffer` loads the entire file into client memory. For file downloads over 250 MB, we recommend downloading the file from a URL instead:
 
 ```razor
 <button @onclick="DownloadFileFromURL">

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -84,7 +84,7 @@ The `fileName` and object `url` are passed to `triggerFileDownload`, which perfo
 * Trigger the download via `click`.
 * Remove the anchor (`<a>`) element.
 
-At this point, the file download is triggered, and it's generally safe to revoke the temporary object URL by calling [`revokeObjectURL`](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) on the URL. **This is an important step to ensure memory isn't leaked on the client.**
+At this point, the file download is triggered and then the temporary object URL is revoked by calling [`revokeObjectURL`](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) on the URL. **This is an important step to ensure memory isn't leaked on the client.**
 
 ```javascript
 async function downloadFileFromStream(fileName, contentStreamReference) {
@@ -106,7 +106,7 @@ function triggerFileDownload(fileName, url) {
 }
 ```
 
-`ArrayBuffer` effectively loads the entire file into client memory. For file downloads over 1 GB, we recommend opening a new tab for each large file download by setting the anchor's [`target`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-target) to `_blank` and [`referrerpolicy`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-referrerpolicy) to `no-referrer`:
+`contentStreamReference.arrayBuffer()` loads the entire file into client memory. For file downloads over 250 MB, we recommend opening a new tab for each large file download by setting the anchor's [`target`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-target) to `_blank` and [`referrerpolicy`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-referrerpolicy) to `no-referrer`:
 
 ```javascript
 anchorElement.target = '_blank';

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -106,12 +106,7 @@ function triggerFileDownload(fileName, url) {
 }
 ```
 
-`contentStreamReference.arrayBuffer()` loads the entire file into client memory. For file downloads over 250 MB, we recommend opening a new tab for each large file download by setting the anchor's [`target`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-target) to `_blank` and [`referrerpolicy`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-referrerpolicy) to `no-referrer`:
-
-```javascript
-anchorElement.target = '_blank';
-anchorElement.referrerpolicy = 'no-referrer';
-```
+`contentStreamReference.arrayBuffer()` loads the entire file into client memory. For file downloads over 250 MB, we recommend downloading the file from a URL instead:
 
 For more information on setting the anchor's Referrer Policy, see the following MDN documentation resources:
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -106,12 +106,27 @@ function triggerFileDownload(fileName, url) {
 }
 ```
 
-`contentStreamReference.arrayBuffer()` loads the entire file into client memory. For file downloads over 250 MB, we recommend downloading the file from a URL instead:
+The call to `contentStreamReference.arrayBuffer` loads the entire file into client memory. For file downloads over 250 MB, we recommend downloading the file from a URL instead:
 
-For more information on setting the anchor's Referrer Policy, see the following MDN documentation resources:
+```razor
+<button @onclick="DownloadFileFromURL">
+    Download File From URL
+</button>
 
-* [`referrerpolicy`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-referrerpolicy)
-* [`<a>`: The Anchor element: Security and privacy](https://developer.mozilla.org/docs/Web/HTML/Element/a#security_and_privacy)
+@code {
+    private async Task DownloadFileFromURL()
+    {
+        var fileURL = "{FILE URL}";
+        var fileName = "{FILE NAME}";
+        await JS.InvokeVoidAsync("triggerFileDownload", fileName, fileURL);
+    }
+}
+```
+
+In the preceding example, replace the placeholders with the following values:
+
+* `{FILE URL}`: The URL of the file to download. Example: `https://www.contoso.com/files/log0001.txt`
+* `{FILE NAME}`: The file name to use for the saved file. Example: `log-0001.txt`
 
 ## File streams
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -71,11 +71,11 @@ The following `DownloadFileFromStream` method performs the following steps:
 }
 ```
 
-The JavaScript `downloadFileFromStream` function accepts the file name and data stream and triggers the client-side download. The function performs the following steps:
+The JavaScript `downloadFileFromStream` function accepts the file name with the data stream and triggers the client-side download. The function performs the following steps:
 
 * Read the provided stream into an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 * Create a [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob) to wrap the `ArrayBuffer`.
-* Create an object URL to serve as the address for the file to be downloaded.
+* Create an object URL to serve as the file's download address.
 
 The `fileName` and object `url` are passed to `triggerFileDownload`, which performs the following steps:
 
@@ -84,14 +84,12 @@ The `fileName` and object `url` are passed to `triggerFileDownload`, which perfo
 * Trigger the download via `click`.
 * Remove the anchor (`<a>`) element.
 
-At this point, the file download is triggered. It should be safe to revoke the temporary object URL by calling [`revokeObjectURL`](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) on the URL. **This is an important step to ensure memory isn't leaked on the client.**
-
+At this point, the file download is triggered, and it's generally safe to revoke the temporary object URL by calling [`revokeObjectURL`](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) on the URL. **This is an important step to ensure memory isn't leaked on the client.**
 
 ```javascript
 async function downloadFileFromStream(fileName, contentStreamReference) {
   const arrayBuffer = await contentStreamReference.arrayBuffer();
   const blob = new Blob([arrayBuffer]);
-
   const url = URL.createObjectURL(blob);
 
   triggerFileDownload(fileName, url);
@@ -102,15 +100,23 @@ async function downloadFileFromStream(fileName, contentStreamReference) {
 function triggerFileDownload(fileName, url) {
   const anchorElement = document.createElement('a');
   anchorElement.href = url;
-
-  if (fileName) {
-    anchorElement.download = fileName;
-  }
-
+  anchorElement.download = fileName ?? '';
   anchorElement.click();
   anchorElement.remove();
 }
 ```
+
+`ArrayBuffer` effectively loads the entire file into client memory. For file downloads over 1 GB, we recommend opening a new tab for each large file download by setting the anchor's [`target`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-target) to `_blank` and [`referrerpolicy`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-referrerpolicy) to `no-referrer`:
+
+```javascript
+anchorElement.target = '_blank';
+anchorElement.referrerpolicy = 'no-referrer';
+```
+
+For more information on setting the anchor's Referrer Policy, see the following MDN documentation resources:
+
+* [`referrerpolicy`](https://developer.mozilla.org/docs/Web/HTML/Element/a#attr-referrerpolicy)
+* [`<a>`: The Anchor element: Security and privacy](https://developer.mozilla.org/docs/Web/HTML/Element/a#security_and_privacy)
 
 ## File streams
 
@@ -118,7 +124,7 @@ In Blazor WebAssembly apps, file data is streamed directly from .NET code into t
 
 ## Security considerations
 
-Use caution when providing users with the ability to download files from a server. Attackers may execute [denial of service (DOS)](/windows-hardware/drivers/ifs/denial-of-service) attacks or attempt to compromise networks and servers in other ways.
+Use caution when providing users with the ability to download files from a server. Attackers may execute [denial of service (DOS)](/windows-hardware/drivers/ifs/denial-of-service) attacks, [API exploitation attacks](https://developer.mozilla.org/docs/Web/HTML/Element/a#security_and_privacy), or attempt to compromise networks and servers in other ways.
 
 Security steps that reduce the likelihood of a successful attack are:
 
@@ -127,6 +133,7 @@ Security steps that reduce the likelihood of a successful attack are:
 
 ## Additional resources
 
+* [`<a>`: The Anchor element: Security and privacy (MDN documentation)](https://developer.mozilla.org/docs/Web/HTML/Element/a#security_and_privacy)
 * <xref:blazor/file-uploads>
 * <xref:mvc/models/file-uploads#security-considerations>
 * <xref:blazor/forms-validation>

--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -248,7 +248,7 @@ In this section, the **Package Manager Console** (PMC) window is used to:
 
 ---
 
-The preceding commands install [the Entity Framework Core tools](https://docs.microsoft.com/ef/core/get-started/overview/install#get-the-entity-framework-core-tools) and run the `migrations` command to generate code that creates the initial database schema.
+The preceding commands install [the Entity Framework Core tools](/ef/core/get-started/overview/install#get-the-entity-framework-core-tools) and run the `migrations` command to generate code that creates the initial database schema.
 
 The following warning is displayed, which is addressed in a later step:
 


### PR DESCRIPTION
Fixes #24521

Thanks @ylr-research! :rocket:

* Recommend that we show the procedure for opening a new tab.
* To cover security aspects for older browsers, I include a bit on the Referrer Policy, but I need verification on the sanity of the remarks and example.
* There are a few other *NITs* on the PR, and I'll be back for a broader UE pass on this topic later.

## ❓ 

For the following remark ...

> At this point, the file download is triggered, and it's generally safe to revoke the temporary object URL by calling \[\`revokeObjectURL\`](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) on the URL.

I'm not keen on the "generally" part without further explanation. What does "generally" mean in this context? I think we should say **_when_**/**_how_** it might be unsafe ... or strike the "generally" language in favor of just saying that the URL should be revoked with the API as indicated. 👂 

cc: @Rick-Anderson @serpent5 **FYI**: There's an unrelated absolute cross-link to EF Core docs in the RP tutorial that popped up on the build report. ~I've added a fix for it on this PR, so you can ignore it if it pops up on other PRs today ...~ **UPDATE (1/13)**: We're a bit delayed here, so I moved the link fix to https://github.com/dotnet/AspNetCore.Docs/pull/24599 for immediate merge.

> The preceding commands install \[the Entity Framework Core tools](https://docs.microsoft.com/ef/core/get-started/overview/install#get-the-entity-framework-core-tools) and run the \`migrations\` command to generate code that creates the initial database schema.

... to ...

> The preceding commands install \[the Entity Framework Core tools](/ef/core/get-started/overview/install#get-the-entity-framework-core-tools) and run the \`migrations\` command to generate code that creates the initial database schema.