### PR TITLE
Show example of multiple UseStaticFiles

### DIFF
--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -70,6 +70,8 @@ The following markup references *MyStaticFiles/images/red-rose.jpg*:
 <!-- zz test via /Home2/MyStaticFilesRR -->
 [!code-html[](~/fundamentals/static-files/samples/6.x/StaticFilesSample/Views/Home2/MyStaticFilesRR.cshtml?range=1)]
 
+To serve files from multiple locations, see [Serve files from multiple locations](#serve-files-from-multiple-locations).
+
 ### Set HTTP response headers
 
 A <xref:Microsoft.AspNetCore.Builder.StaticFileOptions> object can be used to set HTTP response headers. In addition to configuring static file serving from the [web root](xref:fundamentals/index#web-root), the following code sets the [Cache-Control](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control) header:
@@ -219,7 +221,9 @@ With the preceding code, a request for a file with an unknown content type is re
 
 ## Serve files from multiple locations
 
-`UseStaticFiles` and `UseFileServer` default to the file provider pointing at `wwwroot`. Additional instances of `UseStaticFiles` and `UseFileServer` can be provided with other file providers to serve files from other locations. For more information, see [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/15578).
+`UseStaticFiles` and `UseFileServer` default to the file provider pointing at `wwwroot`. Additional instances of `UseStaticFiles` and `UseFileServer` can be provided with other file providers to serve files from other locations. The following example calls `UseStaticFiles` twice to serve files from both `wwwroot` and `static`:
+
+[!code-csharp[](~/fundamentals/static-files/samples/6.x/StaticFilesSample/Program.cs?name=snippet_mul)] 
 
 <a name="sc"></a>
 

--- a/aspnetcore/fundamentals/static-files/samples/6.x/StaticFilesSample/Program.cs
+++ b/aspnetcore/fundamentals/static-files/samples/6.x/StaticFilesSample/Program.cs
@@ -1,4 +1,4 @@
-#define DB // DEFAULT RR RH DB DF DF2 UFS UFS2 TREE FECTP NS
+#define DB // DEFAULT RR RH DB DF DF2 UFS UFS2 TREE FECTP NS MUL
 #if NEVER
 #elif DEFAULT
 #region snippet
@@ -362,4 +362,37 @@ app.MapRazorPages();
 
 app.Run();
 #endregion
+#elif MUL
+using Microsoft.Extensions.FileProviders;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+builder.Services.AddControllersWithViews();
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+
+#region snippet_mul
+app.UseStaticFiles(); // Serve files from wwwroot
+app.UseStaticFiles(new StaticFileOptions
+{
+    FileProvider = new PhysicalFileProvider(
+        Path.Combine(builder.Environment.ContentRootPath, "static"))
+});
+#endregion
+
+app.UseAuthorization();
+
+app.MapDefaultControllerRoute();
+app.MapRazorPages();
+
+app.Run();
 #endif


### PR DESCRIPTION
Fixes #24559.

[Internal Preview URL](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/static-files?view=aspnetcore-6.0&branch=pr-en-us-24576#serve-files-from-multiple-locations).