### PR TITLE
Add a note about subscriptions triggered thru CascadingValue

### DIFF
--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -46,6 +46,32 @@ The following component binds the `ThemeInfo` cascading value to a cascading par
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/ThemedCounter.razor)]
 
+Similar to a regular component parameter, components accepting a cascading parameter are re-rendered when the cascading is changed. For instance, configuring a different theme instance would cause the `ThemedCounter` component from the previous example to re-render:
+
+MainLayout.razor
+```razor
+
+<div class="main">
+    <CascadingValue Value="theme">
+        <div class="content px-4">
+            @Body
+        </div>
+    </CascadingValue>
+    <button @onclick="ChangeToDarkTheme">Dark mode</button>
+</div>
+
+@code {
+    private ThemeInfo theme = new() { ButtonClass = "btn-success" };
+    
+    void ChangeToDarkTheme()
+    {
+        theme = new() { ButtonClass = "btn-darkmode-success" };
+    }
+}
+```
+
+The `IsFixed` parameter on `CascadingValue` can be used to indidcate that a CascadingParameter does not change once initialized. 
+
 ## Cascade multiple values
 
 To cascade multiple values of the same type within the same subtree, provide a unique <xref:Microsoft.AspNetCore.Components.CascadingValue%601.Name%2A> string to each [`CascadingValue`](xref:Microsoft.AspNetCore.Components.CascadingValue%601) component and their corresponding [`[CascadingParameter]` attributes](xref:Microsoft.AspNetCore.Components.CascadingParameterAttribute).

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -46,7 +46,7 @@ The following component binds the `ThemeInfo` cascading value to a cascading par
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/ThemedCounter.razor)]
 
-Similar to a regular component parameter, components accepting a cascading parameter are re-rendered when the cascading is changed. For instance, configuring a different theme instance would cause the `ThemedCounter` component from the previous example to re-render:
+Similar to a regular component parameter, components accepting a cascading parameter are re-rendered when the cascading value is changed. For instance, configuring a different theme instance would cause the `ThemedCounter` component from the previous example to re-render:
 
 MainLayout.razor
 ```razor

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -46,11 +46,11 @@ The following component binds the `ThemeInfo` cascading value to a cascading par
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/ThemedCounter.razor)]
 
-Similar to a regular component parameter, components accepting a cascading parameter are re-rendered when the cascading value is changed. For instance, configuring a different theme instance would cause the `ThemedCounter` component from the previous example to re-render:
+Similar to a regular component parameter, components accepting a cascading parameter are rerendered when the cascading value is changed. For instance, configuring a different theme instance causes the `ThemedCounter` component from the [`CascadingValue` component](#cascadingvalue-component) section to rerender:
 
-MainLayout.razor
+`Shared/MainLayout.razor`:
+
 ```razor
-
 <div class="main">
     <CascadingValue Value="theme">
         <div class="content px-4">
@@ -63,14 +63,14 @@ MainLayout.razor
 @code {
     private ThemeInfo theme = new() { ButtonClass = "btn-success" };
     
-    void ChangeToDarkTheme()
+    private void ChangeToDarkTheme()
     {
         theme = new() { ButtonClass = "btn-darkmode-success" };
     }
 }
 ```
 
-The `IsFixed` parameter on `CascadingValue` can be used to indidcate that a CascadingParameter does not change once initialized. 
+<xref:Microsoft.AspNetCore.Components.CascadingValue%601.IsFixed%2A?displayProperty=nameWithType> can be used to indicate that a <xref:Microsoft.AspNetCore.Components.CascadingParameterAttribute> doesn't change after initialization. 
 
 ## Cascade multiple values
 

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -70,7 +70,7 @@ Similar to a regular component parameter, components accepting a cascading param
 }
 ```
 
-<xref:Microsoft.AspNetCore.Components.CascadingValue%601.IsFixed%2A?displayProperty=nameWithType> can be used to indicate that a <xref:Microsoft.AspNetCore.Components.CascadingParameterAttribute> doesn't change after initialization. 
+<xref:Microsoft.AspNetCore.Components.CascadingValue%601.IsFixed%2A?displayProperty=nameWithType> can be used to indicate that a cascading parameter doesn't change after initialization. 
 
 ## Cascade multiple values
 


### PR DESCRIPTION
CascadingValue causes components to be re-rendered if the value changes. We don't currently document this.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->