### PR TITLE
Injection into constructor allowed by Factory-based middleware

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -117,7 +117,7 @@ See [Service lifetimes](/dotnet/core/extensions/dependency-injection#service-lif
 To use scoped services in middleware, use one of the following approaches:
 
 * Inject the service into the middleware's `Invoke` or `InvokeAsync` method. Using [constructor injection](xref:mvc/controllers/dependency-injection#constructor-injection) throws a runtime exception because it forces the scoped service to behave like a singleton. The sample in the [Lifetime and registration options](#lifetime-and-registration-options) section demonstrates the `InvokeAsync` approach.
-* Use [Factory-based middleware](xref:fundamentals/middleware/extensibility). Middleware registered using this approach is activated per client request (connection), which allows scoped services to be injected into the middleware's `InvokeAsync` method.
+* Use [Factory-based middleware](xref:fundamentals/middleware/extensibility). Middleware registered using this approach is activated per client request (connection), which allows scoped services to be injected into the middleware's constructor.
 
 For more information, see <xref:fundamentals/middleware/write#per-request-middleware-dependencies>.
 


### PR DESCRIPTION
Scoped services can be injected into the middleware's InvokeAsync method (as the previous point mentions) even if the middleware is NOT Factory-based.  Injection into the constructor, on the other hand, throws exception.  So it is the scoped service's injection into constructor -- without throwing exception -- that is allowed by Factory-based middleware. This is also explicitly mentioned in the detailed topic on Factory-based middleware here: 
https://docs.microsoft.com/en-us/aspnet/core/fundamentals/middleware/extensibility?view=aspnetcore-6.0#:~:text=IMiddleware%20is%20activated%20per%20client%20request%20(connection)%2C%20so%20scoped%20services%20can%20be%20injected%20into%20the%20middleware%27s%20constructor.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->