### PR TITLE
Update Blazor article triple-colon syntax

### DIFF
--- a/aspnetcore/blazor/advanced-scenarios.md
+++ b/aspnetcore/blazor/advanced-scenarios.md
@@ -11,7 +11,7 @@ uid: blazor/advanced-scenarios
 ---
 # ASP.NET Core Blazor advanced scenarios
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 ## Manual RenderTreeBuilder logic
 
@@ -127,9 +127,9 @@ This is a trivial example. In more realistic cases with complex and deeply neste
 * If sequence numbers are hardcoded, the diff algorithm only requires that sequence numbers increase in value. The initial value and gaps are irrelevant. One legitimate option is to use the code line number as the sequence number, or start from zero and increase by ones or hundreds (or any preferred interval).
 * Blazor uses sequence numbers, while other tree-diffing UI frameworks don't use them. Diffing is far faster when sequence numbers are used, and Blazor has the advantage of a compile step that deals with sequence numbers automatically for developers authoring `.razor` files.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 ## Manual RenderTreeBuilder logic
 
@@ -245,9 +245,9 @@ This is a trivial example. In more realistic cases with complex and deeply neste
 * If sequence numbers are hardcoded, the diff algorithm only requires that sequence numbers increase in value. The initial value and gaps are irrelevant. One legitimate option is to use the code line number as the sequence number, or start from zero and increase by ones or hundreds (or any preferred interval).
 * Blazor uses sequence numbers, while other tree-diffing UI frameworks don't use them. Diffing is far faster when sequence numbers are used, and Blazor has the advantage of a compile step that deals with sequence numbers automatically for developers authoring `.razor` files.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ## Manual RenderTreeBuilder logic
 
@@ -363,4 +363,4 @@ This is a trivial example. In more realistic cases with complex and deeply neste
 * If sequence numbers are hardcoded, the diff algorithm only requires that sequence numbers increase in value. The initial value and gaps are irrelevant. One legitimate option is to use the code line number as the sequence number, or start from zero and increase by ones or hundreds (or any preferred interval).
 * Blazor uses sequence numbers, while other tree-diffing UI frameworks don't use them. Diffing is far faster when sequence numbers are used, and Blazor has the advantage of a compile step that deals with sequence numbers automatically for developers authoring `.razor` files.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/blazor-server-ef-core.md
+++ b/aspnetcore/blazor/blazor-server-ef-core.md
@@ -11,7 +11,7 @@ uid: blazor/blazor-server-ef-core
 ---
 # ASP.NET Core Blazor Server with Entity Framework Core (EFCore)
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor Server is a stateful app framework. The app maintains an ongoing connection to the server, and the user's state is held in the server's memory in a *circuit*. One example of user state is data held in [dependency injection (DI)](xref:fundamentals/dependency-injection) service instances that are scoped to the circuit. The unique application model that Blazor Server provides requires a special approach to use Entity Framework Core.
 
@@ -133,9 +133,9 @@ We recommend only enabling <xref:Microsoft.EntityFrameworkCore.DbContextOptionsB
 
 * [EF Core documentation](/ef/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor Server is a stateful app framework. The app maintains an ongoing connection to the server, and the user's state is held in the server's memory in a *circuit*. One example of user state is data held in [dependency injection (DI)](xref:fundamentals/dependency-injection) service instances that are scoped to the circuit. The unique application model that Blazor Server provides requires a special approach to use Entity Framework Core.
 
@@ -257,9 +257,9 @@ We recommend only enabling <xref:Microsoft.EntityFrameworkCore.DbContextOptionsB
 
 * [EF Core documentation](/ef/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Blazor Server is a stateful app framework. The app maintains an ongoing connection to the server, and the user's state is held in the server's memory in a *circuit*. One example of user state is data held in [dependency injection (DI)](xref:fundamentals/dependency-injection) service instances that are scoped to the circuit. The unique application model that Blazor Server provides requires a special approach to use Entity Framework Core.
 
@@ -393,4 +393,4 @@ We recommend only enabling <xref:Microsoft.EntityFrameworkCore.DbContextOptionsB
 
 * [EF Core documentation](/ef/)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -12,9 +12,9 @@ zone_pivot_groups: blazor-hosting-models
 ---
 # Call a web API from ASP.NET Core Blazor
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 > [!NOTE]
 > This article has loaded **Blazor WebAssembly** coverage for calling web APIs. The [Blazor Server coverage](?pivots=server) addresses the following subjects:
@@ -480,9 +480,9 @@ else
 
 For more information, see <xref:blazor/fundamentals/handle-errors>.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 > [!NOTE]
 > This article has loaded **Blazor Server** coverage for calling web APIs. The [Blazor WebAssembly coverage](?pivots=webassembly) addresses the following subjects:
@@ -577,25 +577,25 @@ else
 
 For an additional working example, see the Blazor Server file upload example that uploads files to a web API controller in the <xref:blazor/file-uploads#upload-files-to-a-server> article.
 
-::: zone-end
+:::zone-end
 
 ## Cross-origin resource sharing (CORS)
 
 Browser security restricts a webpage from making requests to a different domain than the one that served the webpage. This restriction is called the *same-origin policy*. The same-origin policy restricts (but doesn't prevent) a malicious site from reading sensitive data from another site. To make requests from the browser to an endpoint with a different origin, the *endpoint* must enable [cross-origin resource sharing (CORS)](https://www.w3.org/TR/cors/).
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 For information on CORS requests in Blazor WebAssembly apps, see <xref:blazor/security/webassembly/additional-scenarios#cross-origin-resource-sharing-cors>.
 
 For information on CORS, see <xref:security/cors>. The article's examples don't pertain directly to Blazor WebAssembly apps, but the article is useful for learning general CORS concepts.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 For more information, see <xref:security/cors>.
 
-::: zone-end
+:::zone-end
 
 ## Blazor framework component examples for testing web API access
 
@@ -605,16 +605,16 @@ Various network tools are publicly available for testing web API backend apps di
 
 ## Additional resources
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 * <xref:blazor/security/webassembly/additional-scenarios>: Includes coverage on using <xref:System.Net.Http.HttpClient> to make secure web API requests.
 * <xref:security/cors>: Although the content applies to ASP.NET Core apps, not Blazor WebAssembly apps, the article covers general CORS concepts.
 * [Cross Origin Resource Sharing (CORS) at W3C](https://www.w3.org/TR/cors/)
 * [Fetch API](https://developer.mozilla.org/docs/Web/API/fetch)
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 * <xref:blazor/security/server/additional-scenarios>: Includes coverage on using <xref:System.Net.Http.HttpClient> to make secure web API requests.
 * <xref:fundamentals/http-requests>
@@ -623,13 +623,13 @@ Various network tools are publicly available for testing web API backend apps di
 * [Kestrel HTTPS endpoint configuration](xref:fundamentals/servers/kestrel/endpoints)
 * [Cross Origin Resource Sharing (CORS) at W3C](https://www.w3.org/TR/cors/)
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 > [!NOTE]
 > This article has loaded **Blazor WebAssembly** coverage for calling web APIs. The [Blazor Server coverage](?pivots=server) addresses the following subjects:
@@ -1095,9 +1095,9 @@ else
 
 For more information, see <xref:blazor/fundamentals/handle-errors>.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 > [!NOTE]
 > This article has loaded **Blazor Server** coverage for calling web APIs. The [Blazor WebAssembly coverage](?pivots=webassembly) addresses the following subjects:
@@ -1192,25 +1192,25 @@ else
 
 For an additional working example, see the Blazor Server file upload example that uploads files to a web API controller in the <xref:blazor/file-uploads#upload-files-to-a-server> article.
 
-::: zone-end
+:::zone-end
 
 ## Cross-origin resource sharing (CORS)
 
 Browser security restricts a webpage from making requests to a different domain than the one that served the webpage. This restriction is called the *same-origin policy*. The same-origin policy restricts (but doesn't prevent) a malicious site from reading sensitive data from another site. To make requests from the browser to an endpoint with a different origin, the *endpoint* must enable [cross-origin resource sharing (CORS)](https://www.w3.org/TR/cors/).
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 For information on CORS requests in Blazor WebAssembly apps, see <xref:blazor/security/webassembly/additional-scenarios#cross-origin-resource-sharing-cors>.
 
 For information on CORS, see <xref:security/cors>. The article's examples don't pertain directly to Blazor WebAssembly apps, but the article is useful for learning general CORS concepts.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 For more information, see <xref:security/cors>.
 
-::: zone-end
+:::zone-end
 
 ## Blazor framework component examples for testing web API access
 
@@ -1222,16 +1222,16 @@ Various network tools are publicly available for testing web API backend apps di
 
 ## Additional resources
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 * <xref:blazor/security/webassembly/additional-scenarios>: Includes coverage on using <xref:System.Net.Http.HttpClient> to make secure web API requests.
 * <xref:security/cors>: Although the content applies to ASP.NET Core apps, not Blazor WebAssembly apps, the article covers general CORS concepts.
 * [Cross Origin Resource Sharing (CORS) at W3C](https://www.w3.org/TR/cors/)
 * [Fetch API](https://developer.mozilla.org/docs/Web/API/fetch)
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 * <xref:blazor/security/server/additional-scenarios>: Includes coverage on using <xref:System.Net.Http.HttpClient> to make secure web API requests.
 * <xref:fundamentals/http-requests>
@@ -1240,13 +1240,13 @@ Various network tools are publicly available for testing web API backend apps di
 * [Kestrel HTTPS endpoint configuration](xref:fundamentals/servers/kestrel/endpoints)
 * [Cross Origin Resource Sharing (CORS) at W3C](https://www.w3.org/TR/cors/)
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 > [!NOTE]
 > This article has loaded **Blazor WebAssembly** coverage for calling web APIs. The [Blazor Server coverage](?pivots=server) addresses the following subjects:
@@ -1712,9 +1712,9 @@ else
 
 For more information, see <xref:blazor/fundamentals/handle-errors>.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 > [!NOTE]
 > This article has loaded **Blazor Server** coverage for calling web APIs. The [Blazor WebAssembly coverage](?pivots=webassembly) addresses the following subjects:
@@ -1809,25 +1809,25 @@ else
 
 For an additional working example, see the Blazor Server file upload example that uploads files to a web API controller in the <xref:blazor/file-uploads#upload-files-to-a-server> article.
 
-::: zone-end
+:::zone-end
 
 ## Cross-origin resource sharing (CORS)
 
 Browser security restricts a webpage from making requests to a different domain than the one that served the webpage. This restriction is called the *same-origin policy*. The same-origin policy restricts (but doesn't prevent) a malicious site from reading sensitive data from another site. To make requests from the browser to an endpoint with a different origin, the *endpoint* must enable [cross-origin resource sharing (CORS)](https://www.w3.org/TR/cors/).
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 For information on CORS requests in Blazor WebAssembly apps, see <xref:blazor/security/webassembly/additional-scenarios#cross-origin-resource-sharing-cors>.
 
 For information on CORS, see <xref:security/cors>. The article's examples don't pertain directly to Blazor WebAssembly apps, but the article is useful for learning general CORS concepts.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 For more information, see <xref:security/cors>.
 
-::: zone-end
+:::zone-end
 
 ## Blazor framework component examples for testing web API access
 
@@ -1839,16 +1839,16 @@ Various network tools are publicly available for testing web API backend apps di
 
 ## Additional resources
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 * <xref:blazor/security/webassembly/additional-scenarios>: Includes coverage on using <xref:System.Net.Http.HttpClient> to make secure web API requests.
 * <xref:security/cors>: Although the content applies to ASP.NET Core apps, not Blazor WebAssembly apps, the article covers general CORS concepts.
 * [Cross Origin Resource Sharing (CORS) at W3C](https://www.w3.org/TR/cors/)
 * [Fetch API](https://developer.mozilla.org/docs/Web/API/fetch)
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 * <xref:blazor/security/server/additional-scenarios>: Includes coverage on using <xref:System.Net.Http.HttpClient> to make secure web API requests.
 * <xref:fundamentals/http-requests>
@@ -1857,6 +1857,6 @@ Various network tools are publicly available for testing web API backend apps di
 * [Kestrel HTTPS endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration)
 * [Cross Origin Resource Sharing (CORS) at W3C](https://www.w3.org/TR/cors/)
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/built-in-components.md
+++ b/aspnetcore/blazor/components/built-in-components.md
@@ -11,7 +11,7 @@ uid: blazor/components/built-in-components
 ---
 # ASP.NET Core built-in Razor components
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 The following built-in Razor components are provided by the Blazor framework:
 
@@ -41,9 +41,9 @@ The following built-in Razor components are provided by the Blazor framework:
 * [`Router`](xref:blazor/fundamentals/routing#route-templates)
 * [`Virtualize`](xref:blazor/components/virtualization)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 The following built-in Razor components are provided by ASP.NET Core:
 
@@ -67,9 +67,9 @@ The following built-in Razor components are provided by ASP.NET Core:
 * [`Router`](xref:blazor/fundamentals/routing#route-templates)
 * [`Virtualize`](xref:blazor/components/virtualization)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 The following built-in Razor components are provided by the Blazor framework:
 
@@ -91,4 +91,4 @@ The following built-in Razor components are provided by the Blazor framework:
 * [`NavMenu`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
 * [`Router`](xref:blazor/fundamentals/routing#route-templates)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -11,7 +11,7 @@ uid: blazor/components/cascading-values-and-parameters
 ---
 # ASP.NET Core Blazor cascading values and parameters
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 *Cascading values and parameters* provide a convenient way to flow data down a component hierarchy from an ancestor component to any number of descendent components. Unlike [Component parameters](xref:blazor/components/index#component-parameters), cascading values and parameters don't require an attribute assignment for each descendent component where the data is consumed. Cascading values and parameters also allow components to coordinate with each other across a component hierarchy.
 
@@ -250,9 +250,9 @@ The following `ExampleTabSet` component uses the `TabSet` component, which conta
 }
 ```
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 *Cascading values and parameters* provide a convenient way to flow data down a component hierarchy from an ancestor component to any number of descendent components. Unlike [Component parameters](xref:blazor/components/index#component-parameters), cascading values and parameters don't require an attribute assignment for each descendent component where the data is consumed. Cascading values and parameters also allow components to coordinate with each other across a component hierarchy.
 
@@ -469,9 +469,9 @@ The following `ExampleTabSet` component uses the `TabSet` component, which conta
 }
 ```
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 *Cascading values and parameters* provide a convenient way to flow data down a component hierarchy from an ancestor component to any number of descendent components. Unlike [Component parameters](xref:blazor/components/index#component-parameters), cascading values and parameters don't require an attribute assignment for each descendent component where the data is consumed. Cascading values and parameters also allow components to coordinate with each other across a component hierarchy.
 
@@ -688,4 +688,4 @@ The following `ExampleTabSet` component uses the `TabSet` component, which conta
 }
 ```
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -11,7 +11,7 @@ uid: blazor/components/class-libraries
 ---
 # Consume ASP.NET Core Razor components from Razor class libraries
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Components can be shared in a [Razor class library (RCL)](xref:razor-pages/ui-class) across projects. Include components and static assets in an app from:
 
@@ -382,9 +382,9 @@ Upload the package to NuGet using the [`dotnet nuget push`](/dotnet/core/tools/d
 * [Add an XML Intermediate Language (IL) Trimmer configuration file to a library](xref:blazor/host-and-deploy/configure-trimmer)
 * [CSS isolation support with Razor class libraries](xref:blazor/components/css-isolation#razor-class-library-rcl-support)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Components can be shared in a [Razor class library (RCL)](xref:razor-pages/ui-class) across projects. Include components and static assets in an app from:
 
@@ -672,9 +672,9 @@ Upload the package to NuGet using the [`dotnet nuget push`](/dotnet/core/tools/d
 * [Add an XML Intermediate Language (IL) Trimmer configuration file to a library](xref:blazor/host-and-deploy/configure-trimmer)
 * [CSS isolation support with Razor class libraries](xref:blazor/components/css-isolation#razor-class-library-rcl-support)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Components can be shared in a [Razor class library (RCL)](xref:razor-pages/ui-class) across projects. Include components and static assets in an app from:
 
@@ -904,4 +904,4 @@ Upload the package to NuGet using the [`dotnet nuget push`](/dotnet/core/tools/d
 * <xref:razor-pages/ui-class>
 * [Add an XML Intermediate Language (IL) Linker configuration file to a library](xref:blazor/host-and-deploy/configure-linker#add-an-xml-linker-configuration-file-to-a-library)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -13,7 +13,7 @@ uid: blazor/components/css-isolation
 
 By [Dave Brock](https://twitter.com/daveabrock)
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Isolate CSS styles to individual pages, views, and components to reduce or avoid:
 
@@ -230,9 +230,9 @@ For more information on RCLs, see the following articles:
 * [Razor Pages CSS isolation](xref:razor-pages/index#css-isolation)
 * [MVC CSS isolation](xref:mvc/views/overview#css-isolation)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 CSS isolation simplifies an app's CSS footprint by preventing dependencies on global styles and helps to avoid styling conflicts among components and libraries.
 
@@ -441,4 +441,4 @@ For more information on RCLs, see the following articles:
 * <xref:blazor/components/class-libraries>
 * <xref:razor-pages/ui-class>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -11,7 +11,7 @@ uid: blazor/components/data-binding
 ---
 # ASP.NET Core Blazor data binding
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Razor components provide data binding features with the [`@bind`](xref:mvc/views/razor#bind) Razor directive attribute with a field, property, or Razor expression value.
 
@@ -265,9 +265,9 @@ For an alternative approach suited to sharing data in memory and across componen
 * [Binding `InputSelect` options to C# object `null` values](xref:blazor/forms-validation#binding-inputselect-options-to-c-object-null-values)
 * [ASP.NET Core Blazor event handling: `EventCallback` section](xref:blazor/components/event-handling#eventcallback)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Razor components provide data binding features with the [`@bind`](xref:mvc/views/razor#bind) Razor directive attribute with a field, property, or Razor expression value.
 
@@ -460,9 +460,9 @@ For an alternative approach suited to sharing data in memory and across componen
 * [Binding `InputSelect` options to C# object `null` values](xref:blazor/forms-validation#binding-inputselect-options-to-c-object-null-values)
 * [ASP.NET Core Blazor event handling: `EventCallback` section](xref:blazor/components/event-handling#eventcallback)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Razor components provide data binding features with the [`@bind`](xref:mvc/views/razor#bind) Razor directive attribute with a field, property, or Razor expression value.
 
@@ -655,4 +655,4 @@ For an alternative approach suited to sharing data in memory and across componen
 * [Binding `InputSelect` options to C# object `null` values](xref:blazor/forms-validation#binding-inputselect-options-to-c-object-null-values)
 * [ASP.NET Core Blazor event handling: `EventCallback` section](xref:blazor/components/event-handling#eventcallback)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -11,7 +11,7 @@ uid: blazor/components/event-handling
 ---
 # ASP.NET Core Blazor event handling
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Specify delegate event handlers in Razor component markup with [`@on{DOM EVENT}="{DELEGATE}"`](xref:mvc/views/razor#onevent) Razor syntax:
 
@@ -336,9 +336,9 @@ Call <xref:Microsoft.AspNetCore.Components.ElementReferenceExtensions.FocusAsync
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/event-handling/EventHandlerExample8.razor?highlight=16)]
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Specify delegate event handlers in Razor component markup with [`@on{DOM EVENT}="{DELEGATE}"`](xref:mvc/views/razor#onevent) Razor syntax:
 
@@ -512,9 +512,9 @@ Call <xref:Microsoft.AspNetCore.Components.ElementReferenceExtensions.FocusAsync
 
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Pages/event-handling/EventHandlerExample8.razor?highlight=16)]
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Specify delegate event handlers in Razor component markup with [`@on{DOM EVENT}="{DELEGATE}"`](xref:mvc/views/razor#onevent) Razor syntax:
 
@@ -680,4 +680,4 @@ In the following example, selecting the checkbox prevents click events from the 
 
 [!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Pages/event-handling/EventHandlerExample7.razor?highlight=4,15-16)]
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -11,7 +11,7 @@ uid: blazor/components/index
 ---
 # ASP.NET Core Razor components
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor apps are built using *Razor components*. A component is a self-contained portion of user interface (UI) with processing logic to enable dynamic behavior. Components can be nested, reused, shared among projects, and [used in MVC and Razor Pages apps](xref:blazor/components/prerendering-and-integration).
 
@@ -1124,9 +1124,9 @@ Generate framework-specific JavaScript (JS) components from Razor components for
 > [!WARNING]
 > The Angular and React component features are currently **experimental, unsupported, and subject to change or be removed at any time**. We welcome your feedback on how well this particular approach meets your requirements.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor apps are built using *Razor components*. A component is a self-contained portion of user interface (UI) with processing logic to enable dynamic behavior. Components can be nested, reused, shared among projects, and [used in MVC and Razor Pages apps](xref:blazor/components/prerendering-and-integration).
 
@@ -2077,9 +2077,9 @@ For more information, see the following articles:
 * <xref:mvc/views/razor#typeparam>
 * <xref:blazor/components/templated-components>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Blazor apps are built using *Razor components*. A component is a self-contained portion of user interface (UI) with processing logic to enable dynamic behavior. Components can be nested, reused, shared among projects, and [used in MVC and Razor Pages apps](xref:blazor/components/prerendering-and-integration).
 
@@ -3046,7 +3046,7 @@ For more information, see the following articles:
 * <xref:mvc/views/razor#typeparam>
 * <xref:blazor/components/templated-components>
 
-::: moniker-end
+:::moniker-end
 
 <!--Reference links in article-->
 [1]: <xref:mvc/views/razor#code>

--- a/aspnetcore/blazor/components/layouts.md
+++ b/aspnetcore/blazor/components/layouts.md
@@ -11,7 +11,7 @@ uid: blazor/components/layouts
 ---
 # ASP.NET Core Blazor layouts
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Some app elements, such as menus, copyright messages, and company logos, are usually part of app's overall presentation. Placing a copy of the markup for these elements into all of the components of an app isn't efficient. Every time that one of these elements is updated, every component that uses the element must be updated. This approach is costly to maintain and can lead to inconsistent content if an update is missed. *Layouts* solve these problems.
 
@@ -222,9 +222,9 @@ When routable components are integrated into a Razor Pages app, the app's shared
 
 * <xref:mvc/views/layout>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Some app elements, such as menus, copyright messages, and company logos, are usually part of app's overall presentation. Placing a copy of the markup for these elements into all of the components of an app isn't efficient. Every time that one of these elements is updated, every component that uses the element must be updated. This approach is costly to maintain and can lead to inconsistent content if an update is missed. *Layouts* solve these problems.
 
@@ -439,9 +439,9 @@ When routable components are integrated into a Razor Pages app, the app's shared
 
 * <xref:mvc/views/layout>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Some app elements, such as menus, copyright messages, and company logos, are usually part of app's overall presentation. Placing a copy of the markup for these elements into all of the components of an app isn't efficient. Every time that one of these elements is updated, every component that uses the element must be updated. This approach is costly to maintain and can lead to inconsistent content if an update is missed. *Layouts* solve these problems.
 
@@ -647,4 +647,4 @@ When routable components are integrated into a Razor Pages app, the app's shared
 
 * <xref:mvc/views/layout>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -11,7 +11,7 @@ uid: blazor/components/lifecycle
 ---
 # ASP.NET Core Razor component lifecycle
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 The Razor component processes Razor component lifecycle events in a set of synchronous and asynchronous lifecycle methods. The lifecycle methods can be overridden to perform additional operations in components during component initialization and rendering.
 
@@ -451,9 +451,9 @@ In the following example:
 
 The component lifecycle events covered in this article operate separately from [Blazor Server's reconnection event handlers](xref:blazor/fundamentals/signalr#reflect-the-connection-state-in-the-ui-blazor-server). When a Blazor Server app loses its SignalR connection to the client, only UI updates are interrupted. UI updates are resumed when the connection is re-established. For more information on circuit handler events and configuration, see <xref:blazor/fundamentals/signalr>.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 The Razor component processes Razor component lifecycle events in a set of synchronous and asynchronous lifecycle methods. The lifecycle methods can be overridden to perform additional operations in components during component initialization and rendering.
 
@@ -892,9 +892,9 @@ In the following example:
 
 The component lifecycle events covered in this article operate separately from [Blazor Server's reconnection event handlers](xref:blazor/fundamentals/signalr#reflect-the-connection-state-in-the-ui-blazor-server). When a Blazor Server app loses its SignalR connection to the client, only UI updates are interrupted. UI updates are resumed when the connection is re-established. For more information on circuit handler events and configuration, see <xref:blazor/fundamentals/signalr>.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 The Razor component processes Razor component lifecycle events in a set of synchronous and asynchronous lifecycle methods. The lifecycle methods can be overridden to perform additional operations in components during component initialization and rendering.
 
@@ -1330,4 +1330,4 @@ In the following example:
 
 The component lifecycle events covered in this article operate separately from [Blazor Server's reconnection event handlers](xref:blazor/fundamentals/signalr#reflect-the-connection-state-in-the-ui-blazor-server). When a Blazor Server app loses its SignalR connection to the client, only UI updates are interrupted. UI updates are resumed when the connection is re-established. For more information on circuit handler events and configuration, see <xref:blazor/fundamentals/signalr>.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -12,9 +12,9 @@ zone_pivot_groups: blazor-hosting-models
 ---
 # Prerender and integrate ASP.NET Core Razor components
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Razor components can be integrated into Razor Pages and MVC apps in a hosted Blazor WebAssembly solution. When the page or view is rendered, components can be prerendered at the same time.
 
@@ -409,9 +409,9 @@ Additional work might be required depending on the static resources that compone
 >
 > Navigate to the page or view with the embedded Razor component that uses a CSS selector (for example, `/razorpagescounter2` of the preceding example). The page or view loads with the embedded component, and the embedded component functions as expected.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Razor components can be integrated into Razor Pages and MVC apps in a Blazor Server app. When the page or view is rendered, components can be prerendered at the same time.
 
@@ -799,7 +799,7 @@ The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages
 
 For more information, see <xref:blazor/components/index#namespaces>.
 
-::: zone-end
+:::zone-end
 
 ## Persist prerendered state
 
@@ -902,7 +902,7 @@ else
 
 By initializing components with the same state used during prerendering, any expensive initialization steps are only executed once. The rendered UI also matches the prerendered UI, so no flicker occurs in the browser.
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 ## Additional Blazor WebAssembly resources
 
@@ -919,9 +919,9 @@ By initializing components with the same state used during prerendering, any exp
   * [Support prerendering with authentication](xref:blazor/security/webassembly/additional-scenarios#support-prerendering-with-authentication)
 * [Host and deploy: Blazor WebAssembly](xref:blazor/host-and-deploy/webassembly)
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ## Additional Blazor Server resources
 
@@ -936,13 +936,13 @@ By initializing components with the same state used during prerendering, any exp
 * [Host and deploy: Blazor Server](xref:blazor/host-and-deploy/server)
 * [Threat mitigation: Cross-site scripting (XSS)](xref:blazor/security/server/threat-mitigation#cross-site-scripting-xss)
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Razor components can be integrated into Razor Pages and MVC apps in a hosted Blazor WebAssembly solution. When the page or view is rendered, components can be prerendered at the same time.
 
@@ -1186,9 +1186,9 @@ Additional work might be required depending on the static resources that compone
 >
 > This is normal behavior because prerendering and integrating a Blazor WebAssembly app with routable Razor components is incompatible with the use of CSS selectors.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Razor components can be integrated into Razor Pages and MVC apps in a Blazor Server app. When the page or view is rendered, components can be prerendered at the same time.
 
@@ -1581,9 +1581,9 @@ The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages
 
 For more information, see <xref:blazor/components/index#namespaces>.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 ## Additional Blazor WebAssembly resources
 
@@ -1600,9 +1600,9 @@ For more information, see <xref:blazor/components/index#namespaces>.
   * [Support prerendering with authentication](xref:blazor/security/webassembly/additional-scenarios#support-prerendering-with-authentication)
 * [Host and deploy: Blazor WebAssembly](xref:blazor/host-and-deploy/webassembly)
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ## Additional Blazor Server resources
 
@@ -1617,19 +1617,19 @@ For more information, see <xref:blazor/components/index#namespaces>.
 * [Host and deploy: Blazor Server](xref:blazor/host-and-deploy/server)
 * [Threat mitigation: Cross-site scripting (XSS)](xref:blazor/security/server/threat-mitigation#cross-site-scripting-xss)
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Integrating Razor components into Razor Pages and MVC apps in a hosted Blazor WebAssembly solution is supported in ASP.NET Core in .NET 5 or later. Select a .NET 5 or later version of this article.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Razor components can be integrated into Razor Pages and MVC apps in a Blazor Server app. When the page or view is rendered, components can be prerendered at the same time.
 
@@ -2031,6 +2031,6 @@ For more information, see <xref:blazor/components/index#namespaces>.
 * [Host and deploy: Blazor Server](xref:blazor/host-and-deploy/server)
 * [Threat mitigation: Cross-site scripting (XSS)](xref:blazor/security/server/threat-mitigation#cross-site-scripting-xss)
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -11,7 +11,7 @@ uid: blazor/components/rendering
 ---
 # ASP.NET Core Blazor component rendering
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Components *must* render when they're first added to the component hierarchy by a parent component. This is the only time that a component must render. Components *may* render at other times according to their own logic and conventions.
 
@@ -104,9 +104,9 @@ Since these C# events are outside the Blazor rendering pipeline, call <xref:Micr
 
 This is similar to the earlier case with <xref:System.Timers.Timer?displayProperty=fullName> in the [previous section](#receiving-a-call-from-something-external-to-the-blazor-rendering-and-event-handling-system). Since the execution call stack typically remains on the renderer's synchronization context, calling <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A> isn't normally required. Calling <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A> is only required if the logic escapes the synchronization context, such as calling <xref:System.Threading.Tasks.Task.ContinueWith%2A> on a <xref:System.Threading.Tasks.Task> or awaiting a <xref:System.Threading.Tasks.Task> with [`ConfigureAwait(false)`](xref:System.Threading.Tasks.Task.ConfigureAwait%2A).
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Components *must* render when they're first added to the component hierarchy by a parent component. This is the only time that a component must render. Components *may* render at other times according to their own logic and conventions.
 
@@ -199,9 +199,9 @@ Since these C# events are outside the Blazor rendering pipeline, call <xref:Micr
 
 This is similar to the earlier case with <xref:System.Timers.Timer?displayProperty=fullName> in the [previous section](#receiving-a-call-from-something-external-to-the-blazor-rendering-and-event-handling-system). Since the execution call stack typically remains on the renderer's synchronization context, calling <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A> isn't normally required. Calling <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A> is only required if the logic escapes the synchronization context, such as calling <xref:System.Threading.Tasks.Task.ContinueWith%2A> on a <xref:System.Threading.Tasks.Task> or awaiting a <xref:System.Threading.Tasks.Task> with [`ConfigureAwait(false)`](xref:System.Threading.Tasks.Task.ConfigureAwait%2A).
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Components *must* render when they're first added to the component hierarchy by a parent component. This is the only time that a component must render. Components *may* render at other times according to their own logic and conventions.
 
@@ -294,4 +294,4 @@ Since these C# events are outside the Blazor rendering pipeline, call <xref:Micr
 
 This is similar to the earlier case with <xref:System.Timers.Timer?displayProperty=fullName> in the [previous section](#receiving-a-call-from-something-external-to-the-blazor-rendering-and-event-handling-system). Since the execution call stack typically remains on the renderer's synchronization context, calling <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A> isn't normally required. Calling <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A> is only required if the logic escapes the synchronization context, such as calling <xref:System.Threading.Tasks.Task.ContinueWith%2A> on a <xref:System.Threading.Tasks.Task> or awaiting a <xref:System.Threading.Tasks.Task> with [`ConfigureAwait(false)`](xref:System.Threading.Tasks.Task.ConfigureAwait%2A).
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/templated-components.md
+++ b/aspnetcore/blazor/components/templated-components.md
@@ -11,7 +11,7 @@ uid: blazor/components/templated-components
 ---
 # ASP.NET Core Blazor templated components
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Templated components are components that accept one or more UI templates as parameters, which can then be used as part of the component's rendering logic. Templated components allow you to author higher-level components that are more reusable than regular components. A couple of examples include:
 
@@ -134,9 +134,9 @@ For more information, see the following articles:
 
 * <xref:blazor/performance#define-reusable-renderfragments-in-code>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Templated components are components that accept one or more UI templates as parameters, which can then be used as part of the component's rendering logic. Templated components allow you to author higher-level components that are more reusable than regular components. A couple of examples include:
 
@@ -181,9 +181,9 @@ When using generic-typed components, the type parameter is inferred if possible.
 
 * <xref:blazor/performance#define-reusable-renderfragments-in-code>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Templated components are components that accept one or more UI templates as parameters, which can then be used as part of the component's rendering logic. Templated components allow you to author higher-level components that are more reusable than regular components. A couple of examples include:
 
@@ -228,4 +228,4 @@ When using generic-typed components, the type parameter is inferred if possible.
 
 * <xref:blazor/performance#define-reusable-renderfragments-in-code>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -11,7 +11,7 @@ uid: blazor/components/virtualization
 ---
 # ASP.NET Core Blazor component virtualization
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Improve the perceived performance of component rendering using the Blazor framework's built-in virtualization support with the [`Virtualize` component](xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601). Virtualization is a technique for limiting UI rendering to just the parts that are currently visible. For example, virtualization is helpful when the app must render a long list of items and only a subset of items is required to be visible at any given time.
 
@@ -241,9 +241,9 @@ The placeholder elements internally use an [Intersection Observer](https://devel
 
 Any approach that stops the placeholders and content elements from rendering as a single vertical stack, or causes the content items to vary in height, prevents correct functioning of the `Virtualize` component.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Improve the perceived performance of component rendering using the Blazor framework's built-in virtualization support with the [`Virtualize` component](xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601). Virtualization is a technique for limiting UI rendering to just the parts that are currently visible. For example, virtualization is helpful when the app must render a long list of items and only a subset of items is required to be visible at any given time.
 
@@ -389,4 +389,4 @@ By default, the `Virtualize` component measures the rendering size (height) of i
 
 When making changes to items rendered by the `Virtualize` component, call <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> to force re-evaluation and rerendering of the component. For more information, see <xref:blazor/components/rendering>.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -11,7 +11,7 @@ uid: blazor/debug
 ---
 # Debug ASP.NET Core Blazor WebAssembly
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor WebAssembly apps can be debugged using the browser dev tools in Chromium-based browsers (Edge/Chrome). You can also debug your app using the following integrated development environments (IDEs):
 
@@ -376,9 +376,9 @@ VsRegEdit.exe set "<VSInstallFolder>" HKCU JSDebugger\Options\Debugging "BlazorT
 
 The `{TIMEOUT}` placeholder in the preceding command is in milliseconds. For example, one minute is assigned as `60000`.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor WebAssembly apps can be debugged using the browser dev tools in Chromium-based browsers (Edge/Chrome). You can also debug your app using the following integrated development environments (IDEs):
 
@@ -791,9 +791,9 @@ VsRegEdit.exe set "<VSInstallFolder>" HKCU JSDebugger\Options\Debugging "BlazorT
 
 The `{TIMEOUT}` placeholder in the preceding command is in milliseconds. For example, one minute is assigned as `60000`.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Blazor WebAssembly apps can be debugged using the browser dev tools in Chromium-based browsers (Edge/Chrome). You can also debug your app using the following integrated development environments (IDEs):
 
@@ -1206,4 +1206,4 @@ VsRegEdit.exe set "<VSInstallFolder>" HKCU JSDebugger\Options\Debugging "BlazorT
 
 The `{TIMEOUT}` placeholder in the preceding command is in milliseconds. For example, one minute is assigned as `60000`.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -12,7 +12,7 @@ zone_pivot_groups: blazor-hosting-models
 ---
 # ASP.NET Core Blazor file uploads
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 > [!WARNING]
 > Always follow security best practices when permitting users to upload files. For more information, see <xref:mvc/models/file-uploads#security-considerations>.
@@ -106,17 +106,17 @@ The following example demonstrates multiple file upload in a component. <xref:Mi
 
 `Pages/FileUpload1.razor`:
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload1.razor)]
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_Server/Pages/file-uploads/FileUpload1.razor)]
 
-::: zone-end
+:::zone-end
 
 <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile> returns metadata [exposed by the browser](https://developer.mozilla.org/docs/Web/API/File#Instance_properties) as properties. Use this metadata for preliminary validation.
 
@@ -130,13 +130,13 @@ The following example demonstrates multiple file upload in a component. <xref:Mi
 
 ## Upload files to a server
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 The following example demonstrates uploading files to a web API controller in the **`Server`** app of a hosted Blazor WebAssembly solution.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 The following example demonstrates uploading files from a Blazor Server app to a backend web API controller in a separate app, possibly on a separate server.
 
@@ -157,11 +157,11 @@ For the examples in this section:
 
 For testing, the preceding URLs are configured in the projects' `Properties/launchSettings.json` files.
 
-::: zone-end
+:::zone-end
 
 ### Upload result class
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 The following `UploadResult` class in the **`Shared`** project maintains the result of an uploaded file. When a file fails to upload on the server, an error code is returned in `ErrorCode` for display to the user. A safe file name is generated on the server for each file and returned to the client in `StoredFileName` for display. Files are keyed between the client and server using the unsafe/untrusted file name in `FileName`. In the following example, the project's namespace is `BlazorSample.Shared`.
 
@@ -186,9 +186,9 @@ To make the `UploadResult` class available to the **`Client`** project, add an i
 @using BlazorSample.Shared
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 The following `UploadResult` class is placed in the client project and in the web API project to maintain the result of an uploaded file. When a file fails to upload on the server, an error code is returned in `ErrorCode` for display to the user. A safe file name is generated on the server for each file and returned to the client in `StoredFileName` for display. Files are keyed between the client and server using the unsafe/untrusted file name in `FileName`.
 
@@ -204,7 +204,7 @@ public class UploadResult
 }
 ```
 
-::: zone-end
+:::zone-end
 
 > [!NOTE]
 > A security best practice for production apps is to avoid sending error messages to clients that might reveal sensitive information about an app, server, or network. Providing detailed error messages can aid a malicious user in devising attacks on an app, server, or network. The example code in this section only sends back an error code number (`int`) for display by the component client-side if a server-side error occurs. If a user requires assistance with a file upload, they provide the error code to support personnel for support ticket resolution without ever knowing the exact cause of the error.
@@ -224,25 +224,25 @@ The following `FileUpload2` component:
 >
 > For more information on security considerations when uploading files to a server, see <xref:mvc/models/file-uploads#security-considerations>.
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 `Pages/FileUpload2.razor` in the **`Client`** project:
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor)]
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 `Pages/FileUpload2.razor` in the Blazor Server app:
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_Server/Pages/file-uploads/FileUpload2.razor)]
 
-::: zone-end
+:::zone-end
 
 ### Upload controller
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 The following controller in the **`Server`** project saves uploaded files from the client.
 
@@ -356,9 +356,9 @@ public class FilesaveController : ControllerBase
 }
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 The following controller in the web API project saves uploaded files from the client.
 
@@ -471,11 +471,11 @@ public class FilesaveController : ControllerBase
 }
 ```
 
-::: zone-end
+:::zone-end
 
 In the preceding code, <xref:System.IO.Path.GetRandomFileName%2A> is called to generate a secure filename. Never trust the filename provided by the browser, as an attacker may choose an existing filename that overwrites an existing file or send a path that attempts to write outside of the app.
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ## Upload files with progress
 
@@ -496,30 +496,30 @@ For more information, see the following API resources:
 * <xref:System.IO.FileStream>: Provides a <xref:System.IO.Stream> for a file, supporting both synchronous and asynchronous read and write operations.
 * <xref:System.IO.FileStream.ReadAsync%2A?displayProperty=nameWithType>: The preceding `FileUpload3` component reads the stream asynchronously with <xref:System.IO.FileStream.ReadAsync%2A>. Reading a stream synchronously with <xref:System.IO.FileStream.Read%2A> isn't supported in Razor components.
 
-::: zone-end
+:::zone-end
 
 ## File streams
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 In Blazor WebAssembly, file data is streamed directly into the .NET code within the browser.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 In Blazor Server, file data is streamed over the SignalR connection into .NET code on the server as the file is read.
 
-::: zone-end
+:::zone-end
 
 ## Additional resources
 
 * <xref:mvc/models/file-uploads#security-considerations>
 * <xref:blazor/forms-validation>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 > [!WARNING]
 > Always follow security best practices when permitting users to upload files. For more information, see <xref:mvc/models/file-uploads#security-considerations>.
@@ -616,17 +616,17 @@ The following example demonstrates multiple file upload in a component. <xref:Mi
 
 `Pages/FileUpload1.razor`:
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload1.razor)]
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_Server/Pages/file-uploads/FileUpload1.razor)]
 
-::: zone-end
+:::zone-end
 
 <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile> returns metadata [exposed by the browser](https://developer.mozilla.org/docs/Web/API/File#Instance_properties) as properties. Use this metadata for preliminary validation.
 
@@ -640,13 +640,13 @@ The following example demonstrates multiple file upload in a component. <xref:Mi
 
 ## Upload files to a server
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 The following example demonstrates uploading files to a web API controller in the **`Server`** app of a hosted Blazor WebAssembly solution.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 The following example demonstrates uploading files from a Blazor Server app to a backend web API controller in a separate app, possibly on a separate server.
 
@@ -667,11 +667,11 @@ For the examples in this section:
 
 For testing, the preceding URLs are configured in the projects' `Properties/launchSettings.json` files.
 
-::: zone-end
+:::zone-end
 
 ### Upload result class
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 The following `UploadResult` class in the **`Shared`** project maintains the result of an uploaded file. When a file fails to upload on the server, an error code is returned in `ErrorCode` for display to the user. A safe file name is generated on the server for each file and returned to the client in `StoredFileName` for display. Files are keyed between the client and server using the unsafe/untrusted file name in `FileName`. In the following example, the project's namespace is `BlazorSample.Shared`.
 
@@ -696,9 +696,9 @@ To make the `UploadResult` class available to the **`Client`** project, add an i
 @using BlazorSample.Shared
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 The following `UploadResult` class is placed in the client project and in the web API project to maintain the result of an uploaded file. When a file fails to upload on the server, an error code is returned in `ErrorCode` for display to the user. A safe file name is generated on the server for each file and returned to the client in `StoredFileName` for display. Files are keyed between the client and server using the unsafe/untrusted file name in `FileName`.
 
@@ -714,7 +714,7 @@ public class UploadResult
 }
 ```
 
-::: zone-end
+:::zone-end
 
 > [!NOTE]
 > A security best practice for production apps is to avoid sending error messages to clients that might reveal sensitive information about an app, server, or network. Providing detailed error messages can aid a malicious user in devising attacks on an app, server, or network. The example code in this section only sends back an error code number (`int`) for display by the component client-side if a server-side error occurs. If a user requires assistance with a file upload, they provide the error code to support personnel for support ticket resolution without ever knowing the exact cause of the error.
@@ -734,25 +734,25 @@ The following `FileUpload2` component:
 >
 > For more information on security considerations when uploading files to a server, see <xref:mvc/models/file-uploads#security-considerations>.
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 `Pages/FileUpload2.razor` in the **`Client`** project:
 
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Pages/file-uploads/FileUpload2.razor)]
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 `Pages/FileUpload2.razor` in the Blazor Server app:
 
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_Server/Pages/file-uploads/FileUpload2.razor)]
 
-::: zone-end
+:::zone-end
 
 ### Upload controller
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 The following controller in the **`Server`** project saves uploaded files from the client.
 
@@ -866,9 +866,9 @@ public class FilesaveController : ControllerBase
 }
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 The following controller in the web API project saves uploaded files from the client.
 
@@ -981,9 +981,9 @@ public class FilesaveController : ControllerBase
 }
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ## Upload files with progress
 
@@ -1004,21 +1004,21 @@ For more information, see the following API resources:
 * <xref:System.IO.FileStream>: Provides a <xref:System.IO.Stream> for a file, supporting both synchronous and asynchronous read and write operations.
 * <xref:System.IO.FileStream.ReadAsync%2A?displayProperty=nameWithType>: The preceding `FileUpload3` component reads the stream asynchronously with <xref:System.IO.FileStream.ReadAsync%2A>. Reading a stream synchronously with <xref:System.IO.FileStream.Read%2A> isn't supported in Razor components.
 
-::: zone-end
+:::zone-end
 
 ## File streams
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 In Blazor WebAssembly, file data is streamed directly into the .NET code within the browser.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 In Blazor Server, file data is streamed over the SignalR connection into .NET code on the server as the file is read from the stream. <xref:Microsoft.AspNetCore.Components.Forms.RemoteBrowserFileStreamOptions> allows configuring file upload characteristics for Blazor Server.
 
-::: zone-end
+:::zone-end
 
 ## Additional resources
 
@@ -1027,4 +1027,4 @@ In Blazor Server, file data is streamed over the SignalR connection into .NET co
 * <xref:mvc/models/file-uploads#security-considerations>
 * <xref:blazor/forms-validation>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -11,7 +11,7 @@ uid: blazor/forms-validation
 ---
 # ASP.NET Core Blazor forms and validation
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 The Blazor framework supports webforms with validation using the <xref:Microsoft.AspNetCore.Components.Forms.EditForm> component bound to a model that uses [data annotations](xref:mvc/models/validation).
 
@@ -1058,9 +1058,9 @@ private ExampleModel exampleModel = new();
 * <xref:blazor/security/webassembly/hosted-with-azure-active-directory-b2c>
 * <xref:blazor/security/webassembly/hosted-with-identity-server>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 The Blazor framework supports webforms with validation using the <xref:Microsoft.AspNetCore.Components.Forms.EditForm> component bound to a model that uses [data annotations](xref:mvc/models/validation).
 
@@ -2040,9 +2040,9 @@ private ExampleModel exampleModel = new();
 * <xref:blazor/security/webassembly/hosted-with-azure-active-directory-b2c>
 * <xref:blazor/security/webassembly/hosted-with-identity-server>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 The Blazor framework supports webforms with validation using the <xref:Microsoft.AspNetCore.Components.Forms.EditForm> component bound to a model that uses [data annotations](xref:mvc/models/validation).
 
@@ -2917,4 +2917,4 @@ private ExampleModel exampleModel = new ExampleModel();
 * <xref:blazor/security/webassembly/hosted-with-azure-active-directory-b2c>
 * <xref:blazor/security/webassembly/hosted-with-identity-server>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/configuration
 ---
 # ASP.NET Core Blazor configuration
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, see <xref:fundamentals/configuration/index>.
@@ -240,9 +240,9 @@ Configuration files are cached for offline use. With [Progressive Web Applicatio
 
 For more information on how background updates are handled by PWAs, see <xref:blazor/progressive-web-app#background-updates>.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, see <xref:fundamentals/configuration/index>.
@@ -472,9 +472,9 @@ Configuration files are cached for offline use. With [Progressive Web Applicatio
 
 For more information on how background updates are handled by PWAs, see <xref:blazor/progressive-web-app#background-updates>.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, see <xref:fundamentals/configuration/index>.
@@ -704,4 +704,4 @@ Configuration files are cached for offline use. With [Progressive Web Applicatio
 
 For more information on how background updates are handled by PWAs, see <xref:blazor/progressive-web-app#background-updates>.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -13,7 +13,7 @@ uid: blazor/fundamentals/dependency-injection
 
 By [Rainer Stropek](https://www.timecockpit.com) and [Mike Rousos](https://github.com/mjrousos)
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 [Dependency injection (DI)](xref:fundamentals/dependency-injection) is a technique for accessing services configured in a central location:
 
@@ -337,9 +337,9 @@ Navigate to the `TransientExample` component at `/transient-example` and an <xre
 * [`IDisposable` guidance for Transient and shared instances](xref:fundamentals/dependency-injection#idisposable-guidance-for-transient-and-shared-instances)
 * <xref:mvc/views/dependency-injection>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 [Dependency injection (DI)](xref:fundamentals/dependency-injection) is a technique for accessing services configured in a central location:
 
@@ -699,9 +699,9 @@ Navigate to the `TransientExample` component at `/transient-example` and an <xre
 * [`IDisposable` guidance for Transient and shared instances](xref:fundamentals/dependency-injection#idisposable-guidance-for-transient-and-shared-instances)
 * <xref:mvc/views/dependency-injection>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 [Dependency injection (DI)](xref:fundamentals/dependency-injection) is a technique for accessing services configured in a central location:
 
@@ -1061,4 +1061,4 @@ Navigate to the `TransientExample` component at `/transient-example` and an <xre
 * [`IDisposable` guidance for Transient and shared instances](xref:fundamentals/dependency-injection#idisposable-guidance-for-transient-and-shared-instances)
 * <xref:mvc/views/dependency-injection>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/environments
 ---
 # ASP.NET Core Blazor environments
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
@@ -148,9 +148,9 @@ The <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEn
 * <xref:blazor/fundamentals/startup>
 * <xref:fundamentals/environments>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
@@ -287,9 +287,9 @@ The <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEn
 * <xref:blazor/fundamentals/startup>
 * <xref:fundamentals/environments>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
@@ -401,4 +401,4 @@ The <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEn
 * <xref:blazor/fundamentals/startup>
 * <xref:fundamentals/environments>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/handle-errors
 ---
 # Handle errors in ASP.NET Core Blazor apps
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article describes how Blazor manages unhandled exceptions and how to develop apps that detect and handle errors.
 
@@ -483,9 +483,9 @@ Consider manual render tree builder logic on the same level of complexity and wi
 
 &dagger;Applies to backend ASP.NET Core web API apps that client-side Blazor WebAssembly apps use for logging.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article describes how Blazor manages unhandled exceptions and how to develop apps that detect and handle errors.
 
@@ -977,9 +977,9 @@ Consider manual render tree builder logic on the same level of complexity and wi
 
 &dagger;Applies to server-side ASP.NET Core apps that are web API backend apps for Blazor apps.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article describes how Blazor manages unhandled exceptions and how to develop apps that detect and handle errors.
 
@@ -1471,4 +1471,4 @@ Consider manual render tree builder logic on the same level of complexity and wi
 
 &dagger;Applies to server-side ASP.NET Core apps that are web API backend apps for Blazor apps.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/logging.md
+++ b/aspnetcore/blazor/fundamentals/logging.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/logging
 ---
 # ASP.NET Core Blazor logging
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 ## Logging in Blazor WebAssembly apps
 
@@ -89,9 +89,9 @@ The following example demonstrates logging with an <xref:Microsoft.Extensions.Lo
 
 * <xref:fundamentals/logging/index>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 ## Logging in Blazor WebAssembly apps
 
@@ -169,9 +169,9 @@ The following example demonstrates logging with an <xref:Microsoft.Extensions.Lo
 
 * <xref:fundamentals/logging/index>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ## Logging in Blazor WebAssembly apps
 
@@ -249,4 +249,4 @@ The following example demonstrates logging with an <xref:Microsoft.Extensions.Lo
 
 * <xref:fundamentals/logging/index>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/routing
 ---
 # ASP.NET Core Blazor routing and navigation
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 In this article, learn how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create a navigation links in Blazor apps.
 
@@ -657,9 +657,9 @@ The route specified in the host file is called a *fallback route* because it ope
 For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A> for non-root URL server hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
 -->
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 In this article, learn how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create a navigation links in Blazor apps.
 
@@ -1084,9 +1084,9 @@ The route specified in the host file is called a *fallback route* because it ope
 For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A> for non-root URL server hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
 -->
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 In this article, learn how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create a navigation links in Blazor apps.
 
@@ -1358,4 +1358,4 @@ The route specified in the host file is called a *fallback route* because it ope
 For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A> for non-root URL server hosting, see <xref:blazor/host-and-deploy/index#app-base-path>.
 -->
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/signalr
 ---
 # ASP.NET Core Blazor SignalR guidance
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article explains how to configure and manage SignalR connections in Blazor apps.
 
@@ -324,9 +324,9 @@ When a circuit ends because a user has disconnected and the framework is cleanin
 * [Performance guide for Azure SignalR Service](/azure/azure-signalr/signalr-concept-performance)
 * <xref:signalr/publish-to-azure-web-app>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article explains how to configure and manage SignalR connections in Blazor apps.
 
@@ -643,9 +643,9 @@ When a circuit ends because a user has disconnected and the framework is cleanin
 * [Performance guide for Azure SignalR Service](/azure/azure-signalr/signalr-concept-performance)
 * <xref:signalr/publish-to-azure-web-app>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article explains how to configure and manage SignalR connections in Blazor apps.
 
@@ -933,4 +933,4 @@ When a circuit ends because a user has disconnected and the framework is cleanin
 * [Performance guide for Azure SignalR Service](/azure/azure-signalr/signalr-concept-performance)
 * <xref:signalr/publish-to-azure-web-app>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/startup
 ---
 # ASP.NET Core Blazor Startup
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server):
 
@@ -191,9 +191,9 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
@@ -369,9 +369,9 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
@@ -544,4 +544,4 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -11,7 +11,7 @@ uid: blazor/fundamentals/static-files
 ---
 # ASP.NET Core Blazor static files
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article describes the configuration for serving static files in Blazor apps.
 
@@ -112,9 +112,9 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 * [App base path](xref:blazor/host-and-deploy/index#app-base-path)
 * [Hosted deployment with multiple Blazor WebAssembly apps](xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article describes the configuration for serving static files in Blazor apps.
 
@@ -215,9 +215,9 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 * [App base path](xref:blazor/host-and-deploy/index#app-base-path)
 * [Hosted deployment with multiple Blazor WebAssembly apps](xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article describes the configuration for serving static files in Blazor apps.
 
@@ -323,4 +323,4 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 * [App base path](xref:blazor/host-and-deploy/index#app-base-path)
 * [Hosted deployment with multiple Blazor WebAssembly apps](xref:blazor/host-and-deploy/webassembly#hosted-deployment-with-multiple-blazor-webassembly-apps)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -12,7 +12,7 @@ zone_pivot_groups: blazor-hosting-models
 ---
 # ASP.NET Core Blazor globalization and localization
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Razor components can render globalized and localized content to users in different cultures and languages. For [globalization](/dotnet/standard/globalization-localization/globalization), Blazor provides number and date formatting. For [localization](/dotnet/standard/globalization-localization/localization), Blazor renders content using the [.NET Resources system](/dotnet/framework/resources/).
 
@@ -159,7 +159,7 @@ The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Heade
 
 The app's culture is set by matching the first requested language that matches a supported culture of the app.
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
 
@@ -169,9 +169,9 @@ Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the ap
 </PropertyGroup>
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
 
@@ -191,7 +191,7 @@ app.UseRequestLocalization(new RequestLocalizationOptions()
 
 For information on ordering the Localization Middleware in the middleware pipeline of `Program.cs`, see <xref:fundamentals/middleware/index#middleware-order>.
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again.
 
@@ -210,7 +210,7 @@ When the culture is Chilean Spanish (`es-CL`), the rendered component uses day/m
 
 ## Statically set the culture
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
 
@@ -255,9 +255,9 @@ CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
 
@@ -277,13 +277,13 @@ The culture value for <xref:Microsoft.AspNetCore.Builder.ApplicationBuilderExten
 
 For information on ordering the Localization Middleware in the middleware pipeline of `Program.cs`, see <xref:fundamentals/middleware/index#middleware-order>.
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again. When the requested language is Chilean Spanish, the app's culture remains United States English (`en-US`).
 
 ## Dynamically set the culture by user preference
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Examples of locations where an app might store a user's preference include in [browser local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (common in Blazor WebAssembly apps), in a localization cookie or database (common in Blazor Server apps), or in an external service attached to an external database and accessed by a [web API](xref:blazor/call-web-api). The following example demonstrates how to use browser local storage.
 
@@ -427,9 +427,9 @@ Inside the closing tag of the `<main>` element in `Shared/MainLayout.razor`, add
 </div>
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Examples of locations where an app might store a user's preference include in [browser local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (common in Blazor WebAssembly apps), in a localization cookie or database (common in Blazor Server apps), or in an external service attached to an external database and accessed by a [web API](xref:blazor/call-web-api). The following example demonstrates how to use a localization cookie.
 
@@ -606,7 +606,7 @@ Inside the closing `</div>` tag of the `<div class="main">` element in `Shared/M
 </div>
 ```
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how the preceding example works.
 
@@ -616,7 +616,7 @@ If the app doesn't already support culture selection per the [Dynamically set th
 
 [!INCLUDE[](~/includes/package-reference.md)]
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
 
@@ -638,9 +638,9 @@ Add Blazor's localization service to the app's service collection with <xref:Mic
 builder.Services.AddLocalization();
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Use [Localization Middleware](xref:fundamentals/localization#localization-middleware) to set the app's culture.
 
@@ -671,7 +671,7 @@ For information on ordering the Localization Middleware in the middleware pipeli
 
 If the app should localize resources based on storing a user's culture setting, use a localization culture cookie. Use of a cookie ensures that the WebSocket connection can correctly propagate the culture. If localization schemes are based on the URL path or query string, the scheme might not be able to work with [WebSockets](xref:fundamentals/websockets), thus fail to persist the culture. Therefore, the recommended approach is to use a localization culture cookie. See the [Dynamically set the culture by user preference](#dynamically-set-the-culture-by-user-preference) section of this article to see an example Razor expression for the `Pages/_Layout.cshtml` file that persists the user's culture selection.
 
-::: zone-end
+:::zone-end
 
 The example of localized resources in this section works with the prior examples in this article where the app's supported cultures are English (`en`) as a default locale and Spanish (`es`) as a user-selectable or browser-specified alternate locale.
 
@@ -876,9 +876,9 @@ Optionally, add a menu item to the navigation in `Shared/NavMenu.razor` for the 
 * [Microsoft Multilingual App Toolkit](https://marketplace.visualstudio.com/items?itemName=MultilingualAppToolkit.MultilingualAppToolkit-18308)
 * [Localization & Generics](http://hishambinateya.com/localization-and-generics)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Razor components can render globalized and localized content to users in different cultures and languages. For [globalization](/dotnet/standard/globalization-localization/globalization), Blazor provides number and date formatting. For [localization](/dotnet/standard/globalization-localization/localization), Blazor renders content using the [.NET Resources system](/dotnet/framework/resources/).
 
@@ -1025,7 +1025,7 @@ The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Heade
 
 The app's culture is set by matching the first requested language that matches a supported culture of the app.
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
 
@@ -1035,9 +1035,9 @@ Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the ap
 </PropertyGroup>
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
 
@@ -1057,7 +1057,7 @@ app.UseRequestLocalization(new RequestLocalizationOptions()
 
 For information on ordering the Localization Middleware in the middleware pipeline of `Startup.Configure`, see <xref:fundamentals/middleware/index#middleware-order>.
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again.
 
@@ -1076,7 +1076,7 @@ When the culture is Chilean Spanish (`es-CL`), the rendered component uses day/m
 
 ## Statically set the culture
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
 
@@ -1121,9 +1121,9 @@ CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
 
@@ -1143,13 +1143,13 @@ The culture value for <xref:Microsoft.AspNetCore.Builder.ApplicationBuilderExten
 
 For information on ordering the Localization Middleware in the middleware pipeline of `Startup.Configure`, see <xref:fundamentals/middleware/index#middleware-order>.
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again. When the requested language is Chilean Spanish, the app's culture remains United States English (`en-US`).
 
 ## Dynamically set the culture by user preference
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Examples of locations where an app might store a user's preference include in [browser local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (common in Blazor WebAssembly apps), in a localization cookie or database (common in Blazor Server apps), or in an external service attached to an external database and accessed by a [web API](xref:blazor/call-web-api). The following example demonstrates how to use browser local storage.
 
@@ -1288,9 +1288,9 @@ Inside the closing `</div>` tag of the `<div class="main">` element in `Shared/M
 </div>
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Examples of locations where an app might store a user's preference include in [browser local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (common in Blazor WebAssembly apps), in a localization cookie or database (common in Blazor Server apps), or in an external service attached to an external database and accessed by a [web API](xref:blazor/call-web-api). The following example demonstrates how to use a localization cookie.
 
@@ -1462,7 +1462,7 @@ Inside the closing `</div>` tag of the `<div class="main">` element in `Shared/M
 </div>
 ```
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how the preceding example works.
 
@@ -1472,7 +1472,7 @@ If the app doesn't already support culture selection per the [Dynamically set th
 
 [!INCLUDE[](~/includes/package-reference.md)]
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the app's project file (`.csproj`):
 
@@ -1494,9 +1494,9 @@ Add Blazor's localization service to the app's service collection with <xref:Mic
 builder.Services.AddLocalization();
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Use [Localization Middleware](xref:fundamentals/localization#localization-middleware) to set the app's culture.
 
@@ -1527,7 +1527,7 @@ For information on ordering the Localization Middleware in the middleware pipeli
 
 If the app should localize resources based on storing a user's culture setting, use a localization culture cookie. Use of a cookie ensures that the WebSocket connection can correctly propagate the culture. If localization schemes are based on the URL path or query string, the scheme might not be able to work with [WebSockets](xref:fundamentals/websockets), thus fail to persist the culture. Therefore, the recommended approach is to use a localization culture cookie. See the [Dynamically set the culture by user preference](#dynamically-set-the-culture-by-user-preference) section of this article to see an example Razor expression for the `Pages/_Host.cshtml` file that persists the user's culture selection.
 
-::: zone-end
+:::zone-end
 
 The example of localized resources in this section works with the prior examples in this article where the app's supported cultures are English (`en`) as a default locale and Spanish (`es`) as a user-selectable or browser-specified alternate locale.
 
@@ -1732,9 +1732,9 @@ Optionally, add a menu item to the navigation in `Shared/NavMenu.razor` for the 
 * [Microsoft Multilingual App Toolkit](https://marketplace.visualstudio.com/items?itemName=MultilingualAppToolkit.MultilingualAppToolkit-18308)
 * [Localization & Generics](http://hishambinateya.com/localization-and-generics)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Razor components can render globalized and localized content to users in different cultures and languages. For [globalization](/dotnet/standard/globalization-localization/globalization), Blazor provides number and date formatting. For [localization](/dotnet/standard/globalization-localization/localization), Blazor renders content using the [.NET Resources system](/dotnet/framework/resources/).
 
@@ -1881,7 +1881,7 @@ The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Heade
 
 The app's culture is set by matching the first requested language that matches a supported culture of the app.
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
 
@@ -1901,7 +1901,7 @@ app.UseRequestLocalization(new RequestLocalizationOptions()
 
 For information on ordering the Localization Middleware in the middleware pipeline of `Startup.Configure`, see <xref:fundamentals/middleware/index#middleware-order>.
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again.
 
@@ -1920,13 +1920,13 @@ When the culture is Chilean Spanish (`es-CL`), the rendered component uses day/m
 
 ## Statically set the culture
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 By default, the Intermediate Language (IL) Linker configuration for Blazor WebAssembly apps strips out internationalization information except for locales explicitly requested. For more information, see <xref:blazor/host-and-deploy/configure-linker#configure-the-linker-for-internationalization>.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
 
@@ -1946,13 +1946,13 @@ The culture value for <xref:Microsoft.AspNetCore.Builder.ApplicationBuilderExten
 
 For information on ordering the Localization Middleware in the middleware pipeline of `Startup.Configure`, see <xref:fundamentals/middleware/index#middleware-order>.
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again. When the requested language is Chilean Spanish, the app's culture remains United States English (`en-US`).
 
 ## Dynamically set the culture by user preference
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 Examples of locations where an app might store a user's preference include in [browser local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (common in Blazor WebAssembly apps), in a localization cookie or database (common in Blazor Server apps), or in an external service attached to an external database and accessed by a [web API](xref:blazor/call-web-api). The following example demonstrates how to use browser local storage.
 
@@ -2067,9 +2067,9 @@ Inside the closing `</div>` tag of the `<div class="main">` element in `Shared/M
 </div>
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Examples of locations where an app might store a user's preference include in [browser local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (common in Blazor WebAssembly apps), in a localization cookie or database (common in Blazor Server apps), or in an external service attached to an external database and accessed by a [web API](xref:blazor/call-web-api). The following example demonstrates how to use a localization cookie.
 
@@ -2241,7 +2241,7 @@ Inside the closing `</div>` tag of the `<div class="main">` element in `Shared/M
 </div>
 ```
 
-::: zone-end
+:::zone-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how the preceding example works.
 
@@ -2251,7 +2251,7 @@ If the app doesn't already support culture selection per the [Dynamically set th
 
 [!INCLUDE[](~/includes/package-reference.md)]
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 By default, the Intermediate Language (IL) Linker configuration for Blazor WebAssembly apps strips out internationalization information except for locales explicitly requested. For more information, see <xref:blazor/host-and-deploy/configure-linker#configure-the-linker-for-internationalization>.
 
@@ -2267,9 +2267,9 @@ Add Blazor's localization service to the app's service collection with <xref:Mic
 builder.Services.AddLocalization();
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Use [Localization Middleware](xref:fundamentals/localization#localization-middleware) to set the app's culture.
 
@@ -2300,7 +2300,7 @@ For information on ordering the Localization Middleware in the middleware pipeli
 
 If the app should localize resources based on storing a user's culture setting, use a localization culture cookie. Use of a cookie ensures that the WebSocket connection can correctly propagate the culture. If localization schemes are based on the URL path or query string, the scheme might not be able to work with [WebSockets](xref:fundamentals/websockets), thus fail to persist the culture. Therefore, the recommended approach is to use a localization culture cookie. See the [Dynamically set the culture by user preference](#dynamically-set-the-culture-by-user-preference) section of this article to see an example Razor expression for the `Pages/_Host.cshtml` file that persists the user's culture selection.
 
-::: zone-end
+:::zone-end
 
 The example of localized resources in this section works with the prior examples in this article where the app's supported cultures are English (`en`) as a default locale and Spanish (`es`) as a user-selectable or browser-specified alternate locale.
 
@@ -2505,4 +2505,4 @@ Optionally, add a menu item to the navigation in `Shared/NavMenu.razor` for the 
 * [Microsoft Multilingual App Toolkit](https://marketplace.visualstudio.com/items?itemName=MultilingualAppToolkit.MultilingualAppToolkit-18308)
 * [Localization & Generics](http://hishambinateya.com/localization-and-generics)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -11,7 +11,7 @@ uid: blazor/host-and-deploy/configure-trimmer
 ---
 # Configure the Trimmer for ASP.NET Core Blazor
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor WebAssembly performs [Intermediate Language (IL)](/dotnet/standard/managed-code#intermediate-language--execution) trimming to reduce the size of the published output. By default, trimming occurs when publishing an app.
 
@@ -32,9 +32,9 @@ To configure the Trimmer, see the [Trimming options](/dotnet/core/deploying/trim
 * [Trim self-contained deployments and executables](/dotnet/core/deploying/trimming/trim-self-contained)
 * <xref:blazor/performance#intermediate-language-il-trimming>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor WebAssembly performs [Intermediate Language (IL)](/dotnet/standard/managed-code#intermediate-language--execution) trimming to reduce the size of the published output. By default, trimming occurs when publishing an app.
 
@@ -55,4 +55,4 @@ To configure the Trimmer, see the [Trimming options](/dotnet/core/deploying/trim
 * [Trim self-contained deployments and executables](/dotnet/core/deploying/trimming/trim-self-contained)
 * <xref:blazor/performance#intermediate-language-il-trimming>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -11,7 +11,7 @@ uid: blazor/host-and-deploy/index
 ---
 # Host and deploy ASP.NET Core Blazor
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 ## Publish the app
 
@@ -214,9 +214,9 @@ For deployment guidance, see the following topics:
 * <xref:blazor/host-and-deploy/webassembly>
 * <xref:blazor/host-and-deploy/server>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 ## Publish the app
 
@@ -407,9 +407,9 @@ For deployment guidance, see the following topics:
 * <xref:blazor/host-and-deploy/webassembly>
 * <xref:blazor/host-and-deploy/server>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ## Publish the app
 
@@ -600,4 +600,4 @@ For deployment guidance, see the following topics:
 * <xref:blazor/host-and-deploy/webassembly>
 * <xref:blazor/host-and-deploy/server>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -11,7 +11,7 @@ uid: blazor/host-and-deploy/server
 ---
 # Host and deploy Blazor Server
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 ## Host configuration values
 
@@ -204,9 +204,9 @@ For more information and configuration guidance, consult the following resources
 
 For a reasonable UI experience, we recommend a sustained UI latency of 250 ms or less.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 ## Host configuration values
 
@@ -450,9 +450,9 @@ else
 
 For a reasonable UI experience, we recommend a sustained UI latency of 250 ms or less.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ## Host configuration values
 
@@ -676,4 +676,4 @@ else
 
 For a reasonable UI experience, we recommend a sustained UI latency of 250 ms or less.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -11,7 +11,7 @@ uid: blazor/host-and-deploy/webassembly
 ---
 # Host and deploy ASP.NET Core Blazor WebAssembly
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 With the [Blazor WebAssembly hosting model](xref:blazor/hosting-models#blazor-webassembly):
 
@@ -1001,9 +1001,9 @@ To disable integrity checking, remove the `integrity` parameter by changing the 
 
 Again, disabling integrity checking means that you lose the safety guarantees offered by integrity checking. For example, there is a risk that if the user's browser is caching the app at the exact moment that you deploy a new version, it could cache some files from the old deployment and some from the new deployment. If that happens, the app becomes stuck in a broken state until you deploy a further update.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 With the [Blazor WebAssembly hosting model](xref:blazor/hosting-models#blazor-webassembly):
 
@@ -1837,9 +1837,9 @@ To disable integrity checking, remove the `integrity` parameter by changing the 
 
 Again, disabling integrity checking means that you lose the safety guarantees offered by integrity checking. For example, there is a risk that if the user's browser is caching the app at the exact moment that you deploy a new version, it could cache some files from the old deployment and some from the new deployment. If that happens, the app becomes stuck in a broken state until you deploy a further update.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 With the [Blazor WebAssembly hosting model](xref:blazor/hosting-models#blazor-webassembly):
 
@@ -2673,4 +2673,4 @@ To disable integrity checking, remove the `integrity` parameter by changing the 
 
 Again, disabling integrity checking means that you lose the safety guarantees offered by integrity checking. For example, there is a risk that if the user's browser is caching the app at the exact moment that you deploy a new version, it could cache some files from the old deployment and some from the new deployment. If that happens, the app becomes stuck in a broken state until you deploy a further update.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -68,7 +68,7 @@ The Blazor WebAssembly hosting model has the following limitations:
 * Capable client hardware and software (for example, WebAssembly support) is required.
 * Download size is larger, and apps take longer to load.
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor WebAssembly supports [ahead-of-time (AOT) compilation](/dotnet/standard/glossary#aot), where you can compile your .NET code directly into WebAssembly. AOT compilation results in runtime performance improvements at the expense of a larger app size. For more information, see <xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation>. 
 
@@ -78,13 +78,13 @@ Blazor WebAssembly includes support for trimming unused code from .NET Core fram
 
 Blazor WebAssembly apps can use [native dependencies](xref:blazor/webassembly-native-dependencies) built to run on WebAssembly.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-6.0"
+:::moniker range="< aspnetcore-6.0"
 
 Blazor WebAssembly includes support for trimming unused code from .NET Core framework libraries. For more information, see <xref:blazor/globalization-localization>.
 
-::: moniker-end
+:::moniker-end
 
 ## Hosting model selection
 

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -11,7 +11,7 @@ uid: blazor/js-interop/call-dotnet-from-javascript
 ---
 # Call .NET methods from JavaScript functions in ASP.NET Core Blazor
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article covers invoking .NET methods from JavaScript (JS). For information on how to call JS functions from .NET, see <xref:blazor/js-interop/call-javascript-from-dotnet>.
 
@@ -413,9 +413,9 @@ For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#ja
 * [`InteropComponent.razor` example (dotnet/AspNetCore GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/5.0`), use the **Switch branches or tags** dropdown list to select the branch.
 * [Interaction with the Document Object Model (DOM)](xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article covers invoking .NET methods from JavaScript (JS). For information on how to call JS functions from .NET, see <xref:blazor/js-interop/call-javascript-from-dotnet>.
 
@@ -727,9 +727,9 @@ For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#ja
 * [`InteropComponent.razor` example (dotnet/AspNetCore GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/5.0`), use the **Switch branches or tags** dropdown list to select the branch.
 * [Interaction with the Document Object Model (DOM)](xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article covers invoking .NET methods from JavaScript (JS). For information on how to call JS functions from .NET, see <xref:blazor/js-interop/call-javascript-from-dotnet>.
 
@@ -1028,4 +1028,4 @@ Objects that contain circular references can't be serialized on the client for e
 * [`InteropComponent.razor` example (dotnet/AspNetCore GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/5.0`), use the **Switch branches or tags** dropdown list to select the branch.
 * [Interaction with the Document Object Model (DOM)](xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -11,7 +11,7 @@ uid: blazor/js-interop/call-javascript-from-dotnet
 ---
 # Call JavaScript functions from .NET methods in ASP.NET Core Blazor
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article covers invoking JavaScript (JS) functions from .NET. For information on how to call .NET methods from JS, see <xref:blazor/js-interop/call-dotnet-from-javascript>.
 
@@ -716,9 +716,9 @@ In the following example, the `nonFunction` JS function doesn't exist. When the 
 * <xref:blazor/js-interop/call-dotnet-from-javascript>
 * [`InteropComponent.razor` example (dotnet/AspNetCore GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/5.0`), use the **Switch branches or tags** dropdown list to select the branch.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article covers invoking JavaScript (JS) functions from .NET. For information on how to call .NET methods from JS, see <xref:blazor/js-interop/call-dotnet-from-javascript>.
 
@@ -1324,9 +1324,9 @@ In the following example, the `nonFunction` JS function doesn't exist. When the 
 * <xref:blazor/js-interop/call-dotnet-from-javascript>
 * [`InteropComponent.razor` example (dotnet/AspNetCore GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/5.0`), use the **Switch branches or tags** dropdown list to select the branch.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article covers invoking JavaScript (JS) functions from .NET. For information on how to call .NET methods from JS, see <xref:blazor/js-interop/call-dotnet-from-javascript>.
 
@@ -1727,4 +1727,4 @@ In the following example, the `nonFunction` JS function doesn't exist. When the 
 * <xref:blazor/file-downloads>
 * <xref:blazor/file-uploads>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -11,7 +11,7 @@ uid: blazor/js-interop/index
 ---
 # Blazor JavaScript interoperability (JS interop)
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 A Blazor app can invoke JavaScript (JS) functions from .NET methods and .NET methods from JS functions. These scenarios are called *JavaScript interoperability* (*JS interop*).
 
@@ -210,9 +210,9 @@ For more information, see:
 * <xref:blazor/fundamentals/environments>
 * <xref:performance/caching/response>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 A Blazor app can invoke JavaScript (JS) functions from .NET methods and .NET methods from JS functions. These scenarios are called *JavaScript interoperability* (*JS interop*).
 
@@ -400,9 +400,9 @@ For more information, see:
 * <xref:blazor/fundamentals/environments>
 * <xref:performance/caching/response>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 A Blazor app can invoke JavaScript (JS) functions from .NET methods and .NET methods from JS functions. These scenarios are called *JavaScript interoperability* (*JS interop*).
 
@@ -580,4 +580,4 @@ For more information, see:
 * <xref:blazor/fundamentals/environments>
 * <xref:performance/caching/response>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -11,7 +11,7 @@ uid: blazor/performance
 ---
 # ASP.NET Core Blazor performance best practices
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor is optimized for high performance in most realistic application UI scenarios. However, the best performance depends on developers adopting the correct patterns and features.
 
@@ -768,9 +768,9 @@ Blazor WebAssembly's runtime includes the following .NET features that can be di
 
 * By default, Blazor WebAssembly carries globalization resources required to display values, such as dates and currency, in the user's culture. If the app doesn't require localization, you may [configure the app to support the invariant culture](xref:blazor/globalization-localization#invariant-globalization), which is based on the `en-US` culture.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor is optimized for high performance in most realistic application UI scenarios. However, the best performance depends on developers adopting the correct patterns and features.
 
@@ -1519,9 +1519,9 @@ Blazor WebAssembly's runtime includes the following .NET features that can be di
 
 * By default, Blazor WebAssembly carries globalization resources required to display values, such as dates and currency, in the user's culture. If the app doesn't require localization, you may [configure the app to support the invariant culture](xref:blazor/globalization-localization#invariant-globalization), which is based on the `en-US` culture.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Blazor is optimized for high performance in most realistic application UI scenarios. However, the best performance depends on developers adopting the correct patterns and features.
 
@@ -2245,4 +2245,4 @@ Blazor WebAssembly's runtime includes the following .NET features that can be di
 
 * By default, Blazor WebAssembly carries globalization resources required to display values, such as dates and currency, in the user's culture. If the app doesn't require localization, you may [configure the app to support the invariant culture](xref:blazor/globalization-localization#invariant-globalization), which is based on the `en-US` culture.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -11,7 +11,7 @@ uid: blazor/progressive-web-app
 ---
 # Build Progressive Web Applications with ASP.NET Core Blazor WebAssembly
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 A Progressive Web Application (PWA) is usually a Single Page Application (SPA) that uses modern browser APIs and capabilities to behave like a desktop app. Blazor WebAssembly is a standards-based client-side web app platform, so it can use any browser API, including PWA APIs required for the following capabilities:
 
@@ -366,9 +366,9 @@ The [`CarChecker`](https://github.com/SteveSandersonMS/CarChecker) sample app de
 * [Troubleshoot integrity PowerShell script](xref:blazor/host-and-deploy/webassembly#troubleshoot-integrity-powershell-script)
 * [SignalR cross-origin negotiation for authentication](xref:blazor/fundamentals/signalr#signalr-cross-origin-negotiation-for-authentication-blazor-webassembly)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 A Progressive Web Application (PWA) is usually a Single Page Application (SPA) that uses modern browser APIs and capabilities to behave like a desktop app. Blazor WebAssembly is a standards-based client-side web app platform, so it can use any browser API, including PWA APIs required for the following capabilities:
 
@@ -722,9 +722,9 @@ The [`CarChecker`](https://github.com/SteveSandersonMS/CarChecker) sample app de
 * [Troubleshoot integrity PowerShell script](xref:blazor/host-and-deploy/webassembly#troubleshoot-integrity-powershell-script)
 * [SignalR cross-origin negotiation for authentication](xref:blazor/fundamentals/signalr#signalr-cross-origin-negotiation-for-authentication-blazor-webassembly)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 A Progressive Web Application (PWA) is usually a Single Page Application (SPA) that uses modern browser APIs and capabilities to behave like a desktop app. Blazor WebAssembly is a standards-based client-side web app platform, so it can use any browser API, including PWA APIs required for the following capabilities:
 
@@ -1078,4 +1078,4 @@ The [`CarChecker`](https://github.com/SteveSandersonMS/CarChecker) sample app de
 * [Troubleshoot integrity PowerShell script](xref:blazor/host-and-deploy/webassembly#troubleshoot-integrity-powershell-script)
 * [SignalR cross-origin negotiation for authentication](xref:blazor/fundamentals/signalr#signalr-cross-origin-negotiation-for-authentication-blazor-webassembly)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -11,7 +11,7 @@ uid: blazor/project-structure
 ---
 # ASP.NET Core Blazor project structure
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article describes the files and folders that make up a Blazor app generated from one of the Blazor framework's project templates.
 
@@ -106,9 +106,9 @@ Additional files and folders may appear in an app produced from a Blazor Server 
 * <xref:blazor/hosting-models>
 * <xref:fundamentals/minimal-apis>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article describes the files and folders that make up a Blazor app generated from one of the Blazor framework's project templates. For information on how to use tooling to create a Blazor app from a Blazor project template, see <xref:blazor/tooling>. For information on Blazor's hosting models, Blazor WebAssembly and Blazor Server, see <xref:blazor/hosting-models>.
 
@@ -203,9 +203,9 @@ Additional files and folders may appear in an app produced from a Blazor Server 
 * <xref:blazor/tooling>
 * <xref:blazor/hosting-models>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article describes the files and folders that make up a Blazor app generated from one of the Blazor framework's project templates. For information on how to use tooling to create a Blazor app from a Blazor project template, see <xref:blazor/tooling>. For information on Blazor's hosting models, Blazor WebAssembly and Blazor Server, see <xref:blazor/hosting-models>.
 
@@ -296,4 +296,4 @@ Additional files and folders may appear in an app produced from a Blazor Server 
 * <xref:blazor/tooling>
 * <xref:blazor/hosting-models>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -11,7 +11,7 @@ uid: blazor/security/content-security-policy
 ---
 # Enforce a Content Security Policy for ASP.NET Core Blazor
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 [Cross-Site Scripting (XSS)](xref:security/cross-site-scripting) is a security vulnerability where an attacker places one or more malicious client-side scripts into an app's rendered content. A Content Security Policy (CSP) helps protect against XSS attacks by informing the browser of valid:
 
@@ -158,9 +158,9 @@ Test and update an app's policy every release.
 * [Content Security Policy Level 2](https://www.w3.org/TR/CSP2/)
 * [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 [Cross-Site Scripting (XSS)](xref:security/cross-site-scripting) is a security vulnerability where an attacker places one or more malicious client-side scripts into an app's rendered content. A Content Security Policy (CSP) helps protect against XSS attacks by informing the browser of valid:
 
@@ -310,9 +310,9 @@ Test and update an app's policy every release.
 * [Content Security Policy Level 2](https://www.w3.org/TR/CSP2/)
 * [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 [Cross-Site Scripting (XSS)](xref:security/cross-site-scripting) is a security vulnerability where an attacker places one or more malicious client-side scripts into an app's rendered content. A Content Security Policy (CSP) helps protect against XSS attacks by informing the browser of valid:
 
@@ -465,4 +465,4 @@ Test and update an app's policy every release.
 * [Content Security Policy Level 2](https://www.w3.org/TR/CSP2/)
 * [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -11,7 +11,7 @@ uid: blazor/security/index
 ---
 # ASP.NET Core Blazor authentication and authorization
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 ASP.NET Core supports the configuration and management of security in Blazor apps.
 
@@ -624,9 +624,9 @@ The <xref:Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationS
 * [Build a custom version of the Authentication.MSAL JavaScript library](xref:blazor/security/webassembly/additional-scenarios#build-a-custom-version-of-the-authenticationmsal-javascript-library)
 * [Awesome Blazor: Authentication](https://github.com/AdrienTorris/awesome-blazor#authentication) community sample links
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 ASP.NET Core supports the configuration and management of security in Blazor apps.
 
@@ -1245,9 +1245,9 @@ The <xref:Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationS
 * [Build a custom version of the Authentication.MSAL JavaScript library](xref:blazor/security/webassembly/additional-scenarios#build-a-custom-version-of-the-authenticationmsal-javascript-library)
 * [Awesome Blazor: Authentication](https://github.com/AdrienTorris/awesome-blazor#authentication) community sample links
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ASP.NET Core supports the configuration and management of security in Blazor apps.
 
@@ -1781,4 +1781,4 @@ The <xref:Microsoft.AspNetCore.Components.Authorization.CascadingAuthenticationS
 * [Build a custom version of the Authentication.MSAL JavaScript library](xref:blazor/security/webassembly/additional-scenarios#build-a-custom-version-of-the-authenticationmsal-javascript-library)
 * [Awesome Blazor: Authentication](https://github.com/AdrienTorris/awesome-blazor#authentication) community sample links
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/server/additional-scenarios.md
+++ b/aspnetcore/blazor/security/server/additional-scenarios.md
@@ -11,7 +11,7 @@ uid: blazor/security/server/additional-scenarios
 ---
 # ASP.NET Core Blazor Server additional security scenarios
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 ## Pass tokens to a Blazor Server app
 
@@ -158,9 +158,9 @@ app.MapBlazorHub().RequireAuthorization(
     });
 ```
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 ## Pass tokens to a Blazor Server app
 
@@ -307,9 +307,9 @@ endpoints.MapBlazorHub().RequireAuthorization(
     });
 ```
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ## Pass tokens to a Blazor Server app
 
@@ -520,4 +520,4 @@ If tacking on a segment to the authority isn't appropriate for the app's OIDC pr
 
 You can find the App ID URI to use in the OIDC provider app registration description.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/server/index.md
+++ b/aspnetcore/blazor/security/server/index.md
@@ -11,7 +11,7 @@ uid: blazor/security/server/index
 ---
 # Secure ASP.NET Core Blazor Server apps
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor Server apps are configured for security in the same manner as ASP.NET Core apps. For more information, see the articles under <xref:security/index>. Topics under this overview apply specifically to Blazor Server.
 
@@ -123,126 +123,9 @@ Specify the issuer explicitly when deploying to Azure App Service on Linux with 
   * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-Blazor Server apps are configured for security in the same manner as ASP.NET Core apps. For more information, see the articles under <xref:security/index>. Topics under this overview apply specifically to Blazor Server.
-
-## Blazor Server project template
-
-The [Blazor Server project template](xref:blazor/project-structure) can be configured for authentication when the project is created.
-
-# [Visual Studio](#tab/visual-studio)
-
-Follow the Visual Studio guidance in <xref:blazor/tooling> to create a new Blazor Server project with an authentication mechanism.
-
-After choosing the **Blazor Server App** template in the **Create a new ASP.NET Core Web Application** dialog, select **Change** under **Authentication**.
-
-A dialog opens to offer the same set of authentication mechanisms available for other ASP.NET Core projects:
-
-* **No Authentication**
-* **Individual User Accounts**: User accounts can be stored:
-  * Within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
-  * With [Azure AD B2C](xref:security/authentication/azure-ad-b2c).
-* **Work or School Accounts**
-* **Windows Authentication**
-
-# [Visual Studio Code](#tab/visual-studio-code)
-
-Follow the Visual Studio Code guidance in <xref:blazor/tooling> to create a new Blazor Server project with an authentication mechanism:
-
-```dotnetcli
-dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
-```
-
-Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
-
-| Authentication mechanism | Description |
-| ------------------------ | ----------- |
-| `None` (default)         | No authentication |
-| `Individual`             | Users stored in the app with ASP.NET Core Identity |
-| `IndividualB2C`          | Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c) |
-| `SingleOrg`              | Organizational authentication for a single tenant |
-| `MultiOrg`               | Organizational authentication for multiple tenants |
-| `Windows`                | Windows Authentication |
-
-Using the `-o|--output` option, the command uses the value provided for the `{APP NAME}` placeholder to:
-
-* Create a folder for the project.
-* Name the project.
-
-For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-1. Follow the Visual Studio for Mac guidance in <xref:blazor/tooling>.
-
-1. On the **Configure your new Blazor Server App** step, select **Individual Authentication (in-app)** from the **Authentication** drop down.
-
-1. The app is created for individual users stored in the app with ASP.NET Core Identity.
-
-# [.NET Core CLI](#tab/netcore-cli/)
-
-Create a new Blazor Server project with an authentication mechanism using the following command in a command shell:
-
-```dotnetcli
-dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
-```
-
-Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
-
-| Authentication mechanism | Description |
-| ------------------------ | ----------- |
-| `None` (default)         | No authentication |
-| `Individual`             | Users stored in the app with ASP.NET Core Identity |
-| `IndividualB2C`          | Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c) |
-| `SingleOrg`              | Organizational authentication for a single tenant |
-| `MultiOrg`               | Organizational authentication for multiple tenants |
-| `Windows`                | Windows Authentication |
-
-Using the `-o|--output` option, the command uses the value provided for the `{APP NAME}` placeholder to:
-
-* Create a folder for the project.
-* Name the project.
-
-For more information:
-
-* See the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
-* Execute the help command for the Blazor Server template (`blazorserver`) in a command shell:
-
-  ```dotnetcli
-  dotnet new blazorserver --help
-  ```
-
----
-
-## Scaffold Identity
-
-Scaffold Identity into a Blazor Server project:
-
-* [Without existing authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-without-existing-authorization).
-* [With authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-with-authorization).
-
-## Additional claims and tokens from external providers
-
-To store additional claims from external providers, see <xref:security/authentication/social/additional-claims>.
-
-## Azure App Service on Linux with Identity Server
-
-Specify the issuer explicitly when deploying to Azure App Service on Linux with Identity Server. For more information, see <xref:security/authentication/identity/spa#azure-app-service-on-linux>.
-
-## Additional resources
-
-* [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app](/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp)
-* [Quickstart: Protect an ASP.NET Core web API with Microsoft identity platform](/azure/active-directory/develop/quickstart-v2-aspnet-core-web-api)
-* <xref:host-and-deploy/proxy-load-balancer>: Includes guidance on:
-  * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
-  * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-5.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor Server apps are configured for security in the same manner as ASP.NET Core apps. For more information, see the articles under <xref:security/index>. Topics under this overview apply specifically to Blazor Server.
 
@@ -357,4 +240,121 @@ Specify the issuer explicitly when deploying to Azure App Service on Linux with 
   * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 
-::: moniker-end
+:::moniker-end
+
+:::moniker range="< aspnetcore-5.0"
+
+Blazor Server apps are configured for security in the same manner as ASP.NET Core apps. For more information, see the articles under <xref:security/index>. Topics under this overview apply specifically to Blazor Server.
+
+## Blazor Server project template
+
+The [Blazor Server project template](xref:blazor/project-structure) can be configured for authentication when the project is created.
+
+# [Visual Studio](#tab/visual-studio)
+
+Follow the Visual Studio guidance in <xref:blazor/tooling> to create a new Blazor Server project with an authentication mechanism.
+
+After choosing the **Blazor Server App** template in the **Create a new ASP.NET Core Web Application** dialog, select **Change** under **Authentication**.
+
+A dialog opens to offer the same set of authentication mechanisms available for other ASP.NET Core projects:
+
+* **No Authentication**
+* **Individual User Accounts**: User accounts can be stored:
+  * Within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
+  * With [Azure AD B2C](xref:security/authentication/azure-ad-b2c).
+* **Work or School Accounts**
+* **Windows Authentication**
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+Follow the Visual Studio Code guidance in <xref:blazor/tooling> to create a new Blazor Server project with an authentication mechanism:
+
+```dotnetcli
+dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
+```
+
+Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
+
+| Authentication mechanism | Description |
+| ------------------------ | ----------- |
+| `None` (default)         | No authentication |
+| `Individual`             | Users stored in the app with ASP.NET Core Identity |
+| `IndividualB2C`          | Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c) |
+| `SingleOrg`              | Organizational authentication for a single tenant |
+| `MultiOrg`               | Organizational authentication for multiple tenants |
+| `Windows`                | Windows Authentication |
+
+Using the `-o|--output` option, the command uses the value provided for the `{APP NAME}` placeholder to:
+
+* Create a folder for the project.
+* Name the project.
+
+For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+1. Follow the Visual Studio for Mac guidance in <xref:blazor/tooling>.
+
+1. On the **Configure your new Blazor Server App** step, select **Individual Authentication (in-app)** from the **Authentication** drop down.
+
+1. The app is created for individual users stored in the app with ASP.NET Core Identity.
+
+# [.NET Core CLI](#tab/netcore-cli/)
+
+Create a new Blazor Server project with an authentication mechanism using the following command in a command shell:
+
+```dotnetcli
+dotnet new blazorserver -o {APP NAME} -au {AUTHENTICATION}
+```
+
+Permissible authentication values (`{AUTHENTICATION}`) are shown in the following table.
+
+| Authentication mechanism | Description |
+| ------------------------ | ----------- |
+| `None` (default)         | No authentication |
+| `Individual`             | Users stored in the app with ASP.NET Core Identity |
+| `IndividualB2C`          | Users stored in [Azure AD B2C](xref:security/authentication/azure-ad-b2c) |
+| `SingleOrg`              | Organizational authentication for a single tenant |
+| `MultiOrg`               | Organizational authentication for multiple tenants |
+| `Windows`                | Windows Authentication |
+
+Using the `-o|--output` option, the command uses the value provided for the `{APP NAME}` placeholder to:
+
+* Create a folder for the project.
+* Name the project.
+
+For more information:
+
+* See the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+* Execute the help command for the Blazor Server template (`blazorserver`) in a command shell:
+
+  ```dotnetcli
+  dotnet new blazorserver --help
+  ```
+
+---
+
+## Scaffold Identity
+
+Scaffold Identity into a Blazor Server project:
+
+* [Without existing authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-without-existing-authorization).
+* [With authorization](xref:security/authentication/scaffold-identity#scaffold-identity-into-a-blazor-server-project-with-authorization).
+
+## Additional claims and tokens from external providers
+
+To store additional claims from external providers, see <xref:security/authentication/social/additional-claims>.
+
+## Azure App Service on Linux with Identity Server
+
+Specify the issuer explicitly when deploying to Azure App Service on Linux with Identity Server. For more information, see <xref:security/authentication/identity/spa#azure-app-service-on-linux>.
+
+## Additional resources
+
+* [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app](/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp)
+* [Quickstart: Protect an ASP.NET Core web API with Microsoft identity platform](/azure/active-directory/develop/quickstart-v2-aspnet-core-web-api)
+* <xref:host-and-deploy/proxy-load-balancer>: Includes guidance on:
+  * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
+  * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
+
+:::moniker-end

--- a/aspnetcore/blazor/security/server/threat-mitigation.md
+++ b/aspnetcore/blazor/security/server/threat-mitigation.md
@@ -11,7 +11,7 @@ uid: blazor/security/server/threat-mitigation
 ---
 # Threat mitigation guidance for ASP.NET Core Blazor Server
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor Server apps adopt a *stateful* data processing model, where the server and client maintain a long-lived relationship. The persistent state is maintained by a [circuit](xref:blazor/state-management), which can span connections that are also potentially long-lived.
 
@@ -400,9 +400,9 @@ The following list of security considerations isn't comprehensive:
 * Ensure CORS settings are appropriate when enabling CORS or explicitly disable CORS for Blazor apps.
 * Test to ensure that the server-side limits for the Blazor app provide an acceptable user experience without unacceptable levels of risk.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor Server apps adopt a *stateful* data processing model, where the server and client maintain a long-lived relationship. The persistent state is maintained by a [circuit](xref:blazor/state-management), which can span connections that are also potentially long-lived.
 
@@ -791,9 +791,9 @@ The following list of security considerations isn't comprehensive:
 * Ensure CORS settings are appropriate when enabling CORS or explicitly disable CORS for Blazor apps.
 * Test to ensure that the server-side limits for the Blazor app provide an acceptable user experience without unacceptable levels of risk.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Blazor Server apps adopt a *stateful* data processing model, where the server and client maintain a long-lived relationship. The persistent state is maintained by a [circuit](xref:blazor/state-management), which can span connections that are also potentially long-lived.
 
@@ -1182,4 +1182,4 @@ The following list of security considerations isn't comprehensive:
 * Ensure CORS settings are appropriate when enabling CORS or explicitly disable CORS for Blazor apps.
 * Test to ensure that the server-side limits for the Blazor app provide an acceptable user experience without unacceptable levels of risk.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/additional-scenarios
 ---
 # ASP.NET Core Blazor WebAssembly additional security scenarios
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 ## Attach tokens to outgoing requests
 
@@ -1049,9 +1049,9 @@ If an app requires a custom version of the [Microsoft Authentication Library for
 * <xref:blazor/security/webassembly/graph-api>
 * [`HttpClient` and `HttpRequestMessage` with Fetch API request options](xref:blazor/call-web-api#httpclient-and-httprequestmessage-with-fetch-api-request-options)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 ## Attach tokens to outgoing requests
 
@@ -2094,9 +2094,9 @@ If an app requires a custom version of the [Microsoft Authentication Library for
 * <xref:blazor/security/webassembly/graph-api>
 * [`HttpClient` and `HttpRequestMessage` with Fetch API request options](xref:blazor/call-web-api#httpclient-and-httprequestmessage-with-fetch-api-request-options)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ## Attach tokens to outgoing requests
 
@@ -3135,4 +3135,4 @@ If an app requires a custom version of the [Microsoft Authentication Library for
 * <xref:blazor/security/webassembly/graph-api>
 * [`HttpClient` and `HttpRequestMessage` with Fetch API request options](xref:blazor/call-web-api#httpclient-and-httprequestmessage-with-fetch-api-request-options)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/azure-active-directory-groups-and-roles.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/aad-groups-roles
 ---
 # Azure Active Directory (AAD) groups, Administrator Roles, and App Roles
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Azure Active Directory (AAD) provides several authorization approaches that can be combined with ASP.NET Core Identity:
 
@@ -551,9 +551,9 @@ Multiple role tests are supported:
 * <xref:security/authorization/roles>
 * <xref:blazor/security/index>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Azure Active Directory (AAD) provides several authorization approaches that can be combined with ASP.NET Core Identity:
 
@@ -1093,4 +1093,4 @@ Multiple role tests are supported:
 * <xref:security/authorization/roles>
 * <xref:blazor/security/index>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/graph-api.md
+++ b/aspnetcore/blazor/security/webassembly/graph-api.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/graph-api
 ---
 # Use Graph API with ASP.NET Core Blazor WebAssembly
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 [Microsoft Graph API](/graph/use-the-api) is a RESTful web API that enables Blazor and other .NET Framework apps to access Microsoft Cloud service resources.
 
@@ -500,9 +500,9 @@ builder.Services.AddMsalAuthentication<RemoteAuthenticationState,
 
 The preceding example is for an app that uses AAD authentication with MSAL. Similar patterns exist for OIDC and API authentication. For more information, see the examples in [Customize the user with a payload claim](xref:blazor/security/webassembly/additional-scenarios#customize-the-user-with-a-payload-claim) section.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 [Microsoft Graph API](/graph/use-the-api) is a RESTful web API that enables Blazor and other .NET Framework apps to access Microsoft Cloud service resources.
 
@@ -991,9 +991,9 @@ builder.Services.AddMsalAuthentication<RemoteAuthenticationState,
 
 The preceding example is for an app that uses AAD authentication with MSAL. Similar patterns exist for OIDC and API authentication. For more information, see the examples in [Customize the user with a payload claim](xref:blazor/security/webassembly/additional-scenarios#customize-the-user-with-a-payload-claim) section.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ## Named client with Graph API
 
@@ -1227,4 +1227,4 @@ builder.Services.AddMsalAuthentication<RemoteAuthenticationState,
 
 The preceding example is for an app that uses AAD authentication with MSAL. Similar patterns exist for OIDC and API authentication. For more information, see the examples in [Customize the user with a payload claim](xref:blazor/security/webassembly/additional-scenarios#customize-the-user-with-a-payload-claim) section.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/hosted-with-azure-active-directory-b2c
 ---
 # Secure an ASP.NET Core Blazor WebAssembly hosted app with Azure Active Directory B2C
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article describes how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication.
 
@@ -408,9 +408,9 @@ Run the app from the Server project. When using Visual Studio, either:
 * [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article describes how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication.
 
@@ -805,9 +805,9 @@ Run the app from the Server project. When using Visual Studio, either:
 * [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article describes how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication.
 
@@ -1196,4 +1196,4 @@ Run the app from the Server project. When using Visual Studio, either:
 * [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/hosted-with-azure-active-directory
 ---
 # Secure an ASP.NET Core Blazor WebAssembly hosted app with Azure Active Directory
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article describes how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) for authentication.
 
@@ -404,9 +404,9 @@ Run the app from the Server project. When using Visual Studio, either:
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article describes how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) for authentication.
 
@@ -799,9 +799,9 @@ Run the app from the Server project. When using Visual Studio, either:
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article describes how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) for authentication.
 
@@ -1183,4 +1183,4 @@ Run the app from the Server project. When using Visual Studio, either:
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/hosted-with-identity-server
 ---
 # Secure an ASP.NET Core Blazor WebAssembly hosted app with Identity Server
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article explains how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Duende Identity Server](https://docs.duendesoftware.com) to authenticate users and API calls.
 
@@ -577,9 +577,9 @@ Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Sub
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 * [Duende Identity Server](https://docs.duendesoftware.com)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article explains how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [IdentityServer](https://identityserver.io/) to authenticate users and API calls.
 
@@ -1312,9 +1312,9 @@ Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Sub
   * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article explains how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [IdentityServer](https://identityserver.io/) to authenticate users and API calls.
 
@@ -1876,4 +1876,4 @@ Get-ChildItem -path Cert:\CurrentUser\My -Recurse | Format-List DnsNameList, Sub
   * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/index.md
+++ b/aspnetcore/blazor/security/webassembly/index.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/index
 ---
 # Secure ASP.NET Core Blazor WebAssembly
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor WebAssembly apps are secured in the same manner as Single Page Applications (SPAs). There are several approaches for authenticating users to SPAs, but the most common and comprehensive approach is to use an implementation based on the [OAuth 2.0 protocol](https://oauth.net/), such as [OpenID Connect (OIDC)](https://openid.net/connect/).
 
@@ -149,9 +149,9 @@ Further configuration guidance is found in the following articles:
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 * [Support prerendering with authentication](xref:blazor/security/webassembly/additional-scenarios#support-prerendering-with-authentication)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor WebAssembly apps are secured in the same manner as Single Page Applications (SPAs). There are several approaches for authenticating users to SPAs, but the most common and comprehensive approach is to use an implementation based on the [OAuth 2.0 protocol](https://oauth.net/), such as [OpenID Connect (OIDC)](https://openid.net/connect/).
 
@@ -283,9 +283,9 @@ Further configuration guidance is found in the following articles:
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 * [Support prerendering with authentication](xref:blazor/security/webassembly/additional-scenarios#support-prerendering-with-authentication)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 Blazor WebAssembly apps are secured in the same manner as Single Page Applications (SPAs). There are several approaches for authenticating users to SPAs, but the most common and comprehensive approach is to use an implementation based on the [OAuth 2.0 protocol](https://oauth.net/), such as [OpenID Connect (OIDC)](https://openid.net/connect/).
 
@@ -414,4 +414,4 @@ For further configuration guidance, see <xref:blazor/security/webassembly/additi
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 * [Support prerendering with authentication](xref:blazor/security/webassembly/additional-scenarios#support-prerendering-with-authentication)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/standalone-with-authentication-library
 ---
 # Secure an ASP.NET Core Blazor WebAssembly standalone app with the Authentication library
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 *For Azure Active Directory (AAD) and Azure Active Directory B2C (AAD B2C), don't follow the guidance in this topic. See the AAD and AAD B2C topics in this table of contents node.*
 
@@ -193,193 +193,9 @@ The `LoginDisplay` component (`Shared/LoginDisplay.razor`) is rendered in the `M
   * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-*For Azure Active Directory (AAD) and Azure Active Directory B2C (AAD B2C), don't follow the guidance in this topic. See the AAD and AAD B2C topics in this table of contents node.*
-
-To create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) library, follow the guidance for your choice of tooling. If adding support for authentication, see the following sections of this article for guidance on setting up and configuring the app.
-
-> [!NOTE]
-> The Identity Provider (IP) must use [OpenID Connect (OIDC)](https://openid.net/connect/). For example, Facebook's IP isn't an OIDC-compliant provider, so the guidance in this topic doesn't work with the Facebook IP. For more information, see <xref:blazor/security/webassembly/index#authentication-library>.
-
-# [Visual Studio](#tab/visual-studio)
-
-To create a new Blazor WebAssembly project with an authentication mechanism:
-
-1. After choosing the **Blazor WebAssembly App** template in the **Create a new ASP.NET Core Web Application** dialog, select **Change** under **Authentication**.
-
-1. Select **Individual User Accounts** to use ASP.NET Core's [Identity](xref:security/authentication/identity) system. This selection adds authentication support and doesn't result in storing users in a database. The following sections of this article provide further details.
-
-# [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
-
-Create a new Blazor WebAssembly project with an authentication mechanism in an empty folder. Specify the `Individual` authentication mechanism with the `-au|--auth` option to use ASP.NET Core's [Identity](xref:security/authentication/identity) system. This selection adds authentication support and doesn't result in storing users in a database. The following sections of this article provide further details.
-
-```dotnetcli
-dotnet new blazorwasm -au Individual -o {APP NAME}
-```
-
-| Placeholder  | Example        |
-| ------------ | -------------- |
-| `{APP NAME}` | `BlazorSample` |
-
-The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
-
-For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-To create a new Blazor WebAssembly project with an authentication mechanism:
-
-1. On the **Configure your new Blazor WebAssembly App** step, select **Individual Authentication (in-app)** from the **Authentication** drop down.
-
-1. The app is created to use ASP.NET Core [Identity](xref:security/authentication/identity) and doesn't result in storing users in a database. The following sections of this article provide further details.
-
----
-
-## Authentication package
-
-When an app is created to use Individual User Accounts, the app automatically receives a package reference for the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) package in the app's project file. The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
-
-If adding authentication to an app, manually add the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) package to the app.
-
-[!INCLUDE[](~/includes/package-reference.md)]
-
-## Authentication service support
-
-Support for authenticating users is registered in the service container with the <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication%2A> extension method provided by the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) package. This method sets up the services required for the app to interact with the Identity Provider (IP).
-
-For a new app, provide values for the `{AUTHORITY}` and `{CLIENT ID}` placeholders in the following configuration. Provide other configuration values that are required for use with the app's IP. The example is for Google, which requires `PostLogoutRedirectUri`, `RedirectUri`, and `ResponseType`. If adding authentication to an app, manually add the following code and configuration to the app with values for the placeholders and other configuration values.
-
-`Program.cs`:
-
-```csharp
-builder.Services.AddOidcAuthentication(options =>
-{
-    builder.Configuration.Bind("Local", options.ProviderOptions);
-});
-```
-
-Configuration is supplied by the `wwwroot/appsettings.json` file:
-
-```json
-{
-  "Local": {
-    "Authority": "{AUTHORITY}",
-    "ClientId": "{CLIENT ID}"
-  }
-}
-```
-
-Google OAuth 2.0 OIDC example:
-
-```json
-{
-  "Local": {
-    "Authority": "https://accounts.google.com/",
-    "ClientId": "2.......7-e.....................q.apps.googleusercontent.com",
-    "PostLogoutRedirectUri": "https://localhost:5001/authentication/logout-callback",
-    "RedirectUri": "https://localhost:5001/authentication/login-callback",
-    "ResponseType": "id_token"
-  }
-}
-```
-
-The redirect URI (`https://localhost:5001/authentication/login-callback`) is registered in the [Google APIs console](https://console.developers.google.com/apis/dashboard) in **Credentials** > **`{NAME}`** > **Authorized redirect URIs**, where `{NAME}` is the app's client name in the **OAuth 2.0 Client IDs** app list of the Google APIs console.
-
-Authentication support for standalone apps is offered using OpenID Connect (OIDC). The <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication%2A> method accepts a callback to configure the parameters required to authenticate an app using OIDC. The values required for configuring the app can be obtained from the OIDC-compliant IP. Obtain the values when you register the app, which typically occurs in their online portal.
-
-## Access token scopes
-
-The Blazor WebAssembly template automatically configures default scopes for `openid` and `profile`.
-
-The Blazor WebAssembly template doesn't automatically configure the app to request an access token for a secure API. To provision an access token as part of the sign-in flow, add the scope to the default token scopes of the <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions>. If adding authentication to an app, manually add the following code and configure the scope URI.
-
-`Program.cs`:
-
-```csharp
-builder.Services.AddOidcAuthentication(options =>
-{
-    ...
-    options.ProviderOptions.DefaultScopes.Add("{SCOPE URI}");
-});
-```
-
-For more information, see the following sections of the *Additional scenarios* article:
-
-* [Request additional access tokens](xref:blazor/security/webassembly/additional-scenarios#request-additional-access-tokens)
-* [Attach tokens to outgoing requests](xref:blazor/security/webassembly/additional-scenarios#attach-tokens-to-outgoing-requests)
-
-## Imports file
-
-[!INCLUDE[](~/blazor/security/includes/imports-file-standalone.md)]
-
-## Index page
-
-[!INCLUDE[](~/blazor/security/includes/index-page-authentication.md)]
-
-## App component
-
-[!INCLUDE[](~/blazor/security/includes/app-component.md)]
-
-## RedirectToLogin component
-
-[!INCLUDE[](~/blazor/security/includes/redirecttologin-component.md)]
-
-## LoginDisplay component
-
-The `LoginDisplay` component (`Shared/LoginDisplay.razor`) is rendered in the `MainLayout` component (`Shared/MainLayout.razor`) and manages the following behaviors:
-
-* For authenticated users:
-  * Displays the current username.
-  * Offers a button to log out of the app.
-* For anonymous users, offers the option to log in.
-
-```razor
-@using Microsoft.AspNetCore.Components.Authorization
-@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
-@inject NavigationManager Navigation
-@inject SignOutSessionStateManager SignOutManager
-
-<AuthorizeView>
-    <Authorized>
-        Hello, @context.User.Identity.Name!
-        <button class="nav-link btn btn-link" @onclick="BeginSignOut">
-            Log out
-        </button>
-    </Authorized>
-    <NotAuthorized>
-        <a href="authentication/login">Log in</a>
-    </NotAuthorized>
-</AuthorizeView>
-
-@code {
-    private async Task BeginSignOut(MouseEventArgs args)
-    {
-        await SignOutManager.SetSignOutState();
-        Navigation.NavigateTo("authentication/logout");
-    }
-}
-```
-
-## Authentication component
-
-[!INCLUDE[](~/blazor/security/includes/authentication-component.md)]
-
-[!INCLUDE[](~/blazor/security/includes/troubleshoot.md)]
-
-## Additional resources
-
-* <xref:blazor/security/webassembly/additional-scenarios>
-* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:blazor/security/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)
-* <xref:host-and-deploy/proxy-load-balancer>: Includes guidance on:
-  * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
-  * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-5.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 *For Azure Active Directory (AAD) and Azure Active Directory B2C (AAD B2C), don't follow the guidance in this topic. See the AAD and AAD B2C topics in this table of contents node.*
 
@@ -561,4 +377,188 @@ The `LoginDisplay` component (`Shared/LoginDisplay.razor`) is rendered in the `M
   * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
   * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
 
-::: moniker-end
+:::moniker-end
+
+:::moniker range="< aspnetcore-5.0"
+
+*For Azure Active Directory (AAD) and Azure Active Directory B2C (AAD B2C), don't follow the guidance in this topic. See the AAD and AAD B2C topics in this table of contents node.*
+
+To create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) library, follow the guidance for your choice of tooling. If adding support for authentication, see the following sections of this article for guidance on setting up and configuring the app.
+
+> [!NOTE]
+> The Identity Provider (IP) must use [OpenID Connect (OIDC)](https://openid.net/connect/). For example, Facebook's IP isn't an OIDC-compliant provider, so the guidance in this topic doesn't work with the Facebook IP. For more information, see <xref:blazor/security/webassembly/index#authentication-library>.
+
+# [Visual Studio](#tab/visual-studio)
+
+To create a new Blazor WebAssembly project with an authentication mechanism:
+
+1. After choosing the **Blazor WebAssembly App** template in the **Create a new ASP.NET Core Web Application** dialog, select **Change** under **Authentication**.
+
+1. Select **Individual User Accounts** to use ASP.NET Core's [Identity](xref:security/authentication/identity) system. This selection adds authentication support and doesn't result in storing users in a database. The following sections of this article provide further details.
+
+# [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
+
+Create a new Blazor WebAssembly project with an authentication mechanism in an empty folder. Specify the `Individual` authentication mechanism with the `-au|--auth` option to use ASP.NET Core's [Identity](xref:security/authentication/identity) system. This selection adds authentication support and doesn't result in storing users in a database. The following sections of this article provide further details.
+
+```dotnetcli
+dotnet new blazorwasm -au Individual -o {APP NAME}
+```
+
+| Placeholder  | Example        |
+| ------------ | -------------- |
+| `{APP NAME}` | `BlazorSample` |
+
+The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name.
+
+For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) command in the .NET Core Guide.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+To create a new Blazor WebAssembly project with an authentication mechanism:
+
+1. On the **Configure your new Blazor WebAssembly App** step, select **Individual Authentication (in-app)** from the **Authentication** drop down.
+
+1. The app is created to use ASP.NET Core [Identity](xref:security/authentication/identity) and doesn't result in storing users in a database. The following sections of this article provide further details.
+
+---
+
+## Authentication package
+
+When an app is created to use Individual User Accounts, the app automatically receives a package reference for the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) package in the app's project file. The package provides a set of primitives that help the app authenticate users and obtain tokens to call protected APIs.
+
+If adding authentication to an app, manually add the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) package to the app.
+
+[!INCLUDE[](~/includes/package-reference.md)]
+
+## Authentication service support
+
+Support for authenticating users is registered in the service container with the <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication%2A> extension method provided by the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) package. This method sets up the services required for the app to interact with the Identity Provider (IP).
+
+For a new app, provide values for the `{AUTHORITY}` and `{CLIENT ID}` placeholders in the following configuration. Provide other configuration values that are required for use with the app's IP. The example is for Google, which requires `PostLogoutRedirectUri`, `RedirectUri`, and `ResponseType`. If adding authentication to an app, manually add the following code and configuration to the app with values for the placeholders and other configuration values.
+
+`Program.cs`:
+
+```csharp
+builder.Services.AddOidcAuthentication(options =>
+{
+    builder.Configuration.Bind("Local", options.ProviderOptions);
+});
+```
+
+Configuration is supplied by the `wwwroot/appsettings.json` file:
+
+```json
+{
+  "Local": {
+    "Authority": "{AUTHORITY}",
+    "ClientId": "{CLIENT ID}"
+  }
+}
+```
+
+Google OAuth 2.0 OIDC example:
+
+```json
+{
+  "Local": {
+    "Authority": "https://accounts.google.com/",
+    "ClientId": "2.......7-e.....................q.apps.googleusercontent.com",
+    "PostLogoutRedirectUri": "https://localhost:5001/authentication/logout-callback",
+    "RedirectUri": "https://localhost:5001/authentication/login-callback",
+    "ResponseType": "id_token"
+  }
+}
+```
+
+The redirect URI (`https://localhost:5001/authentication/login-callback`) is registered in the [Google APIs console](https://console.developers.google.com/apis/dashboard) in **Credentials** > **`{NAME}`** > **Authorized redirect URIs**, where `{NAME}` is the app's client name in the **OAuth 2.0 Client IDs** app list of the Google APIs console.
+
+Authentication support for standalone apps is offered using OpenID Connect (OIDC). The <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddOidcAuthentication%2A> method accepts a callback to configure the parameters required to authenticate an app using OIDC. The values required for configuring the app can be obtained from the OIDC-compliant IP. Obtain the values when you register the app, which typically occurs in their online portal.
+
+## Access token scopes
+
+The Blazor WebAssembly template automatically configures default scopes for `openid` and `profile`.
+
+The Blazor WebAssembly template doesn't automatically configure the app to request an access token for a secure API. To provision an access token as part of the sign-in flow, add the scope to the default token scopes of the <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.OidcProviderOptions>. If adding authentication to an app, manually add the following code and configure the scope URI.
+
+`Program.cs`:
+
+```csharp
+builder.Services.AddOidcAuthentication(options =>
+{
+    ...
+    options.ProviderOptions.DefaultScopes.Add("{SCOPE URI}");
+});
+```
+
+For more information, see the following sections of the *Additional scenarios* article:
+
+* [Request additional access tokens](xref:blazor/security/webassembly/additional-scenarios#request-additional-access-tokens)
+* [Attach tokens to outgoing requests](xref:blazor/security/webassembly/additional-scenarios#attach-tokens-to-outgoing-requests)
+
+## Imports file
+
+[!INCLUDE[](~/blazor/security/includes/imports-file-standalone.md)]
+
+## Index page
+
+[!INCLUDE[](~/blazor/security/includes/index-page-authentication.md)]
+
+## App component
+
+[!INCLUDE[](~/blazor/security/includes/app-component.md)]
+
+## RedirectToLogin component
+
+[!INCLUDE[](~/blazor/security/includes/redirecttologin-component.md)]
+
+## LoginDisplay component
+
+The `LoginDisplay` component (`Shared/LoginDisplay.razor`) is rendered in the `MainLayout` component (`Shared/MainLayout.razor`) and manages the following behaviors:
+
+* For authenticated users:
+  * Displays the current username.
+  * Offers a button to log out of the app.
+* For anonymous users, offers the option to log in.
+
+```razor
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+@inject NavigationManager Navigation
+@inject SignOutSessionStateManager SignOutManager
+
+<AuthorizeView>
+    <Authorized>
+        Hello, @context.User.Identity.Name!
+        <button class="nav-link btn btn-link" @onclick="BeginSignOut">
+            Log out
+        </button>
+    </Authorized>
+    <NotAuthorized>
+        <a href="authentication/login">Log in</a>
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    private async Task BeginSignOut(MouseEventArgs args)
+    {
+        await SignOutManager.SetSignOutState();
+        Navigation.NavigateTo("authentication/logout");
+    }
+}
+```
+
+## Authentication component
+
+[!INCLUDE[](~/blazor/security/includes/authentication-component.md)]
+
+[!INCLUDE[](~/blazor/security/includes/troubleshoot.md)]
+
+## Additional resources
+
+* <xref:blazor/security/webassembly/additional-scenarios>
+* [Unauthenticated or unauthorized web API requests in an app with a secure default client](xref:blazor/security/webassembly/additional-scenarios#unauthenticated-or-unauthorized-web-api-requests-in-an-app-with-a-secure-default-client)
+* <xref:host-and-deploy/proxy-load-balancer>: Includes guidance on:
+  * Using Forwarded Headers Middleware to preserve HTTPS scheme information across proxy servers and internal networks.
+  * Additional scenarios and use cases, including manual scheme configuration, request path changes for correct request routing, and forwarding the request scheme for Linux and non-IIS reverse proxies.
+
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/standalone-with-azure-active-directory-b2c
 ---
 # Secure an ASP.NET Core Blazor WebAssembly standalone app with Azure Active Directory B2C
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication.
 
@@ -196,9 +196,9 @@ For more information, see the following sections of the *Additional scenarios* a
 * [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication.
 
@@ -381,9 +381,9 @@ For more information, see the following sections of the *Additional scenarios* a
 * [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication.
 
@@ -560,4 +560,4 @@ For more information, see the following sections of the *Additional scenarios* a
 * [Tutorial: Register an application in Azure Active Directory B2C](/azure/active-directory-b2c/tutorial-register-applications)
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/standalone-with-azure-active-directory
 ---
 # Secure an ASP.NET Core Blazor WebAssembly standalone app with Azure Active Directory
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) for authentication.
 
@@ -182,9 +182,9 @@ For more information, see the following sections of the *Additional scenarios* a
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) for authentication.
 
@@ -355,9 +355,9 @@ For more information, see the following sections of the *Additional scenarios* a
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD)](https://azure.microsoft.com/services/active-directory/) for authentication.
 
@@ -521,4 +521,4 @@ For more information, see the following sections of the *Additional scenarios* a
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-accounts.md
@@ -11,7 +11,7 @@ uid: blazor/security/webassembly/standalone-with-microsoft-accounts
 ---
 # Secure an ASP.NET Core Blazor WebAssembly standalone app with Microsoft Accounts
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Microsoft Accounts with Azure Active Directory (AAD)](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal) for authentication.
 
@@ -173,9 +173,9 @@ For more information, see the following sections of the *Additional scenarios* a
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal)
 * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Microsoft Accounts with Azure Active Directory (AAD)](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal) for authentication.
 
@@ -337,9 +337,9 @@ For more information, see the following sections of the *Additional scenarios* a
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal)
 * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This article covers how to create a [standalone Blazor WebAssembly app](xref:blazor/hosting-models#blazor-webassembly) that uses [Microsoft Accounts with Azure Active Directory (AAD)](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal) for authentication.
 
@@ -497,4 +497,4 @@ For more information, see the following sections of the *Additional scenarios* a
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app#register-a-new-application-using-the-azure-portal)
 * [Quickstart: Configure an application to expose web APIs](/azure/active-directory/develop/quickstart-configure-app-expose-web-apis)
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -12,9 +12,9 @@ zone_pivot_groups: blazor-hosting-models
 ---
 # ASP.NET Core Blazor state management
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 User state created in a Blazor WebAssembly app is held in the browser's memory.
 
@@ -117,9 +117,9 @@ Generally, `sessionStorage` is safer to use. `sessionStorage` avoids the risk th
 * <xref:blazor/call-web-api>
 * <xref:blazor/security/webassembly/index>
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server is a stateful app framework. Most of the time, the app maintains a connection to the server. The user's state is held in the server's memory in a *circuit*. 
 
@@ -452,13 +452,13 @@ To persist many different state objects and consume different subsets of objects
 
 [!INCLUDE[](~/blazor/includes/state-container.md)]
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 User state created in a Blazor WebAssembly app is held in the browser's memory.
 
@@ -561,9 +561,9 @@ Generally, `sessionStorage` is safer to use. `sessionStorage` avoids the risk th
 * <xref:blazor/call-web-api>
 * <xref:blazor/security/webassembly/index>
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server is a stateful app framework. Most of the time, the app maintains a connection to the server. The user's state is held in the server's memory in a *circuit*. 
 
@@ -889,13 +889,13 @@ To persist many different state objects and consume different subsets of objects
 
 [!INCLUDE[](~/blazor/includes/state-container.md)]
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 User state created in a Blazor WebAssembly app is held in the browser's memory.
 
@@ -998,9 +998,9 @@ Generally, `sessionStorage` is safer to use. `sessionStorage` avoids the risk th
 * <xref:blazor/call-web-api>
 * <xref:blazor/security/webassembly/index>
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 Blazor Server is a stateful app framework. Most of the time, the app maintains a connection to the server. The user's state is held in the server's memory in a *circuit*. 
 
@@ -1338,6 +1338,6 @@ To persist many different state objects and consume different subsets of objects
 
 [!INCLUDE[](~/blazor/includes/state-container.md)]
 
-::: zone-end
+:::zone-end
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/supported-platforms.md
+++ b/aspnetcore/blazor/supported-platforms.md
@@ -11,7 +11,7 @@ uid: blazor/supported-platforms
 ---
 # ASP.NET Core Blazor supported platforms
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor WebAssembly and Blazor Server are supported in the browsers shown in the following table.
 
@@ -29,9 +29,9 @@ Blazor WebAssembly and Blazor Server are supported in the browsers shown in the 
 * <xref:blazor/hosting-models>
 * <xref:signalr/supported-platforms>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor WebAssembly and Blazor Server are supported in the browsers shown in the following table.
 
@@ -49,9 +49,9 @@ Blazor WebAssembly and Blazor Server are supported in the browsers shown in the 
 * <xref:blazor/hosting-models>
 * <xref:signalr/supported-platforms>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 ## Blazor WebAssembly
 
@@ -84,4 +84,4 @@ Blazor WebAssembly and Blazor Server are supported in the browsers shown in the 
 * <xref:blazor/hosting-models>
 * <xref:signalr/supported-platforms>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/test.md
+++ b/aspnetcore/blazor/test.md
@@ -13,7 +13,7 @@ uid: blazor/test
 
 By: [Egil Hansen](https://egilhansen.com/)
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Testing is an important aspect of building stable and maintainable software.
 
@@ -141,139 +141,9 @@ The following actions take place at each step of the test:
 
 * [Getting Started with bUnit](https://bunit.egilhansen.com/docs/getting-started/): bUnit instructions include guidance on creating a test project, referencing testing framework packages, and building and running tests.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-Testing is an important aspect of building stable and maintainable software.
-
-To test a Blazor component, the *Component Under Test* (CUT) is:
-
-* Rendered with relevant input for the test.
-* Depending on the type of test performed, possibly subject to interaction or modification. For example, event handlers can be triggered, such as an `onclick` event for a button.
-* Inspected for expected values.
-
-## Test approaches
-
-Two common approaches for testing Blazor components are end-to-end (E2E) testing and unit testing:
-
-* **Unit testing**: [Unit tests](/dotnet/core/testing/) are written with a unit testing library that provides:
-  * Component rendering.
-  * Inspection of component output and state.
-  * Triggering of event handlers and life cycle methods.
-  * Assertions that component behavior is correct.
-
-  [bUnit](https://github.com/egil/bUnit) is an example of a library that enables Razor component unit testing.
-
-* **E2E testing**: A test runner runs a Blazor app containing the CUT and automates a browser instance. The testing tool inspects and interacts with the CUT through the browser. [Playwright for .NET](https://playwright.dev/dotnet/) is an example of an E2E testing framework that can be used with Blazor apps.
-
-In unit testing, only the Blazor component (Razor/C#) is involved. External dependencies, such as services and JS interop, must be mocked. In E2E testing, the Blazor component and all of its auxiliary infrastructure are part of the test, including CSS, JS, and the DOM and browser APIs.
-
-*Test scope* describes how extensive the tests are. Test scope typically has an influence on the speed of the tests. Unit tests run on a subset of the app's subsystems and usually execute in milliseconds. E2E tests, which test a broad group of the app's subsystems, can take several seconds to complete. 
-
-Unit testing also provides access to the instance of the CUT, allowing for inspection and verification of the component's internal state. This normally isn't possible in E2E testing.
-
-With regard to the component's environment, E2E tests must make sure that the expected environmental state has been reached before verification starts. Otherwise, the result is unpredictable. In unit testing, the rendering of the CUT and the life cycle of the test are more integrated, which improves test stability.
-
-E2E testing involves launching multiple processes, network and disk I/O, and other subsystem activity that often lead to poor test reliability. Unit tests are typically insulated from these sorts of issues.
-
-The following table summarizes the difference between the two testing approaches.
-
-| Capability                       | Unit testing                     | E2E testing                             |
-| -------------------------------- | -------------------------------- | --------------------------------------- |
-| Test scope                       | Blazor component (Razor/C#) only | Blazor component (Razor/C#) with CSS/JS |
-| Test execution time              | Milliseconds                     | Seconds                                 |
-| Access to the component instance | Yes                              | No                                      |
-| Sensitive to the environment     | No                               | Yes                                     |
-| Reliability                      | More reliable                    | Less reliable                           |
-
-## Choose the most appropriate test approach
-
-Consider the scenario when choosing the type of testing to perform. Some considerations are described in the following table.
-
-| Scenario | Suggested approach | Remarks |
-| -------- | ------------------ | ------- |
-| Component without JS interop logic | Unit testing | When there's no dependency on JS interop in a Blazor component, the component can be tested without access to JS or the DOM API. In this scenario, there are no disadvantages to choosing unit testing. |
-| Component with simple JS interop logic | Unit testing | It's common for components to query the DOM or trigger animations through JS interop. Unit testing is usually preferred in this scenario, since it's straightforward to mock the JS interaction through the <xref:Microsoft.JSInterop.IJSRuntime> interface. |
-| Component that depends on complex JS code | Unit testing and separate JS testing | If a component uses JS interop to call a large or complex JS library but the interaction between the Blazor component and JS library is simple, then the best approach is likely to treat the component and JS library or code as two separate parts and test each individually. Test the Blazor component with a unit testing library, and test the JS with a JS testing library. |
-| Component with logic that depends on JS manipulation of the browser DOM | E2E testing | When a component's functionality is dependent on JS and its manipulation of the DOM, verify both the JS and Blazor code together in an E2E test. This is the approach that the Blazor framework developers have taken with Blazor's browser rendering logic, which has tightly-coupled C# and JS code. The C# and JS code must work together to correctly render Blazor components in a browser.
-| Component that depends on 3rd party class library with hard-to-mock dependencies | E2E testing | When a component's functionality is dependent on a 3rd party class library that has hard-to-mock dependencies, such as JS interop, E2E testing might be the only option to test the component. |
-
-## Test components with bUnit
-
-There's no official Microsoft testing framework for Blazor, but the community-driven project [bUnit](https://github.com/egil/bUnit) provides a convenient way to unit test Blazor components.
-
-> [!NOTE]
-> bUnit is a third-party testing library and isn't supported or maintained by Microsoft.
-
-bUnit works with general-purpose testing frameworks, such as [MSTest](/dotnet/core/testing/unit-testing-with-mstest), [NUnit](https://nunit.org/), and [xUnit](https://xunit.net/). These testing frameworks make bUnit tests look and feel like regular unit tests. bUnit tests integrated with a general-purpose testing framework are ordinarily executed with:
-
-* [Visual Studio's Test Explorer](/visualstudio/test/run-unit-tests-with-test-explorer).
-* [`dotnet test`](/dotnet/core/tools/dotnet-test) CLI command in a command shell.
-* An automated DevOps testing pipeline.
-
-> [!NOTE]
-> Test concepts and test implementations across different test frameworks are similar but not identical. Refer to the test framework's documentation for guidance.
-
-The following demonstrates the structure of a bUnit test on the `Counter` component in an app based on a [Blazor project template](xref:blazor/project-structure). The `Counter` component displays and increments a counter based on the user selecting a button in the page:
-
-```razor
-@page "/counter"
-
-<h1>Counter</h1>
-
-<p>Current count: @currentCount</p>
-
-<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
-
-@code {
-    private int currentCount = 0;
-
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-```
-
-The following bUnit test verifies that the CUT's counter is incremented correctly when the button is selected:
-
-```csharp
-[Fact]
-public void CounterShouldIncrementWhenSelected()
-{
-    // Arrange
-    using var ctx = new TestContext();
-    var cut = ctx.RenderComponent<Counter>();
-    var paraElm = cut.Find("p");
-
-    // Act
-    cut.Find("button").Click();
-    var paraElmText = paraElm.TextContent;
-
-    // Assert
-    paraElmText.MarkupMatches("Current count: 1");
-}
-```
-
-The following actions take place at each step of the test:
-
-* *Arrange*: The `Counter` component is rendered using bUnit's `TestContext`. The CUT's paragraph element (`<p>`) is found and assigned to `paraElm`.
-
-* *Act*: The button's element (`<button>`) is located and then selected by calling `Click`, which should increment the counter and update the content of the paragraph tag (`<p>`). The paragraph element text content is obtained by calling `TextContent`.
-
-* *Assert*: `MarkupMatches` is called on the text content to verify that it matches the expected string, which is `Current count: 1`.
-
-> [!NOTE]
-> The `MarkupMatches` assert method differs from a regular string comparison assertion (for example, `Assert.Equal("Current count: 1", paraElmText);`) `MarkupMatches` performs a semantic comparison of the input and expected HTML markup. A semantic comparison is aware of HTML semantics, meaning things like insignificant whitespace is ignored. This results in more stable tests. For more information, see [Customizing the Semantic HTML Comparison](https://bunit.egilhansen.com/docs/verification/semantic-html-comparison).
-
-## Additional resources
-
-* [Getting Started with bUnit](https://bunit.egilhansen.com/docs/getting-started/): bUnit instructions include guidance on creating a test project, referencing testing framework packages, and building and running tests.
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-5.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Testing is an important aspect of building stable and maintainable software.
 
@@ -401,4 +271,134 @@ The following actions take place at each step of the test:
 
 * [Getting Started with bUnit](https://bunit.egilhansen.com/docs/getting-started/): bUnit instructions include guidance on creating a test project, referencing testing framework packages, and building and running tests.
 
-::: moniker-end
+:::moniker-end
+
+:::moniker range="< aspnetcore-5.0"
+
+Testing is an important aspect of building stable and maintainable software.
+
+To test a Blazor component, the *Component Under Test* (CUT) is:
+
+* Rendered with relevant input for the test.
+* Depending on the type of test performed, possibly subject to interaction or modification. For example, event handlers can be triggered, such as an `onclick` event for a button.
+* Inspected for expected values.
+
+## Test approaches
+
+Two common approaches for testing Blazor components are end-to-end (E2E) testing and unit testing:
+
+* **Unit testing**: [Unit tests](/dotnet/core/testing/) are written with a unit testing library that provides:
+  * Component rendering.
+  * Inspection of component output and state.
+  * Triggering of event handlers and life cycle methods.
+  * Assertions that component behavior is correct.
+
+  [bUnit](https://github.com/egil/bUnit) is an example of a library that enables Razor component unit testing.
+
+* **E2E testing**: A test runner runs a Blazor app containing the CUT and automates a browser instance. The testing tool inspects and interacts with the CUT through the browser. [Playwright for .NET](https://playwright.dev/dotnet/) is an example of an E2E testing framework that can be used with Blazor apps.
+
+In unit testing, only the Blazor component (Razor/C#) is involved. External dependencies, such as services and JS interop, must be mocked. In E2E testing, the Blazor component and all of its auxiliary infrastructure are part of the test, including CSS, JS, and the DOM and browser APIs.
+
+*Test scope* describes how extensive the tests are. Test scope typically has an influence on the speed of the tests. Unit tests run on a subset of the app's subsystems and usually execute in milliseconds. E2E tests, which test a broad group of the app's subsystems, can take several seconds to complete. 
+
+Unit testing also provides access to the instance of the CUT, allowing for inspection and verification of the component's internal state. This normally isn't possible in E2E testing.
+
+With regard to the component's environment, E2E tests must make sure that the expected environmental state has been reached before verification starts. Otherwise, the result is unpredictable. In unit testing, the rendering of the CUT and the life cycle of the test are more integrated, which improves test stability.
+
+E2E testing involves launching multiple processes, network and disk I/O, and other subsystem activity that often lead to poor test reliability. Unit tests are typically insulated from these sorts of issues.
+
+The following table summarizes the difference between the two testing approaches.
+
+| Capability                       | Unit testing                     | E2E testing                             |
+| -------------------------------- | -------------------------------- | --------------------------------------- |
+| Test scope                       | Blazor component (Razor/C#) only | Blazor component (Razor/C#) with CSS/JS |
+| Test execution time              | Milliseconds                     | Seconds                                 |
+| Access to the component instance | Yes                              | No                                      |
+| Sensitive to the environment     | No                               | Yes                                     |
+| Reliability                      | More reliable                    | Less reliable                           |
+
+## Choose the most appropriate test approach
+
+Consider the scenario when choosing the type of testing to perform. Some considerations are described in the following table.
+
+| Scenario | Suggested approach | Remarks |
+| -------- | ------------------ | ------- |
+| Component without JS interop logic | Unit testing | When there's no dependency on JS interop in a Blazor component, the component can be tested without access to JS or the DOM API. In this scenario, there are no disadvantages to choosing unit testing. |
+| Component with simple JS interop logic | Unit testing | It's common for components to query the DOM or trigger animations through JS interop. Unit testing is usually preferred in this scenario, since it's straightforward to mock the JS interaction through the <xref:Microsoft.JSInterop.IJSRuntime> interface. |
+| Component that depends on complex JS code | Unit testing and separate JS testing | If a component uses JS interop to call a large or complex JS library but the interaction between the Blazor component and JS library is simple, then the best approach is likely to treat the component and JS library or code as two separate parts and test each individually. Test the Blazor component with a unit testing library, and test the JS with a JS testing library. |
+| Component with logic that depends on JS manipulation of the browser DOM | E2E testing | When a component's functionality is dependent on JS and its manipulation of the DOM, verify both the JS and Blazor code together in an E2E test. This is the approach that the Blazor framework developers have taken with Blazor's browser rendering logic, which has tightly-coupled C# and JS code. The C# and JS code must work together to correctly render Blazor components in a browser.
+| Component that depends on 3rd party class library with hard-to-mock dependencies | E2E testing | When a component's functionality is dependent on a 3rd party class library that has hard-to-mock dependencies, such as JS interop, E2E testing might be the only option to test the component. |
+
+## Test components with bUnit
+
+There's no official Microsoft testing framework for Blazor, but the community-driven project [bUnit](https://github.com/egil/bUnit) provides a convenient way to unit test Blazor components.
+
+> [!NOTE]
+> bUnit is a third-party testing library and isn't supported or maintained by Microsoft.
+
+bUnit works with general-purpose testing frameworks, such as [MSTest](/dotnet/core/testing/unit-testing-with-mstest), [NUnit](https://nunit.org/), and [xUnit](https://xunit.net/). These testing frameworks make bUnit tests look and feel like regular unit tests. bUnit tests integrated with a general-purpose testing framework are ordinarily executed with:
+
+* [Visual Studio's Test Explorer](/visualstudio/test/run-unit-tests-with-test-explorer).
+* [`dotnet test`](/dotnet/core/tools/dotnet-test) CLI command in a command shell.
+* An automated DevOps testing pipeline.
+
+> [!NOTE]
+> Test concepts and test implementations across different test frameworks are similar but not identical. Refer to the test framework's documentation for guidance.
+
+The following demonstrates the structure of a bUnit test on the `Counter` component in an app based on a [Blazor project template](xref:blazor/project-structure). The `Counter` component displays and increments a counter based on the user selecting a button in the page:
+
+```razor
+@page "/counter"
+
+<h1>Counter</h1>
+
+<p>Current count: @currentCount</p>
+
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}
+```
+
+The following bUnit test verifies that the CUT's counter is incremented correctly when the button is selected:
+
+```csharp
+[Fact]
+public void CounterShouldIncrementWhenSelected()
+{
+    // Arrange
+    using var ctx = new TestContext();
+    var cut = ctx.RenderComponent<Counter>();
+    var paraElm = cut.Find("p");
+
+    // Act
+    cut.Find("button").Click();
+    var paraElmText = paraElm.TextContent;
+
+    // Assert
+    paraElmText.MarkupMatches("Current count: 1");
+}
+```
+
+The following actions take place at each step of the test:
+
+* *Arrange*: The `Counter` component is rendered using bUnit's `TestContext`. The CUT's paragraph element (`<p>`) is found and assigned to `paraElm`.
+
+* *Act*: The button's element (`<button>`) is located and then selected by calling `Click`, which should increment the counter and update the content of the paragraph tag (`<p>`). The paragraph element text content is obtained by calling `TextContent`.
+
+* *Assert*: `MarkupMatches` is called on the text content to verify that it matches the expected string, which is `Current count: 1`.
+
+> [!NOTE]
+> The `MarkupMatches` assert method differs from a regular string comparison assertion (for example, `Assert.Equal("Current count: 1", paraElmText);`) `MarkupMatches` performs a semantic comparison of the input and expected HTML markup. A semantic comparison is aware of HTML semantics, meaning things like insignificant whitespace is ignored. This results in more stable tests. For more information, see [Customizing the Semantic HTML Comparison](https://bunit.egilhansen.com/docs/verification/semantic-html-comparison).
+
+## Additional resources
+
+* [Getting Started with bUnit](https://bunit.egilhansen.com/docs/getting-started/): bUnit instructions include guidance on creating a test project, referencing testing framework packages, and building and running tests.
+
+:::moniker-end

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -12,9 +12,9 @@ zone_pivot_groups: operating-systems
 ---
 # Tooling for ASP.NET Core Blazor
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
-::: zone pivot="windows"
+:::zone pivot="windows"
 
 1. Install the latest version of [Visual Studio 2022](https://visualstudio.microsoft.com) with the **ASP.NET and web development** workload.
 
@@ -36,9 +36,9 @@ For more information on trusting the ASP.NET Core HTTPS development certificate,
 
 When executing a hosted Blazor WebAssembly app, run the app from the solution's **`Server`** project.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="linux"
+:::zone pivot="linux"
 
 1. Install the latest version of the [.NET Core SDK](https://dotnet.microsoft.com/download). If you previously installed the SDK, you can determine your installed version by executing the following command in a command shell:
 
@@ -231,9 +231,9 @@ There's no centralized way to trust a certificate on Linux. Typically, one of th
 
 For more information, see the guidance provided by your browser manufacturer and Linux distribution.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="macos"
+:::zone pivot="macos"
 
 1. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
 
@@ -257,7 +257,7 @@ If a prompt appears to trust the development certificate, trust the certificate 
 
 When executing a hosted Blazor WebAssembly app, run the app from the solution's **`Server`** project.
 
-::: zone-end
+:::zone-end
 
 ## Use Visual Studio Code for cross-platform Blazor development
 
@@ -300,11 +300,11 @@ For more information, see the following resources:
 * <xref:blazor/hosting-models>
 * <xref:blazor/project-structure>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-::: zone pivot="windows"
+:::zone pivot="windows"
 
 1. Install the latest version of [Visual Studio 2022](https://visualstudio.microsoft.com) with the **ASP.NET and web development** workload.
 
@@ -326,9 +326,9 @@ For more information on trusting the ASP.NET Core HTTPS development certificate,
 
 When executing a hosted Blazor WebAssembly app, run the app from the solution's **`Server`** project.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="linux"
+:::zone pivot="linux"
 
 1. Install the latest version of the [.NET Core SDK](https://dotnet.microsoft.com/download). If you previously installed the SDK, you can determine your installed version by executing the following command in a command shell:
 
@@ -477,9 +477,9 @@ There's no centralized way to trust a certificate on Linux. Typically, one of th
 
 For more information, see the guidance provided by your browser manufacturer and Linux distribution.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="macos"
+:::zone pivot="macos"
 
 1. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
 
@@ -503,7 +503,7 @@ If a prompt appears to trust the development certificate, trust the certificate 
 
 When executing a hosted Blazor WebAssembly app, run the app from the solution's **`Server`** project.
 
-::: zone-end
+:::zone-end
 
 ## Use Visual Studio Code for cross-platform Blazor development
 
@@ -530,11 +530,11 @@ dotnet new blazorserver -h
 * <xref:blazor/hosting-models>
 * <xref:blazor/project-structure>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
-::: zone pivot="windows"
+:::zone pivot="windows"
 
 1. Install the latest version of [Visual Studio 2022](https://visualstudio.microsoft.com) with the **ASP.NET and web development** workload.
 
@@ -556,9 +556,9 @@ For more information on trusting the ASP.NET Core HTTPS development certificate,
 
 When executing a hosted Blazor WebAssembly app, run the app from the solution's **`Server`** project.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="linux"
+:::zone pivot="linux"
 
 1. Install the latest version of the [.NET Core SDK](https://dotnet.microsoft.com/download). If you previously installed the SDK, you can determine your installed version by executing the following command in a command shell:
 
@@ -707,9 +707,9 @@ There's no centralized way to trust a certificate on Linux. Typically, one of th
 
 For more information, see the guidance provided by your browser manufacturer and Linux distribution.
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="macos"
+:::zone pivot="macos"
 
 1. Install [Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).
 
@@ -733,7 +733,7 @@ If a prompt appears to trust the development certificate, trust the certificate 
 
 When executing a hosted Blazor WebAssembly app, run the app from the solution's **`Server`** project.
 
-::: zone-end
+:::zone-end
 
 ## Use Visual Studio Code for cross-platform Blazor development
 
@@ -760,4 +760,4 @@ dotnet new blazorserver -h
 * <xref:blazor/hosting-models>
 * <xref:blazor/project-structure>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/blazor/tutorials.md
+++ b/aspnetcore/blazor/tutorials.md
@@ -11,7 +11,7 @@ uid: blazor/tutorials
 ---
 # ASP.NET Core Blazor tutorials
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 The following tutorials are available for ASP.NET Core Blazor:
 
@@ -23,23 +23,9 @@ The following tutorials are available for ASP.NET Core Blazor:
 
 For more information on Blazor hosting models, Blazor Server and Blazor WebAssembly, see <xref:blazor/hosting-models>.
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-The following tutorials are available for ASP.NET Core Blazor:
-
-* [Build your first Blazor app](https://dotnet.microsoft.com/learn/aspnet/blazor-tutorial/intro) (Blazor Server)
-
-* <xref:tutorials/build-a-blazor-app> (Blazor Server or Blazor WebAssembly)
-
-* <xref:tutorials/signalr-blazor> (Blazor Server or Blazor WebAssembly)
-
-For more information on Blazor hosting models, Blazor Server and Blazor WebAssembly, see <xref:blazor/hosting-models>.
-
-::: moniker-end
-
-::: moniker range="< aspnetcore-5.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 The following tutorials are available for ASP.NET Core Blazor:
 
@@ -51,4 +37,18 @@ The following tutorials are available for ASP.NET Core Blazor:
 
 For more information on Blazor hosting models, Blazor Server and Blazor WebAssembly, see <xref:blazor/hosting-models>.
 
-::: moniker-end
+:::moniker-end
+
+:::moniker range="< aspnetcore-5.0"
+
+The following tutorials are available for ASP.NET Core Blazor:
+
+* [Build your first Blazor app](https://dotnet.microsoft.com/learn/aspnet/blazor-tutorial/intro) (Blazor Server)
+
+* <xref:tutorials/build-a-blazor-app> (Blazor Server or Blazor WebAssembly)
+
+* <xref:tutorials/signalr-blazor> (Blazor Server or Blazor WebAssembly)
+
+For more information on Blazor hosting models, Blazor Server and Blazor WebAssembly, see <xref:blazor/hosting-models>.
+
+:::moniker-end

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -11,7 +11,7 @@ uid: blazor/webassembly-lazy-load-assemblies
 ---
 # Lazy load assemblies in ASP.NET Core Blazor WebAssembly
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 Blazor WebAssembly app startup performance can be improved by waiting to load app assemblies until the assemblies are required, which is called *lazy loading*.
 
@@ -373,9 +373,9 @@ If the `Robot` component from the RCL is requested at `https://localhost:5001/ro
 * [Handle asynchronous navigation events with `OnNavigateAsync`](xref:blazor/fundamentals/routing#handle-asynchronous-navigation-events-with-onnavigateasync)
 * <xref:blazor/performance>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 Blazor WebAssembly app startup performance can be improved by waiting to load app assemblies until the assemblies are required, which is called *lazy loading*.
 
@@ -743,4 +743,4 @@ If the `Robot` component from the RCL is requested at `https://localhost:5001/ro
 * [Handle asynchronous navigation events with `OnNavigateAsync`](xref:blazor/fundamentals/routing#handle-asynchronous-navigation-events-with-onnavigateasync)
 * <xref:blazor/performance>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/tutorials/build-a-blazor-app.md
+++ b/aspnetcore/tutorials/build-a-blazor-app.md
@@ -12,7 +12,7 @@ zone_pivot_groups: blazor-hosting-models
 ---
 # Build a Blazor todo list app
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This tutorial shows you how to build and modify a Blazor app. You learn how to:
 
@@ -32,21 +32,21 @@ At the end of this tutorial, you'll have a working todo list app.
 
 Create a new Blazor app named `TodoList` in a command shell:
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ```dotnetcli
 dotnet new blazorserver -o TodoList
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 ```dotnetcli
 dotnet new blazorwasm -o TodoList
 ```
 
-::: zone-end
+:::zone-end
 
 The preceding command creates a folder named `TodoList` with the `-o|--output` option to hold the app. The `TodoList` folder is the *root folder* of the project. Change directories to the `TodoList` folder with the following command:
 
@@ -187,9 +187,9 @@ Learn about tooling for ASP.NET Core Blazor:
 > [!div class="nextstepaction"]
 > <xref:blazor/tooling>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This tutorial shows you how to build and modify a Blazor app. You learn how to:
 
@@ -209,21 +209,21 @@ At the end of this tutorial, you'll have a working todo list app.
 
 Create a new Blazor app named `TodoList` in a command shell:
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ```dotnetcli
 dotnet new blazorserver -o TodoList
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 ```dotnetcli
 dotnet new blazorwasm -o TodoList
 ```
 
-::: zone-end
+:::zone-end
 
 The preceding command creates a folder named `TodoList` with the `-o|--output` option to hold the app. The `TodoList` folder is the *root folder* of the project. Change directories to the `TodoList` folder with the following command:
 
@@ -364,9 +364,9 @@ Learn about tooling for ASP.NET Core Blazor:
 > [!div class="nextstepaction"]
 > <xref:blazor/tooling>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This tutorial shows you how to build and modify a Blazor app. You learn how to:
 
@@ -386,21 +386,21 @@ At the end of this tutorial, you'll have a working todo list app.
 
 Create a new Blazor app named `TodoList` in a command shell:
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ```dotnetcli
 dotnet new blazorserver -o TodoList
 ```
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 ```dotnetcli
 dotnet new blazorwasm -o TodoList
 ```
 
-::: zone-end
+:::zone-end
 
 The preceding command creates a folder named `TodoList` with the `-o|--output` option to hold the app. The `TodoList` folder is the *root folder* of the project. Change directories to the `TodoList` folder with the following command:
 
@@ -541,4 +541,4 @@ Learn about tooling for ASP.NET Core Blazor:
 > [!div class="nextstepaction"]
 > <xref:blazor/tooling>
 
-::: moniker-end
+:::moniker-end

--- a/aspnetcore/tutorials/signalr-blazor.md
+++ b/aspnetcore/tutorials/signalr-blazor.md
@@ -12,7 +12,7 @@ zone_pivot_groups: blazor-hosting-models
 ---
 # Use ASP.NET Core SignalR with Blazor
 
-::: moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This tutorial teaches the basics of building a real-time app using SignalR with Blazor. You learn how to:
 
@@ -49,7 +49,7 @@ At the end of this tutorial, you'll have a working chat app.
 
 ---
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 ## Create a hosted Blazor WebAssembly app
 
@@ -269,9 +269,9 @@ For information on configuring VS Code assets in the `.vscode` folder, see the *
 
 ---
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ## Create a Blazor Server app
 
@@ -478,7 +478,7 @@ Follow the guidance for your tooling:
 
 ---
 
-::: zone-end
+:::zone-end
 
 ## Next steps
 
@@ -505,9 +505,9 @@ To learn more about building Blazor apps, see the Blazor documentation:
 * <xref:blazor/debug>
 * <xref:blazor/security/server/threat-mitigation>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
 This tutorial teaches the basics of building a real-time app using SignalR with Blazor. You learn how to:
 
@@ -544,7 +544,7 @@ At the end of this tutorial, you'll have a working chat app.
 
 ---
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 ## Create a hosted Blazor WebAssembly app
 
@@ -762,9 +762,9 @@ For information on configuring VS Code assets in the `.vscode` folder, see the *
 
 ---
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ## Create a Blazor Server app
 
@@ -971,7 +971,7 @@ Follow the guidance for your tooling:
 
 ---
 
-::: zone-end
+:::zone-end
 
 ## Next steps
 
@@ -998,9 +998,9 @@ To learn more about building Blazor apps, see the Blazor documentation:
 * <xref:blazor/debug>
 * <xref:blazor/security/server/threat-mitigation>
 
-::: moniker-end
+:::moniker-end
 
-::: moniker range="< aspnetcore-5.0"
+:::moniker range="< aspnetcore-5.0"
 
 This tutorial teaches the basics of building a real-time app using SignalR with Blazor. You learn how to:
 
@@ -1037,7 +1037,7 @@ At the end of this tutorial, you'll have a working chat app.
 
 ---
 
-::: zone pivot="webassembly"
+:::zone pivot="webassembly"
 
 ## Create a hosted Blazor WebAssembly app
 
@@ -1255,9 +1255,9 @@ For information on configuring VS Code assets in the `.vscode` folder, see the *
 
 ---
 
-::: zone-end
+:::zone-end
 
-::: zone pivot="server"
+:::zone pivot="server"
 
 ## Create a Blazor Server app
 
@@ -1520,7 +1520,7 @@ Follow the guidance for your tooling:
 
 ---
 
-::: zone-end
+:::zone-end
 
 ## Next steps
 
@@ -1547,4 +1547,4 @@ To learn more about building Blazor apps, see the Blazor documentation:
 * <xref:blazor/debug>
 * <xref:blazor/security/server/threat-mitigation>
 
-::: moniker-end
+:::moniker-end


### PR DESCRIPTION
Fixes #24616

Rick, I'm focused on the Blazor node for this because I have an opportunity to get this in with only one open Blazor PR at the moment. I don't want to do this repo-wide myself at this time ...

![blood](https://user-images.githubusercontent.com/1622880/149533736-cabcaee1-21ec-4ff4-a99b-a72e65352c8c.png)
[*There Will Be Blood*](https://www.miramax.com/movie/there-will-be-blood/) &copy;2007 [Miramax](https://www.miramax.com/)

I imagine that you/Kirk/Wade may do it later repo-wide during a similar PR lull for the main doc set.

# Break out the *EYE DROPS on this one!!* 👁️💧😄  

I think a quick scan is all that's required. The find-'n-replace looked good in the VSC sidebar before I pulled the trigger on it, and I scanned the diff here and didn't spot anything.