### PR TITLE
1x-to-2x: about CommandLineUtils

### DIFF
--- a/aspnetcore/migration/1x-to-2x/index.md
+++ b/aspnetcore/migration/1x-to-2x/index.md
@@ -65,6 +65,8 @@ For example, here's the list of `<PackageReference />` nodes used in a typical A
 
 [!code-xml[](../1x-to-2x/samples/AspNetCoreDotNetFx2.0App/AspNetCoreDotNetFx2.0App/AspNetCoreDotNetFx2.0App.csproj?range=9-22)]
 
+The package `Microsoft.Extensions.CommandLineUtils` has been [retired](https://github.com/dotnet/extensions/blob/release/2.1/README.md).  It is still available but unsupported.
+
 <a name="dot-net-cli-tool-reference"></a>
 
 ## Update .NET Core CLI tools


### PR DESCRIPTION
The package `Microsoft.Extensions.CommandLineUtils` has been [retired](https://github.com/dotnet/extensions/blob/release/2.1/README.md).



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->