### PR TITLE
hot-reload: macOS also uses Ctrl+R

### DIFF
--- a/aspnetcore/test/hot-reload.md
+++ b/aspnetcore/test/hot-reload.md
@@ -44,7 +44,7 @@ Hot Reload is activated using the [`dotnet watch`](xref:tutorials/dotnet-watch) 
 dotnet watch
 ```
 
-To force the app to rebuild and restart, use the keyboard combination <kbd>Ctrl</kbd>+<kbd>R</kbd> (Windows) or <kbd>⌘</kbd>+<kbd>R</kbd> (macOS) in the command shell.
+To force the app to rebuild and restart, use the keyboard combination <kbd>Ctrl</kbd>+<kbd>R</kbd> in the command shell.
 
 When an unsupported code edit is made, called a *rude edit*, `dotnet watch` asks you if you want to restart the app:
 


### PR DESCRIPTION
Using .NET 6 on macOS, we can see that `dotnet watch` uses Ctrl+R, not Cmd+R:

```
$ dotnet watch
watch : Hot reload enabled. For a list of supported edits, see https://aka.ms/dotnet/hot-reload. Press "Ctrl + R" to restart.
```