### PR TITLE
Code patch

### DIFF
--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program3.cs
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program3.cs
@@ -4,7 +4,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 
-if (builder.Environment.IsDevelopment())
+if (!builder.Environment.IsDevelopment())
 {
     builder.Services.AddHttpsRedirection(options =>
     {


### PR DESCRIPTION
The text leading into the example is ...

> If you prefer to send a permanent redirect status code when the app is in a non-Development environment, wrap the middleware options configuration in a conditional check for a non-Development environment.

The earlier version (5.x) is correct.