### PR TITLE
Update Kestrel Endpoints to 6.0

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -68,11 +68,7 @@ By default, Kestrel configuration is loaded from the `Kestrel` section and reloa
         "Url": "http://localhost:5000"
       },
       "Https": {
-        "Url": "https://localhost:5001",
-        "Certificate": {
-          "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
-        }
+        "Url": "https://localhost:5001"
       }
     }
   }
@@ -159,7 +155,7 @@ In the following *appsettings.json* example:
         "Url": "https://localhost:5001",
         "Certificate": {
           "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
+          "Password": "$CREDENTIAL_PLACEHOLDER$"
         }
       },
       "HttpsInlineCertAndKeyFile": {
@@ -167,7 +163,7 @@ In the following *appsettings.json* example:
         "Certificate": {
           "Path": "<path to .pem/.crt file>",
           "KeyPath": "<path to .key file>",
-          "Password": "<certificate password>"
+          "Password": "$CREDENTIAL_PLACEHOLDER$"
         }
       },
       "HttpsInlineCertStore": {
@@ -186,12 +182,15 @@ In the following *appsettings.json* example:
     "Certificates": {
       "Default": {
         "Path": "<path to .pfx file>",
-        "Password": "<certificate password>"
+        "Password": "$CREDENTIAL_PLACEHOLDER$"
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 Schema notes:
 
@@ -292,7 +291,7 @@ The following configuration adds an endpoint named `MySniEndpoint` that uses SNI
           "*.example.org": {
             "Certificate": {
               "Path": "<path to .pfx file>",
-              "Password": "<certificate password>"
+              "Password": "$CREDENTIAL_PLACEHOLDER$"
             }
           },
           "*": {
@@ -306,12 +305,15 @@ The following configuration adds an endpoint named `MySniEndpoint` that uses SNI
     "Certificates": {
       "Default": {
         "Path": "<path to .pfx file>",
-        "Password": "<certificate password>"
+        "Password": "$CREDENTIAL_PLACEHOLDER$"
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 HTTPS options that can be overridden by SNI:
 
@@ -347,13 +349,16 @@ SSL Protocols are protocols used for encrypting and decrypting traffic between t
         "SslProtocols": ["Tls12", "Tls13"],
         "Certificate": {
           "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
+          "Password": "$CREDENTIAL_PLACEHOLDER$"
         }
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 The default value, `SslProtocols.None`, causes Kestrel to use the operating system defaults to choose the best protocol. Unless you have a specific reason to select a protocol, use the default.
 
@@ -372,13 +377,16 @@ The default value, `SslProtocols.None`, causes Kestrel to use the operating syst
         "ClientCertificateMode": "AllowCertificate",
         "Certificate": {
           "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
+          "Password": "$CREDENTIAL_PLACEHOLDER$"
         }
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 The default value is `ClientCertificateMode.NoCertificate` where Kestrel will not request or require a certificate from the client.
 
@@ -618,11 +626,7 @@ The `Configure(IConfiguration, bool)` overload can be used to enable reloading e
         "Url": "http://localhost:5000"
       },
       "Https": {
-        "Url": "https://localhost:5001",
-        "Certificate": {
-          "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
-        }
+        "Url": "https://localhost:5001"
       }
     }
   }
@@ -718,7 +722,7 @@ In the following *appsettings.json* example:
         "Url": "https://localhost:5001",
         "Certificate": {
           "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
+          "Password": "$CREDENTIAL_PLACEHOLDER$"
         }
       },
       "HttpsInlineCertAndKeyFile": {
@@ -726,7 +730,7 @@ In the following *appsettings.json* example:
         "Certificate": {
           "Path": "<path to .pem/.crt file>",
           "KeyPath": "<path to .key file>",
-          "Password": "<certificate password>"
+          "Password": "$CREDENTIAL_PLACEHOLDER$"
         }
       },
       "HttpsInlineCertStore": {
@@ -745,12 +749,15 @@ In the following *appsettings.json* example:
     "Certificates": {
       "Default": {
         "Path": "<path to .pfx file>",
-        "Password": "<certificate password>"
+        "Password": "$CREDENTIAL_PLACEHOLDER$"
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 Schema notes:
 
@@ -942,7 +949,7 @@ The following configuration adds an endpoint named `MySniEndpoint` that uses SNI
           "*.example.org": {
             "Certificate": {
               "Path": "<path to .pfx file>",
-              "Password": "<certificate password>"
+              "Password": "$CREDENTIAL_PLACEHOLDER$"
             }
           },
           "*": {
@@ -956,12 +963,15 @@ The following configuration adds an endpoint named `MySniEndpoint` that uses SNI
     "Certificates": {
       "Default": {
         "Path": "<path to .pfx file>",
-        "Password": "<certificate password>"
+        "Password": "$CREDENTIAL_PLACEHOLDER$"
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 HTTPS options that can be overridden by SNI:
 
@@ -1006,13 +1016,16 @@ webBuilder.ConfigureKestrel(serverOptions =>
         "SslProtocols": ["Tls12", "Tls13"],
         "Certificate": {
           "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
+          "Password": "$CREDENTIAL_PLACEHOLDER$"
         }
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 The default value, `SslProtocols.None`, causes Kestrel to use the operating system defaults to choose the best protocol. Unless you have a specific reason to select a protocol, use the default.
 
@@ -1039,13 +1052,16 @@ webBuilder.ConfigureKestrel(serverOptions =>
         "ClientCertificateMode": "AllowCertificate",
         "Certificate": {
           "Path": "<path to .pfx file>",
-          "Password": "<certificate password>"
+          "Password": "$CREDENTIAL_PLACEHOLDER$"
         }
       }
     }
   }
 }
 ```
+
+> [!WARNING]
+> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
 
 The default value is `ClientCertificateMode.NoCertificate` where Kestrel will not request or require a certificate from the client.
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -35,7 +35,7 @@ A development certificate is created:
 * When the [.NET SDK](/dotnet/core/sdk) is installed.
 * The [dev-certs tool](xref:security/enforcing-ssl#trust) is used to create a certificate.
 
-Some browsers require granting explicit permission to trust the local development certificate.
+The development certificate is available only for the user that generates the certificate. Some browsers require granting explicit permission to trust the local development certificate.
 
 Project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -5,7 +5,7 @@ description: Learn about configuring endpoints with Kestrel, the cross-platform 
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/04/2020
+ms.date: 01/20/2022
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: fundamentals/servers/kestrel/endpoints
 ---
@@ -190,7 +190,7 @@ In the following *appsettings.json* example:
 ```
 
 > [!WARNING]
-> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration). Development secrets shouldn't be used for production or test.
 
 Schema notes:
 
@@ -313,7 +313,7 @@ The following configuration adds an endpoint named `MySniEndpoint` that uses SNI
 ```
 
 > [!WARNING]
-> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration). Development secrets shouldn't be used for production or test.
 
 HTTPS options that can be overridden by SNI:
 
@@ -358,7 +358,7 @@ SSL Protocols are protocols used for encrypting and decrypting traffic between t
 ```
 
 > [!WARNING]
-> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration). Development secrets shouldn't be used for production or test.
 
 The default value, `SslProtocols.None`, causes Kestrel to use the operating system defaults to choose the best protocol. Unless you have a specific reason to select a protocol, use the default.
 
@@ -757,7 +757,7 @@ In the following *appsettings.json* example:
 ```
 
 > [!WARNING]
-> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration). Development secrets shouldn't be used for production or test.
 
 Schema notes:
 
@@ -971,7 +971,7 @@ The following configuration adds an endpoint named `MySniEndpoint` that uses SNI
 ```
 
 > [!WARNING]
-> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+> In the preceding example, certificate passwords are stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for each certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration). Development secrets shouldn't be used for production or test.
 
 HTTPS options that can be overridden by SNI:
 
@@ -1025,7 +1025,7 @@ webBuilder.ConfigureKestrel(serverOptions =>
 ```
 
 > [!WARNING]
-> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration). Development secrets shouldn't be used for production or test.
 
 The default value, `SslProtocols.None`, causes Kestrel to use the operating system defaults to choose the best protocol. Unless you have a specific reason to select a protocol, use the default.
 
@@ -1061,7 +1061,7 @@ webBuilder.ConfigureKestrel(serverOptions =>
 ```
 
 > [!WARNING]
-> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration).
+> In the preceding example, the certificate password is stored in plain-text in *appsettings.json*. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xfef:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration). Development secrets shouldn't be used for production or test.
 
 The default value is `ClientCertificateMode.NoCertificate` where Kestrel will not request or require a certificate from the client.
 

--- a/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs
@@ -100,7 +100,8 @@ public static class Program
                     var subExampleCert = CertificateLoader.LoadFromStoreCert(
                         "sub.example.com", "My", StoreLocation.CurrentUser,
                         allowInvalid: true);
-                    var certs = new Dictionary<string, X509Certificate2>(StringComparer.OrdinalIgnoreCase)
+                    var certs = new Dictionary<string, X509Certificate2>(
+                        StringComparer.OrdinalIgnoreCase)
                     {
                         ["localhost"] = localhostCert,
                         ["example.com"] = exampleCert,
@@ -142,20 +143,23 @@ public static class Program
 
                     listenOptions.UseHttps((stream, clientHelloInfo, state, cancellationToken) =>
                     {
-                        if (string.Equals(clientHelloInfo.ServerName, "localhost", StringComparison.OrdinalIgnoreCase))
+                        if (string.Equals(clientHelloInfo.ServerName, "localhost",
+                            StringComparison.OrdinalIgnoreCase))
                         {
-                            return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
-                            {
-                                ServerCertificate = localhostCert,
-                                // Different TLS requirements for this host
-                                ClientCertificateRequired = true
-                            });
+                            return new ValueTask<SslServerAuthenticationOptions>(
+                                new SslServerAuthenticationOptions
+                                {
+                                    ServerCertificate = localhostCert,
+                                    // Different TLS requirements for this host
+                                    ClientCertificateRequired = true
+                                });
                         }
 
-                        return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
-                        {
-                            ServerCertificate = exampleCert
-                        });
+                        return new ValueTask<SslServerAuthenticationOptions>(
+                            new SslServerAuthenticationOptions
+                            {
+                                ServerCertificate = exampleCert
+                            });
                     }, state: null!);
                 });
             });
@@ -185,21 +189,24 @@ public static class Program
                     {
                         OnConnection = context =>
                         {
-                            if (string.Equals(context.ClientHelloInfo.ServerName, "localhost", StringComparison.OrdinalIgnoreCase))
+                            if (string.Equals(context.ClientHelloInfo.ServerName, "localhost",
+                                StringComparison.OrdinalIgnoreCase))
                             {
                                 // Different TLS requirements for this host
                                 context.AllowDelayedClientCertificateNegotation = true;
 
-                                return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
-                                {
-                                    ServerCertificate = localhostCert
-                                });
+                                return new ValueTask<SslServerAuthenticationOptions>(
+                                    new SslServerAuthenticationOptions
+                                    {
+                                        ServerCertificate = localhostCert
+                                    });
                             }
 
-                            return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
-                            {
-                                ServerCertificate = exampleCert
-                            });
+                            return new ValueTask<SslServerAuthenticationOptions>(
+                                new SslServerAuthenticationOptions
+                                {
+                                    ServerCertificate = exampleCert
+                                });
                         }
                     });
                 });

--- a/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs
@@ -1,9 +1,376 @@
-﻿using Microsoft.AspNetCore.Server.Kestrel.Core;
+using System.Net;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Connections.Features;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
 
 namespace KestrelSample.Snippets;
 
 public static class Program
 {
+    public static void ConfigureEndpointDefaults(string[] args)
+    {
+        // <snippet_ConfigureEndpointDefaults>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.ConfigureEndpointDefaults(listenOptions =>
+            {
+                // ...
+            });
+        });
+        // </snippet_ConfigureEndpointDefaults>
+    }
+
+    public static void ConfigureHttpsDefaults(string[] args)
+    {
+        // <snippet_ConfigureHttpsDefaults>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                // ...
+            });
+        });
+        // </snippet_ConfigureHttpsDefaults>
+    }
+
+    public static void ConfigurationLoader(string[] args)
+    {
+        // <snippet_ConfigurationLoader>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            var kestrelSection = context.Configuration.GetSection("Kestrel");
+
+            serverOptions.Configure(kestrelSection)
+                .Endpoint("HTTPS", listenOptions =>
+                {
+                    // ...
+                });
+        });
+        // </snippet_ConfigurationLoader>
+    }
+
+    public static void ConfigureEndpointDefaultsConfigureHttpsDefaults(string[] args)
+    {
+        // <snippet_ConfigureEndpointDefaultsConfigureHttpsDefaults>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.ConfigureEndpointDefaults(listenOptions =>
+            {
+                // ...
+            });
+
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                // ...
+            });
+        });
+        // </snippet_ConfigureEndpointDefaultsConfigureHttpsDefaults>
+    }
+
+    public static void ServerCertificateSelector(string[] args)
+    {
+        // <snippet_ServerCertificateSelector>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.ListenAnyIP(5005, listenOptions =>
+            {
+                listenOptions.UseHttps(httpsOptions =>
+                {
+                    var localhostCert = CertificateLoader.LoadFromStoreCert(
+                        "localhost", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var exampleCert = CertificateLoader.LoadFromStoreCert(
+                        "example.com", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var subExampleCert = CertificateLoader.LoadFromStoreCert(
+                        "sub.example.com", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var certs = new Dictionary<string, X509Certificate2>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["localhost"] = localhostCert,
+                        ["example.com"] = exampleCert,
+                        ["sub.example.com"] = subExampleCert
+                    };
+
+                    httpsOptions.ServerCertificateSelector = (connectionContext, name) =>
+                    {
+                        if (name is not null && certs.TryGetValue(name, out var cert))
+                        {
+                            return cert;
+                        }
+
+                        return exampleCert;
+                    };
+                });
+            });
+        });
+        // </snippet_ServerCertificateSelector>
+    }
+
+    public static void ServerOptionsSelectionCallback(string[] args)
+    {
+        // <snippet_ServerOptionsSelectionCallback>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.ListenAnyIP(5005, listenOptions =>
+            {
+                listenOptions.UseHttps(httpsOptions =>
+                {
+                    var localhostCert = CertificateLoader.LoadFromStoreCert(
+                        "localhost", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var exampleCert = CertificateLoader.LoadFromStoreCert(
+                        "example.com", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+
+                    listenOptions.UseHttps((stream, clientHelloInfo, state, cancellationToken) =>
+                    {
+                        if (string.Equals(clientHelloInfo.ServerName, "localhost", StringComparison.OrdinalIgnoreCase))
+                        {
+                            return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                            {
+                                ServerCertificate = localhostCert,
+                                // Different TLS requirements for this host
+                                ClientCertificateRequired = true
+                            });
+                        }
+
+                        return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                        {
+                            ServerCertificate = exampleCert
+                        });
+                    }, state: null!);
+                });
+            });
+        });
+        // </snippet_ServerOptionsSelectionCallback>
+    }
+
+    public static void TlsHandshakeCallbackOptions(string[] args)
+    {
+        // <snippet_TlsHandshakeCallbackOptions>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.ListenAnyIP(5005, listenOptions =>
+            {
+                listenOptions.UseHttps(httpsOptions =>
+                {
+                    var localhostCert = CertificateLoader.LoadFromStoreCert(
+                        "localhost", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+                    var exampleCert = CertificateLoader.LoadFromStoreCert(
+                        "example.com", "My", StoreLocation.CurrentUser,
+                        allowInvalid: true);
+
+                    listenOptions.UseHttps(new TlsHandshakeCallbackOptions
+                    {
+                        OnConnection = context =>
+                        {
+                            if (string.Equals(context.ClientHelloInfo.ServerName, "localhost", StringComparison.OrdinalIgnoreCase))
+                            {
+                                // Different TLS requirements for this host
+                                context.AllowDelayedClientCertificateNegotation = true;
+
+                                return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                                {
+                                    ServerCertificate = localhostCert
+                                });
+                            }
+
+                            return new ValueTask<SslServerAuthenticationOptions>(new SslServerAuthenticationOptions
+                            {
+                                ServerCertificate = exampleCert
+                            });
+                        }
+                    });
+                });
+            });
+        });
+        // </snippet_TlsHandshakeCallbackOptions>
+    }
+
+    public static void ConfigureHttpsDefaultsSslProtocols(string[] args)
+    {
+        // <snippet_ConfigureHttpsDefaultsSslProtocols>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                listenOptions.SslProtocols = SslProtocols.Tls13;
+            });
+        });
+        // </snippet_ConfigureHttpsDefaultsSslProtocols>
+    }
+
+    public static void ConfigureHttpsDefaultsClientCertificateMode(string[] args)
+    {
+        // <snippet_ConfigureHttpsDefaultsClientCertificateMode>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                listenOptions.ClientCertificateMode = ClientCertificateMode.AllowCertificate;
+            });
+        });
+        // </snippet_ConfigureHttpsDefaultsClientCertificateMode>
+    }
+
+    public static void ConfigureKestrelUseConnectionLogging(string[] args)
+    {
+        // <snippet_ConfigureKestrelUseConnectionLogging>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Listen(IPAddress.Any, 8000, listenOptions =>
+            {
+                listenOptions.UseConnectionLogging();
+            });
+        });
+        // </snippet_ConfigureKestrelUseConnectionLogging>
+    }
+
+    public static void Listen(string[] args)
+    {
+        // <snippet_Listen>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Listen(IPAddress.Loopback, 5000);
+            serverOptions.Listen(IPAddress.Loopback, 5001, listenOptions =>
+            {
+                listenOptions.UseHttps("testCert.pfx", "testPassword");
+            });
+        });
+        // </snippet_Listen>
+    }
+
+    public static void ListenUnixSocket(string[] args)
+    {
+        // <snippet_ListenUnixSocket>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock");
+            serverOptions.ListenUnixSocket("/tmp/kestrel-test.sock", listenOptions =>
+            {
+                listenOptions.UseHttps("testCert.pfx", "testpassword");
+            });
+        });
+        // </snippet_ListenUnixSocket>
+    }
+
+    public static void IServerAddressesFeature(WebApplication app)
+    {
+#pragma warning disable CS1998
+        // <snippet_IServerAddressesFeature>
+        app.Run(async (context) =>
+        {
+            var serverAddressFeature = context.Features.Get<IServerAddressesFeature>();
+
+            if (serverAddressFeature is not null)
+            {
+                var listenAddresses = string.Join(", ", serverAddressFeature.Addresses);
+
+                // ...
+            }
+        });
+        // </snippet_IServerAddressesFeature>
+#pragma warning restore CS1998
+    }
+
+    public static void ConfigureKestrelProtocols(string[] args)
+    {
+        // <snippet_ConfigureKestrelProtocols>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Listen(IPAddress.Any, 8000, listenOptions =>
+            {
+                listenOptions.UseHttps("testCert.pfx", "testPassword");
+            });
+        });
+        // </snippet_ConfigureKestrelProtocols>
+    }
+
+    public static void ConfigureHttpsDefaultsCipherSuitesPolicy(string[] args)
+    {
+        // <snippet_ConfigureHttpsDefaultsCipherSuitesPolicy>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.ConfigureHttpsDefaults(listenOptions =>
+            {
+                listenOptions.OnAuthenticate = (context, sslOptions) =>
+                {
+                    sslOptions.CipherSuitesPolicy = new CipherSuitesPolicy(
+                        new[]
+                        {
+                            TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+                            TlsCipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+                            // ...
+                        });
+                };
+            });
+        });
+        // </snippet_ConfigureHttpsDefaultsCipherSuitesPolicy>
+    }
+
+    public static void ConfigureKestrelMiddleware(string[] args)
+    {
+        // <snippet_ConfigureKestrelMiddleware>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel((context, serverOptions) =>
+        {
+            serverOptions.Listen(IPAddress.Any, 8000, listenOptions =>
+            {
+                listenOptions.UseHttps("testCert.pfx", "testPassword");
+
+                listenOptions.Use((context, next) =>
+                {
+                    var tlsFeature = context.Features.Get<ITlsHandshakeFeature>()!;
+
+                    if (tlsFeature.CipherAlgorithm == CipherAlgorithmType.Null)
+                    {
+                        throw new NotSupportedException(
+                            $"Prohibited cipher: {tlsFeature.CipherAlgorithm}");
+                    }
+
+                    return next();
+                });
+            });
+        });
+        // </snippet_ConfigureKestrelMiddleware>
+    }
+
     public static void Http3(string[] args)
     {
         // <snippet_Http3>


### PR DESCRIPTION
Fixes #24604.
Fixes #21799.
Fixes #23244.

[Internal Preview](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-6.0&branch=pr-en-us-24640).

Updated sample code for 6.0, explained random ports as described [here](https://docs.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-6.0?view=aspnetcore-6.0#tgp), and fixed outstanding issues as linked above.