### PR TITLE
Highlighted code snippets

### DIFF
--- a/aspnetcore/includes/RP-MVC/validation-net6.md
+++ b/aspnetcore/includes/RP-MVC/validation-net6.md
@@ -9,7 +9,7 @@ The DataAnnotations namespace provides a set of built-in validation attributes t
 
 Update the `Movie` class to take advantage of the built-in `Required`, `StringLength`, `RegularExpression`, and `Range` validation attributes.
 
-[!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Models/Movie.cs?name=FinalSnippet)]
+[!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Models/Movie.cs?name=FinalSnippet?highlight=11,12,18,19,20,24,25,26,29,30,31)]
 
 The validation attributes specify behavior that you want to enforce on the model properties they're applied to:
 

--- a/aspnetcore/includes/RP-MVC/validation-net6.md
+++ b/aspnetcore/includes/RP-MVC/validation-net6.md
@@ -9,7 +9,7 @@ The DataAnnotations namespace provides a set of built-in validation attributes t
 
 Update the `Movie` class to take advantage of the built-in `Required`, `StringLength`, `RegularExpression`, and `Range` validation attributes.
 
-[!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Models/Movie.cs?name=FinalSnippet?highlight=11,12,18,19,20,24,25,26,29,30,31)]
+[!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Models/Movie.cs?name=FinalSnippet?highlight=11,12,18-20,24-26,29-31)]
 
 The validation attributes specify behavior that you want to enforce on the model properties they're applied to:
 

--- a/aspnetcore/includes/RP-MVC/validation-net6.md
+++ b/aspnetcore/includes/RP-MVC/validation-net6.md
@@ -9,7 +9,7 @@ The DataAnnotations namespace provides a set of built-in validation attributes t
 
 Update the `Movie` class to take advantage of the built-in `Required`, `StringLength`, `RegularExpression`, and `Range` validation attributes.
 
-[!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Models/Movie.cs?name=FinalSnippet?highlight=11,12,18-20,24-26,29-31)]
+[!code-csharp[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Models/Movie.cs?name=FinalSnippet&highlight=11-12,18-20,24-26,29-31)]
 
 The validation attributes specify behavior that you want to enforce on the model properties they're applied to:
 


### PR DESCRIPTION
Added the highlight query when displaying the first code block or snippet in [this](https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/validation?view=aspnetcore-6.0) section of docs.

IDK how the highlight query works so I added the line numbers of the line to highlight relative to that region, `i.e FinalSnippet`, please correct me if that's wrong.

And if someone could please also _explain how to highlight line(s) in different regions_ since it's not mentioned in the [Contributing Guidelines](https://github.com/dotnet/AspNetCore.Docs/blob/main/CONTRIBUTING.md#code-snippets) so that I could add some more similar changes 'cuz those _highlights are really required for some one like me who is following along the tutorial in the docs_.