### PR TITLE
Injected properties are expected to be available

### DIFF
--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -147,6 +147,7 @@ public class ComponentBase : IComponent
 >
 > For more information, see the following resources:
 >
+> * [Nullable reference types (NRTs) and .NET compiler null-state static analysis](xref:migration/50-to-60#nullable-reference-types-nrts-and-net-compiler-null-state-static-analysis)
 > * [Nullable reference types (C# guide)](/dotnet/csharp/nullable-references)
 > * [default value expressions (C# reference)](/dotnet/csharp/language-reference/operators/default#default-literal)
 > * [! (null-forgiving) operator (C# reference)](/dotnet/csharp/language-reference/operators/null-forgiving)

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -142,7 +142,7 @@ public class ComponentBase : IComponent
 >
 > ```csharp
 > [Inject]
-> private IServiceProvider ServiceProvider { get; set; } = default!;
+> private IMyExampleService ExampleService { get; set; } = default!;
 > ```
 >
 > For more information, see the following resources:

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -137,6 +137,20 @@ public class ComponentBase : IComponent
 }
 ```
 
+> [!NOTE]
+> Don't mark injected services as nullable. Instead, assign a default literal with the null-forgiving operator (`default!`). For example:
+>
+> ```csharp
+> [Inject]
+> private IServiceProvider ServiceProvider { get; set; } = default!;
+> ```
+>
+> For more information, see the following resources:
+>
+> * [Nullable reference types (C# guide)](/dotnet/csharp/nullable-references)
+> * [default value expressions (C# reference)](/dotnet/csharp/language-reference/operators/default#default-literal)
+> * [! (null-forgiving) operator (C# reference)](/dotnet/csharp/language-reference/operators/null-forgiving)
+
 In components derived from the base class, the [`@inject`](xref:mvc/views/razor#inject) directive isn't required. The <xref:Microsoft.AspNetCore.Components.InjectAttribute> of the base class is sufficient:
 
 ```razor


### PR DESCRIPTION
Addresses #24615

Per https://github.com/dotnet/aspnetcore/pull/39445#discussion_r787781819 ...

Pranav, *keep/update this? ... or close the PR (e.g., it's too weedy ... too rare)?* 👂 

Currently, this is only for the 6.0 or later versions due to NRT enforcement for C# 8.0 or later. If we keep/modify this, let me know if you feel that 3.1/5.0 should have this guidance as well. 👂