### PR TITLE
Update Kestrel Options to 6.0

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/options.md
+++ b/aspnetcore/fundamentals/servers/kestrel/options.md
@@ -5,7 +5,7 @@ description: Learn about configuring options for Kestrel, the cross-platform web
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/04/2020
+ms.date: 01/20/2022
 no-loc: [Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: fundamentals/servers/kestrel/options
 ---
@@ -13,30 +13,15 @@ uid: fundamentals/servers/kestrel/options
 
 :::moniker range=">= aspnetcore-6.0"
 
-The Kestrel web server has constraint configuration options that are especially useful in Internet-facing deployments.
+The Kestrel web server has constraint configuration options that are especially useful in Internet-facing deployments. To configure Kestrel configuration options, call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.ConfigureKestrel%2A>:
 
-To provide more configuration after calling <xref:Microsoft.Extensions.Hosting.GenericHostBuilderExtensions.ConfigureWebHostDefaults%2A>, use <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.ConfigureKestrel%2A>:
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrel":::
 
-```csharp
-public static IHostBuilder CreateHostBuilder(string[] args) =>
-    Host.CreateDefaultBuilder(args)
-        .ConfigureWebHostDefaults(webBuilder =>
-        {
-            webBuilder.ConfigureKestrel(serverOptions =>
-            {
-                // Set properties and call methods on options
-            })
-            .UseStartup<Startup>();
-        });
-```
+Set constraints on the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Limits%2A?displayProperty=nameWithType> property. This property holds an instance of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits> class.
 
-Set constraints on the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Limits> property of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> class. The `Limits` property holds an instance of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits> class.
+The examples in this article use the <xref:Microsoft.AspNetCore.Server.Kestrel.Core> namespace:
 
-The following examples use the <xref:Microsoft.AspNetCore.Server.Kestrel.Core> namespace:
-
-```csharp
-using Microsoft.AspNetCore.Server.Kestrel.Core;
-```
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_UsingKestrelCore":::
 
 In examples shown later in this article, Kestrel options are configured in C# code. Kestrel options can also be set using a [configuration provider](xref:fundamentals/configuration/index). For example, the [File Configuration Provider](xref:fundamentals/configuration/index#file-configuration-provider) can load Kestrel configuration from an `appsettings.json` or `appsettings.{Environment}.json` file:
 
@@ -52,143 +37,74 @@ In examples shown later in this article, Kestrel options are configured in C# co
 }
 ```
 
+By default, Kestrel configuration is loaded from the `Kestrel` section using a preconfigured set of configuration providers. For more information on the default set of configuration providers, see [Default configuration](xref:fundamentals/configuration/index#default-configuration).
+
 > [!NOTE]
-> <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> and [endpoint configuration](xref:fundamentals/servers/kestrel/endpoints) are configurable from configuration providers. Remaining Kestrel configuration must be configured in C# code.
-
-Use **one** of the following approaches:
-
-* Configure Kestrel in `Startup.ConfigureServices`:
-
-  1. Inject an instance of `IConfiguration` into the `Startup` class. The following example assumes that the injected configuration is assigned to the `Configuration` property.
-  2. In `Startup.ConfigureServices`, load the `Kestrel` section of configuration into Kestrel's configuration:
-
-     ```csharp
-     using Microsoft.Extensions.Configuration
-     
-     public class Startup
-     {
-         public Startup(IConfiguration configuration)
-         {
-             Configuration = configuration;
-         }
-
-         public IConfiguration Configuration { get; }
-
-         public void ConfigureServices(IServiceCollection services)
-         {
-             services.Configure<KestrelServerOptions>(
-                 Configuration.GetSection("Kestrel"));
-         }
-
-         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-         {
-             ...
-         }
-     }
-     ```
-
-* Configure Kestrel when building the host:
-
-  In `Program.cs`, load the `Kestrel` section of configuration into Kestrel's configuration:
-
-  ```csharp
-  // using Microsoft.Extensions.DependencyInjection;
-
-  public static IHostBuilder CreateHostBuilder(string[] args) =>
-      Host.CreateDefaultBuilder(args)
-          .ConfigureServices((context, services) =>
-          {
-              services.Configure<KestrelServerOptions>(
-                  context.Configuration.GetSection("Kestrel"));
-          })
-          .ConfigureWebHostDefaults(webBuilder =>
-          {
-              webBuilder.UseStartup<Startup>();
-          });
-  ```
-
-Both of the preceding approaches work with any [configuration provider](xref:fundamentals/configuration/index).
+> <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> and [endpoint configuration](xref:fundamentals/servers/kestrel/endpoints) are configurable from configuration providers. Set other Kestrel configuration in C# code.
 
 ## General limits
 
 ### Keep-alive timeout
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.KeepAliveTimeout>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.KeepAliveTimeout> gets or sets the [keep-alive timeout](https://tools.ietf.org/html/rfc7230#section-6.5):
 
-Gets or sets the [keep-alive timeout](https://tools.ietf.org/html/rfc7230#section-6.5). Defaults to 2 minutes.
-
-:::code language="csharp" source="samples/5.x/KestrelSample/Program.cs" id="snippet_Limits" highlight="19-20":::
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsKeepAliveTimeout" highlight="3":::
 
 ### Maximum client connections
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentConnections><br>
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentUpgradedConnections>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentConnections> gets or sets the maximum number of open connections.
 
-The maximum number of concurrent open TCP connections can be set for the entire app with the following code:
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsMaxConcurrentConnections" highlight="3":::
 
-:::code language="csharp" source="samples/5.x/KestrelSample/Program.cs" id="snippet_Limits" highlight="3":::
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentUpgradedConnections> gets or sets the maximum number of open, upgraded connections:
 
-There's a separate limit for connections that have been upgraded from HTTP or HTTPS to another protocol (for example, on a WebSockets request). After a connection is upgraded, it isn't counted against the `MaxConcurrentConnections` limit.
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsMaxConcurrentUpgradedConnections" highlight="3":::
 
-:::code language="csharp" source="samples/5.x/KestrelSample/Program.cs" id="snippet_Limits" highlight="4":::
-
-The maximum number of connections is unlimited (null) by default.
+An upgraded connection is one that has been switched from HTTP to another protocol, such as WebSockets. After a connection is upgraded, it isn't counted against the `MaxConcurrentConnections` limit.
 
 ### Maximum request body size
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxRequestBodySize>
-
-The default maximum request body size is 30,000,000 bytes, which is approximately 28.6 MB.
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxRequestBodySize> gets or sets the maximum allowed size of any request body in bytes.
 
 The recommended approach to override the limit in an ASP.NET Core MVC app is to use the <xref:Microsoft.AspNetCore.Mvc.RequestSizeLimitAttribute> attribute on an action method:
 
-```csharp
-[RequestSizeLimit(100000000)]
-public IActionResult MyActionMethod()
-```
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Controllers/SampleController.cs" id="snippet_RequestSizeLimit":::
 
-The following example shows how to configure the constraint for the app on every request:
+The following example configures `MaxRequestBodySize` for all requests:
 
-:::code language="csharp" source="samples/5.x/KestrelSample/Program.cs" id="snippet_Limits" highlight="5":::
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsMaxRequestBodySize" highlight="3":::
 
-Override the setting on a specific request in middleware:
+The following example configures `MaxRequestBodySize` for a specific request using <xref:Microsoft.AspNetCore.Http.Features.IHttpMaxRequestBodySizeFeature> in a custom middleware:
 
-:::code language="csharp" source="samples/5.x/KestrelSample/Startup.cs" id="snippet_Limits" highlight="3-4":::
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_IHttpMaxRequestBodySizeFeatureMiddleware":::
 
-An exception is thrown if the app configures the limit on a request after the app has started to read the request. There's an `IsReadOnly` property that indicates if the `MaxRequestBodySize` property is in read-only state, meaning it's too late to configure the limit.
+If the app attempts to configure the limit on a request after it starts to read the request, an exception is thrown. Ue the <xref:Microsoft.AspNetCore.Http.Features.IHttpMaxRequestBodySizeFeature.IsReadOnly%2A?displayProperty=nameWithType> property to check if it's safe to set the `MaxRequestBodySize` property.
 
-When an app runs [out-of-process](xref:host-and-deploy/iis/index#out-of-process-hosting-model) behind the [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module), Kestrel's request body size limit is disabled. IIS already sets the limit.
+When an app runs [out-of-process](xref:host-and-deploy/iis/index#out-of-process-hosting-model) behind the [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module), IIS sets the limit and Kestrel's request body size limit is disabled.
 
 ### Minimum request body data rate
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinRequestBodyDataRate><br>
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinResponseDataRate>
+Kestrel checks every second if data is arriving at the specified rate in bytes/second. If the rate drops below the minimum, the connection is timed out. The grace period is the amount of time Kestrel allows the client to increase its send rate up to the minimum. The rate isn't checked during that time. The grace period helps avoid dropping connections that are initially sending data at a slow rate because of TCP slow-start. A minimum rate also applies to the response.
 
-Kestrel checks every second if data is arriving at the specified rate in bytes/second. If the rate drops below the minimum, the connection is timed out. The grace period is the amount of time Kestrel allows the client to increase its send rate up to the minimum. The rate isn't checked during that time. The grace period helps avoid dropping connections that are initially sending data at a slow rate because of TCP slow-start.
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinRequestBodyDataRate> gets or sets the request body minimum data rate in bytes/second. <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinResponseDataRate> gets or sets the response minimum data rate in bytes/second.
 
-The default minimum rate is 240 bytes/second with a 5-second grace period.
+The following example configures `MinRequestBodyDataRate` and `MinResponseDataRate` for all requests:
 
-A minimum rate also applies to the response. The code to set the request limit and the response limit is the same except for having `RequestBody` or `Response` in the property and interface names.
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsMinDataRates" highlight="3-6":::
 
-Here's an example that shows how to configure the minimum data rates in `Program.cs`:
+The following example configures `MinRequestBodyDataRate` and `MinResponseDataRate` for a specific request using <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinRequestBodyDataRateFeature> and <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseDataRateFeature> in a custom middleware:
 
-:::code language="csharp" source="samples/5.x/KestrelSample/Program.cs" id="snippet_Limits" highlight="6-11":::
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_DataRateFeaturesMiddleware":::
 
-Override the minimum rate limits per request in middleware:
-
-:::code language="csharp" source="samples/5.x/KestrelSample/Startup.cs" id="snippet_Limits" highlight="6-21":::
-
-The <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseDataRateFeature> referenced in the prior sample isn't present in <xref:Microsoft.AspNetCore.Http.HttpContext.Features?displayProperty=nameWithType> for HTTP/2 requests. Modifying rate limits on a per-request basis isn't generally supported for HTTP/2 because of the protocol's support for request multiplexing. However, the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinRequestBodyDataRateFeature> is still present `HttpContext.Features` for HTTP/2 requests, because the read rate limit can still be *disabled entirely* on a per-request basis by setting <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseDataRateFeature.MinDataRate?displayProperty=nameWithType> to `null` even for an HTTP/2 request. Attempting to read `IHttpMinRequestBodyDataRateFeature.MinDataRate` or attempting to set it to a value other than `null` will result in a <xref:System.NotSupportedException> being thrown given an HTTP/2 request.
+`IHttpMinResponseDataRateFeature` isn't present in <xref:Microsoft.AspNetCore.Http.HttpContext.Features?displayProperty=nameWithType> for HTTP/2 requests. Modifying rate limits on a per-request basis isn't generally supported for HTTP/2 because of the protocol's support for request multiplexing. However, `IHttpMinRequestBodyDataRateFeature` is still present in `HttpContext.Features` for HTTP/2 requests, because the read rate limit can still be *disabled entirely* on a per-request basis by setting <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseDataRateFeature.MinDataRate?displayProperty=nameWithType> to `null`, even for an HTTP/2 request. Attempts to read `IHttpMinRequestBodyDataRateFeature.MinDataRate` or attempts to set it to a value other than `null` result in a <xref:System.NotSupportedException> for HTTP/2 requests.
 
 Server-wide rate limits configured via <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerOptions.Limits?displayProperty=nameWithType> still apply to both HTTP/1.x and HTTP/2 connections.
 
 ### Request headers timeout
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.RequestHeadersTimeout>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.RequestHeadersTimeout> gets or sets the maximum amount of time the server spends receiving request headers:
 
-Gets or sets the maximum amount of time the server spends receiving request headers. Defaults to 30 seconds.
-
-:::code language="csharp" source="samples/5.x/KestrelSample/Program.cs" id="snippet_Limits" highlight="21-22":::
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsRequestHeadersTimeout" highlight="3":::
 
 ## HTTP/2 limits
 
@@ -196,93 +112,43 @@ The limits in this section are set on <xref:Microsoft.AspNetCore.Server.Kestrel.
 
 ### Maximum streams per connection
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxStreamsPerConnection>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxStreamsPerConnection> limits the number of concurrent request streams per HTTP/2 connection. Excess streams are refused:
 
-Limits the number of concurrent request streams per HTTP/2 connection. Excess streams are refused.
-
-```csharp
-webBuilder.ConfigureKestrel(serverOptions =>
-{
-    serverOptions.Limits.Http2.MaxStreamsPerConnection = 100;
-});
-```
-
-The default value is 100.
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelHttp2LimitsMaxStreamsPerConnection" highlight="3":::
 
 ### Header table size
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.HeaderTableSize>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.HeaderTableSize> limits the size of the header compression tables, in octets, the HPACK encoder and decoder on the server can use. The HPACK decoder decompresses HTTP headers for HTTP/2 connections:
 
-The HPACK decoder decompresses HTTP headers for HTTP/2 connections. `HeaderTableSize` limits the size of the header compression table that the HPACK decoder uses. The value is provided in octets and must be greater than zero (0).
-
-```csharp
-webBuilder.ConfigureKestrel(serverOptions =>
-{
-    serverOptions.Limits.Http2.HeaderTableSize = 4096;
-});
-```
-
-The default value is 4096.
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelHttp2LimitsHeaderTableSize" highlight="3":::
 
 ### Maximum frame size
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxFrameSize>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxFrameSize> indicates the size of the largest frame payload that is allowed to be received, in octets:
 
-Indicates the maximum allowed size of an HTTP/2 connection frame payload received or sent by the server. The value is provided in octets and must be between 2^14 (16,384) and 2^24-1 (16,777,215).
-
-```csharp
-webBuilder.ConfigureKestrel(serverOptions =>
-{
-    serverOptions.Limits.Http2.MaxFrameSize = 16384;
-});
-```
-
-The default value is 2^14 (16,384).
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelHttp2LimitsMaxFrameSize" highlight="3":::
 
 ### Maximum request header size
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxRequestHeaderFieldSize>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.MaxRequestHeaderFieldSize> indicates the size of the maximum allowed size of a request header field sequence. This limit applies to both name and value sequences in their compressed and uncompressed representations:
 
-Indicates the maximum allowed size in octets of request header values. This limit applies to both name and value in their compressed and uncompressed representations. The value must be greater than zero (0).
-
-```csharp
-webBuilder.ConfigureKestrel(serverOptions =>
-{
-    serverOptions.Limits.Http2.MaxRequestHeaderFieldSize = 8192;
-});
-```
-
-The default value is 8,192.
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelHttp2LimitsMaxRequestHeaderFieldSize" highlight="3":::
 
 ### Initial connection window size
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.InitialConnectionWindowSize>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.InitialConnectionWindowSize> indicates how much request body data the server is willing to receive and buffer at a time aggregated across all requests (streams) per connection:
 
-Indicates the maximum request body data in bytes the server buffers at one time, aggregated across all requests (streams) per connection. Requests are also limited by `Http2.InitialStreamWindowSize`. The value must be greater than or equal to 65,535 and less than 2^31 (2,147,483,648).
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelHttp2LimitsInitialConnectionWindowSize" highlight="3":::
 
-```csharp
-webBuilder.ConfigureKestrel(serverOptions =>
-{
-    serverOptions.Limits.Http2.InitialConnectionWindowSize = 131072;
-});
-```
-
-The default value is 128 KB (131,072).
+Requests are also limited by [`InitialStreamWindowSize`](#initial-stream-window-size).
 
 ### Initial stream window size
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.InitialStreamWindowSize>
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.InitialStreamWindowSize> indicates how much request body data the server is willing to receive and buffer at a time per stream:
 
-Indicates the maximum request body data in bytes the server buffers at one time per request (stream). Requests are also limited by [`InitialConnectionWindowSize`](#initial-connection-window-size). The value must be greater than or equal to 65,535 and less than 2^31 (2,147,483,648).
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelHttp2LimitsInitialStreamWindowSize" highlight="3":::
 
-```csharp
-webBuilder.ConfigureKestrel(serverOptions =>
-{
-    serverOptions.Limits.Http2.InitialStreamWindowSize = 98304;
-});
-```
-
-The default value is 96 KB (98,304).
+Requests are also limited by [`InitialConnectionWindowSize`](#initial-connection-window-size).
 
 ### HTTP/2 keep alive ping configuration
 
@@ -293,29 +159,25 @@ Kestrel can be configured to send HTTP/2 pings to connected clients. HTTP/2 ping
 
 There are two configuration options related to HTTP/2 keep alive pings:
 
-* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.KeepAlivePingDelay> is a <xref:System.TimeSpan> that configures the ping interval. The server sends a keep alive ping to the client if it doesn't receive any frames for this period of time. Keep alive pings are disabled when this option is set to <xref:System.TimeSpan.MaxValue?displayProperty=nameWithType>. The default value is <xref:System.TimeSpan.MaxValue?displayProperty=nameWithType>.
-* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.KeepAlivePingTimeout> is a <xref:System.TimeSpan> that configures the ping timeout. If the server doesn't receive any frames, such as a response ping, during this timeout then the connection is closed. Keep alive timeout is disabled when this option is set to <xref:System.TimeSpan.MaxValue?displayProperty=nameWithType>. The default value is 20 seconds.
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.KeepAlivePingDelay> is a <xref:System.TimeSpan> that configures the ping interval. The server sends a keep alive ping to the client if it doesn't receive any frames for this period of time. Keep alive pings are disabled when this option is set to <xref:System.TimeSpan.MaxValue?displayProperty=nameWithType>.
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Http2Limits.KeepAlivePingTimeout> is a <xref:System.TimeSpan> that configures the ping timeout. If the server doesn't receive any frames, such as a response ping, during this timeout then the connection is closed. Keep alive timeout is disabled when this option is set to <xref:System.TimeSpan.MaxValue?displayProperty=nameWithType>.
 
-```csharp
-webBuilder.ConfigureKestrel(serverOptions =>
-{
-    serverOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(30);
-    serverOptions.Limits.Http2.KeepAlivePingTimeout = TimeSpan.FromSeconds(60);
-});
-```
+The following example sets `KeepAlivePingDelay` and `KeepAlivePingTimeout`:
+
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelHttp2LimitsKeepAlivePings" highlight="3-4":::
 
 ## Other options
 
 ### Synchronous I/O
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowSynchronousIO> controls whether synchronous I/O is allowed for the request and response. The default value is `false`.
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.AllowSynchronousIO> controls whether synchronous I/O is allowed for the request and response.
 
 > [!WARNING]
 > A large number of blocking synchronous I/O operations can lead to thread pool starvation, which makes the app unresponsive. Only enable `AllowSynchronousIO` when using a library that doesn't support asynchronous I/O.
 
 The following example enables synchronous I/O:
 
-:::code language="csharp" source="samples/5.x/KestrelSample/Program.cs" id="snippet_SyncIO":::
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelAllowSynchronousIO" highlight="3-4":::
 
 For information about other Kestrel options and limits, see:
 

--- a/aspnetcore/fundamentals/servers/kestrel/options.md
+++ b/aspnetcore/fundamentals/servers/kestrel/options.md
@@ -48,7 +48,7 @@ By default, Kestrel configuration is loaded from the `Kestrel` section using a p
 
 ### Maximum client connections
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentConnections> gets or sets the maximum number of open connections.
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MaxConcurrentConnections> gets or sets the maximum number of open connections:
 
 :::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsMaxConcurrentConnections" highlight="3":::
 

--- a/aspnetcore/fundamentals/servers/kestrel/options.md
+++ b/aspnetcore/fundamentals/servers/kestrel/options.md
@@ -13,15 +13,11 @@ uid: fundamentals/servers/kestrel/options
 
 :::moniker range=">= aspnetcore-6.0"
 
-The Kestrel web server has constraint configuration options that are especially useful in Internet-facing deployments. To configure Kestrel configuration options, call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.ConfigureKestrel%2A>:
+The Kestrel web server has constraint configuration options that are especially useful in Internet-facing deployments. To configure Kestrel configuration options, call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.ConfigureKestrel%2A> in *Program.cs*:
 
 :::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrel":::
 
 Set constraints on the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Limits%2A?displayProperty=nameWithType> property. This property holds an instance of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits> class.
-
-The examples in this article use the <xref:Microsoft.AspNetCore.Server.Kestrel.Core> namespace:
-
-:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_UsingKestrelCore":::
 
 In examples shown later in this article, Kestrel options are configured in C# code. Kestrel options can also be set using a [configuration provider](xref:fundamentals/configuration/index). For example, the [File Configuration Provider](xref:fundamentals/configuration/index#file-configuration-provider) can load Kestrel configuration from an `appsettings.json` or `appsettings.{Environment}.json` file:
 
@@ -177,7 +173,7 @@ The following example sets `KeepAlivePingDelay` and `KeepAlivePingTimeout`:
 
 The following example enables synchronous I/O:
 
-:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelAllowSynchronousIO" highlight="3-4":::
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelAllowSynchronousIO" highlight="3":::
 
 For information about other Kestrel options and limits, see:
 

--- a/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Controllers/SampleController.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Controllers/SampleController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace KestrelSample.Snippets.Controllers;
+
+public class SampleController : ControllerBase
+{
+    // <snippet_RequestSizeLimit>
+    [RequestSizeLimit(100_000_000)]
+    public IActionResult Get()
+    // </snippet_RequestSizeLimit>
+        => NoContent();
+}

--- a/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs
@@ -6,10 +6,8 @@ using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Http.Features;
-// <snippet_UsingKestrelCore>
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
-// </snippet_UsingKestrelCore>
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 
 namespace KestrelSample.Snippets;

--- a/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs
+++ b/aspnetcore/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs
@@ -5,7 +5,11 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http.Features;
+// <snippet_UsingKestrelCore>
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Core.Features;
+// </snippet_UsingKestrelCore>
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 
 namespace KestrelSample.Snippets;
@@ -376,6 +380,209 @@ public static class Program
             });
         });
         // </snippet_ConfigureKestrelMiddleware>
+    }
+
+    public static void ConfigureKestrel(string[] args)
+    {
+        // <snippet_ConfigureKestrel>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            // ...
+        });
+        // </snippet_ConfigureKestrel>
+    }
+
+    public static void ConfigureKestrelLimitsKeepAliveTimeout(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelLimitsKeepAliveTimeout>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.KeepAliveTimeout = TimeSpan.FromMinutes(2);
+        });
+        // </snippet_ConfigureKestrelLimitsKeepAliveTimeout>
+    }
+
+    public static void ConfigureKestrelLimitsMaxConcurrentConnections(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelLimitsMaxConcurrentConnections>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.MaxConcurrentConnections = 100;
+        });
+        // </snippet_ConfigureKestrelLimitsMaxConcurrentConnections>
+    }
+
+    public static void ConfigureKestrelLimitsMaxConcurrentUpgradedConnections(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelLimitsMaxConcurrentUpgradedConnections>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.MaxConcurrentUpgradedConnections = 100;
+        });
+        // </snippet_ConfigureKestrelLimitsMaxConcurrentUpgradedConnections>
+    }
+
+    public static void ConfigureKestrelLimitsMaxRequestBodySize(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelLimitsMaxRequestBodySize>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.MaxRequestBodySize = 100_000_000;
+        });
+        // </snippet_ConfigureKestrelLimitsMaxRequestBodySize>
+    }
+
+    public static void IHttpMaxRequestBodySizeFeatureMiddleware(WebApplication app)
+    {
+        // <snippet_IHttpMaxRequestBodySizeFeatureMiddleware>
+        app.Use(async (context, next) =>
+        {
+            var httpMaxRequestBodySizeFeature = context.Features.Get<IHttpMaxRequestBodySizeFeature>();
+
+            if (httpMaxRequestBodySizeFeature is not null)
+                httpMaxRequestBodySizeFeature.MaxRequestBodySize = 10 * 1024;
+
+            // ...
+
+            await next(context);
+        });
+        // </snippet_IHttpMaxRequestBodySizeFeatureMiddleware>
+    }
+
+    public static void ConfigureKestrelLimitsMinDataRates(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelLimitsMinDataRates>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.MinRequestBodyDataRate = new MinDataRate(
+                bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
+            serverOptions.Limits.MinResponseDataRate = new MinDataRate(
+                bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
+        });
+        // </snippet_ConfigureKestrelLimitsMinDataRates>
+    }
+
+    public static void DataRateFeaturesMiddleware(WebApplication app)
+    {
+        // <snippet_DataRateFeaturesMiddleware>
+        app.Use(async (context, next) =>
+        {
+            var httpMinRequestBodyDataRateFeature = context.Features
+                .Get<IHttpMinRequestBodyDataRateFeature>();
+
+            if (httpMinRequestBodyDataRateFeature is not null)
+            {
+                httpMinRequestBodyDataRateFeature.MinDataRate = new MinDataRate(
+                    bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
+            }
+
+            var httpMinResponseDataRateFeature = context.Features
+                .Get<IHttpMinResponseDataRateFeature>();
+
+            if (httpMinResponseDataRateFeature is not null)
+            {
+                httpMinResponseDataRateFeature.MinDataRate = new MinDataRate(
+                    bytesPerSecond: 100, gracePeriod: TimeSpan.FromSeconds(10));
+            }
+
+            // ...
+
+            await next(context);
+        });
+        // </snippet_DataRateFeaturesMiddleware>
+    }
+
+    public static void ConfigureKestrelLimitsRequestHeadersTimeout(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelLimitsRequestHeadersTimeout>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.RequestHeadersTimeout = TimeSpan.FromMinutes(1);
+        });
+        // </snippet_ConfigureKestrelLimitsRequestHeadersTimeout>
+    }
+
+    public static void ConfigureKestrelHttp2LimitsMaxStreamsPerConnection(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelHttp2LimitsMaxStreamsPerConnection>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.Http2.MaxStreamsPerConnection = 100;
+        });
+        // </snippet_ConfigureKestrelHttp2LimitsMaxStreamsPerConnection>
+    }
+
+    public static void ConfigureKestrelHttp2LimitsHeaderTableSize(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelHttp2LimitsHeaderTableSize>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.Http2.HeaderTableSize = 4096;
+        });
+        // </snippet_ConfigureKestrelHttp2LimitsHeaderTableSize>
+    }
+
+    public static void ConfigureKestrelHttp2LimitsMaxFrameSize(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelHttp2LimitsMaxFrameSize>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.Http2.MaxFrameSize = 16_384;
+        });
+        // </snippet_ConfigureKestrelHttp2LimitsMaxFrameSize>
+    }
+
+    public static void ConfigureKestrelHttp2LimitsMaxRequestHeaderFieldSize(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelHttp2LimitsMaxRequestHeaderFieldSize>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.Http2.MaxRequestHeaderFieldSize = 8192;
+        });
+        // </snippet_ConfigureKestrelHttp2LimitsMaxRequestHeaderFieldSize>
+    }
+
+    public static void ConfigureKestrelHttp2LimitsInitialConnectionWindowSize(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelHttp2LimitsInitialConnectionWindowSize>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.Http2.InitialConnectionWindowSize = 131_072;
+        });
+        // </snippet_ConfigureKestrelHttp2LimitsInitialConnectionWindowSize>
+    }
+
+    public static void ConfigureKestrelHttp2LimitsInitialStreamWindowSize(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelHttp2LimitsInitialStreamWindowSize>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.Http2.InitialStreamWindowSize = 98_304;
+        });
+        // </snippet_ConfigureKestrelHttp2LimitsInitialStreamWindowSize>
+    }
+
+    public static void ConfigureKestrelHttp2LimitsKeepAlivePings(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelHttp2LimitsKeepAlivePings>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.Limits.Http2.KeepAlivePingDelay = TimeSpan.FromSeconds(30);
+            serverOptions.Limits.Http2.KeepAlivePingTimeout = TimeSpan.FromMinutes(1);
+        });
+        // </snippet_ConfigureKestrelHttp2LimitsKeepAlivePings>
+    }
+
+    public static void ConfigureKestrelAllowSynchronousIO(WebApplicationBuilder builder)
+    {
+        // <snippet_ConfigureKestrelAllowSynchronousIO>
+        builder.WebHost.ConfigureKestrel(serverOptions =>
+        {
+            serverOptions.AllowSynchronousIO = true;
+        });
+        // </snippet_ConfigureKestrelAllowSynchronousIO>
     }
 
     public static void Http3(string[] args)


### PR DESCRIPTION
Fixes #23653.

[Internal Preview](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options?view=aspnetcore-6.0&branch=pr-en-us-24688).

Updated all code samples to 6.0, and moved inline snippets out to code references. As a couple of the defaults we call out don't match the latest defaults in the code, I decided to drop specifying defaults in general. I concluded that these are all shown and accurate in the API references for each property, so they're very easy to find out for the curious reader, but I can add them back in with the latest correct values if that's preferred.