### PR TITLE
Anchor link: what if page does not exist

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -284,7 +284,7 @@ The generated HTML:
 <a href="/Attendee?attendeeid=10">View Attendee</a>
 ```
 
-If the referenced page doesn't exist, a link to the main page is generated. No warning is indicated.
+If the referenced page doesn't exist, a link to the current page is generated. No warning is indicated.
 
 ### asp-page-handler
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -26,7 +26,7 @@ For an overview of Tag Helpers, see <xref:mvc/views/tag-helpers/intro>.
 
 ### asp-controller
 
-The [asp-controller](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Controller*) attribute assigns the controller used for generating the URL. The following markup lists all speakers:
+The [asp-controller](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Controller%2A) attribute assigns the controller used for generating the URL. The following markup lists all speakers:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspController)]
 
@@ -44,7 +44,7 @@ If the `asp-controller` attribute is specified and `asp-action` isn't, the defau
 
 ### asp-action
 
-The [asp-action](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Action*) attribute value represents the controller action name included in the generated `href` attribute. The following markup sets the generated `href` attribute value to the speaker evaluations page:
+The [asp-action](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Action%2A) attribute value represents the controller action name included in the generated `href` attribute. The following markup sets the generated `href` attribute value to the speaker evaluations page:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspAction)]
 
@@ -60,7 +60,7 @@ If the `asp-action` attribute value is `Index`, then no action is appended to th
 
 ### asp-route-{value}
 
-The [asp-route-{value}](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.RouteValues*) attribute enables a wildcard route prefix. Any value occupying the `{value}` placeholder is interpreted as a potential route parameter. If a default route isn't found, this route prefix is appended to the generated `href` attribute as a request parameter and value. Otherwise, it's substituted in the route template.
+The [asp-route-{value}](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.RouteValues%2A) attribute enables a wildcard route prefix. Any value occupying the `{value}` placeholder is interpreted as a potential route parameter. If a default route isn't found, this route prefix is appended to the generated `href` attribute as a request parameter and value. Otherwise, it's substituted in the route template.
 
 Consider the following controller action:
 
@@ -114,7 +114,7 @@ If either `asp-controller` or `asp-action` aren't specified, then the same defau
 
 ### asp-route
 
-The [asp-route](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Route*) attribute is used for creating a URL linking directly to a named route. Using [routing attributes](xref:mvc/controllers/routing#ar), a route can be named as shown in the `SpeakerController` and used in its `Evaluations` action:
+The [asp-route](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Route%2A) attribute is used for creating a URL linking directly to a named route. Using [routing attributes](xref:mvc/controllers/routing#ar), a route can be named as shown in the `SpeakerController` and used in its `Evaluations` action:
 
 [!code-csharp[](samples/TagHelpersBuiltIn/Controllers/SpeakerController.cs?range=22-24)]
 
@@ -132,7 +132,7 @@ If `asp-controller` or `asp-action` is specified in addition to `asp-route`, the
 
 ### asp-all-route-data
 
-The [asp-all-route-data](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.RouteValues*) attribute supports the creation of a dictionary of key-value pairs. The key is the parameter name, and the value is the parameter value.
+The [asp-all-route-data](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.RouteValues%2A) attribute supports the creation of a dictionary of key-value pairs. The key is the parameter name, and the value is the parameter value.
 
 In the following example, a dictionary is initialized and passed to a Razor view. Alternatively, the data could be passed in with your model.
 
@@ -152,7 +152,7 @@ If any keys in the dictionary match route parameters, those values are substitut
 
 ### asp-fragment
 
-The [asp-fragment](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Fragment*) attribute defines a URL fragment to append to the URL. The Anchor Tag Helper adds the hash character (#). Consider the following markup:
+The [asp-fragment](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Fragment%2A) attribute defines a URL fragment to append to the URL. The Anchor Tag Helper adds the hash character (#). Consider the following markup:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspFragment)]
 
@@ -166,7 +166,7 @@ Hash tags are useful when building client-side apps. They can be used for easy m
 
 ### asp-area
 
-The [asp-area](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Area*) attribute sets the area name used to set the appropriate route. The following examples depict how the `asp-area` attribute causes a remapping of routes.
+The [asp-area](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Area%2A) attribute sets the area name used to set the appropriate route. The following examples depict how the `asp-area` attribute causes a remapping of routes.
 
 #### Usage in Razor Pages
 
@@ -198,7 +198,7 @@ The generated HTML:
 > To support areas in a Razor Pages app, do one of the following in `Startup.ConfigureServices`:
 >
 > * Set the [compatibility version](xref:mvc/compatibility-version) to 2.1 or later.
-> * Set the [RazorPagesOptions.AllowAreas](xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions.AllowAreas*) property to `true`:
+> * Set the <xref:Microsoft.AspNetCore.Mvc.RazorPages.RazorPagesOptions.AllowAreas%2A?displayProperty=nameWithType> property to `true`:
 >
 >   [!code-csharp[](samples/TagHelpersBuiltIn/Startup.cs?name=snippet_AllowAreas)]
 
@@ -236,7 +236,7 @@ The generated HTML:
 
 ### asp-protocol
 
-The [asp-protocol](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Protocol*) attribute is for specifying a protocol (such as `https`) in your URL. For example:
+The [asp-protocol](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Protocol%2A) attribute is for specifying a protocol (such as `https`) in your URL. For example:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspProtocol)]
 
@@ -250,7 +250,7 @@ The host name in the example is localhost. The Anchor Tag Helper uses the websit
 
 ### asp-host
 
-The [asp-host](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Host*) attribute is for specifying a host name in your URL. For example:
+The [asp-host](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Host%2A) attribute is for specifying a host name in your URL. For example:
 
 [!code-cshtml[](samples/TagHelpersBuiltIn/Views/Home/Index.cshtml?name=snippet_AspHost)]
 
@@ -262,7 +262,7 @@ The generated HTML:
 
 ### asp-page
 
-The [asp-page](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Page*) attribute is used with Razor Pages. Use it to set an anchor tag's `href` attribute value to a specific page. Prefixing the page name with a forward slash ("/") creates the URL.
+The [asp-page](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.Page%2A) attribute is used with Razor Pages. Use it to set an anchor tag's `href` attribute value to a specific page. Prefixing the page name with a forward slash ("/") creates the URL.
 
 The following sample points to the attendee Razor Page:
 
@@ -284,11 +284,11 @@ The generated HTML:
 <a href="/Attendee?attendeeid=10">View Attendee</a>
 ```
 
-If the referenced page doesn't exist, a link to the [ambient page](https://docs.microsoft.com/aspnet/core/mvc/controllers/routing#url-generation-and-ambient-values) is generated. No warning is indicated except on debug level.
+If the referenced page doesn't exist, a link to the current page is generated using an [ambient value](xref:fundamentals/routing#ambient-values-and-explicit-values) from the request. No warning is indicated, except at the debug log level.
 
 ### asp-page-handler
 
-The [asp-page-handler](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.PageHandler*) attribute is used with Razor Pages. It's intended for linking to specific page handlers.
+The [asp-page-handler](xref:Microsoft.AspNetCore.Mvc.TagHelpers.AnchorTagHelper.PageHandler%2A) attribute is used with Razor Pages. It's intended for linking to specific page handlers.
 
 Consider the following page handler:
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -284,7 +284,7 @@ The generated HTML:
 <a href="/Attendee?attendeeid=10">View Attendee</a>
 ```
 
-If the referenced page doesn't exist, a link to the current page is generated. No warning is indicated.
+If the referenced page doesn't exist, a link to the current page is generated. No warning is indicated except on debug level.
 
 ### asp-page-handler
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/anchor-tag-helper.md
@@ -284,7 +284,7 @@ The generated HTML:
 <a href="/Attendee?attendeeid=10">View Attendee</a>
 ```
 
-If the referenced page doesn't exist, a link to the current page is generated. No warning is indicated except on debug level.
+If the referenced page doesn't exist, a link to the [ambient page](https://docs.microsoft.com/aspnet/core/mvc/controllers/routing#url-generation-and-ambient-values) is generated. No warning is indicated except on debug level.
 
 ### asp-page-handler
 


### PR DESCRIPTION
If the referenced page does not exist, a link to the current page is generated.

This is a self-correction; the previous wording was correct only if the current page was in fact the main page.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->