### PR TITLE
Clarify requirement for localization

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -367,8 +367,9 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 
 await host.RunAsync();
 ```
-> [!NOTE] 
-> In Blazor WebAssembly, both `DefaultThreadCurrentCulture` and `DefaultThreadCurrentUICulture` must be set to the same culture in order to load and use Localization Resources.
+
+> [!IMPORTANT] 
+> In Blazor WebAssembly, <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to load and use localization resources.
 
 The following `CultureSelector` component shows how to perform the following actions:
 
@@ -1236,6 +1237,9 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 await host.RunAsync();
 ```
 
+> [!IMPORTANT] 
+> In Blazor WebAssembly, <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to load and use localization resources.
+
 The following `CultureSelector` component shows how to set the user's culture selection into browser local storage via JS interop. The component is placed in the `Shared` folder for use throughout the app.
 
 `Shared/CultureSelector.razor`:
@@ -2014,6 +2018,9 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 
 await host.RunAsync();
 ```
+
+> [!IMPORTANT] 
+> In Blazor WebAssembly, <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to load and use localization resources.
 
 The following `CultureSelector` component shows how to set the user's culture selection into browser local storage via JS interop. The component is placed in the `Shared` folder for use throughout the app.
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -368,8 +368,10 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 await host.RunAsync();
 ```
 
-> [!IMPORTANT] 
-> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture.
+> [!IMPORTANT]
+> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to use <xref:System.Web.Globalization.IStringLocalizerProvider> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>. For more information, see [`WebAssemblyCultureProvider` (reference source)](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 The following `CultureSelector` component shows how to perform the following actions:
 
@@ -1237,8 +1239,10 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 await host.RunAsync();
 ```
 
-> [!IMPORTANT] 
-> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture.
+> [!IMPORTANT]
+> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to use <xref:System.Web.Globalization.IStringLocalizerProvider> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>. For more information, see [`WebAssemblyCultureProvider` (reference source)](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 The following `CultureSelector` component shows how to set the user's culture selection into browser local storage via JS interop. The component is placed in the `Shared` folder for use throughout the app.
 
@@ -2019,8 +2023,10 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 await host.RunAsync();
 ```
 
-> [!IMPORTANT] 
-> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture.
+> [!IMPORTANT]
+> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to use <xref:System.Web.Globalization.IStringLocalizerProvider> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>. For more information, see [`WebAssemblyCultureProvider` (reference source)](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 The following `CultureSelector` component shows how to set the user's culture selection into browser local storage via JS interop. The component is placed in the `Shared` folder for use throughout the app.
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -369,7 +369,7 @@ await host.RunAsync();
 ```
 
 > [!IMPORTANT] 
-> In Blazor WebAssembly, <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to load and use localization resources.
+> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture.
 
 The following `CultureSelector` component shows how to perform the following actions:
 
@@ -1238,7 +1238,7 @@ await host.RunAsync();
 ```
 
 > [!IMPORTANT] 
-> In Blazor WebAssembly, <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to load and use localization resources.
+> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture.
 
 The following `CultureSelector` component shows how to set the user's culture selection into browser local storage via JS interop. The component is placed in the `Shared` folder for use throughout the app.
 
@@ -2020,7 +2020,7 @@ await host.RunAsync();
 ```
 
 > [!IMPORTANT] 
-> In Blazor WebAssembly, <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to load and use localization resources.
+> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture.
 
 The following `CultureSelector` component shows how to set the user's culture selection into browser local storage via JS interop. The component is placed in the `Shared` folder for use throughout the app.
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -240,7 +240,7 @@ The app's culture can be set in JavaScript when Blazor starts with the `applicat
 
 The value for `applicationCulture` must conform to the [BCP-47 language tag format](https://www.rfc-editor.org/info/bcp47). For more information on Blazor startup, see <xref:blazor/fundamentals/startup>.
 
-An alternative to setting the culture Blazor's start option is to set the culture in C# code. Set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in `Program.cs`.
+An alternative to setting the culture Blazor's start option is to set the culture in C# code. Set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in `Program.cs` to the same culture.
 
 Add the <xref:System.Globalization?displayProperty=fullName> namespace to `Program.cs`:
 
@@ -254,6 +254,9 @@ Add the culture settings before the line that builds and runs the <xref:Microsof
 CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 ```
+
+> [!IMPORTANT]
+> Always set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> to the same culture in order to use <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>.
 
 :::zone-end
 
@@ -369,9 +372,7 @@ await host.RunAsync();
 ```
 
 > [!IMPORTANT]
-> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to use <xref:System.Web.Globalization.IStringLocalizerProvider> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>. For more information, see [`WebAssemblyCultureProvider` (reference source)](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs).
-
-[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+> Always set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> to the same culture in order to use <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>.
 
 The following `CultureSelector` component shows how to perform the following actions:
 
@@ -872,6 +873,16 @@ Add the namespace for <xref:Microsoft.Extensions.Localization?displayProperty=fu
 
 Optionally, add a menu item to the navigation in `Shared/NavMenu.razor` for the `CultureExample2` component.
 
+:::zone pivot="webassembly"
+
+## Culture provider reference source
+
+To further understand how the Blazor framework processes localization, see the [`WebAssemblyCultureProvider` class](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs) in the ASP.NET Core reference source.
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+:::zone-end
+
 ## Additional resources
 
 * [Set the app base path](xref:blazor/host-and-deploy/index#app-base-path)
@@ -1111,7 +1122,7 @@ The app's culture can be set in JavaScript when Blazor starts with the `applicat
 
 The value for `applicationCulture` must conform to the [BCP-47 language tag format](https://www.rfc-editor.org/info/bcp47). For more information on Blazor startup, see <xref:blazor/fundamentals/startup>.
 
-An alternative to setting the culture Blazor's start option is to set the culture in C# code. Set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in `Program.cs`.
+An alternative to setting the culture Blazor's start option is to set the culture in C# code. Set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in `Program.cs` to the same culture.
 
 Add the <xref:System.Globalization?displayProperty=fullName> namespace to `Program.cs`:
 
@@ -1125,6 +1136,9 @@ Add the culture settings before the line that builds and runs the <xref:Microsof
 CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 ```
+
+> [!IMPORTANT]
+> Always set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> to the same culture in order to use <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>.
 
 :::zone-end
 
@@ -1240,9 +1254,7 @@ await host.RunAsync();
 ```
 
 > [!IMPORTANT]
-> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to use <xref:System.Web.Globalization.IStringLocalizerProvider> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>. For more information, see [`WebAssemblyCultureProvider` (reference source)](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs).
-
-[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+> Always set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> to the same culture in order to use <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>.
 
 The following `CultureSelector` component shows how to set the user's culture selection into browser local storage via JS interop. The component is placed in the `Shared` folder for use throughout the app.
 
@@ -1733,6 +1745,16 @@ Add the namespace for <xref:Microsoft.Extensions.Localization?displayProperty=fu
 
 Optionally, add a menu item to the navigation in `Shared/NavMenu.razor` for the `CultureExample2` component.
 
+:::zone pivot="webassembly"
+
+## Culture provider reference source
+
+To further understand how the Blazor framework processes localization, see the [`WebAssemblyCultureProvider` class](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs) in the ASP.NET Core reference source.
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+:::zone-end
+
 ## Additional resources
 
 * [Set the app base path](xref:blazor/host-and-deploy/index#app-base-path)
@@ -2024,9 +2046,7 @@ await host.RunAsync();
 ```
 
 > [!IMPORTANT]
-> <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> must be set to the same culture in order to use <xref:System.Web.Globalization.IStringLocalizerProvider> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>. For more information, see [`WebAssemblyCultureProvider` (reference source)](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Hosting/WebAssemblyCultureProvider.cs).
-
-[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+> Always set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> to the same culture in order to use <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>.
 
 The following `CultureSelector` component shows how to set the user's culture selection into browser local storage via JS interop. The component is placed in the `Shared` folder for use throughout the app.
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -367,6 +367,8 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 
 await host.RunAsync();
 ```
+> [!NOTE] 
+> In Blazor WebAssembly, both `DefaultThreadCurrentCulture` and `DefaultThreadCurrentUICulture` must be set to the same culture in order to load and use Localization Resources.
 
 The following `CultureSelector` component shows how to perform the following actions:
 


### PR DESCRIPTION
In Blazor Server, it is not a requirement that the `CurrentCulture` and `CurrentUICulture` are set to the same value for resource based localizations to work, but in Blazor WebAssembly they must be set to the same culture or the `SatelliteResourcesLoader` will not load the resources that Localizers are expected to read.

A quick note to this effect for the Blazor WebAssembly section of this doc could save someone else the trouble of figuring this out.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->