### PR TITLE
Param attribute value @-prefix convention

### DIFF
--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -139,7 +139,7 @@ Child `Tab` components aren't explicitly passed as parameters to the `TabSet`. I
 
 <!-- Display the tab headers -->
 
-<CascadingValue Value=this>
+<CascadingValue Value="@this">
     <ul class="nav nav-tabs">
         @ChildContent
     </ul>
@@ -358,7 +358,7 @@ Child `Tab` components aren't explicitly passed as parameters to the `TabSet`. I
 
 <!-- Display the tab headers -->
 
-<CascadingValue Value=this>
+<CascadingValue Value="@this">
     <ul class="nav nav-tabs">
         @ChildContent
     </ul>
@@ -577,7 +577,7 @@ Child `Tab` components aren't explicitly passed as parameters to the `TabSet`. I
 
 <!-- Display the tab headers -->
 
-<CascadingValue Value=this>
+<CascadingValue Value="@this">
     <ul class="nav nav-tabs">
         @ChildContent
     </ul>

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -139,7 +139,7 @@ Child `Tab` components aren't explicitly passed as parameters to the `TabSet`. I
 
 <!-- Display the tab headers -->
 
-<CascadingValue Value="@this">
+<CascadingValue Value="this">
     <ul class="nav nav-tabs">
         @ChildContent
     </ul>
@@ -358,7 +358,7 @@ Child `Tab` components aren't explicitly passed as parameters to the `TabSet`. I
 
 <!-- Display the tab headers -->
 
-<CascadingValue Value="@this">
+<CascadingValue Value="this">
     <ul class="nav nav-tabs">
         @ChildContent
     </ul>
@@ -577,7 +577,7 @@ Child `Tab` components aren't explicitly passed as parameters to the `TabSet`. I
 
 <!-- Display the tab headers -->
 
-<CascadingValue Value="@this">
+<CascadingValue Value="this">
     <ul class="nav nav-tabs">
         @ChildContent
     </ul>

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -52,7 +52,7 @@ Similar to a regular component parameter, components accepting a cascading param
 
 ```razor
 <div class="main">
-    <CascadingValue Value="theme">
+    <CascadingValue Value="@theme">
         <div class="content px-4">
             @Body
         </div>

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -252,7 +252,7 @@ Assign a C# field, property, or result of a method to a component parameter as a
 
 The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
 
-Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required. It's generally easier to remember a simple rule for their use with nonliterals.
+Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -261,7 +261,7 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@`, even when it's optional. Examples: `Title="@title"`, where `title` is a string variable. `Count="@ct"`, where `ct` is an number type.
+* Nonliterals always use the `@` prefix, even when it's optional. Examples: `Title="@title"`, where `title` is a string-typed variable. `Count="@ct"`, where `ct` is a number-typed variable.
 * Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
@@ -1402,7 +1402,7 @@ Assign a C# field, property, or result of a method to a component parameter as a
 
 The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
 
-Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required. It's generally easier to remember a simple rule for their use with nonliterals.
+Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -1411,7 +1411,7 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@`, even when it's optional. Examples: `Title="@title"`, where `title` is a string variable. `Count="@ct"`, where `ct` is an number type.
+* Nonliterals always use the `@` prefix, even when it's optional. Examples: `Title="@title"`, where `title` is a string-typed variable. `Count="@ct"`, where `ct` is a number-typed variable.
 * Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
@@ -2363,7 +2363,7 @@ Assign a C# field, property, or result of a method to a component parameter as a
 
 The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
 
-Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required. It's generally easier to remember a simple rule for their use with nonliterals.
+Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -2372,7 +2372,7 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@`, even when it's optional. Examples: `Title="@title"`, where `title` is a string variable. `Count="@ct"`, where `ct` is an number type.
+* Nonliterals always use the `@` prefix, even when it's optional. Examples: `Title="@title"`, where `title` is a string-typed variable. `Count="@ct"`, where `ct` is a number-typed variable.
 * Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -250,6 +250,20 @@ Assign a C# field, property, or result of a method to a component parameter as a
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
+The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
+
+Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required. It's generally easier to remember a simple rule for their use with nonliterals.
+
+We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
+
+Quotes around parameter attribute values are optional in most cases per the HTML5 specification. For example, `Value=this` is supported, instead of `Value="this"`. However, we recommend using quotes because it's easier to remember and widely adopted across web-based technologies.
+
+Throughout the documentation, code examples:
+
+* Always use quotes. Example: `Value="this"`.
+* Nonliterals always use the `@`, even when it's optional. Examples: `Title="@title"`, where `title` is a string variable. `Count="@ct"`, where `ct` is an number type.
+* Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
+
 `Pages/ParameterParent2.razor`:
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/index/ParameterParent2.razor)]
@@ -267,12 +281,6 @@ Assign a C# field, property, or result of a method to a component parameter as a
 >
 > ```razor
 > <ParameterChild @Title="title" />
-> ```
->
-> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name with `@`, as the following example shows:
->
-> ```razor
-> <ParameterChild Title="@title" IsEnabled="true" />
 > ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:
@@ -1392,6 +1400,20 @@ Assign a C# field, property, or result of a method to a component parameter as a
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
+The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
+
+Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required. It's generally easier to remember a simple rule for their use with nonliterals.
+
+We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
+
+Quotes around parameter attribute values are optional in most cases per the HTML5 specification. For example, `Value=this` is supported, instead of `Value="this"`. However, we recommend using quotes because it's easier to remember and widely adopted across web-based technologies.
+
+Throughout the documentation, code examples:
+
+* Always use quotes. Example: `Value="this"`.
+* Nonliterals always use the `@`, even when it's optional. Examples: `Title="@title"`, where `title` is a string variable. `Count="@ct"`, where `ct` is an number type.
+* Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
+
 `Pages/ParameterParent2.razor`:
 
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Pages/index/ParameterParent2.razor)]
@@ -1409,12 +1431,6 @@ Assign a C# field, property, or result of a method to a component parameter as a
 >
 > ```razor
 > <ParameterChild @Title="title" />
-> ```
->
-> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name with `@`, as the following example shows:
->
-> ```razor
-> <ParameterChild Title="@title" IsEnabled="true" />
 > ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:
@@ -2345,6 +2361,20 @@ Assign a C# field, property, or result of a method to a component parameter as a
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
+The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
+
+Outside of string parameters, we recommend use the use of the `@` prefix for nonliterals, even when they aren't strictly required. It's generally easier to remember a simple rule for their use with nonliterals.
+
+We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
+
+Quotes around parameter attribute values are optional in most cases per the HTML5 specification. For example, `Value=this` is supported, instead of `Value="this"`. However, we recommend using quotes because it's easier to remember and widely adopted across web-based technologies.
+
+Throughout the documentation, code examples:
+
+* Always use quotes. Example: `Value="this"`.
+* Nonliterals always use the `@`, even when it's optional. Examples: `Title="@title"`, where `title` is a string variable. `Count="@ct"`, where `ct` is an number type.
+* Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
+
 `Pages/ParameterParent2.razor`:
 
 [!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Pages/index/ParameterParent2.razor)]
@@ -2362,12 +2392,6 @@ Assign a C# field, property, or result of a method to a component parameter as a
 >
 > ```razor
 > <ParameterChild @Title="title" />
-> ```
->
-> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name with `@`, as the following example shows:
->
-> ```razor
-> <ParameterChild Title="@title" IsEnabled="true" />
 > ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -268,6 +268,12 @@ Assign a C# field, property, or result of a method to a component parameter as a
 > ```razor
 > <ParameterChild @Title="title" />
 > ```
+>
+> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name, as the following example shows:
+>
+> ```razor
+> <ParameterChild Title="@title" IsEnabled="true" />
+> ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:
 
@@ -1404,6 +1410,12 @@ Assign a C# field, property, or result of a method to a component parameter as a
 > ```razor
 > <ParameterChild @Title="title" />
 > ```
+>
+> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name, as the following example shows:
+>
+> ```razor
+> <ParameterChild Title="@title" IsEnabled="true" />
+> ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:
 
@@ -2350,6 +2362,12 @@ Assign a C# field, property, or result of a method to a component parameter as a
 >
 > ```razor
 > <ParameterChild @Title="title" />
+> ```
+>
+> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name, as the following example shows:
+>
+> ```razor
+> <ParameterChild Title="@title" IsEnabled="true" />
 > ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -269,7 +269,7 @@ Assign a C# field, property, or result of a method to a component parameter as a
 > <ParameterChild @Title="title" />
 > ```
 >
-> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name, as the following example shows:
+> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name with `@`, as the following example shows:
 >
 > ```razor
 > <ParameterChild Title="@title" IsEnabled="true" />
@@ -1411,7 +1411,7 @@ Assign a C# field, property, or result of a method to a component parameter as a
 > <ParameterChild @Title="title" />
 > ```
 >
-> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name, as the following example shows:
+> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name with `@`, as the following example shows:
 >
 > ```razor
 > <ParameterChild Title="@title" IsEnabled="true" />
@@ -2364,7 +2364,7 @@ Assign a C# field, property, or result of a method to a component parameter as a
 > <ParameterChild @Title="title" />
 > ```
 >
-> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name, as the following example shows:
+> The only exception to the preceding convention is for the assignment of boolean values. Although assigning `@true` or `@false` is acceptable, we recommend not prefixing the boolean name with `@`, as the following example shows:
 >
 > ```razor
 > <ParameterChild Title="@title" IsEnabled="true" />

--- a/aspnetcore/blazor/forms-validation.md
+++ b/aspnetcore/blazor/forms-validation.md
@@ -756,7 +756,7 @@ Update the `Starfleet Starship Database` form (`FormExample2` component) from th
         @foreach (var manufacturer in (Manufacturer[])Enum
             .GetValues(typeof(Manufacturer)))
         {
-            <InputRadio Value="manufacturer" />
+            <InputRadio Value="@manufacturer" />
             <text>&nbsp;</text>@manufacturer<br>
         }
     </InputRadioGroup>
@@ -766,21 +766,21 @@ Update the `Starfleet Starship Database` form (`FormExample2` component) from th
     combination of engine and color is allowed:<br>
     <InputRadioGroup Name="engine" @bind-Value="starship.Engine">
         <InputRadioGroup Name="color" @bind-Value="starship.Color">
-            <InputRadio Name="engine" Value="Engine.Ion" />
+            <InputRadio Name="engine" Value="@Engine.Ion" />
             Engine: Ion<br>
-            <InputRadio Name="color" Value="Color.ImperialRed" />
+            <InputRadio Name="color" Value="@Color.ImperialRed" />
             Color: Imperial Red<br><br>
-            <InputRadio Name="engine" Value="Engine.Plasma" />
+            <InputRadio Name="engine" Value="@Engine.Plasma" />
             Engine: Plasma<br>
-            <InputRadio Name="color" Value="Color.SpacecruiserGreen" />
+            <InputRadio Name="color" Value="@Color.SpacecruiserGreen" />
             Color: Spacecruiser Green<br><br>
-            <InputRadio Name="engine" Value="Engine.Fusion" />
+            <InputRadio Name="engine" Value="@Engine.Fusion" />
             Engine: Fusion<br>
-            <InputRadio Name="color" Value="Color.StarshipBlue" />
+            <InputRadio Name="color" Value="@Color.StarshipBlue" />
             Color: Starship Blue<br><br>
-            <InputRadio Name="engine" Value="Engine.Warp" />
+            <InputRadio Name="engine" Value="@Engine.Warp" />
             Engine: Warp<br>
-            <InputRadio Name="color" Value="Color.VoyagerOrange" />
+            <InputRadio Name="color" Value="@Color.VoyagerOrange" />
             Color: Voyager Orange
         </InputRadioGroup>
     </InputRadioGroup>
@@ -1738,7 +1738,7 @@ Update the `Starfleet Starship Database` form (`FormExample2` component) from th
         @foreach (var manufacturer in (Manufacturer[])Enum
             .GetValues(typeof(Manufacturer)))
         {
-            <InputRadio Value="manufacturer" />
+            <InputRadio Value="@manufacturer" />
             <text>&nbsp;</text>@manufacturer<br>
         }
     </InputRadioGroup>
@@ -1748,21 +1748,21 @@ Update the `Starfleet Starship Database` form (`FormExample2` component) from th
     combination of engine and color is allowed:<br>
     <InputRadioGroup Name="engine" @bind-Value="starship.Engine">
         <InputRadioGroup Name="color" @bind-Value="starship.Color">
-            <InputRadio Name="engine" Value="Engine.Ion" />
+            <InputRadio Name="engine" Value="@Engine.Ion" />
             Engine: Ion<br>
-            <InputRadio Name="color" Value="Color.ImperialRed" />
+            <InputRadio Name="color" Value="@Color.ImperialRed" />
             Color: Imperial Red<br><br>
-            <InputRadio Name="engine" Value="Engine.Plasma" />
+            <InputRadio Name="engine" Value="@Engine.Plasma" />
             Engine: Plasma<br>
-            <InputRadio Name="color" Value="Color.SpacecruiserGreen" />
+            <InputRadio Name="color" Value="@Color.SpacecruiserGreen" />
             Color: Spacecruiser Green<br><br>
-            <InputRadio Name="engine" Value="Engine.Fusion" />
+            <InputRadio Name="engine" Value="@Engine.Fusion" />
             Engine: Fusion<br>
-            <InputRadio Name="color" Value="Color.StarshipBlue" />
+            <InputRadio Name="color" Value="@Color.StarshipBlue" />
             Color: Starship Blue<br><br>
-            <InputRadio Name="engine" Value="Engine.Warp" />
+            <InputRadio Name="engine" Value="@Engine.Warp" />
             Engine: Warp<br>
-            <InputRadio Name="color" Value="Color.VoyagerOrange" />
+            <InputRadio Name="color" Value="@Color.VoyagerOrange" />
             Color: Voyager Orange
         </InputRadioGroup>
     </InputRadioGroup>

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -204,7 +204,7 @@ The following `Error` component example merely logs errors, but methods of the c
 @using Microsoft.Extensions.Logging
 @inject ILogger<Error> Logger
 
-<CascadingValue Value=this>
+<CascadingValue Value="@this">
     @ChildContent
 </CascadingValue>
 
@@ -531,7 +531,7 @@ The following `Error` component passes itself as a [`CascadingValue`](xref:blazo
 @using Microsoft.Extensions.Logging
 @inject ILogger<Error> Logger
 
-<CascadingValue Value=this>
+<CascadingValue Value="@this">
     @ChildContent
 </CascadingValue>
 
@@ -1025,7 +1025,7 @@ The following `Error` component passes itself as a [`CascadingValue`](xref:blazo
 @using Microsoft.Extensions.Logging
 @inject ILogger<Error> Logger
 
-<CascadingValue Value=this>
+<CascadingValue Value="@this">
     @ChildContent
 </CascadingValue>
 

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -204,7 +204,7 @@ The following `Error` component example merely logs errors, but methods of the c
 @using Microsoft.Extensions.Logging
 @inject ILogger<Error> Logger
 
-<CascadingValue Value="@this">
+<CascadingValue Value="this">
     @ChildContent
 </CascadingValue>
 
@@ -531,7 +531,7 @@ The following `Error` component passes itself as a [`CascadingValue`](xref:blazo
 @using Microsoft.Extensions.Logging
 @inject ILogger<Error> Logger
 
-<CascadingValue Value="@this">
+<CascadingValue Value="this">
     @ChildContent
 </CascadingValue>
 
@@ -1025,7 +1025,7 @@ The following `Error` component passes itself as a [`CascadingValue`](xref:blazo
 @using Microsoft.Extensions.Logging
 @inject ILogger<Error> Logger
 
-<CascadingValue Value="@this">
+<CascadingValue Value="this">
     @ChildContent
 </CascadingValue>
 

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -260,7 +260,7 @@ Setting `IsFixed` to `true` improves performance if there are a large number of 
 Where a component passes `this` as a cascaded value, `IsFixed` can also be set to `true`:
 
 ```razor
-<CascadingValue Value="@this" IsFixed="true">
+<CascadingValue Value="this" IsFixed="true">
     <SomeOtherComponents>
 </CascadingValue>
 ```
@@ -1019,7 +1019,7 @@ Setting `IsFixed` to `true` improves performance if there are a large number of 
 Where a component passes `this` as a cascaded value, `IsFixed` can also be set to `true`:
 
 ```razor
-<CascadingValue Value="@this" IsFixed="true">
+<CascadingValue Value="this" IsFixed="true">
     <SomeOtherComponents>
 </CascadingValue>
 ```
@@ -1762,7 +1762,7 @@ Setting `IsFixed` to `true` improves performance if there are a large number of 
 Where a component passes `this` as a cascaded value, `IsFixed` can also be set to `true`:
 
 ```razor
-<CascadingValue Value="@this" IsFixed="true">
+<CascadingValue Value="this" IsFixed="true">
     <SomeOtherComponents>
 </CascadingValue>
 ```

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -260,7 +260,7 @@ Setting `IsFixed` to `true` improves performance if there are a large number of 
 Where a component passes `this` as a cascaded value, `IsFixed` can also be set to `true`:
 
 ```razor
-<CascadingValue Value="this" IsFixed="true">
+<CascadingValue Value="@this" IsFixed="true">
     <SomeOtherComponents>
 </CascadingValue>
 ```
@@ -1019,7 +1019,7 @@ Setting `IsFixed` to `true` improves performance if there are a large number of 
 Where a component passes `this` as a cascaded value, `IsFixed` can also be set to `true`:
 
 ```razor
-<CascadingValue Value="this" IsFixed="true">
+<CascadingValue Value="@this" IsFixed="true">
     <SomeOtherComponents>
 </CascadingValue>
 ```
@@ -1762,7 +1762,7 @@ Setting `IsFixed` to `true` improves performance if there are a large number of 
 Where a component passes `this` as a cascaded value, `IsFixed` can also be set to `true`:
 
 ```razor
-<CascadingValue Value="this" IsFixed="true">
+<CascadingValue Value="@this" IsFixed="true">
     <SomeOtherComponents>
 </CascadingValue>
 ```

--- a/aspnetcore/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/MainLayout.razor
+++ b/aspnetcore/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/MainLayout.razor
@@ -6,7 +6,7 @@
 </div>
 
 <div class="main">
-    <CascadingValue Value="theme">
+    <CascadingValue Value="@theme">
         <div class="content px-4">
             @Body
         </div>

--- a/aspnetcore/blazor/samples/3.1/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
+++ b/aspnetcore/blazor/samples/3.1/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
@@ -1,4 +1,4 @@
-﻿<CascadingValue Value="this" IsFixed="true">
+﻿<CascadingValue Value="@this" IsFixed="true">
     @ChildContent
 </CascadingValue>
 

--- a/aspnetcore/blazor/samples/3.1/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
+++ b/aspnetcore/blazor/samples/3.1/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
@@ -1,4 +1,4 @@
-﻿<CascadingValue Value="@this" IsFixed="true">
+<CascadingValue Value="this" IsFixed="true">
     @ChildContent
 </CascadingValue>
 

--- a/aspnetcore/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/MainLayout.razor
+++ b/aspnetcore/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/MainLayout.razor
@@ -7,7 +7,7 @@
     </div>
 
     <div class="main">
-        <CascadingValue Value="theme">
+        <CascadingValue Value="@theme">
             <div class="content px-4">
                 @Body
             </div>

--- a/aspnetcore/blazor/samples/5.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
+++ b/aspnetcore/blazor/samples/5.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
@@ -1,4 +1,4 @@
-﻿<CascadingValue Value="this" IsFixed="true">
+﻿<CascadingValue Value="@this" IsFixed="true">
     @ChildContent
 </CascadingValue>
 

--- a/aspnetcore/blazor/samples/5.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
+++ b/aspnetcore/blazor/samples/5.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
@@ -1,4 +1,4 @@
-﻿<CascadingValue Value="@this" IsFixed="true">
+<CascadingValue Value="this" IsFixed="true">
     @ChildContent
 </CascadingValue>
 

--- a/aspnetcore/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/MainLayout.razor
+++ b/aspnetcore/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/MainLayout.razor
@@ -7,7 +7,7 @@
     </div>
 
     <div class="main">
-        <CascadingValue Value="theme">
+        <CascadingValue Value="@theme">
             <div class="content px-4">
                 @Body
             </div>

--- a/aspnetcore/blazor/samples/6.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
+++ b/aspnetcore/blazor/samples/6.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
@@ -1,4 +1,4 @@
-﻿<CascadingValue Value="this" IsFixed="true">
+﻿<CascadingValue Value="@this" IsFixed="true">
     @ChildContent
 </CascadingValue>
 

--- a/aspnetcore/blazor/samples/6.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
+++ b/aspnetcore/blazor/samples/6.0/BlazorServerEFCoreSample/BlazorServerDbContextExample/Shared/GridWrapper.razor
@@ -1,4 +1,4 @@
-﻿<CascadingValue Value="@this" IsFixed="true">
+<CascadingValue Value="this" IsFixed="true">
     @ChildContent
 </CascadingValue>
 


### PR DESCRIPTION
Fixes #24769

Years ago, I performed a similar set of updates to make how we assign to parameters consistent in code examples. While I was working on something else today, I noticed that *a few sneaky devils* 😈 *are back!* This PR seeks to fix them up.

Included here is an effort to fix `this` keyword assignments, which I don't think are fundamentally different to anything else. Let me know if I'm mistaken on that. We've had (and I've seen outside of the doc set) any of the following. The last one is consistent with the earlier decision to quote and `@`-prefix these, and that's what's on this PR ...

* `<Something Value=this />`
* `<Something Value="this" />`
* `<Something Value="@this" />`

What about a boolean tho? Razor seems happy with `@true`. Doesn't the **_second one_** 👇 lend itself to consistency in presentation? If so, I need to apply one more update here.

* `<Something IsBlah="true">`
* `<Something IsBlah="@true">`