### PR TITLE
Update sql.md

### DIFF
--- a/aspnetcore/tutorials/razor-pages/sql.md
+++ b/aspnetcore/tutorials/razor-pages/sql.md
@@ -116,6 +116,7 @@ if (context.Movie.Any())
 
 ### Add the seed initializer
 
+**For older ASP.NET Core applications, meaning versions (5.0\], the instructions below will successfully seed the database. **
 Replace the contents of the *Program.cs* with the following code:
 
 [!code-csharp[](razor-pages-start/sample/RazorPagesMovie50/Program.cs)]
@@ -128,8 +129,21 @@ In the previous code, the `Main` method has been modified to do the following:
 
 The following exception occurs when `Update-Database` has not been run:
 
-> `SqlException: Cannot open database "RazorPagesMovieContext-" requested by the login. The login failed.`
+> `SqlException: Cannot open database "RazorPagesMovieContext-" requeted by the login. The login failed.`
 > `Login failed for user 'user name'.`
+
+**For ASP.NET Core applications using versions \[6.0+), the instructions below will successfully seed the database. Note, this code is necessary because versions 6.0+ of ASP.NET Core condenses the functionality of two files used in versions (5.0\], *Startup.cs* and *Program.cs*, into a single file, the *Program.cs* file. **
+Within the *Program.cs* the following code in bold should be added:
+
+```ASP.NET
+builder.Services.AddDbContext<RazorPagesMovieContext>(options =>
+    options.UseSqlServer(builder.Configuration.GetConnectionString("RazorPagesMovieContext")));
+
+** var scope = builder.Services.BuildServiceProvider().CreateScope(); **
+** SeedData.Initialize((IServiceProvider)scope); **
+
+var app = builder.Build();
+```
 
 ### Test the app
 

--- a/aspnetcore/tutorials/razor-pages/sql.md
+++ b/aspnetcore/tutorials/razor-pages/sql.md
@@ -129,20 +129,23 @@ In the previous code, the `Main` method has been modified to do the following:
 
 The following exception occurs when `Update-Database` has not been run:
 
-> `SqlException: Cannot open database "RazorPagesMovieContext-" requeted by the login. The login failed.`
+> `SqlException: Cannot open database "RazorPagesMovieContext-" requested by the login. The login failed.`
 > `Login failed for user 'user name'.`
 
-**For ASP.NET Core applications using versions \[6.0+), the instructions below will successfully seed the database. Note, this code is necessary because versions 6.0+ of ASP.NET Core condenses the functionality of two files used in versions (5.0\], *Startup.cs* and *Program.cs*, into a single file, the *Program.cs* file. **
-Within the *Program.cs* the following code in bold should be added:
+**For ASP.NET Core applications using versions \[6.0+), the instructions below will successfully seed the database. Note, this code is necessary because versions 6.0+ of ASP.NET Core condenses the functionality of two files used in versions (5.0\], *Startup.cs* and *Program.cs*, into a single file, the *Program.cs* file. As such, obtaining the scope of the services is slightly different.**
+
+If ASP.NET Core 6.0+ is used, then the following code should be added within the *Program.cs* file in order to seed the database:
 
 ```ASP.NET
+
 builder.Services.AddDbContext<RazorPagesMovieContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("RazorPagesMovieContext")));
 
-** var scope = builder.Services.BuildServiceProvider().CreateScope(); **
-** SeedData.Initialize((IServiceProvider)scope); **
+var scope = builder.Services.BuildServiceProvider().CreateScope(); //Add this line to Program.cs to get the scope of the services
+SeedData.Initialize((IServiceProvider)scope); //Add this line to Program.cs to pass the scope to the SeedData.Initialize() method
 
 var app = builder.Build();
+
 ```
 
 ### Test the app


### PR DESCRIPTION
The current documentation for seeding the tutorial database only applies to versions (5.0] of ASP.NET Core. As such, I have added documentation explaining how devs using ASP.NET 6.0+ versions can seed their tutorial database's. Essentially, the documentation states that an object set to the 'scope' of the 'services' must be created and then passed into the 'SeedData.Initializer()' method. Note: The 'scope' must be 'cast' as type 'IServiceProvider' in order to be properly read by the 'SeedData.Initializer()' method.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->