### PR TITLE
Label tag helper: override the default caption

### DIFF
--- a/aspnetcore/mvc/views/working-with-forms.md
+++ b/aspnetcore/mvc/views/working-with-forms.md
@@ -436,7 +436,7 @@ The following HTML is generated for the `<label>` element:
 <label for="Email">Email Address</label>
 ```
 
-The Label Tag Helper generated the `for` attribute value of "Email", which is the ID associated with the `<input>` element. The Tag Helpers generate consistent `id` and `for` elements so they can be correctly associated. The caption in this sample comes from the `Display` attribute. If the model didn't contain a `Display` attribute, the caption would be the property name of the expression.
+The Label Tag Helper generated the `for` attribute value of "Email", which is the ID associated with the `<input>` element. The Tag Helpers generate consistent `id` and `for` elements so they can be correctly associated. The caption in this sample comes from the `Display` attribute. If the model didn't contain a `Display` attribute, the caption would be the property name of the expression.  In order to override the default caption, put your custom caption inside the label tag.
 
 ## The Validation Tag Helpers
 

--- a/aspnetcore/mvc/views/working-with-forms.md
+++ b/aspnetcore/mvc/views/working-with-forms.md
@@ -436,7 +436,7 @@ The following HTML is generated for the `<label>` element:
 <label for="Email">Email Address</label>
 ```
 
-The Label Tag Helper generated the `for` attribute value of "Email", which is the ID associated with the `<input>` element. The Tag Helpers generate consistent `id` and `for` elements so they can be correctly associated. The caption in this sample comes from the `Display` attribute. If the model didn't contain a `Display` attribute, the caption would be the property name of the expression.  In order to override the default caption, put your custom caption inside the label tag.
+The Label Tag Helper generated the `for` attribute value of "Email", which is the ID associated with the `<input>` element. The Tag Helpers generate consistent `id` and `for` elements so they can be correctly associated. The caption in this sample comes from the `Display` attribute. If the model didn't contain a `Display` attribute, the caption would be the property name of the expression.  To override the default caption, add a caption inside the label tag.
 
 ## The Validation Tag Helpers
 


### PR DESCRIPTION
Explain how to override the default caption in the [Label tag helper](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/working-with-forms#the-label-tag-helper)



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->