### PR TITLE
Fix docker docs (deep) links

### DIFF
--- a/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
+++ b/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
@@ -87,8 +87,8 @@ The sample Dockerfile uses the [Docker multi-stage build feature](https://docs.d
     * [Debian](https://docs.docker.com/install/linux/docker-ce/debian/)
     * [Fedora](https://docs.docker.com/install/linux/docker-ce/fedora/)
     * [Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/)
-  * [macOS](https://docs.docker.com/docker-for-mac/install/)
-  * [Windows](https://docs.docker.com/docker-for-windows/install/)
+  * [macOS](https://docs.docker.com/desktop/mac/install/)
+  * [Windows](https://docs.docker.com/desktop/windows/install/)
 
 * [Git](https://git-scm.com/download)
 
@@ -116,7 +116,7 @@ The sample Dockerfile uses the [Docker multi-stage build feature](https://docs.d
 
 ## Run in a Linux container
 
-* In the Docker client, [switch to Linux containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
+* In the Docker client, [switch to Linux containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
 
 * Navigate to the Dockerfile folder at *dotnet-docker/samples/aspnetapp*.
 
@@ -142,7 +142,7 @@ The sample Dockerfile uses the [Docker multi-stage build feature](https://docs.d
 
 ## Run in a Windows container
 
-* In the Docker client, [switch to Windows containers](https://docs.docker.com/docker-for-windows/#switch-between-windows-and-linux-containers).
+* In the Docker client, [switch to Windows containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
 
 Navigate to the docker file folder at `dotnet-docker/samples/aspnetapp`.
 

--- a/aspnetcore/host-and-deploy/docker/visual-studio-tools-for-docker.md
+++ b/aspnetcore/host-and-deploy/docker/visual-studio-tools-for-docker.md
@@ -16,14 +16,14 @@ Visual Studio 2017 and later versions support building, debugging, and running c
 
 ## Prerequisites
 
-* [Docker for Windows](https://docs.docker.com/docker-for-windows/install/)
+* [Docker for Windows](https://docs.docker.com/desktop/windows/install/)
 * [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/?utm_medium=microsoft&utm_source=docs.microsoft.com&utm_campaign=inline+link&utm_content=download+vs2019) with the **.NET Core cross-platform development** workload
 
 ## Installation and setup
 
-For Docker installation, first review the information at [Docker for Windows: What to know before you install](https://docs.docker.com/docker-for-windows/install/#what-to-know-before-you-install). Next, install [Docker For Windows](https://docs.docker.com/docker-for-windows/install/).
+For Docker installation, first review the information at [Docker for Windows: What to know before you install](https://docs.docker.com/desktop/windows/install/#what-to-know-before-you-install). Next, install [Docker For Windows](https://docs.docker.com/desktop/windows/install/).
 
-**[Shared Drives](https://docs.docker.com/docker-for-windows/#shared-drives)** in Docker for Windows must be configured to support volume mapping and debugging. Right-click the System Tray's Docker icon, select **Settings**, and select **Shared Drives**. Select the drive where Docker stores files. Click **Apply**.
+**[Shared Drives](https://docs.docker.com/desktop/windows/#resources)** in Docker for Windows must be configured to support volume mapping and debugging. Right-click the System Tray's Docker icon, select **Settings**, and select **Shared Drives**. Select the drive where Docker stores files. Click **Apply**.
 
 ![Dialog to select local C drive sharing for containers](visual-studio-tools-for-docker/_static/settings-shared-drives-win.png)
 


### PR DESCRIPTION
Fix some (deep) links against docker docs.

One of them is still invalid (`Docker for Windows: What to know before you install`) as it seems that it has been removed in the latest docs.

I don't know how everything is structured (working) on their end regarding the docs but I could find those (old?) resources over here:

https://docs.docker.com.xy2401.com/docker-for-windows/install/#what-to-know-before-you-install