### PR TITLE
No source when property value is empty

### DIFF
--- a/aspnetcore/mvc/models/model-binding.md
+++ b/aspnetcore/mvc/models/model-binding.md
@@ -146,7 +146,7 @@ The preceding code puts the custom value provider after all built-in value provi
 
 ## No source for a model property
 
-By default, a model state error isn't created if no value is found for a model property. The property is set to null or a default value:
+By default, a model state error isn't created if no value is found for a model property or the value is empty. The property is set to null or a default value:
 
 * Nullable simple types are set to `null`.
 * Non-nullable value types are set to `default(T)`. For example, a parameter `int id` is set to 0.


### PR DESCRIPTION
When a default value for property is non-empty and the value passed by the client is empty, the default value wins.

```C#
[Required]
public string Test { get; set; } = "!";
```

```cshtml
<input asp-for="Test" >
```


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->