### PR TITLE
Add MVC example for ModelState.IsValid

### DIFF
--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -21,9 +21,13 @@ This article explains how to validate user input in an ASP.NET Core MVC or Razor
 
 Model state represents errors that come from two subsystems: model binding and model validation. Errors that originate from [model binding](model-binding.md) are generally data conversion errors. For example, an "x" is entered in an integer field. Model validation occurs after model binding and reports errors where data doesn't conform to business rules. For example, a 0 is entered in a field that expects a rating between 1 and 5.
 
-Both model binding and model validation occur before the execution of a controller action or a Razor Pages handler method. For web apps, it's the app's responsibility to inspect `ModelState.IsValid` and react appropriately. Web apps typically redisplay the page with an error message:
+Both model binding and model validation occur before the execution of a controller action or a Razor Pages handler method. For web apps, it's the app's responsibility to inspect `ModelState.IsValid` and react appropriately. Web apps typically redisplay the page with an error message, as shown in the following Razor Pages example:
 
 :::code language="csharp" source="validation/samples/6.x/ValidationSample/Pages/Movies/Create.cshtml.cs" id="snippet_OnPostAsync" highlight="3-6":::
+
+For ASP.NET Core MVC with controllers and views, the following example shows how to check `ModelState.IsValid` inside of a controller action:
+
+:::code language="csharp" source="validation/samples/6.x/ValidationSample/Snippets/Controllers/MoviesController.cs" id="snippet_Create" highlight="3-6":::
 
 Web API controllers don't have to check `ModelState.IsValid` if they have the [[ApiController]](xref:Microsoft.AspNetCore.Mvc.ApiControllerAttribute) attribute. In that case, an automatic HTTP 400 response containing error details is returned when model state is invalid. For more information, see [Automatic HTTP 400 responses](xref:web-api/index#automatic-http-400-responses).
 

--- a/aspnetcore/mvc/models/validation/samples/6.x/ValidationSample/Snippets/Controllers/MoviesController.cs
+++ b/aspnetcore/mvc/models/validation/samples/6.x/ValidationSample/Snippets/Controllers/MoviesController.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using ValidationSample.Data;
+using ValidationSample.Models;
+
+namespace ValidationSample.Snippets.Controllers;
+
+public class MoviesController : Controller
+{
+    private readonly MovieContext _context;
+
+    public MoviesController(MovieContext context)
+        => _context = context;
+
+    public IActionResult Index()
+        => View();
+
+    // <snippet_Create>
+    public async Task<IActionResult> Create(Movie movie)
+    {
+        if (!ModelState.IsValid)
+        {
+            return View(movie);
+        }
+
+        _context.Movies.Add(movie);
+        await _context.SaveChangesAsync();
+
+        return RedirectToAction(nameof(Index));
+    }
+    // </snippet_Create>
+}


### PR DESCRIPTION
Fixes #24579.

[Internal Preview](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/models/validation?view=aspnetcore-6.0&branch=pr-en-us-24909).