### PR TITLE
Surface two Blazor topics in the ToC

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -372,6 +372,8 @@ items:
                 uid: blazor/components/event-handling
               - name: Lifecycle
                 uid: blazor/components/lifecycle
+              - name: Virtualization
+                uid: blazor/components/virtualization
               - name: Rendering
                 uid: blazor/components/rendering
               - name: Templated components
@@ -438,6 +440,8 @@ items:
                     uid: blazor/security/webassembly/hosted-with-identity-server
                   - name: Additional scenarios
                     uid: blazor/security/webassembly/additional-scenarios
+                  - name: AAD groups and roles
+                    uid: blazor/security/webassembly/aad-groups-roles
                   - name: Graph API
                     uid: blazor/security/webassembly/graph-api
               - name: Content Security Policy


### PR DESCRIPTION
Thanks @serpent5 for catching these.

It seems like these were here earlier and that an update ... moving content, perhaps ... knocked them out.

OH! Wait! NO! I know what ... or **_WHO_** ... did this. **_This is IT!_** It's the coded signal to their operatives!

# 👽

### *The ATTACK PLANNING* 🌎 *is in its final stages!* 🛸

*They are among us!* 😆 

Seriously tho ... These have been **_well cross-linked_** into Blazor docs where needed. The major downside to my missing them is when readers strictly read topics in order top-to-bottom from the ToC. Thanks again, @serpent5 ... *great catch!*