### PR TITLE
Fix code example

### DIFF
--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -875,7 +875,8 @@ In the **`Server`** app, create a `Pages` folder if it doesn't exist. Create a `
   <div id="app">
       @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
       {
-          <text>Loading...</text>
+          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+              render-mode="WebAssembly" />
       }
       else
       {
@@ -1926,7 +1927,8 @@ In the server app, create a `Pages` folder if it doesn't exist. Create a `_Host.
   <div id="app">
       @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
       {
-          <text>Loading...</text>
+          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+              render-mode="WebAssembly" />
       }
       else
       {
@@ -2977,7 +2979,8 @@ In the server app, create a `Pages` folder if it doesn't exist. Create a `_Host.
   <app>
       @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
       {
-          <text>Loading...</text>
+          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+              render-mode="WebAssembly" />
       }
       else
       {

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -876,7 +876,12 @@ In the **`Server`** app's `Pages/_Host.cshtml` file, replace the `Component` Tag
 </div>
 ```
 
-In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+In the preceding example:
+
+* The placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+* The conditional check for the `/authentication` path segment:
+  * Avoids prerendering (`render-mode="WebAssembly"`) for authentication paths.
+  * Prerenders (`render-mode="WebAssemblyPrerendered"`) for non-authentication paths.
 
 ## Options for hosted apps and third-party login providers
 
@@ -1915,7 +1920,12 @@ In the **`Server`** app's `Pages/_Host.cshtml` file, replace the `Component` Tag
 </div>
 ```
 
-In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+In the preceding example:
+
+* The placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+* The conditional check for the `/authentication` path segment:
+  * Avoids prerendering (`render-mode="WebAssembly"`) for authentication paths.
+  * Prerenders (`render-mode="WebAssemblyPrerendered"`) for non-authentication paths.
 
 ## Options for hosted apps and third-party login providers
 
@@ -2954,7 +2964,12 @@ In the **`Server`** app's `Pages/_Host.cshtml` file, replace the `Component` Tag
 </div>
 ```
 
-In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+In the preceding example:
+
+* The placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+* The conditional check for the `/authentication` path segment:
+  * Avoids prerendering (`render-mode="WebAssembly"`) for authentication paths.
+  * Prerenders (`render-mode="WebAssemblyPrerendered"`) for non-authentication paths.
 
 ## Options for hosted apps and third-party login providers
 

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -859,34 +859,24 @@ builder.Services.AddScoped<SignOutSessionStateManager>();
 Client.Program.ConfigureCommonServices(services);
 ```
 
-In the **`Server`** app's `Program.cs` file, replace [`app.MapFallbackToFile("index.html")`](xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A) with [`app.MapFallbackToPage("/_Host")`](xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A):
+In the **`Server`** app's `Pages/_Host.cshtml` file, replace the `Component` Tag Helper (`<component ... />`) with the following:
 
-```csharp
-app.MapControllers();
-app.MapFallbackToPage("/_Host");
+```cshtml
+<div id="app">
+    @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
+    {
+        <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+            render-mode="WebAssembly" />
+    }
+    else
+    {
+        <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+            render-mode="WebAssemblyPrerendered" />
+    }
+</div>
 ```
 
-In the **`Server`** app, create a `Pages` folder if it doesn't exist. Create a `_Host.cshtml` page inside the **`Server`** app's `Pages` folder. Paste the contents from the client app's `wwwroot/index.html` file into the `Pages/_Host.cshtml` file. Update the file's contents:
-
-* Add `@page "_Host"` to the top of the file.
-* Replace the `<div id="app">Loading...</div>` tag with the following:
-
-  ```cshtml
-  <div id="app">
-      @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
-      {
-          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
-              render-mode="WebAssembly" />
-      }
-      else
-      {
-          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
-              render-mode="WebAssemblyPrerendered" />
-      }
-  </div>
-  ```
-
-  In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
 
 ## Options for hosted apps and third-party login providers
 
@@ -1908,37 +1898,24 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-In the server app's `Startup.Configure` method, replace [`endpoints.MapFallbackToFile("index.html")`](xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A) with [`endpoints.MapFallbackToPage("/_Host")`](xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A):
+In the **`Server`** app's `Pages/_Host.cshtml` file, replace the `Component` Tag Helper (`<component ... />`) with the following:
 
-```csharp
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllers();
-    endpoints.MapFallbackToPage("/_Host");
-});
+```cshtml
+<div id="app">
+    @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
+    {
+        <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+            render-mode="WebAssembly" />
+    }
+    else
+    {
+        <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+            render-mode="WebAssemblyPrerendered" />
+    }
+</div>
 ```
 
-In the server app, create a `Pages` folder if it doesn't exist. Create a `_Host.cshtml` page inside the server app's `Pages` folder. Paste the contents from the client app's `wwwroot/index.html` file into the `Pages/_Host.cshtml` file. Update the file's contents:
-
-* Add `@page "_Host"` to the top of the file.
-* Replace the `<div id="app">Loading...</div>` tag with the following:
-
-  ```cshtml
-  <div id="app">
-      @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
-      {
-          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
-              render-mode="WebAssembly" />
-      }
-      else
-      {
-          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
-              render-mode="WebAssemblyPrerendered" />
-      }
-  </div>
-  ```
-
-  In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
 
 ## Options for hosted apps and third-party login providers
 
@@ -2960,37 +2937,24 @@ public void ConfigureServices(IServiceCollection services)
 }
 ```
 
-In the server app's `Startup.Configure` method, replace [`endpoints.MapFallbackToFile("index.html")`](xref:Microsoft.AspNetCore.Builder.StaticFilesEndpointRouteBuilderExtensions.MapFallbackToFile%2A) with [`endpoints.MapFallbackToPage("/_Host")`](xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapFallbackToPage%2A):
+In the **`Server`** app's `Pages/_Host.cshtml` file, replace the `Component` Tag Helper (`<component ... />`) with the following:
 
-```csharp
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapControllers();
-    endpoints.MapFallbackToPage("/_Host");
-});
+```cshtml
+<div id="app">
+    @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
+    {
+        <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+            render-mode="WebAssembly" />
+    }
+    else
+    {
+        <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
+            render-mode="WebAssemblyPrerendered" />
+    }
+</div>
 ```
 
-In the server app, create a `Pages` folder if it doesn't exist. Create a `_Host.cshtml` page inside the server app's `Pages` folder. Paste the contents from the client app's `wwwroot/index.html` file into the `Pages/_Host.cshtml` file. Update the file's contents:
-
-* Add `@page "_Host"` to the top of the file.
-* Replace the `<app>Loading...</app>` tag with the following:
-
-  ```cshtml
-  <app>
-      @if (HttpContext.Request.Path.StartsWithSegments("/authentication"))
-      {
-          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
-              render-mode="WebAssembly" />
-      }
-      else
-      {
-          <component type="typeof({CLIENT APP ASSEMBLY NAME}.App)" 
-              render-mode="WebAssemblyPrerendered" />
-      }
-  </app>
-  ```
-
-  In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
+In the preceding example, the placeholder `{CLIENT APP ASSEMBLY NAME}` is the client app's assembly name (for example `BlazorSample.Client`).
 
 ## Options for hosted apps and third-party login providers
 


### PR DESCRIPTION
Fixes #24926 

Thanks @jerrevds! :rocket: ... I'll ping Tanay to look, too, but see if the additional update here makes sense to you. There's a duplication of guidance for the `Pages/_Host.cshtml` page that I'm striking in the process.

Tanay ... This is Javier's original code for the scenario and then updated from https://github.com/dotnet/aspnetcore/issues/37713#issuecomment-961838175 and his following answer to my question there.

However, this looks correct. In the *Prerender and Integrate* topic, we guide adding the Component TH to `Pages/_Host.cshtml` ...

```razor
<component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
```

... in the **_NON-auth case_**. Then, the WASM security doc should just pick up from there.

Cross-reference: **Step 4 of** https://docs.microsoft.com/en-us/aspnet/core/blazor/components/prerendering-and-integration?view=aspnetcore-6.0&pivots=webassembly#prerendering-configuration

In the WASM security doc, I'm dropping the extra bit of guidance for the `_Host.cshtml` file because ... as @jerrevds points out ... the dev should've already taken care of it by following the *Prerender and Integrate* topic guidance (Step 4). What we'll be left with in the WASM security doc is ...

* Factor services to a common location.
* **AVOID** prerendering for relative paths that start with `/authentication` with the code provided (i.e., @jerrevds update to Javier's code).