### PR TITLE
Add File Downloads topic CORS guidance

### DIFF
--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -138,9 +138,17 @@ In the preceding example, replace the placeholders with the following values:
 
 ## Cross-Origin Resource Sharing (CORS)
 
-Without taking further steps to enable cross-origin requests, downloading files from the same origin (same domain) must pass [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS) checks made by the browser.
+Without taking further steps to enable cross-origin requests, downloading files won't pass [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS) checks made by the browser.
 
-For more information on CORS with ASP.NET Core apps and Microsoft services that host files for download, see <xref:security/cors>. For more information on CORS with non-ASP.NET Core apps and non-Microsoft services, consult the CORS documentation of external framework or service.
+For more information on CORS with ASP.NET Core apps and other Microsoft products and services that host files for download, see the following resources:
+
+* <xref:security/cors>
+* [Using Azure CDN with CORS (Azure documentation)](/azure/cdn/cdn-cors)
+* [Cross-Origin Resource Sharing (CORS) support for Azure Storage (REST documentation)](/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services)
+* [Core Cloud Services - Set up CORS for your website and storage assets (Learn Module)](/learn/modules/set-up-cors-website-storage/)
+* [IIS CORS module Configuration Reference (IIS documentation)](/iis/extensions/cors-module/cors-module-configuration-reference)
+
+For more information on CORS with non-ASP.NET Core apps and non-Microsoft services, consult the external framework or service CORS documentation.
 
 ## Security considerations
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -11,6 +11,11 @@ uid: blazor/file-downloads
 ---
 # ASP.NET Core Blazor file downloads
 
+This article covers downloading files in Blazor apps. The guidance in this article:
+
+* Addresses downloading files from the app's own static assets or from any other location. When downloading files, [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) considerations apply.
+* Applies to any [Blazor hosting model](xref:blazor/hosting-models).
+
 > [!WARNING]
 > Always follow security best practices when allowing users to download files. For more information, see the [Security considerations](#security-considerations) section.
 
@@ -133,11 +138,9 @@ In the preceding example, replace the placeholders with the following values:
 
 ## Cross-Origin Resource Sharing (CORS)
 
-Without taking further steps to enable cross-origin requests, downloading files from the same origin (same domain) must pass [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS) checks made by the browser. For more information, see <xref:security/cors>.
+Without taking further steps to enable cross-origin requests, downloading files from the same origin (same domain) must pass [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS) checks made by the browser.
 
-## File streams
-
-In Blazor WebAssembly apps, file data is streamed directly from .NET code into the browser. In Blazor Server apps, file data is streamed over the SignalR connection from .NET code into the browser.
+For more information on CORS with ASP.NET Core apps and Microsoft services that host files for download, see <xref:security/cors>. For more information on CORS with non-ASP.NET Core apps and non-Microsoft services, consult the CORS documentation of external framework or service.
 
 ## Security considerations
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -16,6 +16,9 @@ uid: blazor/file-downloads
 
 The following example demonstrates how to download a file. Native `byte[]` streaming interop is used to ensure efficient transfer to the client.
 
+> [!IMPORTANT]
+> The example in this article pertains to downloading files that pass Cross-Origin Resource Sharing (CORS) checks. For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
+
 In a Razor component (`.razor`), add [`@using`](xref:mvc/views/razor#using) and [`@inject`](xref:mvc/views/razor#inject) directives for the following:
 
 * <xref:System.IO?displayProperty=fullName>
@@ -125,8 +128,12 @@ In the preceding example, the call to `contentStreamReference.arrayBuffer` loads
 
 In the preceding example, replace the placeholders with the following values:
 
-* `{FILE URL}`: The URL of the file to download. Example: `https://www.contoso.com/files/log0001.txt`
+* `{FILE URL}`: The URL of the file to download at the same origin (same domain) that the app uses. Example: `https://www.contoso.com/files/log0001.txt` for a text file physically located at the path `/wwwroot/files/` in the app and for an app that loads from `https://www.contoso.com`. For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
 * `{FILE NAME}`: The file name to use for the saved file. Example: `log-0001.txt`
+
+## Cross-Origin Resource Sharing (CORS)
+
+Without taking further steps to enable cross-origin requests, downloading files from the same origin (same domain) must pass [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS) checks made by the browser. For more information, see <xref:security/cors>.
 
 ## File streams
 


### PR DESCRIPTION
Fixes #24887

Thanks @bisaacson100! :rocket:

Tanay ... I think we'll need to do more than what I currently have on the PR. A couple of things cropped up as I was adding a simple *"watch out for CORS ... and see this"* remarks ...

1. Did this topic (on downloads) inadvertently receive a copy of the *File streams* section in the uploads topic? Even if the remarks should be here, can that first sentence ... perhaps the second sentence, too ... be more specific as to what it's explaining in this context (i.e., downloads)?

   > \#\# File streams
   >
   > In Blazor WebAssembly apps, file data is streamed directly from .NET code into the browser. In Blazor Server apps, file data is streamed over the SignalR connection from .NET code into the browser.

1. I think we need to scope the whole topic better. The topic starts with ...

    > The following example demonstrates how to download a file.

    Is the whole topic for hosted WASM only, or does it apply to Blazor Server, too? The earlier remark (perhaps out of place tho) that data is streamed "over the SignalR connection" is throwing me off because that shouldn't trigger a CORS failure, but the topic is using a browser download gesture ... i.e., it seems to apply to both hosting models. We probably need to say right at the top of the doc what hosting model this topic applies to (hosted WASM and Blazor Server) ... and qualify it further if it's talking about downloading from the app's own static assets or any file anywhere for each. The remark should clarify when CORS (different scheme/origin/port) is a potential problem.

1. Finally ... following up on that last point :point_up: ... we should be careful tossing readers to the main doc set CORS article for dealing with cross-origin file downloads. Depending on scoping of the overall scenario, when will readers find guidance on resolving CORS problems by merely following the guidance in our main CORS doc? When is referring a reader to CORS doc unhelpful? For example, the app/service that hosts the files for download isn't an ASP.NET Core app, so they won't be able to configure CORS using our CORS doc. Those devs must access docs for whatever is serving the files. Is that the only case where our CORS doc isn't going to help? It seems the CORS doc is good for hosted WASM with the **`Server`** app serving the files (or a different ASP.NET Core app serving the files) and Blazor Server apps where the Blazor Server app is hosting the files (or a different ASP.NET Core app is serving the files). Is that correct?

**NOTE TO SELF**: On the next commit, improve the sidebar ToC because the first link is down to the *File streams* section. That section might drop; but whatever the case, I think we need to isolate the example from introductory content (paragraph) that explains what the topic is about.