### PR TITLE
Removed erroneous NOT operator.

### DIFF
--- a/aspnetcore/security/authentication/identity/sample/WebApp6x/Program.cs
+++ b/aspnetcore/security/authentication/identity/sample/WebApp6x/Program.cs
@@ -93,7 +93,7 @@ builder.Services.ConfigureApplicationCookie(options =>
 
 var app = builder.Build();
 
-if (!app.Environment.IsDevelopment())
+if (app.Environment.IsDevelopment())
 {
     app.UseMigrationsEndPoint();
 }


### PR DESCRIPTION
Removed erroneous NOT operator from 'if' statement resulting in the following inverted behaviour;
* `UseExceptionHandler()` & `UseHsts()` *ONLY* being called in Development.
* `UseMigrationsEndPoint()` *ONLY* being called in `Staging` or `Production`

Fixes #24937 