### PR TITLE
Remove .wasm file extension before redefining it

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly/_samples/web.config
+++ b/aspnetcore/blazor/host-and-deploy/webassembly/_samples/web.config
@@ -6,6 +6,7 @@
       <remove fileExtension=".json" />
       <remove fileExtension=".woff" />
       <remove fileExtension=".woff2" />
+      <remove fileExtension=".wasm" />
       <mimeMap fileExtension=".json" mimeType="application/json" />
       <mimeMap fileExtension=".woff" mimeType="font/woff" />
       <mimeMap fileExtension=".woff2" mimeType="font/woff2" />


### PR DESCRIPTION
I had to remove the `.wasm` file extension because IIS was complaining about duplicate entries in order to make it work with `br` and `https`.

Others also reported this issue on stackoverflow:
https://stackoverflow.com/a/69888016
https://stackoverflow.com/a/70967738