### PR TITLE
Update Blazor tutorials ToC link

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -83,7 +83,7 @@ items:
               - name: Examine Details and Delete
                 uid: tutorials/first-mvc-app/details
           - name: Blazor
-            href: blazor/tutorials/index.md
+            uid: blazor/tutorials/index
       - name: Web API apps
         items:
           - name: Create a web API with controllers


### PR DESCRIPTION
So far, so good. I'd like to try a UID here in the root *Tutorials* node instead of the HREF for the Blazor tutorials overview article.