### PR TITLE
v6 prep code-first gRPC Services

### DIFF
--- a/aspnetcore/grpc/code-first.md
+++ b/aspnetcore/grpc/code-first.md
@@ -12,6 +12,8 @@ uid: grpc/code-first
 
 By [James Newton-King](https://twitter.com/jamesnk) and [Marc Gravell](https://twitter.com/marcgravell)
 
+:::moniker range=">= aspnetcore-6.0"
+
 Code-first gRPC uses .NET types to define service and message contracts.
 
 Code-first is a good choice when an entire system uses .NET:
@@ -91,3 +93,87 @@ A code-first gRPC client is created from a channel. Just like a regular client, 
 
 * [protobuf-net.Grpc website](https://protobuf-net.github.io/protobuf-net.Grpc/)
 * [protobuf-net.Grpc GitHub repository](https://github.com/protobuf-net/protobuf-net.Grpc)
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-6.0"
+
+Code-first is a good choice when an entire system uses .NET:
+
+* .NET service and data contract types can be shared between the .NET server and clients.
+* Avoids the need to define contracts in `.proto` files and code generation.
+
+Code-first isn't recommended in polyglot systems with multiple languages. .NET service and data contract types can't be used with non-.NET platforms. To call a gRPC service written using code-first, other platforms must create a `.proto` contract that matches the service.
+
+## protobuf-net.Grpc
+
+> [!IMPORTANT]
+> For help with protobuf-net.Grpc, visit the [protobuf-net.Grpc website](https://protobuf-net.github.io/protobuf-net.Grpc/) or create an issue on the [protobuf-net.Grpc GitHub repository](https://github.com/protobuf-net/protobuf-net.Grpc).
+
+[protobuf-net.Grpc](https://protobuf-net.github.io/protobuf-net.Grpc/) is a community project and isn't supported by Microsoft. It adds code-first support to `Grpc.AspNetCore` and `Grpc.Net.Client`. It uses .NET types annotated with attributes to define an app's gRPC services and messages.
+
+The first step to creating a code-first gRPC service is defining the code contract:
+
+* Create a new project that will be shared by the server and client.
+* Add a [protobuf-net.Grpc](https://www.nuget.org/packages/protobuf-net.Grpc) package reference.
+* Create service and data contract types.
+
+[!code-csharp[](code-first/samples/5.x/Shared/Contracts.cs?name=snippet)]
+
+The preceding code:
+
+* Defines `HelloRequest` and `HelloReply` messages.
+* Defines the `IGreeterService` contract interface with the unary `SayHelloAsync` gRPC method.
+
+The service contract is implemented on the server and called from the client. Methods defined on service interfaces must match certain signatures depending on whether they're unary, server streaming, client streaming, or bidirectional streaming.
+
+For more information on defining service contracts, see the [protobuf-net.Grpc getting started documentation](https://protobuf-net.github.io/protobuf-net.Grpc/gettingstarted).
+
+## Create a code-first gRPC service
+
+To add gRPC code-first service to an ASP.NET Core app:
+
+* Add a [protobuf-net.Grpc.AspNetCore](https://www.nuget.org/packages/protobuf-net.Grpc.AspNetCore) package reference.
+* Add a reference to the shared code-contract project.
+
+Create a new `GreeterService.cs` file and implement the `IGreeterService` service interface:
+
+[!code-csharp[](code-first/samples/5.x/GrpcGreeter/Services/GreeterService.cs?name=snippet&highlight=1)]
+
+Update the `Startup.cs` file:
+
+[!code-csharp[](code-first/samples/5.x/GrpcGreeter/Startup.cs?name=snippet&highlight=3,17)]
+
+In the preceding code:
+
+* `AddCodeFirstGrpc` registers services that enable code-first.
+* `MapGrpcService<GreeterService>` adds the code-first service endpoint.
+
+gRPC services implemented with code-first and `.proto` files can co-exist in the same app. All gRPC services use [gRPC service configuration](xref:grpc/configuration#configure-services-options).
+
+## Create a code-first gRPC client
+
+A code-first gRPC client uses the service contract to call gRPC services. To call a gRPC service using a code-first client:
+
+* Add a [protobuf-net.Grpc](https://www.nuget.org/packages/protobuf-net.Grpc) package reference.
+* Add a reference to the shared code-contract project.
+* Add a [Grpc.Net.Client](https://www.nuget.org/packages/Grpc.Net.Client) package reference.
+
+[!code-csharp[](code-first/samples/5.x/GrpcGreeterClient/Program.cs?name=snippet&highlight=2,4-5)]
+
+The preceding code:
+
+* Creates a gRPC channel.
+* Creates a code-first client from the channel with the `CreateGrpcService<IGreeterService>` extension method.
+* Calls the gRPC service with `SayHelloAsync`.
+
+A code-first gRPC client is created from a channel. Just like a regular client, a code-first client uses its [channel configuration](xref:grpc/configuration#configure-client-options).
+
+[View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/grpc/code-first/samples/5.x) ([how to download](xref:index#how-to-download-a-sample))
+
+## Additional resources
+
+* [protobuf-net.Grpc website](https://protobuf-net.github.io/protobuf-net.Grpc/)
+* [protobuf-net.Grpc GitHub repository](https://github.com/protobuf-net/protobuf-net.Grpc)
+
+:::moniker-end

--- a/aspnetcore/grpc/code-first.md
+++ b/aspnetcore/grpc/code-first.md
@@ -98,6 +98,8 @@ A code-first gRPC client is created from a channel. Just like a regular client, 
 
 :::moniker range="< aspnetcore-6.0"
 
+Code-first gRPC uses .NET types to define service and message contracts.
+
 Code-first is a good choice when an entire system uses .NET:
 
 * .NET service and data contract types can be shared between the .NET server and clients.

--- a/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/GrpcGreeter.csproj
+++ b/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/GrpcGreeter.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.152" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/Program.cs
+++ b/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/Program.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace GrpcGreeter
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
+    }
+}

--- a/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/Services/GreeterService.cs
+++ b/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/Services/GreeterService.cs
@@ -1,0 +1,20 @@
+using ProtoBuf.Grpc;
+using Shared.Contracts;
+using System.Threading.Tasks;
+
+namespace GrpcGreeter
+{
+    #region snippet
+    public class GreeterService : IGreeterService
+    {
+        public Task<HelloReply> SayHelloAsync(HelloRequest request, CallContext context = default)
+        {
+            return Task.FromResult(
+                   new HelloReply
+                   {
+                       Message = $"Hello {request.Name}"
+                   });
+        }
+    }
+    #endregion
+}

--- a/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/Startup.cs
+++ b/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/Startup.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ProtoBuf.Grpc.Server;
+
+namespace GrpcGreeter
+{
+    public class Startup
+    {
+        #region snippet
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddCodeFirstGrpc();
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapGrpcService<GreeterService>();
+            });
+        }
+        #endregion
+    }
+}

--- a/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/appsettings.Development.json
+++ b/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Grpc": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/appsettings.json
+++ b/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeter/appsettings.json
@@ -1,0 +1,15 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}

--- a/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeterClient/GrpcGreeterClient.csproj
+++ b/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeterClient/GrpcGreeterClient.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.Net.Client" Version="2.37.0" />
+    <PackageReference Include="protobuf-net.Grpc" Version="1.0.152" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.Contracts.csproj" />
+  </ItemGroup>
+</Project>

--- a/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/code-first/samples/6.x/GrpcGreeterClient/Program.cs
@@ -1,0 +1,24 @@
+﻿using Grpc.Net.Client;
+using ProtoBuf.Grpc.Client;
+using Shared.Contracts;
+using System;
+using System.Threading.Tasks;
+
+namespace GrpcGreeterClient
+{
+    internal class Program
+    {
+        private static async Task Main(string[] args)
+        {
+            #region snippet
+            using var channel = GrpcChannel.ForAddress("https://localhost:5001");
+            var client = channel.CreateGrpcService<IGreeterService>();
+
+            var reply = await client.SayHelloAsync(
+                new HelloRequest { Name = "GreeterClient" });
+
+            Console.WriteLine($"Greeting: {reply.Message}");
+            #endregion
+        }
+    }
+}

--- a/aspnetcore/grpc/code-first/samples/6.x/Shared/Contracts.cs
+++ b/aspnetcore/grpc/code-first/samples/6.x/Shared/Contracts.cs
@@ -1,0 +1,31 @@
+﻿using ProtoBuf.Grpc;
+using System.Runtime.Serialization;
+using System.ServiceModel;
+using System.Threading.Tasks;
+
+namespace Shared.Contracts
+{
+    #region snippet
+    [DataContract]
+    public class HelloReply
+    {
+        [DataMember(Order = 1)]
+        public string Message { get; set; }
+    }
+
+    [DataContract]
+    public class HelloRequest
+    {
+        [DataMember(Order = 1)]
+        public string Name { get; set; }
+    }
+
+    [ServiceContract]
+    public interface IGreeterService
+    {
+        [OperationContract]
+        Task<HelloReply> SayHelloAsync(HelloRequest request,
+            CallContext context = default);
+    }
+    #endregion
+}

--- a/aspnetcore/grpc/code-first/samples/6.x/Shared/Shared.Contracts.csproj
+++ b/aspnetcore/grpc/code-first/samples/6.x/Shared/Shared.Contracts.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="protobuf-net.Grpc" Version="1.0.152" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Prep for #25071 by creating a new moniker range in the content for 6.x.

[Internal review, verify versions intact](https://review.docs.microsoft.com/en-us/aspnet/core/grpc/code-first?view=aspnetcore-6.0&branch=pr-en-us-25073).