### PR TITLE
Update Blazor-SignalR tutorial

### DIFF
--- a/aspnetcore/blazor/tutorials/signalr-blazor.md
+++ b/aspnetcore/blazor/tutorials/signalr-blazor.md
@@ -414,7 +414,7 @@ Create a `Hubs` (plural) folder and add the following `ChatHub` class (`Hubs/Cha
 
    ```csharp
    using Microsoft.AspNetCore.ResponseCompression;
-   using BlazorServerSignalRApp.Server.Hubs;
+   using BlazorServerSignalRApp.Hubs;
    ```
 
 1. Add Response Compression Middleware services to `Program.cs`:
@@ -424,7 +424,11 @@ Create a `Hubs` (plural) folder and add the following `ChatHub` class (`Hubs/Cha
 1. In `Program.cs`:
 
    * Use Response Compression Middleware at the top of the processing pipeline's configuration.
-   * Between the endpoints for mapping the Blazor hub and the client-side fallback, add an endpoint for the hub.
+   * Between the endpoints for mapping the Blazor hub and the client-side fallback, add an endpoint for the hub:
+
+     ```csharp
+     app.MapHub<ChatHub>("/chathub");
+     ```
 
    [!code-csharp[](signalr-blazor/samples/6.0/BlazorServerSignalRApp/Program.cs?name=snippet_Configure)]
 

--- a/aspnetcore/blazor/tutorials/signalr-blazor/samples/6.0/BlazorServerSignalRApp/Hubs/ChatHub.cs
+++ b/aspnetcore/blazor/tutorials/signalr-blazor/samples/6.0/BlazorServerSignalRApp/Hubs/ChatHub.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.SignalR;
 
-namespace BlazorServerSignalRApp.Server.Hubs
+namespace BlazorServerSignalRApp.Hubs
 {
     public class ChatHub : Hub
     {

--- a/aspnetcore/blazor/tutorials/signalr-blazor/samples/6.0/BlazorServerSignalRApp/Program.cs
+++ b/aspnetcore/blazor/tutorials/signalr-blazor/samples/6.0/BlazorServerSignalRApp/Program.cs
@@ -1,8 +1,8 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Web;
 using BlazorServerSignalRApp.Data;
-using BlazorServerSignalRApp.Server.Hubs;
 using Microsoft.AspNetCore.ResponseCompression;
+using BlazorServerSignalRApp.Hubs;
 
 var builder = WebApplication.CreateBuilder(args);
 


### PR DESCRIPTION
Fixes #25074

Thanks @smiller7812! :rocket: ... This renames that namespace in the Blazor Server tutorial+sample to drop the "**`Server`**" segment that's present in the hosted WASM version of the tutorial+sample. I won't bother fixing the earlier versions. I'm just going to patch the present release on this one. The earlier versions still work ... devs just copy-'n-paste the code out of the topic instead of using the VS features to set the namespace for them. Most of our readers use the latest version of the SDK and doc. If more feedback comes in later, I'll reach back into the older 5.0 tutorial+sample and make similar updates. I'll take these updates live immediately after this PR merges, so the updates will appear in the live topic generally within 20 minutes (for English-US, localized topics take longer due to a delay on translation services). Thanks again for reporting this.