### PR TITLE
Update versioning

### DIFF
--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -2,6 +2,7 @@
 title: Logging in .NET Core and ASP.NET Core
 author: rick-anderson
 description: Learn how to use the logging framework provided by the Microsoft.Extensions.Logging NuGet package.
+monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
 ms.date: 11/28/2020
@@ -896,7 +897,7 @@ To create a custom logger, see [Implement a custom logging provider in .NET](/do
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-3.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-3.1 < aspnetcore-6.0"
 
 By [Kirk Larkin](https://twitter.com/serpent5), [Juergen Gutsch](https://github.com/JuergenGutsch), and [Rick Anderson](https://twitter.com/RickAndMSFT)
 
@@ -1826,7 +1827,7 @@ If the `traceparent` http request header is set, the `ParentId` in the log scope
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-3.0 < aspnetcore-6.0"
+:::moniker range=">= aspnetcore-3.1 < aspnetcore-6.0"
 
 ## Create a custom logger
 


### PR DESCRIPTION
Fixes #25085

Thanks @slabarque! :rocket:

@serpent5 @wadepickett @Rick-Anderson ... Plz let me know if something changed internally because it looks like an update removed this by-design; but as @slabarque points out, without the versioning metadata ...

* Empty topics will load on the live site.

  ![Capture](https://user-images.githubusercontent.com/1622880/154994345-2a646aa4-a06d-4865-b60a-42456e249aae.PNG)

* Readers don't get the nice message ...

  > The requested page is not available for ASP.NET Core {VERSION}. You have been redirected to the newest product version this page is available for.

I'm going to go ahead and put this in; but if there was an internal change on the way we're moving forward, I'm 📣👂, and I'll revert this before it goes on the live site.