### PR TITLE
Blazor no-loc test

### DIFF
--- a/aspnetcore/blazor/no-loc-test.md
+++ b/aspnetcore/blazor/no-loc-test.md
@@ -1,0 +1,47 @@
+---
+title: Localization test doc
+author: guardrex
+description: This is a localization test doc.
+monikerRange: '>= aspnetcore-3.1'
+ms.author: riande
+ms.custom: mvc
+ms.date: 03/03/2022
+uid: blazor/no-loc-test
+---
+# Localization test doc
+
+`This topic doesn't have a no-loc metadata entry. There's a no-loc entry in the docfx.json file`:
+
+```json
+"no-loc": {
+  "**/blazor/no-loc-test.md": "[ computer, cat ]"
+}
+```
+
+`Entries from the existing no-loc list`:
+
+* Blazor Hybrid
+* Home
+* Privacy
+* Kestrel
+* appsettings.json
+* ASP.NET Core Identity
+* cookie
+* Cookie
+* Blazor
+* Blazor Server
+* Blazor WebAssembly
+* Identity
+* Let's Encrypt
+* Razor
+* SignalR
+
+`Entries in the docfx.json fileMetadata no-loc list`:
+
+* computer
+* cat
+
+`Sentences`:
+
+* The computer is ten years old.
+* The cat ate the mouse.

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -65,6 +65,9 @@
         "**/getting-started/**/**.md": "tutorial",
         "**/tutorials/**/**.md": "tutorial"
       },
+      "no-loc": {
+        "**/blazor/no-loc-test.md": "[ computer, cat ]"
+      },
       "recommendations": {
         "**/tutorials/**/**.md": "false"
       }


### PR DESCRIPTION
Addresses #25187

Establishes a test doc to see if `docfx.json`'s entry for `fileMetadata` can apply `no-loc` entries to a topic.

# 🇺🇦 