### PR TITLE
Fix signalR reference links

### DIFF
--- a/aspnetcore/signalr/javascript-client.md
+++ b/aspnetcore/signalr/javascript-client.md
@@ -320,7 +320,7 @@ For the preceding code example:
 ## Additional resources
 
 * [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/signalr/javascript-client/samples) ([how to download](xref:index#how-to-download-a-sample))
-* [JavaScript API reference](/javascript/api/&preserve-view=true )
+* [JavaScript API reference](/javascript/api/@microsoft/signalr/?view=signalr-js-latest )
 * [JavaScript tutorial](xref:tutorials/signalr)
 * [WebPack and TypeScript tutorial](xref:tutorials/signalr-typescript-webpack)
 * [Hubs](xref:signalr/hubs)
@@ -628,7 +628,7 @@ For the preceding code example:
 
 ## Additional resources
 
-* [JavaScript API reference](/javascript/api/&preserve-view=true )
+* [JavaScript API reference](/javascript/api/@microsoft/signalr/?view=signalr-js-latest )
 * [JavaScript tutorial](xref:tutorials/signalr)
 * [WebPack and TypeScript tutorial](xref:tutorials/signalr-typescript-webpack)
 * [Hubs](xref:signalr/hubs)

--- a/aspnetcore/signalr/javascript-client.md
+++ b/aspnetcore/signalr/javascript-client.md
@@ -320,7 +320,7 @@ For the preceding code example:
 ## Additional resources
 
 * [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/signalr/javascript-client/samples) ([how to download](xref:index#how-to-download-a-sample))
-* [JavaScript API reference](/javascript/api/@microsoft/signalr/?view=signalr-js-latest )
+* [JavaScript API reference](/javascript/api/@microsoft/signalr)
 * [JavaScript tutorial](xref:tutorials/signalr)
 * [WebPack and TypeScript tutorial](xref:tutorials/signalr-typescript-webpack)
 * [Hubs](xref:signalr/hubs)
@@ -628,7 +628,7 @@ For the preceding code example:
 
 ## Additional resources
 
-* [JavaScript API reference](/javascript/api/@microsoft/signalr/?view=signalr-js-latest )
+* [JavaScript API reference](/javascript/api/@microsoft/signalr)
 * [JavaScript tutorial](xref:tutorials/signalr)
 * [WebPack and TypeScript tutorial](xref:tutorials/signalr-typescript-webpack)
 * [Hubs](xref:signalr/hubs)


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #25197

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.

Fixed the reference links to Javascript API reference.
-->