### PR TITLE
Clarify component disposal async+sync

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -218,6 +218,10 @@ Although the content in this section focuses on Blazor Server and stateful Signa
 
 If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for unmanaged resource disposal when the component is removed from the UI. Disposal can occur at any time, including during [component initialization](#component-initialization-oninitializedasync).
 
+Components shouldn't need to implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable> simultaneously. If both are implemented, the framework only executes the asynchronous overload.
+
+Developer code must ensure that <xref:System.IAsyncDisposable> implementations don't take a long time to complete.
+
 ### Synchronous `IDisposable`
 
 For synchronous disposal tasks, use <xref:System.IDisposable.Dispose%2A?displayProperty=nameWithType>.
@@ -662,6 +666,10 @@ Although the content in this section focuses on Blazor Server and stateful Signa
 
 If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for unmanaged resource disposal when the component is removed from the UI. Disposal can occur at any time, including during [component initialization](#component-initialization-oninitializedasync).
 
+Components shouldn't need to implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable> simultaneously. If both are implemented, the framework only executes the asynchronous overload.
+
+Developer code must ensure that <xref:System.IAsyncDisposable> implementations don't take a long time to complete.
+
 ### Synchronous `IDisposable`
 
 For synchronous disposal tasks, use <xref:System.IDisposable.Dispose%2A?displayProperty=nameWithType>.
@@ -1101,6 +1109,10 @@ Although the content in this section focuses on Blazor Server and stateful Signa
 ## Component disposal with `IDisposable` and `IAsyncDisposable`
 
 If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for unmanaged resource disposal when the component is removed from the UI. Disposal can occur at any time, including during [component initialization](#component-initialization-oninitializedasync).
+
+Components shouldn't need to implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable> simultaneously. If both are implemented, the framework only executes the asynchronous overload.
+
+Developer code must ensure that <xref:System.IAsyncDisposable> implementations don't take a long time to complete.
 
 ### Synchronous `IDisposable`
 


### PR DESCRIPTION
Fixes #24863

Thanks @jkdba! :rocket: ... Looks like Pranav isn't on the PU team any longer. This should be fine tho given that it comes directly from reference source.

Ref source code comment:

> Components shouldn't need to implement IAsyncDisposable and IDisposable simultaneously,
> but in case they do, we prefer the async overload since we understand the sync overload
> is implemented for more "constrained" scenarios.
> Component authors are responsible for their IAsyncDisposable implementations not taking
> forever.

Cross-reference: https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/RenderTree/Renderer.cs#L1009-L1013