### PR TITLE
Update overwritten param examples

### DIFF
--- a/aspnetcore/blazor/samples/3.1/BlazorSample_Server/Shared/index/BadExpander.razor
+++ b/aspnetcore/blazor/samples/3.1/BlazorSample_Server/Shared/index/BadExpander.razor
@@ -11,7 +11,7 @@
 
 @code {
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/3.1/BlazorSample_Server/Shared/index/Expander.razor
+++ b/aspnetcore/blazor/samples/3.1/BlazorSample_Server/Shared/index/Expander.razor
@@ -13,7 +13,7 @@
     private bool expanded;
 
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/index/BadExpander.razor
+++ b/aspnetcore/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/index/BadExpander.razor
@@ -11,7 +11,7 @@
 
 @code {
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/index/Expander.razor
+++ b/aspnetcore/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/index/Expander.razor
@@ -13,7 +13,7 @@
     private bool expanded;
 
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/5.0/BlazorSample_Server/Shared/index/BadExpander.razor
+++ b/aspnetcore/blazor/samples/5.0/BlazorSample_Server/Shared/index/BadExpander.razor
@@ -11,7 +11,7 @@
 
 @code {
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/5.0/BlazorSample_Server/Shared/index/Expander.razor
+++ b/aspnetcore/blazor/samples/5.0/BlazorSample_Server/Shared/index/Expander.razor
@@ -13,7 +13,7 @@
     private bool expanded;
 
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/index/BadExpander.razor
+++ b/aspnetcore/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/index/BadExpander.razor
@@ -11,7 +11,7 @@
 
 @code {
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/index/Expander.razor
+++ b/aspnetcore/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/index/Expander.razor
@@ -13,7 +13,7 @@
     private bool expanded;
 
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/6.0/BlazorSample_Server/Shared/index/BadExpander.razor
+++ b/aspnetcore/blazor/samples/6.0/BlazorSample_Server/Shared/index/BadExpander.razor
@@ -11,7 +11,7 @@
 
 @code {
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/6.0/BlazorSample_Server/Shared/index/Expander.razor
+++ b/aspnetcore/blazor/samples/6.0/BlazorSample_Server/Shared/index/Expander.razor
@@ -13,7 +13,7 @@
     private bool expanded;
 
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/index/BadExpander.razor
+++ b/aspnetcore/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/index/BadExpander.razor
@@ -11,7 +11,7 @@
 
 @code {
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }

--- a/aspnetcore/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/index/Expander.razor
+++ b/aspnetcore/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/index/Expander.razor
@@ -13,7 +13,7 @@
     private bool expanded;
 
     [Parameter]
-    public bool Expanded { get; set; }
+    public bool Expanded { private get; set; }
 
     [Parameter]
     public RenderFragment? ChildContent { get; set; }


### PR DESCRIPTION
Fixes #23715

Thanks @omuleanu! 🚀

I haven't forgotten about #23704, but I'll have to get back to that one later. I'd like Steve to answer it, but I still can't ping him on that one at the moment given the workload of high priority issues. It's tracked, and we'll get to it *ASAP* 🏃.

WRT this update: You originally only called out the revised `Expander` (the "good" one) for the update mentioning that it's only used once in `OnInitialized` (as far as parent/children would be concerned). There's no problem applying the update to the "bad"-behaving one, too, so I do that here as well.

Also, I'd like to ask Tanay about this. We don't really sweat private getters. It's when the setter must be restricted that the access modification is particularly relevant. We might not want to make this change at all. I defer to a **_real programmer_** on this point 😄, but I don't see us modifying getter access like this very often, if at all.

# 🇺🇦 