### PR TITLE
Update grpc-start.md

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -188,6 +188,8 @@ dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 * Update the namespace inside the `greet.proto` file to the project's namespace:
 
   ```
+  syntax = "proto3";
+  
   option csharp_namespace = "GrpcGreeterClient";
   ```
 


### PR DESCRIPTION
If the syntax version is not provided, latest Visual Studio will fail on compile with error: 
```
\altsrc\github\grpc\workspace_protoc_windows_x64\third_party\protobuf\src\google\protobuf\compiler\parser.cc:649] No syntax specified for the proto file: Protos/greet.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->