### PR TITLE
Add warning about limited range of decimal encoding

### DIFF
--- a/aspnetcore/grpc/protobuf.md
+++ b/aspnetcore/grpc/protobuf.md
@@ -202,7 +202,7 @@ The `nanos` field represents values from `0.999_999_999` to `-0.999_999_999`. Fo
 > 
 > * Is easy to understand.
 > * Isn't affected by big-endian or little-endian on different platforms.
-> * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` with a maximum precision of nine decimal places, which isn't the full range of a `decimal`.
+> * Supports decimal numbers ranging from positive `9,223,372,036,854,775,807.999999999` to negative `9,223,372,036,854,775,808.999999999` with a maximum precision of nine decimal places, which isn't the full range of a `decimal`.
 
 Conversion between this type and the BCL `decimal` type might be implemented in C# like this:
 

--- a/aspnetcore/grpc/protobuf.md
+++ b/aspnetcore/grpc/protobuf.md
@@ -202,7 +202,7 @@ The `nanos` field represents values from `0.999_999_999` to `-0.999_999_999`. Fo
 > 
 > * Is easy to understand.
 > * Not affected by big-endian or little-endian on different platforms.
-> * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` and with a precision of maximum nine decimal places, which isn't the full range of a `decimal`.
+> * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` with a precision of maximum nine decimal places, which isn't the full range of a `decimal`.
 
 Conversion between this type and the BCL `decimal` type might be implemented in C# like this:
 

--- a/aspnetcore/grpc/protobuf.md
+++ b/aspnetcore/grpc/protobuf.md
@@ -198,10 +198,11 @@ message DecimalValue {
 The `nanos` field represents values from `0.999_999_999` to `-0.999_999_999`. For example, the `decimal` value `1.5m` would be represented as `{ units = 1, nanos = 500_000_000 }`. This is why the `nanos` field in this example uses the `sfixed32` type, which encodes more efficiently than `int32` for larger values. If the `units` field is negative, the `nanos` field should also be negative.
 
 > [!NOTE]
-> There are multiple other algorithms for encoding `decimal` values as byte strings. This algorithm:
+> Additional algorithms are available for encoding `decimal` values as byte strings. The Protobuf algorithm:
+> 
 > * Is easy to understand.
 > * Not affected by big-endian or little-endian on different platforms.
-> * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` and with a precision of maximum 9&nbsp;decimals. This isn't the full range of a `decimal`.
+> * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` and with a precision of maximum nine decimal places, which isn't the full range of a `decimal`.
 
 Conversion between this type and the BCL `decimal` type might be implemented in C# like this:
 

--- a/aspnetcore/grpc/protobuf.md
+++ b/aspnetcore/grpc/protobuf.md
@@ -202,7 +202,7 @@ The `nanos` field represents values from `0.999_999_999` to `-0.999_999_999`. Fo
 > 
 > * Is easy to understand.
 > * Not affected by big-endian or little-endian on different platforms.
-> * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` with a precision of maximum nine decimal places, which isn't the full range of a `decimal`.
+> * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` with a maximum precision of nine decimal places, which isn't the full range of a `decimal`.
 
 Conversion between this type and the BCL `decimal` type might be implemented in C# like this:
 

--- a/aspnetcore/grpc/protobuf.md
+++ b/aspnetcore/grpc/protobuf.md
@@ -200,6 +200,9 @@ The `nanos` field represents values from `0.999_999_999` to `-0.999_999_999`. Fo
 > [!NOTE]
 > There are multiple other algorithms for encoding `decimal` values as byte strings, but this message is easier to understand than any of them. The values are not affected by big-endian or little-endian on different platforms.
 
+> [!WARNING]
+> This algorithm can't encode the full range of a `decimal`. It's limited to values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` and only with a precision of maximum 9&nbsp;decimals.
+
 Conversion between this type and the BCL `decimal` type might be implemented in C# like this:
 
 ```csharp

--- a/aspnetcore/grpc/protobuf.md
+++ b/aspnetcore/grpc/protobuf.md
@@ -201,7 +201,7 @@ The `nanos` field represents values from `0.999_999_999` to `-0.999_999_999`. Fo
 > Additional algorithms are available for encoding `decimal` values as byte strings. The Protobuf algorithm:
 > 
 > * Is easy to understand.
-> * Not affected by big-endian or little-endian on different platforms.
+> * Isn't affected by big-endian or little-endian on different platforms.
 > * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` with a maximum precision of nine decimal places, which isn't the full range of a `decimal`.
 
 Conversion between this type and the BCL `decimal` type might be implemented in C# like this:

--- a/aspnetcore/grpc/protobuf.md
+++ b/aspnetcore/grpc/protobuf.md
@@ -198,10 +198,10 @@ message DecimalValue {
 The `nanos` field represents values from `0.999_999_999` to `-0.999_999_999`. For example, the `decimal` value `1.5m` would be represented as `{ units = 1, nanos = 500_000_000 }`. This is why the `nanos` field in this example uses the `sfixed32` type, which encodes more efficiently than `int32` for larger values. If the `units` field is negative, the `nanos` field should also be negative.
 
 > [!NOTE]
-> There are multiple other algorithms for encoding `decimal` values as byte strings, but this message is easier to understand than any of them. The values are not affected by big-endian or little-endian on different platforms.
-
-> [!WARNING]
-> This algorithm can't encode the full range of a `decimal`. It's limited to values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` and only with a precision of maximum 9&nbsp;decimals.
+> There are multiple other algorithms for encoding `decimal` values as byte strings. This algorithm:
+> * Is easy to understand.
+> * Not affected by big-endian or little-endian on different platforms.
+> * Supports values in the range `9,223,372,036,854,775,808.999999999` to `9,223,372,036,854,775,807.999999999` and with a precision of maximum 9&nbsp;decimals. This isn't the full range of a `decimal`.
 
 Conversion between this type and the BCL `decimal` type might be implemented in C# like this:
 

--- a/aspnetcore/grpc/protobuf.md
+++ b/aspnetcore/grpc/protobuf.md
@@ -198,7 +198,7 @@ message DecimalValue {
 The `nanos` field represents values from `0.999_999_999` to `-0.999_999_999`. For example, the `decimal` value `1.5m` would be represented as `{ units = 1, nanos = 500_000_000 }`. This is why the `nanos` field in this example uses the `sfixed32` type, which encodes more efficiently than `int32` for larger values. If the `units` field is negative, the `nanos` field should also be negative.
 
 > [!NOTE]
-> Additional algorithms are available for encoding `decimal` values as byte strings. The Protobuf algorithm:
+> Additional algorithms are available for encoding `decimal` values as byte strings. The algorithm used by `DecimalValue`:
 > 
 > * Is easy to understand.
 > * Isn't affected by big-endian or little-endian on different platforms.


### PR DESCRIPTION
I was pleasantly surprised to see that Microsoft provides guidance on how to encode `decimal` in protobuf but I quickly realized that this encoding only supports a limited range of values with a limited precision. While this limitation probably is fine in most cases I think it should be mentioned so I added a warning and placed it after the note that hints at the superiority of this encoding to contextualize it a bit and also help the "copy-paste developer" to better understand the encoding at a glance.