### PR TITLE
Fix request-response mixup

### DIFF
--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -110,7 +110,7 @@ ASP.NET Core MVC uses the <xref:Microsoft.AspNetCore.Mvc.Infrastructure.ModelSta
 
 ### Default BadRequest response
 
-The following request body is an example of the serialized type:
+The following response body is an example of the serialized type:
 
 ```json
 {
@@ -120,7 +120,7 @@ The following request body is an example of the serialized type:
 }
 ```
 
-The default response type for an HTTP 400 response is <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails>. The following request body is an example of the serialized type:
+The default response type for an HTTP 400 response is <xref:Microsoft.AspNetCore.Mvc.ValidationProblemDetails>. The following response body is an example of the serialized type:
 
 ```json
 {


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/web-api/?view=aspnetcore-6.0&branch=pr-en-us-25302)

It seems like the word "request" was used instead of "response" in these two places.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->