### PR TITLE
Enhance example description

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -662,6 +662,7 @@ Use a collection to reference components in a loop. In the following example:
 
 * Components are added to a <xref:System.Collections.Generic.List%601>.
 * A button is created for each component that triggers the corresponding component's `ChildMethod` by its component index in the <xref:System.Collections.Generic.List%601>.
+* There's no need to clear the list of component references in developer code. The <xref:System.Collections.Generic.List%601> is a [managed resource](/dotnet/standard/managed-code) and cleared by the [.NET garbage collector](/dotnet/standard/garbage-collection/) automatically when the framework disposes of the component. 
 
 `Pages/ReferenceParent3.razor` using the preceding `ReferenceChild` component:
 
@@ -2090,6 +2091,7 @@ Use a collection to reference components in a loop. In the following example:
 
 * Components are added to a <xref:System.Collections.Generic.List%601>.
 * A button is created for each component that triggers the corresponding component's `ChildMethod` by its component index in the <xref:System.Collections.Generic.List%601>.
+* There's no need to clear the list of component references in developer code. The <xref:System.Collections.Generic.List%601> is a [managed resource](/dotnet/standard/managed-code) and cleared by the [.NET garbage collector](/dotnet/standard/garbage-collection/) automatically when the framework disposes of the component.
 
 `Pages/ReferenceParent3.razor` using the preceding `ReferenceChild` component:
 
@@ -3070,6 +3072,7 @@ Use a collection to reference components in a loop. In the following example:
 
 * Components are added to a <xref:System.Collections.Generic.List%601>.
 * A button is created for each component that triggers the corresponding component's `ChildMethod` by its component index in the <xref:System.Collections.Generic.List%601>.
+* There's no need to clear the list of component references in developer code. The <xref:System.Collections.Generic.List%601> is a [managed resource](/dotnet/standard/managed-code) and cleared by the [.NET garbage collector](/dotnet/standard/garbage-collection/) automatically when the framework disposes of the component.
 
 `Pages/ReferenceParent3.razor` using the preceding `ReferenceChild` component:
 


### PR DESCRIPTION
Fixes #25330

Thanks @mrpmorris! 🎸

I'm going to add a remark to the example to call it out. It's a managed list, and it should be GC'ed along with anything else managed by the CLR AFAIK. Let's not get too deep into the weeds here with this example on the whole subject, because ...

* We'd end up on a slippery slope where **_many things_** get a "this is managed, don't sweat disposal"-type of remark. We prefer to go the other way and mostly call it out where object disposal matters.
* The whole subject of object management and GC is covered in great detail by the .NET docs on memory management.
* We call out spots where disposal is important in the section that's dedicated to disposal, [Component disposal with `IDisposable` and `IAsyncDisposable`](https://docs.microsoft.com/aspnet/core/blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable).

Still tho, I think this is a good spot to add a brief remark as you suggest. Actually, I'm even going to add a quick cross-link down to that disposal section of this topic.

IIRC, the PU has told devs over the years that *potential* memory leaks time-consuming to investigate; so when someone opens a 'I think I have a memory leak' issue, the PU will close it if the dev can't repro the leak clearly. If this example ... the one that you're calling out for this update ... generates a memory leak, for sure, please do open an issue for the product unit and feel free to CC: me on it so that I can follow the discussion. Just fair warning that you'll probably need clear evidence of the leak for them to proceed.

Thanks again for opening the issue.