### PR TITLE
Add MongoDB Shell annotation

### DIFF
--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -67,6 +67,7 @@ Use the mongo Shell in the following steps to create a database, make collection
    ```console
    mongo
    ```
+   Remark: MongoDB 5.x and newer versions recommend using the [MongoDB Shell](https://docs.mongodb.com/mongodb-shell/install/). You can invoke the MongoDB Shell with `mongosh` after installing it.
 
 1. Run the following command in a command shell:
 


### PR DESCRIPTION
Fixes #25379 

This PR adds an annotation that MongoDB 5.x and newer versions use MongoDB Shell ("mongosh") instead of "mongo". Some hyperlinks also point to the MongoDB 4.x documentation which is unaware of MongoDB Shell. Maybe some of those links should be replaced with newer versions or `mongosh` should be the standard command for this tutorial instead of `mongo`.