### PR TITLE
Added instructions for header key Content-Type

### DIFF
--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -299,6 +299,8 @@ The following instructions post data to the app:
   * Create a new request.
   * Set the HTTP method to `POST`.
   * Set the URI to `https://localhost:<port>/todoitems`. For example: `https://localhost:5001/todoitems`
+  * Select the **Headers** tab.
+  * Add the key `Content-Type` with the value of `application/json`
   * Select the **Body** tab.
   * Select **raw**.
   * Set the type to **JSON**.


### PR DESCRIPTION
Set Content-Type to "application\json" - other wise example returns 415 Unsupported Media Type



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->