### PR TITLE
Remove commented out bullet

### DIFF
--- a/aspnetcore/test/hot-reload.md
+++ b/aspnetcore/test/hot-reload.md
@@ -66,6 +66,5 @@ For more information, see the following resources in the Visual Studio documenta
 * YouTube video [.NET 6 Hot Reload in Visual Studio 2022, VS Code, and NOTEPAD?!?](https://www.youtube.com/watch?v=4S3vPzawnoQ)
 * [Introducing the .NET Hot Reload experience for editing code at runtime](https://devblogs.microsoft.com/dotnet/introducing-net-hot-reload/)
 * [Write and debug running code with Hot Reload in Visual Studio](/visualstudio/debugger/hot-reload)
-*  <!--I can't find hot in that link.[Visual Studio 2022 version 17.0 RC and Preview Release Notes: .NET Hot Reload](/visualstudio/releases/2022/release-notes-preview#net-hot-reload) -->
 * [Updates for Blazor & Razor editors + Hot Reload for ASP.NET](/visualstudio/ide/whats-new-visual-studio-2022#updates-for-blazor--razor-editors--hot-reload-for-aspnet)
 * [Test Execution with Hot Reload](/visualstudio/test/test-execution-with-hot-reload)


### PR DESCRIPTION
This is just showing a blank bullet since the content is commented out. Since it's not linkable in the release notes, I suggest just removing the list item.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->