### PR TITLE
Replace "Related Resources" with "Additional Resources"

### DIFF
--- a/aspnetcore/signalr/groups.md
+++ b/aspnetcore/signalr/groups.md
@@ -44,8 +44,8 @@ To protect access to resources while using groups, use [authentication and autho
 > [!NOTE]
 > Group names are case-sensitive.
 
-## Related resources
+## Additional resources
 
-* [Get started](xref:tutorials/signalr)
-* [Hubs](xref:signalr/hubs)
-* [Publish to Azure](xref:signalr/publish-to-azure-web-app)
+* <xref:tutorials/signalr>
+* <xref:signalr/hubs>
+* <xref:signalr/publish-to-azure-web-app>

--- a/aspnetcore/signalr/hubcontext.md
+++ b/aspnetcore/signalr/hubcontext.md
@@ -139,8 +139,8 @@ This is useful when:
 
 :::moniker-end
 
-## Related resources
+## Additional resources
 
-* [Get started](xref:tutorials/signalr)
-* [Hubs](xref:signalr/hubs)
-* [Publish to Azure](xref:signalr/publish-to-azure-web-app)
+* <xref:tutorials/signalr>
+* <xref:signalr/hubs>
+* <xref:signalr/publish-to-azure-web-app>

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -191,8 +191,8 @@ If you have an exceptional condition you *do* want to propagate to the client, y
 > [!NOTE]
 > SignalR only sends the `Message` property of the exception to the client. The stack trace and other properties on the exception aren't available to the client.
 
-## Related resources
+## Additional resources
 
-* [Intro to ASP.NET Core SignalR](xref:signalr/introduction)
-* [JavaScript client](xref:signalr/javascript-client)
-* [Publish to Azure](xref:signalr/publish-to-azure-web-app)
+* <xref:signalr/introduction>
+* <xref:signalr/javascript-client>
+* <xref:signalr/publish-to-azure-web-app>

--- a/aspnetcore/signalr/messagepackhubprotocol.md
+++ b/aspnetcore/signalr/messagepackhubprotocol.md
@@ -13,7 +13,7 @@ uid: signalr/messagepackhubprotocol
 # Use MessagePack Hub Protocol in SignalR for ASP.NET Core
 :::moniker range=">= aspnetcore-6.0"
 
-This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
+This article assumes the reader is familiar with the topics covered in <xref:tutorials/signalr>.
 
 ## What is MessagePack?
 
@@ -179,17 +179,16 @@ For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](
 
 In the java client, `char` objects will be serialized as one-character `String` objects. This is in contrast with the C# and JavaScript client, which serialize them as `short` objects. The MessagePack spec itself does not define behavior for `char` objects, so it is up to the library author to determine how to serialize them. The difference in behavior between our clients is a result of the libraries we used for our implementations.
 
-## Related resources
+## Additional resources
 
-* [Get Started](xref:tutorials/signalr)
-* [.NET client](xref:signalr/dotnet-client)
-* [JavaScript client](xref:signalr/javascript-client)
+* <xref:signalr/dotnet-client>
+* <xref:signalr/javascript-client>
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
+This article assumes the reader is familiar with the topics covered in <xref:tutorials/signalr>.
 
 ## What is MessagePack?
 
@@ -371,17 +370,16 @@ For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](
 
 In the java client, `char` objects will be serialized as one-character `String` objects. This is in contrast with the C# and JavaScript client, which serialize them as `short` objects. The MessagePack spec itself does not define behavior for `char` objects, so it is up to the library author to determine how to serialize them. The difference in behavior between our clients is a result of the libraries we used for our implementations.
 
-## Related resources
+## Additional resources
 
-* [Get Started](xref:tutorials/signalr)
-* [.NET client](xref:signalr/dotnet-client)
-* [JavaScript client](xref:signalr/javascript-client)
+* <xref:signalr/dotnet-client>
+* <xref:signalr/javascript-client>
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-3.0 < aspnetcore-5.0"
 
-This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
+This article assumes the reader is familiar with the topics covered in <xref:tutorials/signalr>.
 
 ## What is MessagePack?
 
@@ -551,17 +549,16 @@ InvalidDataException: Error binding arguments. Make sure that the types of the p
 
 For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](https://github.com/aspnet/SignalR/issues/2937).
 
-## Related resources
+## Additional resources
 
-* [Get Started](xref:tutorials/signalr)
-* [.NET client](xref:signalr/dotnet-client)
-* [JavaScript client](xref:signalr/javascript-client)
+* <xref:signalr/dotnet-client>
+* <xref:signalr/javascript-client>
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-3.0"
 
-This article assumes the reader is familiar with the topics covered in [Get Started](xref:tutorials/signalr).
+This article assumes the reader is familiar with the topics covered in <xref:tutorials/signalr>.
 
 ## What is MessagePack?
 
@@ -731,10 +728,9 @@ InvalidDataException: Error binding arguments. Make sure that the types of the p
 
 For more information on this limitation, see GitHub issue [aspnet/SignalR#2937](https://github.com/aspnet/SignalR/issues/2937).
 
-## Related resources
+## Additional resources
 
-* [Get Started](xref:tutorials/signalr)
-* [.NET client](xref:signalr/dotnet-client)
-* [JavaScript client](xref:signalr/javascript-client)
+* <xref:signalr/dotnet-client>
+* <xref:signalr/javascript-client>
 
 :::moniker-end


### PR DESCRIPTION
We have a few "Related Resources" headers that should be "Additional Resources".

Internal Reviews:

- [Manage users and groups in SignalR](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/groups?view=aspnetcore-6.0&branch=pr-en-us-25419)
- [Send messages from outside a hub](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/hubcontext?view=aspnetcore-6.0&branch=pr-en-us-25419)
- [Use hubs in SignalR for ASP.NET Core](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-6.0&branch=pr-en-us-25419)
- [Use MessagePack Hub Protocol in SignalR for ASP.NET Core](https://review.docs.microsoft.com/en-us/aspnet/core/signalr/messagepackhubprotocol?view=aspnetcore-6.0&branch=pr-en-us-25419)