### PR TITLE
Clarify build tool effect on size

### DIFF
--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -74,7 +74,7 @@ The Blazor WebAssembly hosting model has the following limitations:
 
 Blazor WebAssembly supports ahead-of-time (AOT) compilation, where you can compile your .NET code directly into WebAssembly. AOT compilation results in runtime performance improvements at the expense of a larger app size. For more information, see <xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation>. 
 
-The same .NET WebAssembly build tools used for AOT compilation also [relink the .NET WebAssembly runtime](xref:blazor/host-and-deploy/webassembly#runtime-relinking) to trim unused runtime code resulting in a smaller app size and thus improved download speed. 
+The same .NET WebAssembly build tools used for AOT compilation also [relink the .NET WebAssembly runtime](xref:blazor/host-and-deploy/webassembly#runtime-relinking) to trim unused runtime code. 
 
 Blazor WebAssembly includes support for trimming unused code from .NET Core framework libraries. For more information, see <xref:blazor/globalization-localization>. The .NET compiler further precompresses a Blazor WebAssembly app for a smaller app payload.
 


### PR DESCRIPTION
Fixes #25454

Thanks @DrEsteban! :rocket:

The language used to describe the result of trimming the runtime can be removed from the *Hosting Models* topic, mostly because AOT is going to make the overall app larger ... much larger in most cases. The product unit claims that production apps will be around twice the size with AOT.

When runtime relinking is performed **_with disabling globalization_**, the *runtime size reduction* is probably significant for small apps. For large apps, I expect the size increase due to AOT to swamp any savings from runtime relinking. As you said, devs should test their apps to see what sort of size gains/reductions occur, taking into account if they can get away with dropping globalization and how much performance they gain on the client with AOT. The good news is that these are active areas of development by the framework engineers. I expect improvements in future releases.

There are more details back in the [linked content for *runtime relinking*](https://docs.microsoft.com/aspnet/core/blazor/host-and-deploy/webassembly#runtime-relinking). I checked that coverage, and it's not as specific on app size effects. I think that content can remain in its present state.

Thanks again for your feedback, @DrEsteban.