### PR TITLE
Blazor JS interop with generic methods

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -52,7 +52,8 @@ In the following example:
 }
 ```
 
-Calling open generic methods isn't supported with static .NET methods but is supported with [instance methods](#invoke-an-instance-net-method), which are described later in this article.
+> [!NOTE]
+> Calling open generic methods isn't supported with static .NET methods but is supported with instance methods. For more information, see the [Call .NET generic class methods](#call-net-generic-class-methods) section.
 
 In the following `CallDotNetExample1` component, the `ReturnArrayAsync` C# method returns an `int` array. The [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) is applied to the method, which makes the method invokable by JS.
 
@@ -117,14 +118,17 @@ To invoke an instance .NET method from JavaScript (JS):
 * Invoke a .NET instance method from JS using `invokeMethod` or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
-### Component instance examples
-
-The examples in this section demonstrate how to pass a <xref:Microsoft.JSInterop.DotNetObjectReference> to an individual JavaScript function and to a JavaScript class with multiple functions:
+The following sections of this article demonstrate various approaches for invoking an instance .NET method:
 
 * [Pass a `DotNetObjectReference` to an individual JavaScript function](#pass-a-dotnetobjectreference-to-an-individual-javascript-function)
 * [Pass a `DotNetObjectReference` to a class with multiple JavaScript functions](#pass-a-dotnetobjectreference-to-a-class-with-multiple-javascript-functions)
+* [Call .NET generic class methods](#call-net-generic-class-methods)
+* [Class instance examples](#class-instance-examples)
+* [Component instance .NET method helper class](#component-instance-net-method-helper-class)
 
-#### Pass a `DotNetObjectReference` to an individual JavaScript function
+## Pass a `DotNetObjectReference` to an individual JavaScript function
+
+The example in this section demonstrates how to pass a <xref:Microsoft.JSInterop.DotNetObjectReference> to an individual JavaScript (JS) function.
 
 The following `sayHello1` JS function receives a <xref:Microsoft.JSInterop.DotNetObjectReference> and calls `invokeMethodAsync` to call the `GetHelloMethod` .NET method of a component.
 
@@ -178,9 +182,11 @@ To pass arguments to an instance method:
 
    In the preceding example, the variable name `dotNetHelper` is arbitrary and can be changed to any preferred name.
 
-#### Pass a `DotNetObjectReference` to a class with multiple JavaScript functions
+## Pass a `DotNetObjectReference` to a class with multiple JavaScript functions
 
-Create and pass a <xref:Microsoft.JSInterop.DotNetObjectReference> from the [`OnAfterRenderAsync` lifecycle method](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync) to a JavaScript (JS) class for multiple functions to use. Make sure that the .NET code disposes of the <xref:Microsoft.JSInterop.DotNetObjectReference>, as the following example shows.
+The example in this section demonstrates how to pass a <xref:Microsoft.JSInterop.DotNetObjectReference> to a JavaScript (JS) class with multiple functions.
+
+Create and pass a <xref:Microsoft.JSInterop.DotNetObjectReference> from the [`OnAfterRenderAsync` lifecycle method](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync) to a JS class for multiple functions to use. Make sure that the .NET code disposes of the <xref:Microsoft.JSInterop.DotNetObjectReference>, as the following example shows.
 
 In the following `CallDotNetExampleOneHelper` component, the `Trigger JS function` buttons call JS functions by setting the [JS `onclick` property](https://developer.mozilla.org/docs/Web/API/GlobalEventHandlers/onclick), ***not*** Blazor's `@onclick` directive attribute.
 
@@ -278,7 +284,171 @@ In the preceding example:
 * The `GreetingHelpers` class is added to the `window` object to globally define the class, which permits Blazor to locate the class for JS interop.
 * The variable name `dotNetHelper` is arbitrary and can be changed to any preferred name.
 
-### Class instance examples
+## Call .NET generic class methods
+
+JavaScript (JS) functions can call [.NET generic class](/dotnet/csharp/programming-guide/generics/generic-classes) methods, where a JS function calls a .NET method of a generic class.
+
+In the following generic type class (`GenericType<TValue>`):
+
+* The class has a single type parameter (`TValue`) with a single generic `Value` property.
+* The class has two non-generic methods marked with the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute), each with a generic type parameter named `newValue`:
+  * `Update` synchronously updates the value of `Value` from `newValue`.
+  * `UpdateAsync` asynchronously updates the value of `Value` from `newValue` after creating an awaitable task with <xref:System.Threading.Tasks.Task.Yield%2A?displayProperty=nameWithType> that asynchronously yields back to the current context when awaited.
+* Each of the class methods write the type of `TValue` and the value of `Value` to the console. Writing to the console is only for demonstration purposes. Production apps usually avoid writing to the console in favor of app *logging*. For more information, see <xref:blazor/fundamentals/logging> and <xref:fundamentals/logging/index>.
+
+> [!NOTE]
+> *Open generic types and methods* don't specify types for type placeholders. Conversely, *closed generics* supply types for all type placeholders. The examples in this section demonstrate closed generics, but invoking JS interop *instance methods* with open generics ***is supported***. Use of open generics is ***not*** supported for [static .NET method invocations](#invoke-a-static-net-method), which were described earlier in this article.
+
+For more information, see the following articles:
+
+* [Generic classes and methods (C# documentation)](/dotnet/csharp/fundamentals/types/generics)
+* [Generic Classes (C# Programming Guide)](/dotnet/csharp/programming-guide/generics/generic-classes)
+* [Generics in .NET (.NET documentation)](/dotnet/standard/generics/)
+
+`GenericType.cs`:
+
+```csharp
+using Microsoft.JSInterop;
+
+public class GenericType<TValue>
+{
+    public TValue? Value { get; set; }
+
+    [JSInvokable]
+    public void Update(TValue newValue)
+    {
+        Value = newValue;
+
+        Console.WriteLine($"Update: GenericType<{typeof(TValue)}>: {Value}");
+    }
+
+    [JSInvokable]
+    public async void UpdateAsync(TValue newValue)
+    {
+        await Task.Yield();
+        Value = newValue;
+
+        Console.WriteLine($"UpdateAsync: GenericType<{typeof(TValue)}>: {Value}");
+    }
+}
+```
+
+Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server), add the following `<script>` block.
+
+In the `invokeDotNetMethodsAsync` function:
+
+* The generic type class's `Update` and `UpdateAsync` methods are called with arguments representing strings and numbers.
+* Blazor WebAssembly apps support calling .NET methods synchronously with `invokeMethod`. `supportSyncInterop` receives a boolean value indicating if the JS interop is occurring in a Blazor WebAssembly app. When `supportSyncInterop` is `true`, `invokeMethod` is safely called. If the value of `supportSyncInterop` is `false`, only the asynchronous function `invokeMethodAsync` is called because the JS interop is executing in a Blazor Server app.
+* For demonstration purposes, the <xref:Microsoft.JSInterop.DotNetObjectReference> function call (`invokeMethod` or `invokeMethodAsync`), the .NET method called (`Update` or `UpdateAsync`), and the argument are written to the console. The arguments use a random number to permit matching the JS function call to the .NET method invocation (also written to the console on the .NET side). Production code usually doesn't write to the console, either on the client or the server. Production apps usually rely upon app *logging*. For more information, see <xref:blazor/fundamentals/logging> and <xref:fundamentals/logging/index>.
+
+```html
+<script>
+  const randomInt = () => Math.floor(Math.random() * 99999);
+
+  window.invokeDotNetMethodsAsync = 
+      async (supportSyncInterop, dotNetHelper1, dotNetHelper2) => {
+
+    var n = randomInt();
+    console.log(`JS: invokeMethodAsync:Update('string ${n}')`);
+    await dotNetHelper1.invokeMethodAsync('Update', `string ${n}`);
+
+    n = randomInt();
+    console.log(`JS: invokeMethodAsync:UpdateAsync('string ${n}')`);
+    await dotNetHelper1.invokeMethodAsync('UpdateAsync', `string ${n}`);
+
+    if (supportSyncInterop) {
+      n = randomInt();
+      console.log(`JS: invokeMethod:Update('string ${n}')`);
+      dotNetHelper1.invokeMethod('Update', `string ${n}`);
+    }
+
+    n = randomInt();
+    console.log(`JS: invokeMethodAsync:Update(${n})`);
+    await dotNetHelper2.invokeMethodAsync('Update', n);
+
+    n = randomInt();
+    console.log(`JS: invokeMethodAsync:UpdateAsync(${n})`);
+    await dotNetHelper2.invokeMethodAsync('UpdateAsync', n);
+
+    if (supportSyncInterop) {
+      n = randomInt();
+      console.log(`JS: invokeMethod:Update(${n})`);
+      dotNetHelper2.invokeMethod('Update', n);
+   }
+  };
+</script>
+```
+
+In the following `GenericsExample` component:
+
+* The JS function `invokeDotNetMethodsAsync` is called when the **`Invoke Interop`** button is selected.
+* A pair of <xref:Microsoft.JSInterop.DotNetObjectReference> types are created and passed to the JS function for instances of the `GenericType` as a `string` and a `double`.
+
+`Pages/GenericsExample.razor`:
+
+```razor
+@page "/generics-example"
+@using System.Runtime.InteropServices
+@inject IJSRuntime JSRuntime
+
+<p>
+    <button @onclick="InvokeInterop">Invoke Interop</button>
+</p>
+
+<ul>
+    <li>genericType1: @genericType1?.Value</li>
+    <li>genericType2: @genericType2?.Value</li>
+</ul>
+
+@code {
+    private GenericType<string> genericType1 = new() { Value = "string 0" };
+    private GenericType<double> genericType2 = new() { Value = 0 };
+
+    public async Task InvokeInterop()
+    {
+        var supportSyncInterop = 
+            RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+
+        await JSRuntime.InvokeVoidAsync(
+            "invokeDotNetMethodsAsync",
+            supportSyncInterop,
+            DotNetObjectReference.Create(genericType1),
+            DotNetObjectReference.Create(genericType2));
+    }
+}
+```
+
+The following demonstrates typical output of the preceding example when the **`Invoke Interop`** button is selected in a Blazor WebAssembly app:
+
+> JS: invokeMethodAsync:Update('string 37802')
+> .NET: Update: GenericType<System.String>: string 37802
+> JS: invokeMethodAsync:UpdateAsync('string 53051')
+> JS: invokeMethod:Update('string 26784')
+> .NET: Update: GenericType<System.String>: string 26784
+> JS: invokeMethodAsync:Update(14107)
+> .NET: Update: GenericType<System.Double>: 14107
+> JS: invokeMethodAsync:UpdateAsync(48995)
+> JS: invokeMethod:Update(12872)
+> .NET: Update: GenericType<System.Double>: 12872
+> .NET: UpdateAsync: GenericType<System.String>: string 53051
+> .NET: UpdateAsync: GenericType<System.Double>: 48995
+
+If the preceding example is implemented in a Blazor Server app, the synchronous calls with `invokeMethod` are avoided. The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) in Blazor Server scenarios.
+
+Typical output of a Blazor Server app:
+
+> JS: invokeMethodAsync:Update('string 34809')
+> .NET: Update: GenericType<System.String>: string 34809
+> JS: invokeMethodAsync:UpdateAsync('string 93059')
+> JS: invokeMethodAsync:Update(41997)
+> .NET: Update: GenericType<System.Double>: 41997
+> JS: invokeMethodAsync:UpdateAsync(24652)
+> .NET: UpdateAsync: GenericType<System.String>: string 93059
+> .NET: UpdateAsync: GenericType<System.Double>: 24652
+
+The preceding output examples demonstrate that asynchronous methods execute and complete in an *arbitrary order* depending on several factors, including thread scheduling and the speed of method execution. It usually isn't possible to predict the order of completion for asynchronous method calls.
+
+## Class instance examples
 
 The following `sayHello1` JS function:
 
@@ -580,7 +750,8 @@ In the following example:
 }
 ```
 
-Calling open generic methods isn't supported with static .NET methods but is supported with [instance methods](#invoke-an-instance-net-method), which are described later in this article.
+> [!NOTE]
+> Calling open generic methods isn't supported with static .NET methods but is supported with [instance methods](#invoke-an-instance-net-method), which are described later in this article.
 
 In the following `CallDotNetExample1` component, the `ReturnArrayAsync` C# method returns an `int` array. The [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) is applied to the method, which makes the method invokable by JS.
 
@@ -645,7 +816,13 @@ To invoke an instance .NET method from JavaScript (JS):
 * Invoke a .NET instance method from JS using `invokeMethod` or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
-### Component instance examples
+The following sections of this article demonstrate various approaches for invoking an instance .NET method:
+
+* [Component instance examples](#component-instance-examples)
+* [Class instance examples](#class-instance-examples)
+* [Component instance .NET method helper class](#component-instance-net-method-helper-class)
+
+## Component instance examples
 
 The following `sayHello1` JS function receives a <xref:Microsoft.JSInterop.DotNetObjectReference> and calls `invokeMethodAsync` to call the `GetHelloMethod` .NET method of a component.
 
@@ -691,7 +868,7 @@ To pass arguments to an instance method:
 
    [!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Pages/call-dotnet-from-js/CallDotNetExample3.razor?highlight=31,35)]
 
-### Class instance examples
+## Class instance examples
 
 The following `sayHello1` JS function:
 
@@ -895,7 +1072,8 @@ In the following example:
 }
 ```
 
-Calling open generic methods isn't supported with static .NET methods but is supported with [instance methods](#invoke-an-instance-net-method), which are described later in this article.
+> [!NOTE]
+> Calling open generic methods isn't supported with static .NET methods but is supported with [instance methods](#invoke-an-instance-net-method), which are described later in this article.
 
 In the following `CallDotNetExample1` component, the `ReturnArrayAsync` C# method returns an `int` array. The [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) is applied to the method, which makes the method invokable by JS.
 
@@ -960,7 +1138,13 @@ To invoke an instance .NET method from JavaScript (JS):
 * Invoke a .NET instance method from JS using `invokeMethod` or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
-### Component instance examples
+The following sections of this article demonstrate various approaches for invoking an instance .NET method:
+
+* [Component instance examples](#component-instance-examples)
+* [Class instance examples](#class-instance-examples)
+* [Component instance .NET method helper class](#component-instance-net-method-helper-class)
+
+## Component instance examples
 
 The following `sayHello1` JS function receives a <xref:Microsoft.JSInterop.DotNetObjectReference> and calls `invokeMethodAsync` to call the `GetHelloMethod` .NET method of a component.
 
@@ -1006,7 +1190,7 @@ To pass arguments to an instance method:
 
    [!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Pages/call-dotnet-from-js/CallDotNetExample3.razor?highlight=31,35)]
 
-### Class instance examples
+## Class instance examples
 
 The following `sayHello1` JS function:
 


### PR DESCRIPTION
Fixes #25450
Addresses #24615

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?view=aspnetcore-3.1&branch=pr-en-us-25465#call-net-generic-class-methods)

We don't currently carry coverage on this. This is a subject on the UE tracking issue that I've been hoping to reach for over a year now ... *and here it is!* 🎉👏 ... hopefully, it isn't another **_Rex Stinker_**&trade; 💩👃😆. 

The framework's `BasicTestApp` bits were used as a basis for this and can be found at ...

* [`InteropComponent.razor`](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor)
* [`jsinteroptests.js`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsinteroptests.js)
* [`GenericType<TValue>`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/InteropTest/JavaScriptInterop.cs#L507)

The `BasicTestApp` approach seems overly engineered for a basic explanation and example. I think what's on the PR is a bit more *bare bones* for a good demo and explanation.

## Notes

* I'd like to retain the `double` vs. `string` because it illustrates that the `GenericType` really is **_generically typed_**. I know ... *duh, of course* 🙄 on this point ... still tho ... I think that it's a nicer demo with a pair of types over only using one `DotNetObjectReference` and set of .NET calls.
* I'd like to retain the logging on both sides of the calls (JS and .NET) because it isn't clear from the final values of `GenericType<TValue>.Value` in the component what's happening behind the scenes. I don't want separate examples (even in the same component) for each .NET call or call set (sync vs. async). Digesting this all from a single interop action means that we'll need to log on both sides.
* I'd like to retain the random numbers so that the reader can identify which call from the JS side matches a .NET method execution.
* WRT attaching to `window` and with a `<script>` for the JS side is fine. We adopted (thus far, anyway) the lowest common denominator for setting up most of our JS interop examples. Other, better approaches (colocation and modules) are described in the "Location of JS" parts of these articles. In the future, we might switch everything over to use *fancier, modern approaches* ... possibly more use of JS classes, too. For now tho, this should be fine.
* I'm refactoring the heading levels a bit. We need to try and stick to H2s as much as we can because H2s are what show up in the topic's ToC in the sidebar, which helps with finding content.
* Note that I'm not getting into "open" vs. "closed" generics all that much **_by-design_**. The critical aspect on this subject is that **_open generics don't work with static .NET method calls_** (AFAIK, this has been here a long time ... years! ... it may have changed). I don't necessarily want to go beyond that remark on open vs. closed. I'm not sure that it's all that helpful to get that deep in the weeds when open generics should ✨ **_Just Work!_**&trade; ✨ as expected with instance calls. On the PR, I go with a closed generic type class with a non-generic method (i.e., the methods don't specify a type in the method signature, which seems to be the difference between a generic and non-generic method if I'm reading the C# guide/.NET docs correctly). This is the first time I've ever tried to describe these aspects, so I won't be surprised to see some corrections on review.

### ❓ *Questions* ❓

1. I did all of my testing with WASM. It looks like what I've done (and the changes I made for the output to cover Blazor Server at the end of the new section) are all good for Blazor Server apps. **_Can you confirm that without my having to explicitly test for Blazor Server?_** 👂 I'm 🏃 on a lot of things, so it saves time ... and thus 💰 ... not to test further.
1. On the PR, the new section on generics is only in the 6.0 guidance. Once we get this coverage right on review, I think it should all work as far back as 3.1. **_Can you confirm that without me testing?_** 👂 If it all looks good for all supported releases, I'll duplicate the new section on generics for the 5.0 and 3.1 versions of the coverage here after we get past review. Otherwise, this is fine if we only want to add this section for 6.0 or later (that's the way the PR is structured right now).
1. WRT sync/async order of execution, I placed the following remark at the very end of the new section ...

    > The preceding output examples demonstrate that asynchronous methods execute and complete in an *arbitrary order* depending on several factors, including thread scheduling and the speed of method execution. It usually isn't possible to predict the order of completion for asynchronous method calls.

   That probably needs some work 🙈. **_What should that say?_** 👂 I think you can see where I'm going with it. I'd like to reader to understand something about the ordering in the console output. AFAIK, we should say that the async calls execute in an *arbitrary* fashion depending on several factors ... order can't be predicted in most cases. Currently, the text says "usually isn't possible" (to predict), but I think we might go with "*impossible*" (to predict) there. Anyway ... if you give me a full paragraph, I'll replace that dribble that I wrote with it.

# 🇺🇦 