### PR TITLE
v6 udpate: Test gRPC services with gRPCurl: doc and samples

### DIFF
--- a/aspnetcore/grpc/test-tools.md
+++ b/aspnetcore/grpc/test-tools.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: Learn how to test services with gRPC tools. gRPCurl a command-line tool for interacting with gRPC services. gRPCui is an interactive web UI.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: jamesnk
-ms.date: 03/30/2022
+ms.date: 03/31/2022
 no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: grpc/test-tools
 ---
@@ -39,11 +39,11 @@ It's easier to use gRPC reflection. gRPC reflection adds a new gRPC service to t
 gRPC ASP.NET Core has built-in support for gRPC reflection with the [`Grpc.AspNetCore.Server.Reflection`](https://www.nuget.org/packages/Grpc.AspNetCore.Server.Reflection) package. To configure reflection in an app:
 
 * Add a `Grpc.AspNetCore.Server.Reflection` package reference.
-* Register reflection in `Startup.cs`:
+* Register reflection in `Program.cs`:
   * `AddGrpcReflection` to register services that enable reflection.
   * `MapGrpcReflectionService` to add a reflection service endpoint.
 
-[!code-csharp[](~/grpc/test-tools/Startup.cs?name=snippet_1&highlight=4,15-18)]
+[!code-csharp[](~/grpc/test-tools/samples/6.x/Program.cs?name=snippet_1&highlight=2,10-13)]
 
 When gRPC reflection is set up:
 
@@ -123,7 +123,7 @@ In the preceding example:
 * Calls the `SayHello` method on the `greeter.Greeter` service.
 * Prints the response message as JSON.
 
-The preceding example uses `\` to escape the `"` character. Escaping `"` is required in a PowerShell console but must not be used in some consoles. For example, the previous command for a MacOS console:
+The preceding example uses `\` to escape the `"` character. Escaping `"` is required in a PowerShell console but must not be used in some consoles. For example, the previous command for a macOS console:
 
 ```console
 $ grpcurl -d '{ "name": "World" }' localhost:5001 greet.Greeter/SayHello
@@ -134,7 +134,7 @@ $ grpcurl -d '{ "name": "World" }' localhost:5001 greet.Greeter/SayHello
 
 ## gRPCui
 
-gRPCui is an interactive web UI for gRPC. It builds on top of gRPCurl and offers a GUI for discovering and testing gRPC services, similar to HTTP tools such as Postman or Swagger UI.
+gRPCui is an interactive web UI for gRPC. gRPCui builds on top of gRPCurl. gRPCui offers a GUI for discovering and testing gRPC services, similar to HTTP tools such as Postman or Swagger UI.
 
 For information about downloading and installing `grpcui`, see the [gRPCui GitHub homepage](https://github.com/fullstorydev/grpcui#installation).
 
@@ -193,7 +193,7 @@ gRPC ASP.NET Core has built-in support for gRPC reflection with the [`Grpc.AspNe
   * `AddGrpcReflection` to register services that enable reflection.
   * `MapGrpcReflectionService` to add a reflection service endpoint.
 
-[!code-csharp[](~/grpc/test-tools/Startup.cs?name=snippet_1&highlight=4,15-18)]
+[!code-csharp[](~/grpc/test-tools/samples/5.x/Startup.cs?name=snippet_1&highlight=4,15-18)]
 
 When gRPC reflection is set up:
 
@@ -273,7 +273,7 @@ In the preceding example:
 * Calls the `SayHello` method on the `greeter.Greeter` service.
 * Prints the response message as JSON.
 
-The preceding example uses `\` to escape the `"` character. Escaping `"` is required in a PowerShell console but must not be used in some consoles. For example, the previous command for a MacOS console:
+The preceding example uses `\` to escape the `"` character. Escaping `"` is required in a PowerShell console but must not be used in some consoles. For example, the previous command for a macOS console:
 
 ```console
 $ grpcurl -d '{ "name": "World" }' localhost:5001 greet.Greeter/SayHello
@@ -284,7 +284,7 @@ $ grpcurl -d '{ "name": "World" }' localhost:5001 greet.Greeter/SayHello
 
 ## gRPCui
 
-gRPCui is an interactive web UI for gRPC. It builds on top of gRPCurl and offers a GUI for discovering and testing gRPC services, similar to HTTP tools such as Postman or Swagger UI.
+gRPCui is an interactive web UI for gRPC. gRPCui builds on top of gRPCurl. gRPCui offers a GUI for discovering and testing gRPC services, similar to HTTP tools such as Postman or Swagger UI.
 
 For information about downloading and installing `grpcui`, see the [gRPCui GitHub homepage](https://github.com/fullstorydev/grpcui#installation).
 

--- a/aspnetcore/grpc/test-tools.md
+++ b/aspnetcore/grpc/test-tools.md
@@ -106,8 +106,6 @@ message HelloRequest {
 }
 ```
 
-In the preceding example, Specify `<port>` as the localhost port number of the gRPC server. The port number is randomly assigned when the project is created and set in `Properties/launchSettings.json`.
-
 ### Call gRPC services
 
 Call a gRPC service by specifying a service and method name along with a JSON argument that represents the request message. The JSON is converted into Protobuf and sent to the service.
@@ -134,8 +132,6 @@ $ grpcurl -d '{ "name": "World" }' localhost:<port> greet.Greeter/SayHello
   "message": "Hello World"
 }
 ```
-
-In the preceding example, specify `<port>` as the localhost port number of the gRPC server. The port number is randomly assigned when the project is created and set in `Properties/launchSettings.json`
 
 ## gRPCui
 

--- a/aspnetcore/grpc/test-tools.md
+++ b/aspnetcore/grpc/test-tools.md
@@ -74,10 +74,10 @@ $ grpcurl -help
 
 ### Discover services
 
-Use the `describe` verb to view the services defined by the server:
+Use the `describe` verb to view the services defined by the server. Specify `<port>` as the localhost port number of the gRPC server. The port number is randomly assigned when the project is created and set in `Properties/launchSettings.json`:
 
 ```console
-$ grpcurl localhost:5001 describe
+$ grpcurl localhost:<port> describe
 greet.Greeter is a service:
 service Greeter {
   rpc SayHello ( .greet.HelloRequest ) returns ( .greet.HelloReply );
@@ -91,7 +91,7 @@ service ServerReflection {
 
 The preceding example:
 
-* Runs the `describe` verb on server `localhost:5001`.
+* Runs the `describe` verb on server `localhost:<port>`. Where `<port>` is randomly assigned when the gRPC server project is created and set in `Properties/launchSettings.json`
 * Prints services and methods returned by gRPC reflection.
   * `Greeter` is a service implemented by the app.
   * `ServerReflection` is the service added by the `Grpc.AspNetCore.Server.Reflection` package.
@@ -99,19 +99,21 @@ The preceding example:
 Combine `describe` with a service, method, or message name to view its detail:
 
 ```powershell
-$ grpcurl localhost:5001 describe greet.HelloRequest
+$ grpcurl localhost:<port> describe greet.HelloRequest
 greet.HelloRequest is a message:
 message HelloRequest {
   string name = 1;
 }
 ```
 
+In the preceding example, Specify `<port>` as the localhost port number of the gRPC server. The port number is randomly assigned when the project is created and set in `Properties/launchSettings.json`.
+
 ### Call gRPC services
 
 Call a gRPC service by specifying a service and method name along with a JSON argument that represents the request message. The JSON is converted into Protobuf and sent to the service.
 
 ```console
-$ grpcurl -d '{ \"name\": \"World\" }' localhost:5001 greet.Greeter/SayHello
+$ grpcurl -d '{ \"name\": \"World\" }' localhost:<port> greet.Greeter/SayHello
 {
   "message": "Hello World"
 }
@@ -122,15 +124,18 @@ In the preceding example:
 * The `-d` argument specifies a request message with JSON. This argument must come before the server address and method name.
 * Calls the `SayHello` method on the `greeter.Greeter` service.
 * Prints the response message as JSON.
+* Where `<port>` is randomly assigned when the gRPC server project is created and set in `Properties/launchSettings.json`
 
 The preceding example uses `\` to escape the `"` character. Escaping `"` is required in a PowerShell console but must not be used in some consoles. For example, the previous command for a macOS console:
 
 ```console
-$ grpcurl -d '{ "name": "World" }' localhost:5001 greet.Greeter/SayHello
+$ grpcurl -d '{ "name": "World" }' localhost:<port> greet.Greeter/SayHello
 {
   "message": "Hello World"
 }
 ```
+
+In the preceding example, specify `<port>` as the localhost port number of the gRPC server. The port number is randomly assigned when the project is created and set in `Properties/launchSettings.json`
 
 ## gRPCui
 
@@ -143,9 +148,11 @@ For information about downloading and installing `grpcui`, see the [gRPCui GitHu
 Run `grpcui` with the server address to interact with as an argument:
 
 ```powershell
-$ grpcui localhost:5001
+$ grpcui localhost:<port>
 gRPC Web UI available at http://127.0.0.1:55038/
 ```
+
+In the preceding example, specify `<port>` as the localhost port number of the gRPC server. The port number is randomly assigned when the project is created and set in `Properties/launchSettings.json`
 
 The tool launches a browser window with the interactive web UI. gRPC services are automatically discovered using gRPC reflection.
 

--- a/aspnetcore/grpc/test-tools/samples/5.x/Startup.cs
+++ b/aspnetcore/grpc/test-tools/samples/5.x/Startup.cs
@@ -1,0 +1,22 @@
+#region snippet_1
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddGrpc();
+    services.AddGrpcReflection();
+}
+
+public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+{
+    app.UseRouting();
+    
+    app.UseEndpoints(endpoints =>
+    {
+        endpoints.MapGrpcService<GreeterService>();
+
+        if (env.IsDevelopment())
+        {
+            endpoints.MapGrpcReflectionService();
+        }
+    });
+}
+#endregion

--- a/aspnetcore/grpc/test-tools/samples/6.x/GrpcGreeter.csproj
+++ b/aspnetcore/grpc/test-tools/samples/6.x/GrpcGreeter.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.44.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server.Reflection" Version="2.44.0" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/grpc/test-tools/samples/6.x/Program.cs
+++ b/aspnetcore/grpc/test-tools/samples/6.x/Program.cs
@@ -1,0 +1,23 @@
+using GrpcGreeter.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Additional configuration is required to successfully run gRPC on macOS.
+// For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
+#region snippet_1
+builder.Services.AddGrpc();
+builder.Services.AddGrpcReflection();
+
+var app = builder.Build();
+
+app.MapGrpcService<GreeterService>();
+
+IWebHostEnvironment env = app.Environment;
+
+if (env.IsDevelopment())
+{
+    app.MapGrpcReflectionService();
+}
+#endregion
+
+app.Run();

--- a/aspnetcore/grpc/test-tools/samples/6.x/Protos/greet.proto
+++ b/aspnetcore/grpc/test-tools/samples/6.x/Protos/greet.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "GrpcGreeter";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings.
+message HelloReply {
+  string message = 1;
+}

--- a/aspnetcore/grpc/test-tools/samples/6.x/Services/GreeterService.cs
+++ b/aspnetcore/grpc/test-tools/samples/6.x/Services/GreeterService.cs
@@ -1,0 +1,22 @@
+using Grpc.Core;
+using GrpcGreeter;
+
+namespace GrpcGreeter.Services
+{
+    public class GreeterService : Greeter.GreeterBase
+    {
+        private readonly ILogger<GreeterService> _logger;
+        public GreeterService(ILogger<GreeterService> logger)
+        {
+            _logger = logger;
+        }
+
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply
+            {
+                Message = "Hello " + request.Name
+            });
+        }
+    }
+}

--- a/aspnetcore/grpc/test-tools/samples/6.x/appsettings.Development.json
+++ b/aspnetcore/grpc/test-tools/samples/6.x/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/grpc/test-tools/samples/6.x/appsettings.json
+++ b/aspnetcore/grpc/test-tools/samples/6.x/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/grpc/test-tools?view=aspnetcore-6.0&branch=pr-en-us-25480)

Fixes #25072 

Doc updated to .NET 6 
New app sample added for .NET 6 / VS 2022 + Latest packages