### PR TITLE
.NET 6 in-proc-hosting /2

### DIFF
--- a/aspnetcore/host-and-deploy/iis/in-process-hosting.md
+++ b/aspnetcore/host-and-deploy/iis/in-process-hosting.md
@@ -54,12 +54,8 @@ Apps published as a single file executable can't be loaded by the in-process hos
 
 To configure IIS options, include a service configuration for <xref:Microsoft.AspNetCore.Builder.IISServerOptions> in <xref:Microsoft.AspNetCore.Hosting.IStartup.ConfigureServices%2A>. The following example disables AutomaticAuthentication:
 
-```csharp
-services.Configure<IISServerOptions>(options => 
-{
-    options.AutomaticAuthentication = false;
-});
-```
+~/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs
+[!code-csharp[](~/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs?highlight=2,10)]
 
 | Option | Default | Setting |
 | ------ | :-----: | ------- |

--- a/aspnetcore/host-and-deploy/iis/in-process-hosting.md
+++ b/aspnetcore/host-and-deploy/iis/in-process-hosting.md
@@ -52,10 +52,9 @@ Apps published as a single file executable can't be loaded by the in-process hos
 
 ## Application configuration
 
-To configure IIS options, include a service configuration for <xref:Microsoft.AspNetCore.Builder.IISServerOptions> in <xref:Microsoft.AspNetCore.Hosting.IStartup.ConfigureServices%2A>. The following example disables AutomaticAuthentication:
+To configure IIS options, include a service configuration for <xref:Microsoft.AspNetCore.Builder.IISServerOptions> in <xref:Microsoft.AspNetCore.Hosting.IStartup.ConfigureServices%2A>. The following example disables `AutomaticAuthentication`:
 
-~/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs
-[!code-csharp[](~/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs?highlight=2,10)]
+[!code-csharp[](~/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs?highlight=17-20)]
 
 | Option | Default | Setting |
 | ------ | :-----: | ------- |
@@ -84,18 +83,7 @@ The following characteristics apply when hosting in-process:
 
 * When hosting in-process, <xref:Microsoft.AspNetCore.Authentication.AuthenticationService.AuthenticateAsync%2A> isn't called internally to initialize a user. Therefore, an <xref:Microsoft.AspNetCore.Authentication.IClaimsTransformation> implementation used to transform claims after every authentication isn't activated by default. When transforming claims with an <xref:Microsoft.AspNetCore.Authentication.IClaimsTransformation> implementation, call <xref:Microsoft.Extensions.DependencyInjection.AuthenticationServiceCollectionExtensions.AddAuthentication%2A> to add authentication services:
 
-  ```csharp
-  public void ConfigureServices(IServiceCollection services)
-  {
-      services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
-      services.AddAuthentication(IISServerDefaults.AuthenticationScheme);
-  }
-
-  public void Configure(IApplicationBuilder app)
-  {
-      app.UseAuthentication();
-  }
-  ```
+[!code-csharp[](~/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs?highlight=22-23)]
   
 * [Web Package (single-file) deployments](/aspnet/web-forms/overview/deployment/web-deployment-in-the-enterprise/deploying-web-packages) aren't supported.
 

--- a/aspnetcore/host-and-deploy/iis/in-process-hosting.md
+++ b/aspnetcore/host-and-deploy/iis/in-process-hosting.md
@@ -52,7 +52,7 @@ Apps published as a single file executable can't be loaded by the in-process hos
 
 ## Application configuration
 
-To configure IIS options, include a service configuration for <xref:Microsoft.AspNetCore.Builder.IISServerOptions> in <xref:Microsoft.AspNetCore.Hosting.IStartup.ConfigureServices%2A>. The following example disables `AutomaticAuthentication`:
+To configure IIS options, include a service configuration for <xref:Microsoft.AspNetCore.Builder.IISServerOptions> in `Program.cs`. The following example disables <xref:Microsoft.AspNetCore.Builder.IISServerOptions.AutomaticAuthentication%2A>:
 
 [!code-csharp[](~/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs?highlight=17-20)]
 

--- a/aspnetcore/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs
+++ b/aspnetcore/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Server.IIS;
+using Microsoft.EntityFrameworkCore;
+using RPauth.Data;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlServer(connectionString));
+builder.Services.AddDatabaseDeveloperPageExceptionFilter();
+
+builder.Services.AddDefaultIdentity<IdentityUser>(options => options.SignIn.RequireConfirmedAccount = true)
+    .AddEntityFrameworkStores<ApplicationDbContext>();
+
+builder.Services.Configure<IISServerOptions>(options =>
+{
+    options.AutomaticAuthentication = false;
+});
+
+builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
+builder.Services.AddAuthentication(IISServerDefaults.AuthenticationScheme);
+
+builder.Services.AddRazorPages();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseMigrationsEndPoint();
+}
+else
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();

--- a/aspnetcore/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs
+++ b/aspnetcore/host-and-deploy/iis/in-process-hosting/6.0samples/Program.cs
@@ -19,7 +19,7 @@ builder.Services.Configure<IISServerOptions>(options =>
     options.AutomaticAuthentication = false;
 });
 
-builder.Services.AddTransient<IClaimsTransformation, ClaimsTransformer>();
+builder.Services.AddTransient<IClaimsTransformation, MyClaimsTransformation>();
 builder.Services.AddAuthentication(IISServerDefaults.AuthenticationScheme);
 
 builder.Services.AddRazorPages();


### PR DESCRIPTION
Fixes #25325
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/in-process-hosting?view=aspnetcore-6.0&branch=pr-en-us-25489) and [bottom of page here](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/in-process-hosting?view=aspnetcore-6.0&branch=pr-en-us-25489#differences-between-in-process-and-out-of-process-hosting)

Replaced `ClaimsTransformer` with [`MyClaimsTransformation `](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/claims?view=aspnetcore-6.0#extend-or-add-custom-claims-using-iclaimstransformation) because there is a .NET 1.1 class called [ `ClaimsTransformer` ](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.claimstransformer?view=aspnetcore-1.1) and I don't think that's the intention. Folks can easily find  [`MyClaimsTransformation `](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/claims?view=aspnetcore-6.0#extend-or-add-custom-claims-using-iclaimstransformation) 

Please review the two snippets I updated. Let me know if we need PU review.