### PR TITLE
Remove closing comment marker

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -168,7 +168,7 @@ Launching the app without debugging by selecting Ctrl+F5 allows you to:
 
 For Visual Studio for Mac, see the .NET 5 version of this tutorial.
 
-<!-->
+<!--
 * Select **Run** > **Start Without Debugging** to launch the app.
 
   Visual Studio for Mac:


### PR DESCRIPTION
Comment was closed prematurely for VS.Mac tabbed content.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->