### PR TITLE
confusing overriding of variables

### DIFF
--- a/aspnetcore/security/cors/6.0sample/Cors/WebAPI/Program.cs
+++ b/aspnetcore/security/cors/6.0sample/Cors/WebAPI/Program.cs
@@ -9,9 +9,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
-                      builder =>
+                      b =>
                       {
-                          builder.WithOrigins("http://example.com",
+                          b.WithOrigins("http://example.com",
                                               "http://www.contoso.com");
                       });
 });

--- a/aspnetcore/security/cors/6.0sample/Cors/WebAPI/Program.cs
+++ b/aspnetcore/security/cors/6.0sample/Cors/WebAPI/Program.cs
@@ -9,9 +9,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
-                      b =>
+                      policy  =>
                       {
-                          b.WithOrigins("http://example.com",
+                          policy.WithOrigins("http://example.com",
                                               "http://www.contoso.com");
                       });
 });


### PR DESCRIPTION
I see this a lot and I always think it's a bad practice. Not sure "b" is the right choice,but "builder" is definitely one of the few wrong choices.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->