### PR TITLE
Replace "builder" with "policy" for CORS snippets

### DIFF
--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how CORS as a standard for allowing or rejecting cross-origin requests in an ASP.NET Core app.
 ms.author: riande
 ms.custom: mvc
-ms.date: 9/11/2021
+ms.date: 04/06/2022
 no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: security/cors
 ---
@@ -69,8 +69,8 @@ CORS Middleware handles cross-origin requests. The following code applies a CORS
 The preceding code:
 
 * Sets the policy name to `_myAllowSpecificOrigins`. The policy name is arbitrary.
-* Calls the <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors*> extension method and specifies the  `_myAllowSpecificOrigins` CORS policy. `UseCors` adds the CORS middleware. The call to `UseCors` must be placed after `UseRouting`, but before `UseAuthorization`. For more information, see [Middleware order](xref:fundamentals/middleware/index#middleware-order).
-* Calls <xref:Microsoft.Extensions.DependencyInjection.CorsServiceCollectionExtensions.AddCors*> with a [lambda expression](/dotnet/csharp/programming-guide/statements-expressions-operators/lambda-expressions). The lambda takes a <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder> object. [Configuration options](#cors-policy-options), such as `WithOrigins`, are described later in this article.
+* Calls the <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A> extension method and specifies the  `_myAllowSpecificOrigins` CORS policy. `UseCors` adds the CORS middleware. The call to `UseCors` must be placed after `UseRouting`, but before `UseAuthorization`. For more information, see [Middleware order](xref:fundamentals/middleware/index#middleware-order).
+* Calls <xref:Microsoft.Extensions.DependencyInjection.CorsServiceCollectionExtensions.AddCors%2A> with a [lambda expression](/dotnet/csharp/programming-guide/statements-expressions-operators/lambda-expressions). The lambda takes a <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder> object. [Configuration options](#cors-policy-options), such as `WithOrigins`, are described later in this article.
 * Enables the `_myAllowSpecificOrigins` CORS policy for all controller endpoints. See [endpoint routing](#ecors6) to apply a CORS policy to specific endpoints.
 * When using [Response Caching Middleware](xref:performance/caching/middleware), call <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A> before <xref:Microsoft.AspNetCore.Builder.ResponseCachingExtensions.UseResponseCaching%2A>.
 
@@ -78,7 +78,7 @@ With endpoint routing, the CORS middleware **must** be configured to execute bet
 
 See [Test CORS](#testc6) for instructions on testing code similar to the preceding code.
 
-The <xref:Microsoft.Extensions.DependencyInjection.MvcCorsMvcCoreBuilderExtensions.AddCors*> method call adds CORS services to the app's service container:
+The <xref:Microsoft.Extensions.DependencyInjection.MvcCorsMvcCoreBuilderExtensions.AddCors%2A> method call adds CORS services to the app's service container:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet&highlight=5-13)]
 
@@ -112,7 +112,7 @@ The preceding code applies the default CORS policy to all controller endpoints.
 
 Enabling CORS on a per-endpoint basis using `RequireCors` ***does not support [automatic preflight requests](#apf).*** For more information, see [this GitHub issue](https://github.com/dotnet/aspnetcore/issues/20709) and [Test CORS with endpoint routing and [HttpOptions]](#tcer).
 
-With endpoint routing, CORS can be enabled on a per-endpoint basis using the <xref:Microsoft.AspNetCore.Builder.CorsEndpointConventionBuilderExtensions.RequireCors*> set of extension methods:
+With endpoint routing, CORS can be enabled on a per-endpoint basis using the <xref:Microsoft.AspNetCore.Builder.CorsEndpointConventionBuilderExtensions.RequireCors%2A> set of extension methods:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_endp&highlight=1,5-13,24,32,35,38)]
 
@@ -199,35 +199,35 @@ This section describes the various options that can be set in a CORS policy:
 * [Credentials in cross-origin requests](#credentials-in-cross-origin-requests)
 * [Set the preflight expiration time](#set-the-preflight-expiration-time)
 
-<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsOptions.AddPolicy*> is called in `Program.cs`. For some options, it may be helpful to read the [How CORS works](#how-cors) section first.
+<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsOptions.AddPolicy%2A> is called in `Program.cs`. For some options, it may be helpful to read the [How CORS works](#how-cors) section first.
 
 ## Set the allowed origins
 
-<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyOrigin*>: Allows CORS requests from all origins with any scheme (`http` or `https`). `AllowAnyOrigin` is insecure because *any website* can make cross-origin requests to the app.
+<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyOrigin%2A>: Allows CORS requests from all origins with any scheme (`http` or `https`). `AllowAnyOrigin` is insecure because *any website* can make cross-origin requests to the app.
 
 > [!NOTE]
 > Specifying `AllowAnyOrigin` and `AllowCredentials` is an insecure configuration and can result in cross-site request forgery. The CORS service returns an invalid CORS response when an app is configured with both methods.
 
 `AllowAnyOrigin` affects preflight requests and the `Access-Control-Allow-Origin` header. For more information, see the [Preflight requests](#preflight-requests) section.
 
-<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.SetIsOriginAllowedToAllowWildcardSubdomains*>: Sets the <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy.IsOriginAllowed*> property of the policy to be a function that allows origins to match a configured wildcard domain when evaluating if the origin is allowed.
+<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.SetIsOriginAllowedToAllowWildcardSubdomains%2A>: Sets the <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy.IsOriginAllowed%2A> property of the policy to be a function that allows origins to match a configured wildcard domain when evaluating if the origin is allowed.
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_aa)]
 
 ### Set the allowed HTTP methods
 
-<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyMethod*>:
+<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyMethod%2A>:
 
 * Allows any HTTP method:
 * Affects preflight requests and the `Access-Control-Allow-Methods` header. For more information, see the [Preflight requests](#preflight-requests) section.
 
 ### Set the allowed request headers
 
-To allow specific headers to be sent in a CORS request, called [author request headers](https://xhr.spec.whatwg.org/#request), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders*> and specify the allowed headers:
+To allow specific headers to be sent in a CORS request, called [author request headers](https://xhr.spec.whatwg.org/#request), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders%2A> and specify the allowed headers:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_sa)]
 
-To allow all [author request headers](https://www.w3.org/TR/cors/#author-request-headers), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyHeader*>:
+To allow all [author request headers](https://www.w3.org/TR/cors/#author-request-headers), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyHeader%2A>:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_aah)]
 
@@ -262,7 +262,7 @@ The response headers that are available by default are:
 * `Last-Modified`
 * `Pragma`
 
-The CORS specification calls these headers *simple response headers*. To make other headers available to the app, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithExposedHeaders*>:
+The CORS specification calls these headers *simple response headers*. To make other headers available to the app, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithExposedHeaders%2A>:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_erh)]
 
@@ -298,7 +298,7 @@ fetch('https://www.example.com/api/test', {
 });
 ```
 
-The server must allow the credentials. To allow cross-origin credentials, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowCredentials*>:
+The server must allow the credentials. To allow cross-origin credentials, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowCredentials%2A>:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_cco)]
 
@@ -369,18 +369,18 @@ Using the F12 tools, the console app shows an error similar to one of the follow
 * Firefox: Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at `https://cors1.azurewebsites.net/api/TodoItems1/MyDelete2/5`. (Reason: CORS request did not succeed). [Learn More](https://developer.mozilla.org/docs/Web/HTTP/CORS/Errors/CORSDidNotSucceed)
 * Chromium based: Access to fetch at 'https://cors1.azurewebsites.net/api/TodoItems1/MyDelete2/5' from origin 'https://cors3.azurewebsites.net' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
 
-To allow specific headers, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders*>:
+To allow specific headers, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders%2A>:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_whx)]
 
-To allow all [author request headers](https://www.w3.org/TR/cors/#author-request-headers), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyHeader*>:
+To allow all [author request headers](https://www.w3.org/TR/cors/#author-request-headers), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyHeader%2A>:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_aah2)]
 
 Browsers aren't consistent in how they set `Access-Control-Request-Headers`. If either:
 
 * Headers are set to anything other than `"*"`
-* <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy.AllowAnyHeader*> is called:
+* <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy.AllowAnyHeader%2A> is called:
   Include at least `Accept`, `Content-Type`, and `Origin`, plus any custom headers that you want to support.
 
 <a name="apf"></a>
@@ -412,7 +412,7 @@ See [Test CORS with endpoint routing and [HttpOptions]](#tcer) for instructions 
 
 ### Set the preflight expiration time
 
-The `Access-Control-Max-Age` header specifies how long the response to the preflight request can be cached. To set this header, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.SetPreflightMaxAge*>:
+The `Access-Control-Max-Age` header specifies how long the response to the preflight request can be cached. To set this header, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.SetPreflightMaxAge%2A>:
 
 [!code-csharp[](cors/6.0sample/Cors/WebAPI/Program.cs?name=snippet_pfx)]
 
@@ -520,7 +520,7 @@ User-Agent: Mozilla/5.0
 
 In the preceding **Response headers**, the server sets the [Access-Control-Allow-Origin](https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) header in the response. The `https://cors1.azurewebsites.net` value of this header matches the `Origin` header from the request.
 
-If <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyOrigin*> is called, the `Access-Control-Allow-Origin: *`, the wildcard value, is returned. `AllowAnyOrigin` allows any origin.
+If <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyOrigin%2A> is called, the `Access-Control-Allow-Origin: *`, the wildcard value, is returned. `AllowAnyOrigin` allows any origin.
 
 If the response doesn't include the `Access-Control-Allow-Origin` header, the cross-origin request fails. Specifically, the browser disallows the request. Even if the server returns a successful response, the browser doesn't make the response available to the client app.
 
@@ -691,8 +691,8 @@ CORS Middleware handles cross-origin requests. The following code applies a CORS
 The preceding code:
 
 * Sets the policy name to `_myAllowSpecificOrigins`. The policy name is arbitrary.
-* Calls the <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors*> extension method and specifies the  `_myAllowSpecificOrigins` CORS policy. `UseCors` adds the CORS middleware. The call to `UseCors` must be placed after `UseRouting`, but before `UseAuthorization`. For more information, see [Middleware order](xref:fundamentals/middleware/index#middleware-order).
-* Calls <xref:Microsoft.Extensions.DependencyInjection.CorsServiceCollectionExtensions.AddCors*> with a [lambda expression](/dotnet/csharp/programming-guide/statements-expressions-operators/lambda-expressions). The lambda takes a <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder> object. [Configuration options](#cors-policy-options), such as `WithOrigins`, are described later in this article.
+* Calls the <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A> extension method and specifies the  `_myAllowSpecificOrigins` CORS policy. `UseCors` adds the CORS middleware. The call to `UseCors` must be placed after `UseRouting`, but before `UseAuthorization`. For more information, see [Middleware order](xref:fundamentals/middleware/index#middleware-order).
+* Calls <xref:Microsoft.Extensions.DependencyInjection.CorsServiceCollectionExtensions.AddCors%2A> with a [lambda expression](/dotnet/csharp/programming-guide/statements-expressions-operators/lambda-expressions). The lambda takes a <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder> object. [Configuration options](#cors-policy-options), such as `WithOrigins`, are described later in this article.
 * Enables the `_myAllowSpecificOrigins` CORS policy for all controller endpoints. See [endpoint routing](#ecors) to apply a CORS policy to specific endpoints.
 * When using [Response Caching Middleware](xref:performance/caching/middleware), call <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A> before <xref:Microsoft.AspNetCore.Builder.ResponseCachingExtensions.UseResponseCaching%2A>.
 
@@ -700,7 +700,7 @@ With endpoint routing, the CORS middleware **must** be configured to execute bet
 
 See [Test CORS](#testc) for instructions on testing code similar to the preceding code.
 
-The <xref:Microsoft.Extensions.DependencyInjection.MvcCorsMvcCoreBuilderExtensions.AddCors*> method call adds CORS services to the app's service container:
+The <xref:Microsoft.Extensions.DependencyInjection.MvcCorsMvcCoreBuilderExtensions.AddCors%2A> method call adds CORS services to the app's service container:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/Startup.cs?name=snippet2)]
 
@@ -728,7 +728,7 @@ The preceding code applies the default CORS policy to all controller endpoints.
 
 Enabling CORS on a per-endpoint basis using `RequireCors` ***does not support [automatic preflight requests](#apf).*** For more information, see [this GitHub issue](https://github.com/dotnet/aspnetcore/issues/20709) and [Test CORS with endpoint routing and [HttpOptions]](#tcer).
 
-With endpoint routing, CORS can be enabled on a per-endpoint basis using the <xref:Microsoft.AspNetCore.Builder.CorsEndpointConventionBuilderExtensions.RequireCors*> set of extension methods:
+With endpoint routing, CORS can be enabled on a per-endpoint basis using the <xref:Microsoft.AspNetCore.Builder.CorsEndpointConventionBuilderExtensions.RequireCors%2A> set of extension methods:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupEndPt.cs?name=snippet2&highlight=3,7-15,32,40,43)]
 
@@ -815,35 +815,35 @@ This section describes the various options that can be set in a CORS policy:
 * [Credentials in cross-origin requests](#credentials-in-cross-origin-requests)
 * [Set the preflight expiration time](#set-the-preflight-expiration-time)
 
-<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsOptions.AddPolicy*> is called in `Startup.ConfigureServices`. For some options, it may be helpful to read the [How CORS works](#how-cors) section first.
+<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsOptions.AddPolicy%2A> is called in `Startup.ConfigureServices`. For some options, it may be helpful to read the [How CORS works](#how-cors) section first.
 
 ## Set the allowed origins
 
-<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyOrigin*>: Allows CORS requests from all origins with any scheme (`http` or `https`). `AllowAnyOrigin` is insecure because *any website* can make cross-origin requests to the app.
+<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyOrigin%2A>: Allows CORS requests from all origins with any scheme (`http` or `https`). `AllowAnyOrigin` is insecure because *any website* can make cross-origin requests to the app.
 
 > [!NOTE]
 > Specifying `AllowAnyOrigin` and `AllowCredentials` is an insecure configuration and can result in cross-site request forgery. The CORS service returns an invalid CORS response when an app is configured with both methods.
 
 `AllowAnyOrigin` affects preflight requests and the `Access-Control-Allow-Origin` header. For more information, see the [Preflight requests](#preflight-requests) section.
 
-<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.SetIsOriginAllowedToAllowWildcardSubdomains*>: Sets the <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy.IsOriginAllowed*> property of the policy to be a function that allows origins to match a configured wildcard domain when evaluating if the origin is allowed.
+<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.SetIsOriginAllowedToAllowWildcardSubdomains%2A>: Sets the <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy.IsOriginAllowed%2A> property of the policy to be a function that allows origins to match a configured wildcard domain when evaluating if the origin is allowed.
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs?name=snippet)]
 
 ### Set the allowed HTTP methods
 
-<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyMethod*>:
+<xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyMethod%2A>:
 
 * Allows any HTTP method:
 * Affects preflight requests and the `Access-Control-Allow-Methods` header. For more information, see the [Preflight requests](#preflight-requests) section.
 
 ### Set the allowed request headers
 
-To allow specific headers to be sent in a CORS request, called [author request headers](https://xhr.spec.whatwg.org/#request), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders*> and specify the allowed headers:
+To allow specific headers to be sent in a CORS request, called [author request headers](https://xhr.spec.whatwg.org/#request), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders%2A> and specify the allowed headers:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs?name=snippet2)]
 
-To allow all [author request headers](https://www.w3.org/TR/cors/#author-request-headers), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyHeader*>:
+To allow all [author request headers](https://www.w3.org/TR/cors/#author-request-headers), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyHeader%2A>:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs?name=snippet3)]
 
@@ -876,9 +876,10 @@ The response headers that are available by default are:
 * `Last-Modified`
 * `Pragma`
 
-The CORS specification calls these headers *simple response headers*. To make other headers available to the app, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithExposedHeaders*>:
+The CORS specification calls these headers *simple response headers*. To make other headers available to the app, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithExposedHeaders%2A>:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs?name=snippet5)]
+
 ### Credentials in cross-origin requests
 
 Credentials require special handling in a CORS request. By default, the browser doesn't send credentials with a cross-origin request. Credentials include cookies and HTTP authentication schemes. To send credentials with a cross-origin request, the client must set `XMLHttpRequest.withCredentials` to `true`.
@@ -911,7 +912,7 @@ fetch('https://www.example.com/api/test', {
 });
 ```
 
-The server must allow the credentials. To allow cross-origin credentials, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowCredentials*>:
+The server must allow the credentials. To allow cross-origin credentials, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowCredentials%2A>:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs?name=snippet6)]
 
@@ -982,18 +983,18 @@ Using the F12 tools, the console app shows an error similar to one of the follow
 * Firefox: Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at `https://cors1.azurewebsites.net/api/TodoItems1/MyDelete2/5`. (Reason: CORS request did not succeed). [Learn More](https://developer.mozilla.org/docs/Web/HTTP/CORS/Errors/CORSDidNotSucceed)
 * Chromium based: Access to fetch at 'https://cors1.azurewebsites.net/api/TodoItems1/MyDelete2/5' from origin 'https://cors3.azurewebsites.net' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
 
-To allow specific headers, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders*>:
+To allow specific headers, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.WithHeaders%2A>:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs?name=snippet2)]
 
-To allow all [author request headers](https://www.w3.org/TR/cors/#author-request-headers), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyHeader*>:
+To allow all [author request headers](https://www.w3.org/TR/cors/#author-request-headers), call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyHeader%2A>:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs?name=snippet3)]
 
 Browsers aren't consistent in how they set `Access-Control-Request-Headers`. If either:
 
 * Headers are set to anything other than `"*"`
-* <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy.AllowAnyHeader*> is called:
+* <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicy.AllowAnyHeader%2A> is called:
   Include at least `Accept`, `Content-Type`, and `Origin`, plus any custom headers that you want to support.
 
 <a name="apf"></a>
@@ -1025,7 +1026,7 @@ See [Test CORS with endpoint routing and [HttpOptions]](#tcer) for instructions 
 
 ### Set the preflight expiration time
 
-The `Access-Control-Max-Age` header specifies how long the response to the preflight request can be cached. To set this header, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.SetPreflightMaxAge*>:
+The `Access-Control-Max-Age` header specifies how long the response to the preflight request can be cached. To set this header, call <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.SetPreflightMaxAge%2A>:
 
 [!code-csharp[](cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs?name=snippet7)]
 <a name="how-cors"></a>
@@ -1132,7 +1133,7 @@ User-Agent: Mozilla/5.0
 
 In the preceding **Response headers**, the server sets the [Access-Control-Allow-Origin](https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) header in the response. The `https://cors1.azurewebsites.net` value of this header matches the `Origin` header from the request.
 
-If <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyOrigin*> is called, the `Access-Control-Allow-Origin: *`, the wildcard value, is returned. `AllowAnyOrigin` allows any origin.
+If <xref:Microsoft.AspNetCore.Cors.Infrastructure.CorsPolicyBuilder.AllowAnyOrigin%2A> is called, the `Access-Control-Allow-Origin: *`, the wildcard value, is returned. `AllowAnyOrigin` allows any origin.
 
 If the response doesn't include the `Access-Control-Allow-Origin` header, the cross-origin request fails. Specifically, the browser disallows the request. Even if the server returns a successful response, the browser doesn't make the response available to the client app.
 

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/Startup.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/Startup.cs
@@ -18,9 +18,9 @@ namespace WebAPI
             services.AddCors(options =>
             {
                 options.AddPolicy(name: MyAllowSpecificOrigins,
-                                  builder =>
+                                  policy =>
                                   {
-                                      builder.WithOrigins("http://example.com",
+                                      policy.WithOrigins("http://example.com",
                                                           "http://www.contoso.com");
                                   });
             });

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/Startup2.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/Startup2.cs
@@ -25,9 +25,9 @@ namespace WebAPI
             services.AddCors(options =>
             {
                 options.AddPolicy(MyAllowSpecificOrigins,
-                                  builder =>
+                                  policy =>
                                   {
-                                      builder.WithOrigins("http://example.com",
+                                      policy.WithOrigins("http://example.com",
                                                           "http://www.contoso.com")
                                                           .AllowAnyHeader()
                                                           .AllowAnyMethod();

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/Startup3.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/Startup3.cs
@@ -23,16 +23,16 @@ namespace WebAPI3
             services.AddCors(options =>
             {
                 options.AddPolicy("Policy1",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com",
+                        policy.WithOrigins("http://example.com",
                                             "http://www.contoso.com");
                     });
 
                 options.AddPolicy("AnotherPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://www.contoso.com")
+                        policy.WithOrigins("http://www.contoso.com")
                                             .AllowAnyHeader()
                                             .AllowAnyMethod();
                     });

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupAllowSubdomain.cs
@@ -25,55 +25,55 @@ namespace WebAPI
             {
                 #region snippet
                 options.AddPolicy("MyAllowSubdomainPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("https://*.example.com")
+                        policy.WithOrigins("https://*.example.com")
                             .SetIsOriginAllowedToAllowWildcardSubdomains();
                     });
                 #endregion
 
                 #region snippet2
                 options.AddPolicy("MyAllowHeadersPolicy",
-                    builder =>
+                    policy =>
                     {
                         // requires using Microsoft.Net.Http.Headers;
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .WithHeaders(HeaderNames.ContentType, "x-custom-header");
                     });
                 #endregion
 
                 #region snippet3
                 options.AddPolicy("MyAllowAllHeadersPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("https://*.example.com")
+                        policy.WithOrigins("https://*.example.com")
                                .AllowAnyHeader();
                     });
                 #endregion
 
                 #region snippet5
                 options.AddPolicy("MyExposeResponseHeadersPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("https://*.example.com")
+                        policy.WithOrigins("https://*.example.com")
                                .WithExposedHeaders("x-custom-header");
                     });
                 #endregion
 
                 #region snippet6
                 options.AddPolicy("MyMyAllowCredentialsPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .AllowCredentials();
                     });
                 #endregion
 
                 #region snippet7
                 options.AddPolicy("MySetPreflightExpirationPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .SetPreflightMaxAge(TimeSpan.FromSeconds(2520));
                     });
                 #endregion

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupDefaultPolicy.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupDefaultPolicy.cs
@@ -15,9 +15,9 @@ namespace WebAPIDefault
             services.AddCors(options =>
             {
                 options.AddDefaultPolicy(
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com",
+                        policy.WithOrigins("http://example.com",
                                             "http://www.contoso.com");
                     });
             });

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupEndPointBugTest.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupEndPointBugTest.cs
@@ -18,9 +18,9 @@ namespace WebAPI
             services.AddCors(options =>
             {
                 options.AddPolicy(name: MyPolicy,
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com",
+                        policy.WithOrigins("http://example.com",
                                             "http://www.contoso.com",
                                             "https://cors1.azurewebsites.net",
                                             "https://cors3.azurewebsites.net",

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupEndPt.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupEndPt.cs
@@ -18,9 +18,9 @@ namespace WebAPIendPt
             services.AddCors(options =>
             {
                 options.AddPolicy(name: MyAllowSpecificOrigins,
-                                  builder =>
+                                  policy =>
                                   {
-                                      builder.WithOrigins("http://example.com",
+                                      policy.WithOrigins("http://example.com",
                                                           "http://www.contoso.com");
                                   });
             });

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupTest2.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupTest2.cs
@@ -11,9 +11,9 @@ namespace WebAPI
             services.AddCors(options =>
             {
                 options.AddPolicy(name: "MyPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com",
+                        policy.WithOrigins("http://example.com",
                             "http://www.contoso.com",
                             "https://cors1.azurewebsites.net",
                             "https://cors3.azurewebsites.net",

--- a/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupTestMyPolicy.cs
+++ b/aspnetcore/security/cors/3.1sample/Cors/WebAPI/StartupTestMyPolicy.cs
@@ -13,9 +13,9 @@ namespace MyPolicy
             services.AddCors(options =>
             {
                 options.AddPolicy(name: "MyPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com",
+                        policy.WithOrigins("http://example.com",
                                             "http://www.contoso.com")
                                 .WithMethods("PUT", "DELETE", "GET");
                     });

--- a/aspnetcore/security/cors/6.0sample/Cors/WebAPI/Program.cs
+++ b/aspnetcore/security/cors/6.0sample/Cors/WebAPI/Program.cs
@@ -42,9 +42,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(MyAllowSpecificOrigins,
-                          builder =>
+                          policy =>
                           {
-                              builder.WithOrigins("http://example.com",
+                              policy.WithOrigins("http://example.com",
                                                   "http://www.contoso.com")
                                                   .AllowAnyHeader()
                                                   .AllowAnyMethod();
@@ -73,9 +73,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddDefaultPolicy(
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("http://example.com",
+            policy.WithOrigins("http://example.com",
                                 "http://www.contoso.com");
         });
 });
@@ -105,9 +105,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
-                      builder =>
+                      policy =>
                       {
-                          builder.WithOrigins("http://example.com",
+                          policy.WithOrigins("http://example.com",
                                               "http://www.contoso.com");
                       });
 });
@@ -149,16 +149,16 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("Policy1",
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("http://example.com",
+            policy.WithOrigins("http://example.com",
                                 "http://www.contoso.com");
         });
 
     options.AddPolicy("AnotherPolicy",
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("http://www.contoso.com")
+            policy.WithOrigins("http://www.contoso.com")
                                 .AllowAnyHeader()
                                 .AllowAnyMethod();
         });
@@ -187,9 +187,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: "MyPolicy",
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("http://example.com",
+            policy.WithOrigins("http://example.com",
                                 "http://www.contoso.com")
                     .WithMethods("PUT", "DELETE", "GET");
         });
@@ -222,9 +222,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: "MyPolicy",
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("http://example.com",
+            policy.WithOrigins("http://example.com",
                                 "http://www.contoso.com")
                     .WithMethods("PUT", "DELETE", "GET");
         });
@@ -257,9 +257,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("https://*.example.com")
+            policy.WithOrigins("https://*.example.com")
                 .SetIsOriginAllowedToAllowWildcardSubdomains();
         });
 });
@@ -291,9 +291,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
-       builder =>
+       policy =>
        {
-           builder.WithOrigins("http://example.com")
+           policy.WithOrigins("http://example.com")
                   .WithHeaders(HeaderNames.ContentType, "x-custom-header");
        });
 });
@@ -323,9 +323,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: MyAllowSpecificOrigins,
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("https://*.example.com")
+            policy.WithOrigins("https://*.example.com")
                    .AllowAnyHeader();
         });
 });
@@ -352,9 +352,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("MyExposeResponseHeadersPolicy",
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("https://*.example.com")
+            policy.WithOrigins("https://*.example.com")
                    .WithExposedHeaders("x-custom-header");
         });
 });
@@ -381,9 +381,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("MyMyAllowCredentialsPolicy",
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("http://example.com")
+            policy.WithOrigins("http://example.com")
                    .AllowCredentials();
         });
 });
@@ -412,9 +412,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("MyAllowHeadersPolicy",
-        builder =>
+        policy =>
         {
-        builder.WithOrigins("http://example.com")
+        policy.WithOrigins("http://example.com")
                    .WithHeaders(HeaderNames.ContentType, "x-custom-header");
         });
 });
@@ -443,9 +443,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("MyAllowAllHeadersPolicy",
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("https://*.example.com")
+            policy.WithOrigins("https://*.example.com")
                    .AllowAnyHeader();
         });
 });
@@ -472,9 +472,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("MySetPreflightExpirationPolicy",
-        builder =>
+        policy =>
         {
-            builder.WithOrigins("http://example.com")
+            policy.WithOrigins("http://example.com")
                    .SetPreflightMaxAge(TimeSpan.FromSeconds(2520));
         });
 });

--- a/aspnetcore/security/cors/6.0sample/Cors/WebAPI/ProgramTest.cs
+++ b/aspnetcore/security/cors/6.0sample/Cors/WebAPI/ProgramTest.cs
@@ -7,9 +7,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: "MyPolicy",
-                builder =>
+                policy =>
                 {
-                    builder.WithOrigins("http://example.com",
+                    policy.WithOrigins("http://example.com",
                         "http://www.contoso.com",
                         "https://cors1.azurewebsites.net",
                         "https://cors3.azurewebsites.net",
@@ -44,9 +44,9 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddCors(options =>
 {
     options.AddPolicy(name: "MyPolicy",
-                builder =>
+                policy =>
                 {
-                    builder.WithOrigins("http://example.com",
+                    policy.WithOrigins("http://example.com",
                         "http://www.contoso.com",
                         "https://cors1.azurewebsites.net",
                         "https://cors3.azurewebsites.net",

--- a/aspnetcore/security/cors/sample/Cors/WebAPI/Startup.cs
+++ b/aspnetcore/security/cors/sample/Cors/WebAPI/Startup.cs
@@ -24,9 +24,9 @@ namespace WebAPI
             services.AddCors(options =>
             {
                 options.AddPolicy(MyAllowSpecificOrigins,
-                builder =>
+                policy =>
                 {
-                    builder.WithOrigins("http://example.com",
+                    policy.WithOrigins("http://example.com",
                                         "http://www.contoso.com");
                 });
             });

--- a/aspnetcore/security/cors/sample/Cors/WebAPI/Startup2.cs
+++ b/aspnetcore/security/cors/sample/Cors/WebAPI/Startup2.cs
@@ -23,9 +23,9 @@ namespace WebAPI
             services.AddCors(options =>
             {
                 options.AddPolicy(MyAllowSpecificOrigins,
-                builder =>
+                policy =>
                 {
-                    builder.WithOrigins("http://example.com",
+                    policy.WithOrigins("http://example.com",
                                         "http://www.contoso.com")
                                         .AllowAnyHeader()
                                         .AllowAnyMethod();

--- a/aspnetcore/security/cors/sample/Cors/WebAPI/StartupMultiPolicy.cs
+++ b/aspnetcore/security/cors/sample/Cors/WebAPI/StartupMultiPolicy.cs
@@ -21,17 +21,17 @@ namespace WebAPI
             services.AddCors(options =>
             {
                 options.AddDefaultPolicy(
-                    builder =>
+                    policy =>
                     {
                        
-                        builder.WithOrigins("http://example.com",
+                        policy.WithOrigins("http://example.com",
                                             "http://www.contoso.com");
                     });
 
                 options.AddPolicy("AnotherPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://www.contoso.com")
+                        policy.WithOrigins("http://www.contoso.com")
                                             .AllowAnyHeader()
                                             .AllowAnyMethod();
                     });

--- a/aspnetcore/security/cors/sample/Cors/WebAPI/StartupTest.cs
+++ b/aspnetcore/security/cors/sample/Cors/WebAPI/StartupTest.cs
@@ -35,9 +35,9 @@ namespace WebAPI
             }
 
             // Shows UseCors with CorsPolicyBuilder.
-            app.UseCors(builder =>
+            app.UseCors(policy =>
             {
-                builder.WithOrigins("http://example.com",
+                policy.WithOrigins("http://example.com",
                                     "http://www.contoso.com",
                                     "https://localhost:44375",
                                     "https://localhost:5001");

--- a/aspnetcore/security/cors/sample/Cors/WebAPI/StartupTestMultiPolicy.cs
+++ b/aspnetcore/security/cors/sample/Cors/WebAPI/StartupTestMultiPolicy.cs
@@ -21,19 +21,19 @@ namespace WebAPI
             services.AddCors(options =>
             {
                 options.AddDefaultPolicy(
-                    builder =>
+                    policy =>
                     {
                        
-                        builder.WithOrigins("http://example.com",
+                        policy.WithOrigins("http://example.com",
                                             "https://localhost:5001",
                                             "https://localhost:44375",
                                             "http://www.contoso.com");
                     });
 
                 options.AddPolicy("AnotherPolicy",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://www.contoso.com",
+                        policy.WithOrigins("http://www.contoso.com",
                                             "https://localhost:44375",
                                             "https://localhost:5001")
                                             .AllowAnyHeader()

--- a/aspnetcore/security/cors/sample/CorsExample4/Startup.cs
+++ b/aspnetcore/security/cors/sample/CorsExample4/Startup.cs
@@ -18,89 +18,89 @@ namespace CorsExample4
             {
                 // BEGIN01
                 options.AddPolicy("AllowSpecificOrigins",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com", 
+                        policy.WithOrigins("http://example.com", 
                             "http://www.contoso.com");
                     });
                 // END01
 
                 // BEGIN02
                 options.AddPolicy("AllowAllOrigins",
-                    builder =>
+                    policy =>
                     {
-                        builder.AllowAnyOrigin();
+                        policy.AllowAnyOrigin();
                     });
                 // END02
 
                 // BEGIN03
                 options.AddPolicy("AllowSpecificMethods",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .WithMethods("GET", "POST", "HEAD");
                     });
                 // END03
 
                 // BEGIN04
                 options.AddPolicy("AllowAllMethods",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .AllowAnyMethod();
                     });
                 // END04
 
                 // BEGIN05
                 options.AddPolicy("AllowHeaders",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .WithHeaders(HeaderNames.ContentType, "x-custom-header");
                     });
                 // END05
 
                 // BEGIN06
                 options.AddPolicy("AllowAllHeaders",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .AllowAnyHeader();
                     });
                 // END06
 
                 // BEGIN07
                 options.AddPolicy("ExposeResponseHeaders",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .WithExposedHeaders("x-custom-header");
                     });
                 // END07
 
                 // BEGIN08
                 options.AddPolicy("AllowCredentials",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .AllowCredentials();
                     });
                 // END08
 
                 // BEGIN09
                 options.AddPolicy("SetPreflightExpiration",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("http://example.com")
+                        policy.WithOrigins("http://example.com")
                                .SetPreflightMaxAge(TimeSpan.FromSeconds(2520));
                     });
                 // END09
 
                 // BEGIN10
                 options.AddPolicy("AllowSubdomain",
-                    builder =>
+                    policy =>
                     {
-                        builder.WithOrigins("https://*.example.com")
+                        policy.WithOrigins("https://*.example.com")
                             .SetIsOriginAllowedToAllowWildcardSubdomains();
                     });
                 // END11


### PR DESCRIPTION
Follow-up for #25496.

[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/security/cors?view=aspnetcore-6.0&branch=pr-en-us-25529).