### PR TITLE
Localization Test 2

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -30,7 +30,8 @@
       "ms.topic": "conceptual",
       "uhfHeaderId": "MSDocsHeader-AspNet",
       "searchScope": [ "ASP.NET Core" ],
-      "zone_pivot_group_filename": "core/zone-pivot-groups.json"
+      "zone_pivot_group_filename": "core/zone-pivot-groups.json",
+      "no-loc": [ "toaster", "bowl", "toothbrush", "magnet", "oak" ]
     },
     "fileMetadata": {
       "author": {
@@ -64,9 +65,6 @@
       "ms.topic": {
         "**/getting-started/**/**.md": "tutorial",
         "**/tutorials/**/**.md": "tutorial"
-      },
-      "no-loc": {
-        "**/migration/no-loc-test.md": [ "computer", "cat" ]
       },
       "recommendations": {
         "**/tutorials/**/**.md": "false"

--- a/aspnetcore/migration/no-loc-test.md
+++ b/aspnetcore/migration/no-loc-test.md
@@ -5,20 +5,27 @@ description: This is a localization test doc.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/26/2022
+ms.date: 04/06/2022
+no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: migration/no-loc-test
 ---
-# Localization test doc
+# Localization test doc (TEST 2)
 
-`This topic doesn't have a no-loc metadata entry. There's a no-loc entry in the docfx.json file`:
+`The second test seeks to confirm that globalMetadata applies a no-loc array and that the globalMetadata no-loc array MERGES WITH a topic-specific no-loc array.`
 
-```json
-"no-loc": {
-  "**/migration/no-loc-test.md": [ "computer", "cat" ]
-}
+`This topic has our standard no-loc metadata entry:`
+
+```
+no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ```
 
-`Entries from the existing no-loc list`:
+`There's also a globalMetadata no-loc entry in the docfx.json file for some words that aren't found anywhere in the docs and that should normally localize:`
+
+```json
+"no-loc": [ "toaster", "bowl", "toothbrush", "magnet", "oak" ]
+```
+
+`Entries from the topic's no-loc array should be prevented from localization:`
 
 * .NET MAUI
 * Mac Catalyst
@@ -38,12 +45,18 @@ uid: migration/no-loc-test
 * Razor
 * SignalR
 
-`Entries in the docfx.json fileMetadata no-loc list`:
+`Entries in the docfx.json globalMetadata no-loc array should also be prevented from localization`:
 
-* computer
-* cat
+* toaster
+* bowl
+* toothbrush
+* magnet
+* oak
 
 `Sentences`:
 
-* The computer is ten years old.
-* The cat ate the mouse.
+* The toaster is broken.
+* The cat ate from the bowl.
+* The toothbrush should be replaced.
+* A magnet is in the motor.
+* My desk is made of oak.


### PR DESCRIPTION
Addresses #25187

Test 2:

* See if `globalMetadata` works as well as `fileMetadata` did in the first test.
* Confirm that `globalMetadata` merges with a topic-specific `no-loc` array. We'll just use our normal `no-loc` for the topic-specific array here.

The words used in the `globalMetadata` array aren't found anywhere in the doc set, so they won't interfere with normal topic localization ... 🤔 *well* ... unless the whole loc system **_blows up in my face and all loc goes out the window!_** 💣💥😨

# 🇺🇦 