### PR TITLE
Inconsistency fixed when updating appsettings.

### DIFF
--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -117,7 +117,6 @@ There are a few changes to the other files generated for the Web App template:
 * `"Microsoft.Hosting.Lifetime": "Information"` was removed from both `appsettings.json` and `appsettings.Development.json`:
 
 ```diff
-- "Microsoft": "Warning",
 - "Microsoft.Hosting.Lifetime": "Information"
 + "Microsoft.AspNetCore": "Warning"
 ```


### PR DESCRIPTION
Fix for issue #25550 

The bullet (below) mentions that |Microsoft.Hosting.Lifetime| should be removed from the appsettings, but the diff example underneath shows erroneously that "Microsoft":"Warning" should be removed too

"Microsoft.Hosting.Lifetime": "Information" was removed from both appsettings.json and appsettings.Development.json:
```diff
- "Microsoft": "Warning", <---- This was removed
- "Microsoft.Hosting.Lifetime": "Information"
+ "Microsoft.AspNetCore": "Warning"
```
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->