### PR TITLE
Localization Test 3

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -30,8 +30,7 @@
       "ms.topic": "conceptual",
       "uhfHeaderId": "MSDocsHeader-AspNet",
       "searchScope": [ "ASP.NET Core" ],
-      "zone_pivot_group_filename": "core/zone-pivot-groups.json",
-      "no-loc": [ "toaster", "bowl", "toothbrush", "magnet", "oak" ]
+      "zone_pivot_group_filename": "core/zone-pivot-groups.json"
     },
     "fileMetadata": {
       "author": {
@@ -65,6 +64,9 @@
       "ms.topic": {
         "**/getting-started/**/**.md": "tutorial",
         "**/tutorials/**/**.md": "tutorial"
+      },
+      "no-loc": {
+        "**/**.md": [ "toaster", "bowl", "toothbrush", "magnet", "oak" ]
       },
       "recommendations": {
         "**/tutorials/**/**.md": "false"

--- a/aspnetcore/migration/no-loc-test.md
+++ b/aspnetcore/migration/no-loc-test.md
@@ -5,13 +5,13 @@ description: This is a localization test doc.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/06/2022
+ms.date: 04/07/2022
 no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: migration/no-loc-test
 ---
-# Localization test doc (TEST 2)
+# Localization test doc (TEST 3)
 
-`The second test seeks to confirm that globalMetadata applies a no-loc array and that the globalMetadata no-loc array MERGES WITH a topic-specific no-loc array.`
+`The third test tries a wildcard fileMetadata to see if it MERGES WITH a topic-specific no-loc array.`
 
 `This topic has our standard no-loc metadata entry:`
 
@@ -19,10 +19,12 @@ uid: migration/no-loc-test
 no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 ```
 
-`There's also a globalMetadata no-loc entry in the docfx.json file for some words that aren't found anywhere in the docs and that should normally localize:`
+`There's also a wildcard fileMetadata no-loc entry in the docfx.json file for some words that aren't found anywhere in the docs and that should normally localize:`
 
 ```json
-"no-loc": [ "toaster", "bowl", "toothbrush", "magnet", "oak" ]
+"no-loc": {
+  "**/**.md": [ "toaster", "bowl", "toothbrush", "magnet", "oak" ]
+},
 ```
 
 `Entries from the topic's no-loc array should be prevented from localization:`
@@ -45,7 +47,7 @@ no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, a
 * Razor
 * SignalR
 
-`Entries in the docfx.json globalMetadata no-loc array should also be prevented from localization`:
+`Entries in the docfx.json wildcard fileMetadata no-loc array should also be prevented from localization`:
 
 * toaster
 * bowl


### PR DESCRIPTION
Addresses #25187

Test 3:

* See if a wildcard `fileMetadata` merges with a topic-specific `no-loc` array. We'll just use our normal `no-loc` for the topic-specific array here.
* The words used in the `fileMetadata` array aren't found anywhere in the doc set, so they won't interfere with normal topic localization.

# 🇺🇦 