### PR TITLE
Fix indentation in complex-data-model.md

### DIFF
--- a/aspnetcore/data/ef-rp/complex-data-model.md
+++ b/aspnetcore/data/ef-rp/complex-data-model.md
@@ -358,7 +358,7 @@ public ICollection<Enrollment> Enrollments { get; set; }
 A course may be taught by multiple instructors, so the `Instructors` navigation property is a collection:
 
 ```csharp
-        public ICollection<Instructor> Instructors { get; set; }
+public ICollection<Instructor> Instructors { get; set; }
 ```
 
 ## The Department entity


### PR DESCRIPTION
Incorrect code block indentation has been fixed:
```diff
-         public ICollection<Instructor> Instructors { get; set; }
+ public ICollection<Instructor> Instructors { get; set; }
```