### PR TITLE
Minor cleanup of using Minimal API as a Windows Service code /2

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service/samples/6.x/WebAppServiceSample/Pages/Error.cshtml.cs
+++ b/aspnetcore/host-and-deploy/windows-service/samples/6.x/WebAppServiceSample/Pages/Error.cshtml.cs
@@ -11,7 +11,7 @@ namespace SampleApp.Pages
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public class ErrorModel : PageModel
     {
-        public string RequestId { get; set; }
+        public string? RequestId { get; set; }
 
         public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 

--- a/aspnetcore/host-and-deploy/windows-service/samples/6.x/WebAppServiceSample/Program.cs
+++ b/aspnetcore/host-and-deploy/windows-service/samples/6.x/WebAppServiceSample/Program.cs
@@ -18,5 +18,5 @@ var app = builder.Build();
 
 app.UseStaticFiles();
 app.UseRouting();
-app.UseEndpoints(endpoints => { endpoints.MapRazorPages(); });
+app.MapRazorPages();
 await app.RunAsync();


### PR DESCRIPTION
@tothalexlaszlo please review

1. Get rid of nullable warning.
2. Use standard API.