### PR TITLE
Remove obsolete references to UseEndpoints

### DIFF
--- a/aspnetcore/mvc/controllers/routing.md
+++ b/aspnetcore/mvc/controllers/routing.md
@@ -487,11 +487,11 @@ For convenience, attribute routes support *token replacement* by enclosing a tok
 
 In the preceding code:
 
-  [!code-csharp[](routing/samples/6.x/main/Controllers/ProductsController.cs?name=snippet10)]
+[!code-csharp[](routing/samples/6.x/main/Controllers/ProductsController.cs?name=snippet10)]
 
 * Matches `/Products0/List`
 
-  [!code-csharp[](routing/samples/6.x/main/Controllers/ProductsController.cs?name=snippet11)]
+[!code-csharp[](routing/samples/6.x/main/Controllers/ProductsController.cs?name=snippet11)]
 
 * Matches `/Products0/Edit/{id}`
 

--- a/aspnetcore/mvc/controllers/routing.md
+++ b/aspnetcore/mvc/controllers/routing.md
@@ -3,7 +3,7 @@ title: Routing to controller actions in ASP.NET Core
 author: rick-anderson
 description: Learn how ASP.NET Core MVC uses Routing Middleware to match URLs of incoming requests and map them to actions.
 ms.author: riande
-ms.date: 9/15/2021
+ms.date: 04/08/2022
 no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: mvc/controllers/routing
 ---
@@ -55,7 +55,7 @@ The route template `"{controller=Home}/{action=Index}/{id?}"`:
 * `/Products/Details/5` model binds the value of `id = 5` to set the `id` parameter to `5`. See [Model Binding](xref:mvc/models/model-binding) for more details.
 * `{controller=Home}` defines `Home` as the default `controller`.
 * `{action=Index}` defines `Index` as the default `action`.
-*  The `?` character in `{id?}` defines `id` as optional.
+* The `?` character in `{id?}` defines `id` as optional.
   * Default and optional route parameters don't need to be present in the URL path for a match. See [Route Template Reference](xref:fundamentals/routing#route-template-reference) for a detailed description of route template syntax.
 * Matches the URL path `/`.
 * Produces the route values `{ controller = Home, action = Index }`.
@@ -65,7 +65,7 @@ The values for `controller` and `action` make use of the default values. `id` do
 ```csharp
 public class HomeController : Controller
 {
-  public IActionResult Index() { ... }
+    public IActionResult Index() { ... }
 }
 ```
 
@@ -91,6 +91,8 @@ Replaces:
 >
 > * Call <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapControllers%2A> to map [attribute routed](#ar6) controllers.
 > * Call <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapControllerRoute%2A> or <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapAreaControllerRoute%2A>, to map both [conventionally routed](#cr6) controllers and [attribute routed](#ar6) controllers.
+>
+> Apps typically don't need to call `UseRouting` or `UseEndpoints`. <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> configures a middleware pipeline that wraps middleware added in `Program.cs` with `UseRouting` and `UseEndpoints`. For more information, see <xref:fundamentals/routing>.
 
 <a name="routing-conventional-ref-label"></a>
 <a name="crd6"></a>
@@ -153,7 +155,7 @@ Enable [Logging](xref:fundamentals/logging/index) to see how the built-in routin
 
 ### Multiple conventional routes
 
-Multiple [conventional routes](#cr6) can be added inside `UseEndpoints` by adding more calls to <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapControllerRoute%2A> and <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapAreaControllerRoute%2A>. Doing so allows defining multiple conventions, or to adding conventional routes that are dedicated to a specific [action](#action), such as:
+Multiple [conventional routes](#cr6) can be configured by adding more calls to <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapControllerRoute%2A> and <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapAreaControllerRoute%2A>. Doing so allows defining multiple conventions, or to adding conventional routes that are dedicated to a specific [action](#action), such as:
 
 [!code-csharp[](routing/samples/6.x/main/Program.cs?name=snippet_mcr)]
 
@@ -257,7 +259,7 @@ Attribute routing uses a set of attributes to map actions directly to route temp
 
 [!code-csharp[](routing/samples/6.x/main/Program.cs?name=snippet_webapi)]
 
-In the preceding code, <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapControllers%2A> is called inside `UseEndpoints` to map attribute routed controllers.
+In the preceding code, <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapControllers%2A> is called to map attribute routed controllers.
 
 In the following example:
 
@@ -302,15 +304,16 @@ Using `page` as a route parameter with attribute routing is a common error. Doin
 The special parameter names are used by the URL generation to determine if a URL generation operation refers to a Razor Page or to a Controller.
 
 * The following keywords are reserved in the context of a Razor view or a Razor Page:
-   * `page`
-   * `using`
-   * `namespace`
-   * `inject`
-   * `section`
-   * `inherits`
-   * `model`
-   * `addTagHelper`
-   * `removeTagHelper`
+
+* `page`
+* `using`
+* `namespace`
+* `inject`
+* `section`
+* `inherits`
+* `model`
+* `addTagHelper`
+* `removeTagHelper`
 
 These keywords shouldn't be used for link generations, model bound parameters, or top level properties.
 
@@ -486,11 +489,11 @@ In the preceding code:
 
   [!code-csharp[](routing/samples/6.x/main/Controllers/ProductsController.cs?name=snippet10)]
 
-  * Matches `/Products0/List`
+* Matches `/Products0/List`
 
   [!code-csharp[](routing/samples/6.x/main/Controllers/ProductsController.cs?name=snippet11)]
 
-  * Matches `/Products0/Edit/{id}`
+* Matches `/Products0/Edit/{id}`
 
 Token replacement occurs as the last step of building the attribute routes. The preceding example behaves the same as the following code:
 


### PR DESCRIPTION
Fixes #25580.

[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/controllers/routing?view=aspnetcore-6.0&branch=pr-en-us-25581).