### PR TITLE
Note support in Options Validation for IValidatableObject

### DIFF
--- a/aspnetcore/fundamentals/configuration/options.md
+++ b/aspnetcore/fundamentals/configuration/options.md
@@ -113,8 +113,7 @@ Consider the following `appsettings.json` file:
 
 :::code language="json" source="options/samples/6.x/OptionsSample/appsettings.NO.json":::
 
-Rather than creating two classes to bind `TopItem:Month` and `TopItem:Year`,
-the following class is used for each section:
+Rather than creating two classes to bind `TopItem:Month` and `TopItem:Year`, the following class is used for each section:
 
 :::code language="csharp" source="options/samples/6.x/OptionsSample/Models/TopItemSettings.cs":::
 
@@ -184,7 +183,7 @@ The following code applies a more complex validation rule using a delegate:
 
 :::code language="csharp" source="options/samples/6.x/OptionsValidationSample/Program.cs" id="snippet_mc":::
 
-### IValidateOptions for complex validation
+### `IValidateOptions<TOptions>` and `IValidatableObject`
 
 The following class implements <xref:Microsoft.Extensions.Options.IValidateOptions%601>:
 
@@ -195,6 +194,8 @@ The following class implements <xref:Microsoft.Extensions.Options.IValidateOptio
 Using the preceding code, validation is enabled in `Program.cs` with the following code:
 
 :::code language="csharp" source="options/samples/6.x/OptionsValidationSample/Program.cs" id="snippet_xm":::
+
+Options validation also supports <xref:System.ComponentModel.DataAnnotations.IValidatableObject>. To perform class-level validation of a class within the class itself, implement the `IValidatableObject` interface and its <xref:System.ComponentModel.DataAnnotations.IValidatableObject.Validate%2A> method.
 
 <!-- The following comment doesn't seem that useful 
 Options validation doesn't guard against options modifications after the options instance is created. For example, `IOptionsSnapshot` options are created and validated once per request when the options are first accessed. The `IOptionsSnapshot` options aren't validated again on subsequent access attempts *for the same request*.

--- a/aspnetcore/fundamentals/configuration/options.md
+++ b/aspnetcore/fundamentals/configuration/options.md
@@ -195,7 +195,10 @@ Using the preceding code, validation is enabled in `Program.cs` with the followi
 
 :::code language="csharp" source="options/samples/6.x/OptionsValidationSample/Program.cs" id="snippet_xm":::
 
-Options validation also supports <xref:System.ComponentModel.DataAnnotations.IValidatableObject>. To perform class-level validation of a class within the class itself, implement the `IValidatableObject` interface and its <xref:System.ComponentModel.DataAnnotations.IValidatableObject.Validate%2A> method.
+Options validation also supports <xref:System.ComponentModel.DataAnnotations.IValidatableObject>. To perform class-level validation of a class within the class itself:
+
+* Implement the `IValidatableObject` interface and its <xref:System.ComponentModel.DataAnnotations.IValidatableObject.Validate%2A> method within the class.
+* Call <xref:Microsoft.Extensions.DependencyInjection.OptionsBuilderDataAnnotationsExtensions.ValidateDataAnnotations%2A> in `Program.cs`.
 
 <!-- The following comment doesn't seem that useful 
 Options validation doesn't guard against options modifications after the options instance is created. For example, `IOptionsSnapshot` options are created and validated once per request when the options are first accessed. The `IOptionsSnapshot` options aren't validated again on subsequent access attempts *for the same request*.


### PR DESCRIPTION
Fixes #25579.

[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-6.0&branch=pr-en-us-25596#ivalidateoptionstoptions-and-ivalidatableobject).