### PR TITLE
Document LinkParser.ParsePathByEndpointName

### DIFF
--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -804,6 +804,20 @@ In the preceding code, the `culture` route parameter is used for localization. T
 * In the `"default"` route template, the `culture` route parameter is to the left of `controller`, so changes to `controller` won't invalidate `culture`.
 * In the `"blog"` route template, the `culture` route parameter is considered to be to the right of `controller`, which appears in the required values.
 
+## Parse URL paths with `LinkParser`
+
+The <xref:Microsoft.AspNetCore.Routing.LinkParser> class adds support for parsing a URL path into a set of route values. The <xref:Microsoft.AspNetCore.Routing.LinkParserEndpointNameAddressExtensions.ParsePathByEndpointName%2A> method takes a URL path and an endpoint name, and returns a set of route values extracted from the URL path.
+
+In the following example controller, the `GetProduct` action uses a route template of `api/Products/{id}` and has a <xref:Microsoft.AspNetCore.Mvc.RouteAttribute.Name%2A> of `GetProduct`: 
+
+:::code language="csharp" source="routing/samples/6.x/RoutingSample/Snippets/Controllers/ProductsController.cs" id="snippet_ClassGet" highlight="2,5":::
+
+In the same controller class, the `AddRelatedProduct` action expects a URL path, `pathToRelatedProduct`, which can be provided as a query-string parameter:
+
+:::code language="csharp" source="routing/samples/6.x/RoutingSample/Snippets/Controllers/ProductsController.cs" id="snippet_AddRelatedProduct":::
+
+In the preceding example, the `AddRelatedProduct` action extracts the `id` route value from the URL path. For example, with a URL path of `/api/Products/1`, the `relatedProductId` value is set to `1`. This approach allows the API's clients to use URL paths when referring to resources, without requiring knowledge of how such a URL is structured.
+
 ## Configure endpoint metadata
 
 The following links provide information on how to configure endpoint metadata:
@@ -835,7 +849,7 @@ The following code uses `RequireHost` to require the specified host on the route
 
 The following code uses the `[Host]` attribute on the controller to require any of the specified hosts:
 
-:::code language="csharp" source="routing/samples/6.x/RoutingSample/Snippets/Controllers/ProductsController.cs" id="snippet_Host":::
+:::code language="csharp" source="routing/samples/6.x/RoutingSample/Snippets/Controllers/HostsController.cs" id="snippet_Class":::
 
 When the `[Host]` attribute is applied to both the controller and action method:
 

--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -806,7 +806,7 @@ In the preceding code, the `culture` route parameter is used for localization. T
 
 ## Parse URL paths with `LinkParser`
 
-The <xref:Microsoft.AspNetCore.Routing.LinkParser> class adds support for parsing a URL path into a set of route values. The <xref:Microsoft.AspNetCore.Routing.LinkParserEndpointNameAddressExtensions.ParsePathByEndpointName%2A> method takes a URL path and an endpoint name, and returns a set of route values extracted from the URL path.
+The <xref:Microsoft.AspNetCore.Routing.LinkParser> class adds support for parsing a URL path into a set of route values. The <xref:Microsoft.AspNetCore.Routing.LinkParserEndpointNameAddressExtensions.ParsePathByEndpointName%2A> method takes an endpoint name and a URL path, and returns a set of route values extracted from the URL path.
 
 In the following example controller, the `GetProduct` action uses a route template of `api/Products/{id}` and has a <xref:Microsoft.AspNetCore.Mvc.RouteAttribute.Name%2A> of `GetProduct`: 
 

--- a/aspnetcore/fundamentals/routing/samples/6.x/RoutingSample/Snippets/Controllers/HostsController.cs
+++ b/aspnetcore/fundamentals/routing/samples/6.x/RoutingSample/Snippets/Controllers/HostsController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace RoutingSample.Snippets.Controllers;
+
+[NonController]
+// <snippet_Class>
+[Host("contoso.com", "adventure-works.com")]
+public class HostsController : Controller
+{
+    public IActionResult Index() =>
+        View();
+
+    [Host("example.com")]
+    public IActionResult Example() =>
+        View();
+}
+// </snippet_Class>

--- a/aspnetcore/fundamentals/routing/samples/6.x/RoutingSample/Snippets/Controllers/ProductsController.cs
+++ b/aspnetcore/fundamentals/routing/samples/6.x/RoutingSample/Snippets/Controllers/ProductsController.cs
@@ -1,16 +1,32 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc;
 
 namespace RoutingSample.Snippets.Controllers;
-    
-// <snippet_Host>
-[Host("contoso.com", "adventure-works.com")]
-public class ProductsController : Controller
-{
-    public IActionResult Index() =>
-        View();
 
-    [Host("example.com")]
-    public IActionResult Example() =>
-        View();
+// <snippet_ClassGet>
+[ApiController]
+[Route("api/[controller]")]
+public class ProductsController : ControllerBase
+{
+    [HttpGet("{id}", Name = nameof(GetProduct))]
+    public IActionResult GetProduct(string id)
+    {
+        // ...
+        // </snippet_ClassGet>
+        return Ok();
+    }
+
+    // <snippet_AddRelatedProduct>
+    [HttpPost("{id}/Related")]
+    public IActionResult AddRelatedProduct(
+        string id, string pathToRelatedProduct, [FromServices] LinkParser linkParser)
+    {
+        var routeValues = linkParser.ParsePathByEndpointName(
+            nameof(GetProduct), pathToRelatedProduct);
+        var relatedProductId = routeValues?["id"];
+
+        // ...
+        // </snippet_AddRelatedProduct>
+
+        return NoContent();
+    }
 }
-// </snippet_Host>


### PR DESCRIPTION
Fixes #16913.

[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/routing?view=aspnetcore-6.0&branch=pr-en-us-25600#parse-url-paths-with-linkparser).