### PR TITLE
Blazor debug published, non-production, hosted WASM

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -220,9 +220,7 @@ To debug a **published**, hosted Blazor WebAssembly app, configure debugger supp
 By default, publishing an app disables the preceding properties by setting them to `false`.
 
 > [!WARNING]
-> Published, hosted Blazor WebAssembly apps should only enable debugging when deploying published assets ***locally***. Do **not*** deploy a published app into production with the `DebuggerSupport` property set to `true`.
->
-> If `CopyOutputSymbolsToPublishDirectory` is set to `true` in a published, production app, there are no security risks, but app size and deployment speed are adversely impacted for no benefit. Therefore, apps deployed into production should ***not** enable copying symbols to the `publish` directory.
+> Published, hosted Blazor WebAssembly apps should only enable debugging and copying output symbols when deploying published assets ***locally***. Do **not*** deploy a published app into production with the `DebuggerSupport` and `CopyOutputSymbolsToPublishDirectory` properties set to `true`.
 
 ## Attach to an existing debugging session
 
@@ -649,9 +647,7 @@ To debug a **published**, hosted Blazor WebAssembly app, configure debugger supp
 By default, publishing an app disables the preceding properties by setting them to `false`.
 
 > [!WARNING]
-> Published, hosted Blazor WebAssembly apps should only enable debugging when deploying published assets ***locally***. Do **not*** deploy a published app into production with the `DebuggerSupport` property set to `true`.
->
-> If `CopyOutputSymbolsToPublishDirectory` is set to `true` in a published, production app, there are no security risks, but app size and deployment speed are adversely impacted for no benefit. Therefore, apps deployed into production should ***not** enable copying symbols to the `publish` directory.
+> Published, hosted Blazor WebAssembly apps should only enable debugging and copying output symbols when deploying published assets ***locally***. Do **not*** deploy a published app into production with the `DebuggerSupport` and `CopyOutputSymbolsToPublishDirectory` properties set to `true`.
 
 ## Attach to an existing debugging session
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -210,6 +210,20 @@ For guidance on configuring VS Code assets in the `.vscode` folder and where to 
 >
 > You can't automatically rebuild the backend **`Server`** app of a hosted Blazor WebAssembly solution during debugging, for example by running the app with [`dotnet watch run`](xref:tutorials/dotnet-watch).
 
+To debug a **published**, hosted Blazor WebAssembly app, configure debugger support (`DebuggerSupport`) and copy output symbols to the `publish` directory (`CopyOutputSymbolsToPublishDirectory`) in the **`Client`** app's project file:
+
+```xml
+<DebuggerSupport>true</DebuggerSupport>
+<CopyOutputSymbolsToPublishDirectory>true</CopyOutputSymbolsToPublishDirectory>
+```
+
+By default, publishing an app disables the preceding properties by setting them to `false`.
+
+> [!WARNING]
+> Published, hosted Blazor WebAssembly apps should only enable debugging when deploying published assets ***locally***. Do **not*** deploy a published app into production with the `DebuggerSupport` property set to `true`.
+>
+> If `CopyOutputSymbolsToPublishDirectory` is set to `true` in a published, production app, there are no security risks, but app size and deployment speed are adversely impacted for no benefit. Therefore, apps deployed into production should ***not** enable copying symbols to the `publish` directory.
+
 ## Attach to an existing debugging session
 
 To attach to a running Blazor app, create a `.vscode/launch.json` file with the following configuration. Replace the `{URL}` placeholder with the URL where the app is running:
@@ -624,6 +638,20 @@ The **`Server`** project's `Properties/launchSettings.json` file includes the `i
   }
 }
 ```
+
+To debug a **published**, hosted Blazor WebAssembly app, configure debugger support (`DebuggerSupport`) and copy output symbols to the `publish` directory (`CopyOutputSymbolsToPublishDirectory`) in the **`Client`** app's project file:
+
+```xml
+<DebuggerSupport>true</DebuggerSupport>
+<CopyOutputSymbolsToPublishDirectory>true</CopyOutputSymbolsToPublishDirectory>
+```
+
+By default, publishing an app disables the preceding properties by setting them to `false`.
+
+> [!WARNING]
+> Published, hosted Blazor WebAssembly apps should only enable debugging when deploying published assets ***locally***. Do **not*** deploy a published app into production with the `DebuggerSupport` property set to `true`.
+>
+> If `CopyOutputSymbolsToPublishDirectory` is set to `true` in a published, production app, there are no security risks, but app size and deployment speed are adversely impacted for no benefit. Therefore, apps deployed into production should ***not** enable copying symbols to the `publish` directory.
 
 ## Attach to an existing debugging session
 


### PR DESCRIPTION
Fixes #25512

Are the problems that ...

* Debugger support introduces security risk?
* Copying output symbols introduces perf risk (of deployment ... larger app, slower deployment)?

I think it's good if we say why these should be disabled for published, production apps.