### PR TITLE
Migration topic fix: Logging defaults

### DIFF
--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -122,7 +122,7 @@ There are a few changes to the other files generated for the Web App template:
 + "Microsoft.AspNetCore": "Warning"
 ```
 
-In the preceding ASP.NET Core sample, `"Microsoft": "Warning"` has been changed to `"Microsoft.AspNetCore": "Warning"`. This change results in logging all informational messages from the `Microsoft` namespace ***except*** `Microsoft.AspNetCore`. For example, `Microsoft.EntityFrameworkCore` is now logged at the informational level.
+In the preceding ASP.NET Core template code, `"Microsoft": "Warning"` has been changed to `"Microsoft.AspNetCore": "Warning"`. This change results in logging all informational messages from the `Microsoft` namespace ***except*** `Microsoft.AspNetCore`. For example, `Microsoft.EntityFrameworkCore` is now logged at the informational level.
 
 For more details on the new hosting model, see the [Frequently asked questions](#faq) section. For more information on the adoption of NRTs and .NET compiler null-state analysis, see the [Nullable reference types (NRTs) and .NET compiler null-state static analysis](#nullable-reference-types-nrts-and-net-compiler-null-state-static-analysis) section.
 

--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to migrate an ASP.NET Core 5.0 project to ASP.NET Core 6.0.
 ms.author: riande
 monikerRange: '>= aspnetcore-5.0'
-ms.date: 10/25/2021
+ms.date: 04/11/2022
 no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: migration/50-to-60
 ---
@@ -114,13 +114,15 @@ There are a few changes to the other files generated for the Web App template:
 + public string? RequestId { get; set; }
 ```
 
-* `"Microsoft.Hosting.Lifetime": "Information"` was removed from both `appsettings.json` and `appsettings.Development.json`:
+* Log level defaults have changed in `appsettings.json` and `appsettings.Development.json`:
 
 ```diff
 - "Microsoft": "Warning",
 - "Microsoft.Hosting.Lifetime": "Information"
 + "Microsoft.AspNetCore": "Warning"
 ```
+
+In the preceding ASP.NET Core sample, `"Microsoft": "Warning"` has been changed to `"Microsoft.AspNetCore": "Warning"`. This change results in logging all informational messages from the `Microsoft` namespace ***except*** `Microsoft.AspNetCore`. For example, `Microsoft.EntityFrameworkCore` is now logged at the informational level.
 
 For more details on the new hosting model, see the [Frequently asked questions](#faq) section. For more information on the adoption of NRTs and .NET compiler null-state analysis, see the [Nullable reference types (NRTs) and .NET compiler null-state static analysis](#nullable-reference-types-nrts-and-net-compiler-null-state-static-analysis) section.
 


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/migration/50-to-60?view=aspnetcore-6.0&branch=pr-en-us-25606&tabs=visual-studio)

Fixes #25550 

Clarified the changes made in the default appsettings for logging.