### PR TITLE
Add example how to use the AsyncAuthInterceptor

### DIFF
--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -171,7 +171,7 @@ The preceeding code:
 * Registers the `GreeterClient` type with client factory.
 * Configures the `AuthInterceptor` for this client using `InterceptorScope.Client`. A new interceptor is created for each client instance. When a client is created for a gRPC service or Web API controller, the scoped `ITokenProvider` is injected into the interceptor.
 
-##### Bearer token with gRPC client factory using AsyncAuthInterceptor
+##### Bearer token with gRPC client factory using `AsyncAuthInterceptor`
 
 If the bearer token can only be generated using asynchronous method calls, the `AsyncAuthInterceptor` must be used.
 

--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -199,7 +199,7 @@ services
         {
             using var scope = scopeFactory.CreateScope();
             var tokenProvider = scope.ServiceProvider.GetRequiredService<ITokenProvider>();
-            var token = await tokenProvider.GetToken();
+            var token = await tokenProvider.GetTokenAsync();
             metadata.Add("Authorization", $"Bearer {token}");
         });
         options.Credentials = ChannelCredentials.Create(

--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -180,7 +180,7 @@ Assuming the token provider is defined as follows and has been registered as sco
 ```csharp
 public interface ITokenProvider
 {
-    Task<string> GetToken();
+    Task<string> GetTokenAsync();
 }
 ``` 
 


### PR DESCRIPTION
* added example service registration that uses the AsyncAuthInterceptor to request a bearer token

Fixes [https://github.com/grpc/grpc-dotnet/issues/1682](https://github.com/grpc/grpc-dotnet/issues/1682)
Fixes #24132