### PR TITLE
Update getting-started-with-swashbuckle.md

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -126,9 +126,6 @@ XML comments can be enabled with the following approaches:
 * Right-click the project in **Solution Explorer** and select *`Edit <project_name>.csproj`*.
 * Add [GenerateDocumentationFile](/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)  to the `.csproj` file:
 
-<!--
-:::code language="xml" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/SwashbuckleSample.csproj" range="9-12" highlight="1-2,4":::
--->
 ```XML
 <PropertyGroup>
   <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -144,15 +141,23 @@ XML comments can be enabled with the following approaches:
 
 #### [Visual Studio Code](#tab/visual-studio-code)
 
-Manually add the highlighted lines to the `.csproj` file:
+Add [GenerateDocumentationFile](/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)  to the `.csproj` file:
 
-:::code language="xml" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/SwashbuckleSample.csproj" range="9-12" highlight="1-2,4":::
+```XML
+<PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+</PropertyGroup>
+```
 
 #### [.NET Core CLI](#tab/netcore-cli)
 
-Manually add the highlighted lines to the `.csproj` file:
+Add [GenerateDocumentationFile](/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)  to the `.csproj` file:
 
-:::code language="xml" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/SwashbuckleSample.csproj" range="9-12" highlight="1-2,4":::
+```XML
+<PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+</PropertyGroup>
+```
 
 ---
 

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -124,7 +124,7 @@ XML comments can be enabled with the following approaches:
 #### [Visual Studio](#tab/visual-studio)
 
 * Right-click the project in **Solution Explorer** and select *`Edit <project_name>.csproj`*.
-* Add `<GenerateDocumentationFile>true</GenerateDocumentationFile>`  to the `.csproj` file:
+* Add [GenerateDocumentationFile](/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)  to the `.csproj` file:
 
 <!--
 :::code language="xml" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/SwashbuckleSample.csproj" range="9-12" highlight="1-2,4":::

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -126,7 +126,14 @@ XML comments can be enabled with the following approaches:
 * Right-click the project in **Solution Explorer** and select *`Edit <project_name>.csproj`*.
 * Manually add the highlighted lines to the `.csproj` file:
 
+<!--
 :::code language="xml" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/SwashbuckleSample.csproj" range="9-12" highlight="1-2,4":::
+-->
+```XML
+<PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+</PropertyGroup>
+```
 
 #### [Visual Studio for Mac](#tab/visual-studio-mac)
 

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -135,9 +135,13 @@ XML comments can be enabled with the following approaches:
 #### [Visual Studio for Mac](#tab/visual-studio-mac)
 
 * From the *Solution Pad*, press **control** and click the project name. Navigate to **Tools** > **Edit File**.
-* Manually add the highlighted lines to the `.csproj` file:
+* Add [GenerateDocumentationFile](/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile)  to the `.csproj` file:
 
-:::code language="xml" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/SwashbuckleSample.csproj" range="9-12" highlight="1-2,4":::
+```XML
+<PropertyGroup>
+  <GenerateDocumentationFile>true</GenerateDocumentationFile>
+</PropertyGroup>
+```
 
 #### [Visual Studio Code](#tab/visual-studio-code)
 

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -124,7 +124,7 @@ XML comments can be enabled with the following approaches:
 #### [Visual Studio](#tab/visual-studio)
 
 * Right-click the project in **Solution Explorer** and select *`Edit <project_name>.csproj`*.
-* Manually add the highlighted lines to the `.csproj` file:
+* Add `<GenerateDocumentationFile>true</GenerateDocumentationFile>`  to the `.csproj` file:
 
 <!--
 :::code language="xml" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/SwashbuckleSample.csproj" range="9-12" highlight="1-2,4":::


### PR DESCRIPTION
Remove `  <NoWarn>$(NoWarn);1591</NoWarn>` and complicated range highlight.

[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-6.0&branch=pr-en-us-25621&tabs=visual-studio#xml-comments)