### PR TITLE
Update building-net-docker-images.md port mapping in Windows Container

### DIFF
--- a/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
+++ b/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
@@ -122,8 +122,8 @@ The sample Dockerfile uses the [Docker multi-stage build feature](https://docs.d
 
 ## Run in a Linux container or Windows container
 
-* To run in a Linux container, in the Docker client, [switch to Linux containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
-* To run in a Windows container, in the Docker client, [switch to Windows containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
+* To run in a Linux container, right-click the System Tray's Docker client icon and select [switch to Linux containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
+* To run in a Windows container, right-click the System Tray's Docker client icon and select [switch to Windows containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
 
 * Navigate to the Dockerfile folder at *dotnet-docker/samples/aspnetapp*.
 

--- a/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
+++ b/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
@@ -156,25 +156,10 @@ Navigate to the docker file folder at `dotnet-docker/samples/aspnetapp`.
 
   ```console
   docker build -t aspnetapp .
-  docker run -it --rm --name aspnetcore_sample aspnetapp
+  docker run -it --rm -p 5000:80 --name aspnetcore_sample aspnetapp
   ```
 
-* For Windows containers, you need the IP address of the container (browsing to `http://localhost:5000` won't work):
-  * Open up another command prompt.
-  * Run `docker ps` to see the running containers. Verify that the "aspnetcore_sample" container is there.
-  * Run `docker exec aspnetcore_sample ipconfig` to display the IP address of the container. The output from the command looks like this example:
-
-    ```console
-    Ethernet adapter Ethernet:
-
-       Connection-specific DNS Suffix  . : contoso.com
-       Link-local IPv6 Address . . . . . : fe80::1967:6598:124:cfa3%4
-       IPv4 Address. . . . . . . . . . . : 172.29.245.43
-       Subnet Mask . . . . . . . . . . . : 255.255.240.0
-       Default Gateway . . . . . . . . . : 172.29.240.1
-    ```
-
-* Copy the container IPv4 address (for example, 172.29.245.43) and paste into the browser address bar to test the app.
+* Go to `http://localhost:5000` in a browser to test the app.
 
 ## Build and deploy manually
 

--- a/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
+++ b/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
@@ -120,9 +120,10 @@ The sample Dockerfile uses the [Docker multi-stage build feature](https://docs.d
 
 * Press Ctrl+C at the command prompt to stop the app.
 
-## Run in a Linux container
+## Run in a Linux container or Windows container
 
-* In the Docker client, [switch to Linux containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
+* To run in a Linux container, in the Docker client, [switch to Linux containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
+* To run in a Windows container, in the Docker client, [switch to Windows containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
 
 * Navigate to the Dockerfile folder at *dotnet-docker/samples/aspnetapp*.
 
@@ -143,21 +144,6 @@ The sample Dockerfile uses the [Docker multi-stage build feature](https://docs.d
   * Map port 5000 on the local machine to port 80 in the container.
   * Name the container aspnetcore_sample.
   * Specify the aspnetapp image.
-
-* Go to `http://localhost:5000` in a browser to test the app.
-
-## Run in a Windows container
-
-* In the Docker client, [switch to Windows containers](https://docs.docker.com/desktop/windows/#switch-between-windows-and-linux-containers).
-
-Navigate to the docker file folder at `dotnet-docker/samples/aspnetapp`.
-
-* Run the following commands to build and run the sample in Docker:
-
-  ```console
-  docker build -t aspnetapp .
-  docker run -it --rm -p 5000:80 --name aspnetcore_sample aspnetapp
-  ```
 
 * Go to `http://localhost:5000` in a browser to test the app.
 


### PR DESCRIPTION
Update port mapping in Windows Container, I run the instruction on my Windows 10 machine and it works



***@Rick-Anderson  EDIT*** 
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/building-net-docker-images?view=aspnetcore-6.0&branch=pr-en-us-25687#run-in-a-windows-container)
Fixes #25708