### PR TITLE
Adjust the code sample for adding an Authorization header in a gRPC interceptor

### DIFF
--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -148,7 +148,16 @@ public class AuthInterceptor : Interceptor
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
     {
-        context.Options.Metadata.Add("Authorization", $"Bearer {_tokenProvider.GetToken()}");
+        if(context.Options.Headers == null)
+        {
+            context = new ClientInterceptorContext<TRequest, TResponse>(
+                context.Method,
+                context.Host,
+                context.Options.WithHeaders(new Metadata()));
+        }
+
+        context.Options.Headers!.Add("Authorization", $"Bearer {_tokenProvider.GetToken()}");
+
         return continuation(request, context);
     }
 }
@@ -405,7 +414,16 @@ public class AuthInterceptor : Interceptor
         ClientInterceptorContext<TRequest, TResponse> context,
         AsyncUnaryCallContinuation<TRequest, TResponse> continuation)
     {
-        context.Options.Metadata.Add("Authorization", $"Bearer {_tokenProvider.GetToken()}");
+        if(context.Options.Headers == null)
+        {
+            context = new ClientInterceptorContext<TRequest, TResponse>(
+                context.Method,
+                context.Host,
+                context.Options.WithHeaders(new Metadata()));
+        }
+        
+        context.Options.Headers!.Add("Authorization", $"Bearer {_tokenProvider.GetToken()}");
+
         return continuation(request, context);
     }
 }


### PR DESCRIPTION
The PR fixes a potential problem in the code sample for adding an `Authorization` header in a gRPC interceptor.

The code sample wasn't working for me, because the property is called `Headers`, and not `Metadata`: https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.Core.Api/CallOptions.cs#L63, so as far as I can tell, this was just a mistake.

And the other issue is that `context.Options.Headers` might be `null`, in which case I assume it has to be initialized, I hope I did that correctly.