### PR TITLE
Update MS Learn cross-link

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -332,7 +332,7 @@ items:
               - name: SignalR with Blazor
                 uid: blazor/tutorials/signalr-blazor
               - name: Microsoft Learn modules
-                href: /learn/modules/build-blazor-webassembly-visual-studio-code/
+                href: /learn/paths/build-web-apps-with-blazor/
           - name: Hosting models
             uid: blazor/hosting-models
           - name: Blazor Hybrid


### PR DESCRIPTION
Pointing this to the MS Learn landing page for Blazor. This endpoint is the one that I've already used in the Blazor Tutorials topic, so I think this is the only spot that requires an update. IIRC, this path (and endpoint in Learn pages) didn't exist when the first Learn module went up, so this pointed to that one tutorial. It's best for us to use the path endpoint because they have several experiences now.