### PR TITLE
Changed end-of-sentence punctuation from : to .

### DIFF
--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -155,7 +155,7 @@ Run the app and select **Log in**. An option to sign in with Microsoft appears. 
 
 Tap **Yes** and you will be redirected back to the web site where you can set your email.
 
-You are now logged in using your Microsoft credentials:
+You are now logged in using your Microsoft credentials.
 
 [!INCLUDE[](includes/chain-auth-providers.md)]
 

--- a/aspnetcore/security/authentication/social/microsoft-logins.md
+++ b/aspnetcore/security/authentication/social/microsoft-logins.md
@@ -72,7 +72,7 @@ For more information about configuration options supported by Microsoft Account 
 * Select to sign in with Microsoft. You are redirected to Microsoft for authentication. After signing in with your Microsoft Account, you will be prompted to let the app access your info:
 * Select **Yes**. You are redirected back to the web site where you can set your email.
 
-You are now logged in using your Microsoft credentials:
+You are now logged in using your Microsoft credentials.
 
 [!INCLUDE[](includes/chain-auth-providers.md)]
 


### PR DESCRIPTION
In the documentation about [Microsoft authentication](https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/microsoft-logins?view=aspnetcore-6.0), there is a wrong punctuation at the end of the following sentence:

`You are now logged in using your Microsoft credentials:`

It should be:

`You are now logged in using your Microsoft credentials.`