### PR TITLE
Clarify change detection

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -262,6 +262,7 @@ For an alternative approach suited to sharing data in memory and across componen
 
 ## Additional resources
 
+* [Parameter change detection and additional guidance on Razor component rendering](xref:blazor/components/rendering)
 * <xref:blazor/forms-validation>
 * [Binding to radio buttons in a form](xref:blazor/forms-validation#radio-buttons)
 * [Binding `InputSelect` options to C# object `null` values](xref:blazor/forms-validation#binding-inputselect-options-to-c-object-null-values)
@@ -457,6 +458,7 @@ For an alternative approach suited to sharing data in memory and across componen
 
 ## Additional resources
 
+* [Parameter change detection and additional guidance on Razor component rendering](xref:blazor/components/rendering)
 * <xref:blazor/forms-validation>
 * [Binding to radio buttons in a form](xref:blazor/forms-validation#radio-buttons)
 * [Binding `InputSelect` options to C# object `null` values](xref:blazor/forms-validation#binding-inputselect-options-to-c-object-null-values)
@@ -652,6 +654,7 @@ For an alternative approach suited to sharing data in memory and across componen
 
 ## Additional resources
 
+* [Parameter change detection and additional guidance on Razor component rendering](xref:blazor/components/rendering)
 * <xref:blazor/forms-validation>
 * [Binding to radio buttons in a form](xref:blazor/forms-validation#radio-buttons)
 * [Binding `InputSelect` options to C# object `null` values](xref:blazor/forms-validation#binding-inputselect-options-to-c-object-null-values)

--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -28,7 +28,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set. 
+* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set.
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
 
 Blazor's framework uses a set of built-in rules for change detection, which are subject to change at any time. For more information, see the [`ChangeDetection` API in the ASP.NET Core reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ChangeDetection.cs).
@@ -129,7 +129,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set. 
+* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set.
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
 
 Blazor's framework uses a set of built-in rules for change detection, which are subject to change at any time. For more information, see the [`ChangeDetection` API in the ASP.NET Core reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ChangeDetection.cs).
@@ -230,7 +230,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set. 
+* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set.
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
 
 Blazor's framework uses a set of built-in rules for change detection, which are subject to change at any time. For more information, see the [`ChangeDetection` API in the ASP.NET Core reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ChangeDetection.cs).

--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -28,8 +28,12 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* All of the parameter values are of known immutable primitive types, such as `int`, `string`, `DateTime`, and haven't changed since the previous set of parameters were set.
+* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set. 
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
+
+Blazor's framework uses a set of built-in rules for change detection, which are subject to change at any time. For more information, see the [`ChangeDetection` API in the ASP.NET Core reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ChangeDetection.cs).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 ## Control the rendering flow
 
@@ -125,8 +129,12 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* All of the parameter values are of known immutable primitive types, such as `int`, `string`, `DateTime`, and haven't changed since the previous set of parameters were set.
+* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set. 
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
+
+Blazor's framework uses a set of built-in rules for change detection, which are subject to change at any time. For more information, see the [`ChangeDetection` API in the ASP.NET Core reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ChangeDetection.cs).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 ## Control the rendering flow
 
@@ -222,8 +230,12 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
-* All of the parameter values are of known immutable primitive types, such as `int`, `string`, `DateTime`, and haven't changed since the previous set of parameters were set.
+* Generally, all of the parameter values are of known immutable primitive types, such as `int`, `string`, and `DateTime` (including nullable types), and haven't changed since the previous set of parameters were set. 
 * The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
+
+Blazor's framework uses a set of built-in rules for change detection, which are subject to change at any time. For more information, see the [`ChangeDetection` API in the ASP.NET Core reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ChangeDetection.cs).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 ## Control the rendering flow
 


### PR DESCRIPTION
Fixes #23084 

Thanks @szalapski! 🚀 ... Sorry for the delay. We tend to work through the backlog in H1 of each year following a hectic end-of-year release cycle and the holidays.

For the *Binding* topic, I'm adding a cross-link to the *Rendering* topic, where the subject is covered. I think it could go either way ... it could be an INCLUDES file shared in both spots; however, this subject is bit more in-the-weeds ... more implementation-ish ... than perhaps binding needs to cover directly. For most devs in most scenarios, the change detection should ✨ **_Just Work!_**&trade; ✨. The *Rendering* topic comes up fairly fast in the reading list down the ToC, so they'll get there PDQ anyway. Let's try this. If more feedback comes in on the *Binding* topic asking for more detail earlier, then I'll make further mods.

Thanks again, @szalapski. Although the coverage is rather .... uh .... **_vague_** 😆 ... I hope this answers your question(s) and gets you to the right part of the reference source to see the framework's magic bits that make it happen.
