### PR TITLE
Update intro.md

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/intro.md
+++ b/aspnetcore/mvc/views/tag-helpers/intro.md
@@ -178,7 +178,7 @@ builder.Services.AddSingleton
 
 ## IntelliSense support for Tag Helpers
 
-When you create a new ASP.NET Core web app in Visual Studio, it adds the NuGet package "Microsoft.AspNetCore.Razor.Tools". This is the package that adds Tag Helper tooling.
+When you create a new ASP.NET Core web app using .NET Core 3 and older in Visual Studio, it adds the NuGet package "Microsoft.AspNetCore.Razor.Tools". This is the package that adds Tag Helper tooling.
 
 Consider writing an HTML `<label>` element. As soon as you enter `<l` in the Visual Studio editor, IntelliSense displays matching elements:
 

--- a/aspnetcore/mvc/views/tag-helpers/intro.md
+++ b/aspnetcore/mvc/views/tag-helpers/intro.md
@@ -178,7 +178,6 @@ builder.Services.AddSingleton
 
 ## IntelliSense support for Tag Helpers
 
-When you create a new ASP.NET Core web app using .NET Core 3 and older in Visual Studio, it adds the NuGet package "Microsoft.AspNetCore.Razor.Tools". This is the package that adds Tag Helper tooling.
 
 Consider writing an HTML `<label>` element. As soon as you enter `<l` in the Visual Studio editor, IntelliSense displays matching elements:
 


### PR DESCRIPTION
Microsoft.AspNetCore.Razor.Tools is not added to an ASP.NET MVC Core app newly created by Visual Studio when creating a .NET 6 app. I don't believe it incorporates Microsoft.AspNetCore.Razor.Tools in a .NET 5 app, either. I've tried to make this clearer in the editing I've made.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->