### PR TITLE
Add note to call UseRouting after UsePathBase

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -108,6 +108,8 @@ In other hosting scenarios, such as GitHub Pages and IIS sub-apps, the app base 
 
   ```csharp
   app.UsePathBase("/CoolApp");
+  // ...
+  app.UseRouting();
   ```
 
 * In a Blazor Server app, use ***either*** of the following approaches:
@@ -124,6 +126,8 @@ In other hosting scenarios, such as GitHub Pages and IIS sub-apps, the app base 
 
     ```csharp
     app.UsePathBase("/CoolApp");
+    // ...
+    app.UseRouting();
     ```
 
     Calling <xref:Microsoft.AspNetCore.Builder.UsePathBaseExtensions.UsePathBase%2A> is recommended when you also wish to run the Blazor Server app locally. For example, supply the launch URL in `Properties/launchSettings.json`:
@@ -145,6 +149,9 @@ In other hosting scenarios, such as GitHub Pages and IIS sub-apps, the app base 
         "ASPNETCORE_ENVIRONMENT": "Development"
     }
     ```
+
+> [!NOTE]
+> When using [WebApplication](xref:Microsoft.AspNetCore.Builder.WebApplication) (see <xref:migration/50-to-60#new-hosting-model>), [app.UseRouting](xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A) must be called explicitly after `UsePathBase` so the routing middleware can observe the modified path before matching routes. Otherwise, routes will be matched before the path is rewritten by `UsePathBase` as described in the[Middleware Ordering](xref:fundamentals/middleware/index#order) and [Routing](xref:fundamentals/routing) docs.
 
 Do ***not*** prefix links throughout the app with a forward slash. Either avoid the use of a path segment separator or use dot-slash (`./`) relative path notation:
 

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -151,7 +151,7 @@ In other hosting scenarios, such as GitHub Pages and IIS sub-apps, the app base 
     ```
 
 > [!NOTE]
-> When using [WebApplication](xref:Microsoft.AspNetCore.Builder.WebApplication) (see <xref:migration/50-to-60#new-hosting-model>), [app.UseRouting](xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A) must be called explicitly after `UsePathBase` so the routing middleware can observe the modified path before matching routes. Otherwise, routes will be matched before the path is rewritten by `UsePathBase` as described in the[Middleware Ordering](xref:fundamentals/middleware/index#order) and [Routing](xref:fundamentals/routing) docs.
+> When using <xref:Microsoft.AspNetCore.Builder.WebApplication> (see <xref:migration/50-to-60#new-hosting-model>), [`app.UseRouting`](xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A) must be called after `UsePathBase` so that the routing middleware can observe the modified path before matching routes. Otherwise, routes are matched before the path is rewritten by `UsePathBase` as described in the [Middleware Ordering](xref:fundamentals/middleware/index#order) and [Routing](xref:fundamentals/routing) articles.
 
 Do ***not*** prefix links throughout the app with a forward slash. Either avoid the use of a path segment separator or use dot-slash (`./`) relative path notation:
 

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -129,7 +129,12 @@ If `/foo` is the app base path for a proxy path passed as `/foo/api/1`, the midd
 
 ```csharp
 app.UsePathBase("/foo");
+// ...
+app.UseRouting();
 ```
+
+> [!NOTE]
+> When using [WebApplication](xref:Microsoft.AspNetCore.Builder.WebApplication) (see <xref:migration/50-to-60#new-hosting-model>), [app.UseRouting](xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A) must be called explicitly after `UsePathBase` so the routing middleware can observe the modified path before matching routes. Otherwise, routes will be matched before the path is rewritten by `UsePathBase` as described in the[Middleware Ordering](xref:fundamentals/middleware/index#order) and [Routing](xref:fundamentals/routing) docs.
 
 The original path and path base are reapplied when the middleware is called again in reverse. For more information on middleware order processing, see <xref:fundamentals/middleware/index>.
 

--- a/aspnetcore/host-and-deploy/proxy-load-balancer.md
+++ b/aspnetcore/host-and-deploy/proxy-load-balancer.md
@@ -134,7 +134,7 @@ app.UseRouting();
 ```
 
 > [!NOTE]
-> When using [WebApplication](xref:Microsoft.AspNetCore.Builder.WebApplication) (see <xref:migration/50-to-60#new-hosting-model>), [app.UseRouting](xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A) must be called explicitly after `UsePathBase` so the routing middleware can observe the modified path before matching routes. Otherwise, routes will be matched before the path is rewritten by `UsePathBase` as described in the[Middleware Ordering](xref:fundamentals/middleware/index#order) and [Routing](xref:fundamentals/routing) docs.
+> When using <xref:Microsoft.AspNetCore.Builder.WebApplication> (see <xref:migration/50-to-60#new-hosting-model>), [`app.UseRouting`](xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A) must be called after `UsePathBase` so that the routing middleware can observe the modified path before matching routes. Otherwise, routes are matched before the path is rewritten by `UsePathBase` as described in the [Middleware Ordering](xref:fundamentals/middleware/index#order) and [Routing](xref:fundamentals/routing) articles.
 
 The original path and path base are reapplied when the middleware is called again in reverse. For more information on middleware order processing, see <xref:fundamentals/middleware/index>.
 


### PR DESCRIPTION
We plan to fix `UsePathBase()` in .NET 7 so it's unnecessary to call `UseRouting()` afterwards like we did for `UseExceptionHandler()`, `UseStatusCodePagesWithReExecute()` and `UseRewriter()` in .NET 6. https://github.com/dotnet/aspnetcore/pull/35426

For now, we want to document that explicitly calling `UseRouting()` is necessary for `UsePathBase()` to work with `WebApplication`.

Partially addresses: https://github.com/dotnet/aspnetcore/issues/38448