### PR TITLE
Fix Powershell script in /fundamentals/host/platform-specific-configuration sample

### DIFF
--- a/aspnetcore/fundamentals/host/platform-specific-configuration/samples/2.x/RuntimeStore/deploy.ps1
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration/samples/2.x/RuntimeStore/deploy.ps1
@@ -2,7 +2,7 @@ function AppendToEnvironmentVariable($name, $appendValue)
 {
     $value = [Environment]::GetEnvironmentVariable($name, 'Machine')
     if ($value -eq $null) {
-      [Environment]::SetEnvironmentVariable($name, 'StartupDiagnostics', 'Machine')
+      [Environment]::SetEnvironmentVariable($name, $appendValue, 'Machine')
     } else {
       if ($value -notcontains $appendValue) {
         [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue, 'Machine')

--- a/aspnetcore/fundamentals/host/platform-specific-configuration/samples/3.x/RuntimeStore/deployment/deploy.ps1
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration/samples/3.x/RuntimeStore/deployment/deploy.ps1
@@ -1,11 +1,11 @@
 function AppendToEnvironmentVariable($name, $appendValue)
 {
-    $value = [Environment]::GetEnvironmentVariable($name, 'Machine')
+    $value = [Environment]::GetEnvironmentVariable($name)
     if ($value -eq $null) {
-      [Environment]::SetEnvironmentVariable($name, 'StartupDiagnostics', 'Machine')
+      [Environment]::SetEnvironmentVariable($name, $appendValue)
     } else {
       if ($value -notcontains $appendValue) {
-        [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue, 'Machine')
+        [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue)
       }
     }
 }

--- a/aspnetcore/fundamentals/host/platform-specific-configuration/samples/3.x/RuntimeStore/deployment/deploy.ps1
+++ b/aspnetcore/fundamentals/host/platform-specific-configuration/samples/3.x/RuntimeStore/deployment/deploy.ps1
@@ -1,11 +1,11 @@
 function AppendToEnvironmentVariable($name, $appendValue)
 {
-    $value = [Environment]::GetEnvironmentVariable($name)
+    $value = [Environment]::GetEnvironmentVariable($name, 'Machine')
     if ($value -eq $null) {
-      [Environment]::SetEnvironmentVariable($name, $appendValue)
+      [Environment]::SetEnvironmentVariable($name, $appendValue, 'Machine')
     } else {
       if ($value -notcontains $appendValue) {
-        [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue)
+        [Environment]::SetEnvironmentVariable($name, $value + ';' + $appendValue, 'Machine')
       }
     }
 }


### PR DESCRIPTION
The `AppendToEnvironmentVariable` function in `Deploy.ps1` is incorrectly setting environment variables to `StartupDiagnostics` instead of the supplied value when setting instead of appending.