### PR TITLE
Environments guidance updates

### DIFF
--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -85,9 +85,7 @@ In the following example for IIS, the custom header (`Blazor-Environment`) is ad
 ***The guidance in this section requires the use of a hosted Blazor WebAssembly app.***
 
 > [!NOTE]
-> **Standalone Blazor WebAssembly apps**
->
-> For standalone Blazor Webassembly apps, set the environment manually via [start configuration](#set-the-environment-via-startup-configuration) or the [`Blazor-Environment` header](#set-the-environment-via-header).
+> For **standalone Blazor Webassembly apps**, set the environment manually via [start configuration](#set-the-environment-via-startup-configuration) or the [`Blazor-Environment` header](#set-the-environment-via-header).
 
 Use the following guidance for hosted Blazor WebAssembly solutions hosted by Azure App Service:
 
@@ -224,9 +222,7 @@ In the following example for IIS, the custom header (`Blazor-Environment`) is ad
 ***The guidance in this section requires the use of a hosted Blazor WebAssembly app.***
 
 > [!NOTE]
-> **Standalone Blazor WebAssembly apps**
->
-> For standalone Blazor Webassembly apps, set the environment manually via [start configuration](#set-the-environment-via-startup-configuration) or the [`Blazor-Environment` header](#set-the-environment-via-header).
+> For **standalone Blazor Webassembly apps**, set the environment manually via [start configuration](#set-the-environment-via-startup-configuration) or the [`Blazor-Environment` header](#set-the-environment-via-header).
 
 Use the following guidance for hosted Blazor WebAssembly solutions hosted by Azure App Service:
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -43,8 +43,7 @@ Inside the closing `</body>` tag of `wwwroot/index.html`:
     Blazor.start({
       environment: "Staging"
     });
-  }
-  else {
+  } else {
     Blazor.start({
       environment: "Production"
     });
@@ -183,8 +182,7 @@ Inside the closing `</body>` tag of `wwwroot/index.html`:
     Blazor.start({
       environment: "Staging"
     });
-  }
-  else {
+  } else {
     Blazor.start({
       environment: "Production"
     });

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -32,21 +32,24 @@ For a standalone Blazor WebAssembly app running locally, the development server 
 
 ## Set the environment via startup configuration
 
-The following example starts Blazor in the `Staging` environment.
+The following example starts Blazor in the `Staging` environment if the hostname includes `localhost`. Otherwise, the environment is set to `Production`.
 
-In `wwwroot/index.html`:
+Inside the closing `</body>` tag of `wwwroot/index.html`:
 
 ```cshtml
-<body>
-    ...
-
-    <script src="_framework/blazor.webassembly.js" autostart="false"></script>
-    <script>
-      Blazor.start({
-        environment: "Staging"
-      });
-    </script>
-</body>
+<script src="_framework/blazor.webassembly.js" autostart="false"></script>
+<script>
+  if (window.location.hostname.includes("localhost")) {
+    Blazor.start({
+      environment: "Staging"
+    });
+  }
+  else {
+    Blazor.start({
+      environment: "Production"
+    });
+  }
+</script>
 ```
 
 Using the `environment` property overrides the environment set by the [`Blazor-Environment` header](#set-the-environment-via-header).
@@ -86,10 +89,6 @@ In the following example for IIS, the custom header (`Blazor-Environment`) is ad
 > **Standalone Blazor WebAssembly apps**
 >
 > For standalone Blazor Webassembly apps, set the environment manually via [start configuration](#set-the-environment-via-startup-configuration) or the [`Blazor-Environment` header](#set-the-environment-via-header).
->
-> **Apps built and deployed with continuous integration (CI)**
->
-> For app's built and deployed by a continuous integration (CI) process, you might be able to use a [JS Initializer](xref:blazor/js-interop/index#javascript-initializers) in conjunction with a build environment variable in the CI process to add an initializer specific to the environment as part of the build.
 
 Use the following guidance for hosted Blazor WebAssembly solutions hosted by Azure App Service:
 
@@ -173,19 +172,24 @@ For a standalone Blazor WebAssembly app running locally, the development server 
 
 ## Set the environment via startup configuration
 
-The following example starts Blazor in the `Staging` environment:
+The following example starts Blazor in the `Staging` environment if the hostname includes `localhost`. Otherwise, the environment is set to `Production`.
+
+Inside the closing `</body>` tag of `wwwroot/index.html`:
 
 ```cshtml
-<body>
-    ...
-
-    <script src="_framework/blazor.{webassembly|server}.js" autostart="false"></script>
-    <script>
-      Blazor.start({
-        environment: "Staging"
-      });
-    </script>
-</body>
+<script src="_framework/blazor.webassembly.js" autostart="false"></script>
+<script>
+  if (window.location.hostname.includes("localhost")) {
+    Blazor.start({
+      environment: "Staging"
+    });
+  }
+  else {
+    Blazor.start({
+      environment: "Production"
+    });
+  }
+</script>
 ```
 
 Using the `environment` property overrides the environment set by the [`Blazor-Environment` header](#set-the-environment-via-header).
@@ -225,10 +229,6 @@ In the following example for IIS, the custom header (`Blazor-Environment`) is ad
 > **Standalone Blazor WebAssembly apps**
 >
 > For standalone Blazor Webassembly apps, set the environment manually via [start configuration](#set-the-environment-via-startup-configuration) or the [`Blazor-Environment` header](#set-the-environment-via-header).
->
-> **Apps built and deployed with continuous integration (CI)**
->
-> For app's built and deployed by a continuous integration (CI) process, you might be able to use a [JS Initializer](xref:blazor/js-interop/index#javascript-initializers) in conjunction with a build environment variable in the CI process to add an initializer specific to the environment as part of the build.
 
 Use the following guidance for hosted Blazor WebAssembly solutions hosted by Azure App Service:
 
@@ -339,10 +339,6 @@ In the following example for IIS, the custom header (`Blazor-Environment`) is ad
 > **Standalone Blazor WebAssembly apps**
 >
 > For standalone Blazor Webassembly apps, set the environment manually via [start configuration](#set-the-environment-via-startup-configuration) or the [`Blazor-Environment` header](#set-the-environment-via-header).
->
-> **Apps built and deployed with continuous integration (CI)**
->
-> For app's built and deployed by a continuous integration (CI) process, you might be able to use a [JS Initializer](xref:blazor/js-interop/index#javascript-initializers) in conjunction with a build environment variable in the CI process to add an initializer specific to the environment as part of the build.
 
 Use the following guidance for hosted Blazor WebAssembly solutions hosted by Azure App Service:
 


### PR DESCRIPTION
Fixes #24041

Thanks @buzzluck68! :rocket:

I'm labeling this as 'fixes' to close the issue, but the core of the issue is actually a `won't-fix` scenario for docs **_at the moment_** because there's a framework bug/feature that hasn't been addressed yet by the PU **_&mdash;OR&mdash;_** approaches described by the community on the [PU issue (dotnet/aspnetcore #25152)](https://github.com/dotnet/aspnetcore/issues/25152) are perhaps valid to address the scenario and the PU won't bless **one** of them as a recommendation.

This bug/feature is under investigation (or in design) over there for .NET 7, and I can't do much over here at the moment. It is OK to close the issue and pick it back up if they work the PU issue for .NET 7. We maintain dedicated doc tracking issues for .NET releases, so it should end up on a .NET 7 tracking issue and with a new dedicated issue if they work it for .NET 7.

Today, I'm enhancing the manual start example on this PR, and I'm removing the following content because Javier didn't explain how it actually would work and I couldn't make it work in testing. We shouldn't document things that *might work* that would send readers on a wild goose chase if they actually, really, truly **_don't work_** 💥 ...

> **Apps built and deployed with continuous integration (CI)**
>
> For app's built and deployed by a continuous integration (CI) process, you might be able to use a [JS Initializer](xref:blazor/js-interop/index#javascript-initializers) in conjunction with a build environment variable in the CI process to add an initializer specific to the environment as part of the build.

So, I hope that the PU issue is addressed for .NET 7. If so, we'll pick this back up for a doc update later this year. If it gets pushed off to .NET 8, then it would be worked here for docs in 23H2. In the meantime, see the PU issue for the suggestions that the community made to deal with it.