### PR TITLE
Link fix in model-binding.md

### DIFF
--- a/aspnetcore/mvc/models/model-binding.md
+++ b/aspnetcore/mvc/models/model-binding.md
@@ -752,7 +752,7 @@ These attributes:
 
 ### [FromBody] attribute
 
-Apply the `[FromBody]` attribute to a parameter to populate its properties from the body of an HTTP request. The ASP.NET Core runtime delegates the responsibility of reading the body to an input formatter. Input formatters are explained [later in this article](#input-formatters).
+Apply the `[FromBody]` attribute to a parameter to populate its properties from the body of an HTTP request. The ASP.NET Core runtime delegates the responsibility of reading the body to an input formatter. Input formatters are explained [later in this article](#input-formatters-1).
 
 When `[FromBody]` is applied to a complex type parameter, any binding source attributes applied to its properties are ignored. For example, the following `Create` action specifies that its `pet` parameter is populated from the body:
 
@@ -904,7 +904,7 @@ Several built-in attributes are available for controlling model binding of compl
 * `[BindNever]`
 
 > [!WARNING]
-> These attributes affect model binding when posted form data is the source of values. They do ***not*** affect input formatters, which process posted JSON and XML request bodies. Input formatters are explained [later in this article](#input-formatters).
+> These attributes affect model binding when posted form data is the source of values. They do ***not*** affect input formatters, which process posted JSON and XML request bodies. Input formatters are explained [later in this article](#input-formatters-1).
 
 ### [Bind] attribute
 


### PR DESCRIPTION
[Internal Review - 5.x-3.x version](https://review.docs.microsoft.com/en-us/aspnet/core/mvc/models/model-binding?view=aspnetcore-5.0&branch=pr-en-us-25858)

Fixes #25856

Minor: Fixed H2 link for 5.0-3.1
