### PR TITLE
Clarify automatic Razor evaluation

### DIFF
--- a/aspnetcore/blazor/tutorials/build-a-blazor-app.md
+++ b/aspnetcore/blazor/tutorials/build-a-blazor-app.md
@@ -158,7 +158,7 @@ cd TodoList
    </ul>
    ```
 
-1. Update the `<h1>` header to show a count of the number of todo items that aren't complete (`IsDone` is `false`).
+1. Update the `<h1>` header to show a count of the number of todo items that aren't complete (`IsDone` is `false`). The Razor expression in the following header evaluates each time Blazor rerenders the component.
 
    ```razor
    <h1>Todo (@todos.Count(todo => !todo.IsDone))</h1>
@@ -339,7 +339,7 @@ cd TodoList
    </ul>
    ```
 
-1. Update the `<h1>` header to show a count of the number of todo items that aren't complete (`IsDone` is `false`).
+1. Update the `<h1>` header to show a count of the number of todo items that aren't complete (`IsDone` is `false`). The Razor expression in the following header evaluates each time Blazor rerenders the component.
 
    ```razor
    <h1>Todo (@todos.Count(todo => !todo.IsDone))</h1>
@@ -520,7 +520,7 @@ cd TodoList
    </ul>
    ```
 
-1. Update the `<h1>` header to show a count of the number of todo items that aren't complete (`IsDone` is `false`).
+1. Update the `<h1>` header to show a count of the number of todo items that aren't complete (`IsDone` is `false`). The Razor expression in the following header evaluates each time Blazor rerenders the component.
 
    ```razor
    <h1>Todo (@todos.Count(todo => !todo.IsDone))</h1>


### PR DESCRIPTION
Fixes #25877

Thanks @MichaelBrooks-Informatyx ... This briefly calls out that the automatic Blazor rerender triggers the Razor expression re-evaluation. I don't want to get into more detail on rendering behaviors than this (along with the other remarks here about the button that does have an event handler). The Razor syntax topic gets into the details and is cross-linked liberally from the Blazor node in various spots.

https://docs.microsoft.com/aspnet/core/mvc/views/razor