### PR TITLE
Add to TestServer limitations: TestServer ignores stream positioning

### DIFF
--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -117,7 +117,7 @@ TestServer:
 * Does ***not*** try to replicate all <xref:System.Net.Http.HttpClient> behaviors.
 * Attempts to give the client access to as much control over the server as possible, and with as much visibility into what's happening on the server as possible. For example it may throw exceptions not normally thrown by `HttpClient` in order to directly communicate server state.
 * Doesn't set some transport specific headers by default as those aren't usually relevant to middleware. For more information, see the next section.
-* Ignores positioning in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.HttpRequest.StreamContent>. <xref:System.Net.Http.HttpClient> will send the whole stream from the start position. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
+* Ignores positioning in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.StreamContent>. <xref:System.Net.Http.HttpClient> will send the whole stream from the start position. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
 
 ### Content-Length and Transfer-Encoding headers
 

--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -5,7 +5,7 @@ description: Learn how to test ASP.NET Core middleware with TestServer.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 5/12/2020
+ms.date: 05/18/2022
 no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR]
 uid: test/middleware
 ---
@@ -116,7 +116,8 @@ TestServer:
 * Was created to replicate server behaviors to test middleware.
 * Does ***not*** try to replicate all <xref:System.Net.Http.HttpClient> behaviors.
 * Attempts to give the client access to as much control over the server as possible, and with as much visibility into what's happening on the server as possible. For example it may throw exceptions not normally thrown by `HttpClient` in order to directly communicate server state.
-* Doesn't set some transport specific headers by default as those are not usually relevant to middleware. For more information, see the next section.
+* Doesn't set some transport specific headers by default as those aren't usually relevant to middleware. For more information, see the next section.
+* Ignores positioning in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.HttpRequestStreamContent>. <xref:System.Net.Http.HttpClient> will send the whole stream from the start position. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
 
 ### Content-Length and Transfer-Encoding headers
 

--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -117,7 +117,7 @@ TestServer:
 * Does ***not*** try to replicate all <xref:System.Net.Http.HttpClient> behaviors.
 * Attempts to give the client access to as much control over the server as possible, and with as much visibility into what's happening on the server as possible. For example it may throw exceptions not normally thrown by `HttpClient` in order to directly communicate server state.
 * Doesn't set some transport specific headers by default as those aren't usually relevant to middleware. For more information, see the next section.
-* Ignores positioning in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.StreamContent>. <xref:System.Net.Http.HttpClient> will send the whole stream from the start position. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
+* Ignores positioning set in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.StreamContent>. <xref:System.Net.Http.HttpClient> will send the whole stream from the start position. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
 
 ### Content-Length and Transfer-Encoding headers
 

--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -117,7 +117,7 @@ TestServer:
 * Does ***not*** try to replicate all <xref:System.Net.Http.HttpClient> behaviors.
 * Attempts to give the client access to as much control over the server as possible, and with as much visibility into what's happening on the server as possible. For example it may throw exceptions not normally thrown by `HttpClient` in order to directly communicate server state.
 * Doesn't set some transport specific headers by default as those aren't usually relevant to middleware. For more information, see the next section.
-* Ignores positioning in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.HttpRequestStreamContent>. <xref:System.Net.Http.HttpClient> will send the whole stream from the start position. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
+* Ignores positioning in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.HttpRequest.StreamContent>. <xref:System.Net.Http.HttpClient> will send the whole stream from the start position. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
 
 ### Content-Length and Transfer-Encoding headers
 

--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -117,7 +117,7 @@ TestServer:
 * Does ***not*** try to replicate all <xref:System.Net.Http.HttpClient> behaviors.
 * Attempts to give the client access to as much control over the server as possible, and with as much visibility into what's happening on the server as possible. For example it may throw exceptions not normally thrown by `HttpClient` in order to directly communicate server state.
 * Doesn't set some transport specific headers by default as those aren't usually relevant to middleware. For more information, see the next section.
-* Ignores positioning set in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.StreamContent>. <xref:System.Net.Http.HttpClient> will send the whole stream from the start position. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
+* Ignores positioning set in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.StreamContent>. So <xref:System.Net.Http.HttpClient> will send the whole stream from the start position, even when positioning is set. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
 
 ### Content-Length and Transfer-Encoding headers
 

--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -117,7 +117,7 @@ TestServer:
 * Does ***not*** try to replicate all <xref:System.Net.Http.HttpClient> behaviors.
 * Attempts to give the client access to as much control over the server as possible, and with as much visibility into what's happening on the server as possible. For example it may throw exceptions not normally thrown by `HttpClient` in order to directly communicate server state.
 * Doesn't set some transport specific headers by default as those aren't usually relevant to middleware. For more information, see the next section.
-* Ignores positioning set in a <xref:System.IO.Stream> passed through <xref:System.Net.Http.StreamContent>. So <xref:System.Net.Http.HttpClient> will send the whole stream from the start position, even when positioning is set. For more information, see GitHub issues [dotnet/aspnetcore#33780](https://github.com/dotnet/aspnetcore/issues/33780).
+* Ignores the `Stream` position passed through <xref:System.Net.Http.StreamContent>. <xref:System.Net.Http.HttpClient> sends the entire stream from the start position, even when positioning is set. For more information, see [this GitHub issue](https://github.com/dotnet/aspnetcore/issues/33780).
 
 ### Content-Length and Transfer-Encoding headers
 


### PR DESCRIPTION
[Internal Review: Section: TestServer Limitations](https://review.docs.microsoft.com/en-us/aspnet/core/test/middleware?view=aspnetcore-6.0&branch=pr-en-us-25896#testserver-limitations)

Fixes #22618