### PR TITLE
Promote and revise role auth config

### DIFF
--- a/aspnetcore/security/authorization/roles.md
+++ b/aspnetcore/security/authorization/roles.md
@@ -20,7 +20,7 @@ While roles are claims, not all claims are roles. Depending on the identity issu
 
 ## Add Role services to Identity
 
-Register role-based authorization services with <xref:Microsoft.AspNetCore.Identity.IdentityBuilder.AddRoles%2A> as part of the authorization service configuration in the app's `Program.cs` file:
+Register role-based authorization services in `Program.cs` by calling <xref:Microsoft.AspNetCore.Identity.IdentityBuilder.AddRoles%2A> with the role type in the app's Identity configuration. The role type in the following example is `IdentityRole`:
 
 ```csharp
 builder.Services.AddDefaultIdentity<IdentityUser>( ... )

--- a/aspnetcore/security/authorization/roles.md
+++ b/aspnetcore/security/authorization/roles.md
@@ -22,7 +22,11 @@ While roles are claims, not all claims are roles. Depending on the identity issu
 
 Register role-based authorization services with <xref:Microsoft.AspNetCore.Identity.IdentityBuilder.AddRoles%2A> as part of the authorization service configuration in the app's `Program.cs` file:
 
-[!code-csharp[](~/security/authorization/roles/samples/6_0/WebAll/Program.cs?name=snippet_ef&highlight=12)]
+```csharp
+builder.Services.AddDefaultIdentity<IdentityUser>( ... )
+    .AddRoles<IdentityRole>()
+    ...
+```
 
 ## Adding role checks
 

--- a/aspnetcore/security/authorization/roles.md
+++ b/aspnetcore/security/authorization/roles.md
@@ -18,6 +18,12 @@ When an identity is created it may belong to one or more roles. For example, Tra
 
 While roles are claims, not all claims are roles. Depending on the identity issuer a role may be a collection of users that may apply claims for group members, as well as an actual claim on an identity. However, claims are meant to be information about an individual user. Using roles to add claims to a user can confuse the boundary between the user and their individual claims. This confusion is why the SPA templates are not designed around roles. In addition, for organizations migrating from an on-premises legacy system the proliferation of roles over the years can mean a role claim may be too large to be contained within a token usable by SPAs. To secure SPAs, see <xref:security/authentication/identity/spa>.
 
+## Add Role services to Identity
+
+Register role-based authorization services with <xref:Microsoft.AspNetCore.Identity.IdentityBuilder.AddRoles%2A> as part of the authorization service configuration in the app's `Program.cs` file:
+
+[!code-csharp[](~/security/authorization/roles/samples/6_0/WebAll/Program.cs?name=snippet_ef&highlight=12)]
+
 ## Adding role checks
 
 Role based authorization checks:
@@ -80,12 +86,6 @@ To specify multiple allowed roles in a requirement, specify them as parameters t
 [!code-csharp[](~/security/authorization/roles/samples/6_0/WebAll/Program.cs?name=snippet2&highlight=6-10)]
 
 The preceding code authorizes users who belong to the `Administrator`, `PowerUser` or `BackupAdministrator` roles.
-
-### Add Role services to Identity
-
-Append <xref:Microsoft.AspNetCore.Identity.IdentityBuilder.AddRoles%2A> to add Role services:
-
-[!code-csharp[](~/security/authorization/roles/samples/6_0/WebAll/Program.cs?name=snippet_ef&highlight=12)]
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #25906

The config is way down at the bottom. This PR moves it to the top, similar to the way that the policy-based auth topic does it ...

https://docs.microsoft.com/aspnet/core/security/authorization/policies

... but I do leave it as a section, just in case that the section is cross-linked from anywhere.

Also, this full fledged startup code example is overkill and not applicable to all app types. I recommend that we just shoot in a generic **_Code Nibblet&trade;_** 😆 ... with just the bit that they need to implement, the `AddRoles` call.

cc: @gregoryagu ... In addition to the Blazor doc cross-link improvement, this hopefully will help avoid your experience. *Future generations will thank us!* 😄