### PR TITLE
gRPC JSON transcoding: Move openAPIto gRPC HTTP API doc and link out

### DIFF
--- a/aspnetcore/grpc/httpapi.md
+++ b/aspnetcore/grpc/httpapi.md
@@ -29,7 +29,7 @@ gRPC JSON transcoding is an extension for ASP.NET Core that creates RESTful JSON
 gRPC can still be used to call services.
 
 > [!NOTE]
-> gRPC JSON transcoding replaces gRPC HTTP API, an alternative experimental extension. For more information on gRPC HTTP API, see [gRPC HTTP API](https://github.com/aspnet/AspLabs/tree/main/src/GrpcHttpApi).
+> gRPC JSON transcoding replaces [gRPC HTTP API](https://github.com/aspnet/AspLabs/tree/main/src/GrpcHttpApi), an alternative experimental extension.
 
 ### Usage
 

--- a/aspnetcore/grpc/httpapi.md
+++ b/aspnetcore/grpc/httpapi.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: Learn how to create JSON HTTP APIs for gRPC services using gRPC JSON transcoding.
 monikerRange: '>= aspnetcore-7.0'
 ms.author: jamesnk
-ms.date: 05/10/2022
+ms.date: 05/20/2022
 no-loc: [".NET MAUI", "Mac Catalyst", "Blazor Hybrid", Home, Privacy, Kestrel, appsettings.json, "ASP.NET Core Identity", cookie, Cookie, Blazor, "Blazor Server", "Blazor WebAssembly", "Identity", "Let's Encrypt", Razor, SignalR, REST]
 uid: grpc/httpapi
 ---
@@ -27,6 +27,9 @@ gRPC JSON transcoding is an extension for ASP.NET Core that creates RESTful JSON
 * JSON requests/responses
 
 gRPC can still be used to call services.
+
+> [!NOTE]
+> gRPC JSON transcoding replaces gRPC HTTP API, an alternative experimental extension. For more information on gRPC HTTP API, see [gRPC HTTP API](https://github.com/aspnet/AspLabs/tree/main/src/GrpcHttpApi).
 
 ### Usage
 


### PR DESCRIPTION
[Internal Review](https://review.docs.microsoft.com/en-us/aspnet/core/grpc/httpapi?view=aspnetcore-7.0&branch=pr-en-us-25920)

Fixes: #25837 

Adding a note on gRPC HTTP API and linking out to its gitHub readme.


