### PR TITLE
Add missing host & fixed number of hosts available

### DIFF
--- a/aspnetcore/fundamentals/index.md
+++ b/aspnetcore/fundamentals/index.md
@@ -69,12 +69,11 @@ On startup, an ASP.NET Core app builds a *host*. The host encapsulates all of th
 * Dependency injection (DI) services
 * Configuration
 
-The different hosts include:
+There are three different hosts:
 
-* .NET WebApplication Host
-* .NET Generic Host
-* .NET Minimal Host
-* ASP.NET Core Web Host
+* [.NET Minimal Host](xref:migration/50-to-60#new-hosting-model)
+* [.NET Generic Host](xref:fundamentals/host/generic-host)
+* <xref:fundamentals/host/web-host>
 
 The .NET Minimal Host is recommended and used in all the ASP.NET Core templates. The Minimal and Generic hosts share many of the same interfaces and classes. The ASP.NET Core Web Host is available only for backwards compatibility.
 

--- a/aspnetcore/fundamentals/index.md
+++ b/aspnetcore/fundamentals/index.md
@@ -71,7 +71,7 @@ On startup, an ASP.NET Core app builds a *host*. The host encapsulates all of th
 
 There are three different hosts:
 
-* [.NET WebApplication Host](xref:migration/50-to-60#new-hosting-model), also known as the minimal host.
+* [.NET WebApplication Host](xref:migration/50-to-60#new-hosting-model), also known as the Minimum Host.
 * [.NET Generic Host](xref:fundamentals/host/generic-host)
 * <xref:fundamentals/host/web-host>
 

--- a/aspnetcore/fundamentals/index.md
+++ b/aspnetcore/fundamentals/index.md
@@ -71,7 +71,7 @@ On startup, an ASP.NET Core app builds a *host*. The host encapsulates all of th
 
 There are three different hosts:
 
-* [.NET Minimal Host](xref:migration/50-to-60#new-hosting-model)
+* [.NET WebApplication Host](xref:migration/50-to-60#new-hosting-model), also known as the minimal host.
 * [.NET Generic Host](xref:fundamentals/host/generic-host)
 * <xref:fundamentals/host/web-host>
 

--- a/aspnetcore/fundamentals/index.md
+++ b/aspnetcore/fundamentals/index.md
@@ -69,10 +69,11 @@ On startup, an ASP.NET Core app builds a *host*. The host encapsulates all of th
 * Dependency injection (DI) services
 * Configuration
 
-There are three different hosts:
+The different hosts include:
 
 * .NET WebApplication Host
 * .NET Generic Host
+* .NET Minimal Host
 * ASP.NET Core Web Host
 
 The .NET Minimal Host is recommended and used in all the ASP.NET Core templates. The Minimal and Generic hosts share many of the same interfaces and classes. The ASP.NET Core Web Host is available only for backwards compatibility.


### PR DESCRIPTION
The original section said: 
There are three different hosts:

.NET WebApplication Host
.NET Generic Host
ASP.NET Core Web Host
The .NET Minimal Host is recommended and used in all the ASP.NET Core templates. 
----

Notice a 4th host, ".NET Minimal Host" is discussed under the list. I added it to the bulleted list.

The strart setence said "There are three different hosts:" but the number three is wrong (the correct number is four) but I made the setence agnostic to the number of hosts in case a 5ht, 6th or 7th host is added. The new setence is "The different hosts include:" which works for 50 or 100 or 1000 hosts.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->