### PR TITLE
Update netstandard.md

### DIFF
--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -66,7 +66,7 @@ For more information, see [Configure gRPC-Web with the .NET gRPC client](xref:gr
 
 Requirements and restrictions to using `WinHttpHandler`:
 
-* Windows 10 Build 19622 or later. May require the use of a [Windows Insider](https://insider.windows.com) build.
+* Windows 11.
 * A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.1 or later.
 * .NET Framework 4.6.1 or later.
 * Only unary and server streaming gRPC calls are supported.


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/25930

Looks like a Win10 build that supports gRPC+WinHttp wasn't publically released, so change the requirement to Windows 11.