### PR TITLE
Update table in Examine the GET endpoints section

### DIFF
--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -330,6 +330,7 @@ The sample app implements several GET endpoints using calls to `MapGet`:
 |--- | ---- | ---- | ---- |
 |`GET /` | Browser test, "Hello World" | None | `Hello World!`|
 |`GET /todoitems` | Get all to-do items | None | Array of to-do items|
+|`GET /todoitems/complete` | Get all completed to-do items | None | Array of to-do items|
 |`GET /todoitems/{id}` | Get an item by ID | None | To-do item|
 
 [!code-csharp[](min-web-api/samples/6.x/todo/Program.cs?name=snippet_get)]


### PR DESCRIPTION
The table under Examine the GET endpoints was supposed to enumerate all GET endpoints in the example, but `todoitems/complete` was missing for some reason.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->