### PR TITLE
Improve overwritten parameter guidance

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -519,7 +519,6 @@ Consider the following `Expander` component that:
 
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).
-* The component writes directly to the `Expanded` parameter, which demonstrates the problem with overwritten parameters and should be avoided.
 
 After the following `Expander` component demonstrates the incorrect approach for this scenario, a modified `Expander` component is shown to demonstrate the correct approach. The following examples can be placed in a local sample app to experience the behaviors described.
 
@@ -1952,7 +1951,6 @@ Consider the following `Expander` component that:
 
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).
-* The component writes directly to the `Expanded` parameter, which demonstrates the problem with overwritten parameters and should be avoided.
 
 After the following `Expander` component demonstrates the incorrect approach for this scenario, a modified `Expander` component is shown to demonstrate the correct approach. The following examples can be placed in a local sample app to experience the behaviors described.
 
@@ -2937,7 +2935,6 @@ Consider the following `Expander` component that:
 
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).
-* The component writes directly to the `Expanded` parameter, which demonstrates the problem with overwritten parameters and should be avoided.
 
 After the following `Expander` component demonstrates the incorrect approach for this scenario, a modified `Expander` component is shown to demonstrate the correct approach. The following examples can be placed in a local sample app to experience the behaviors described.
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -515,7 +515,7 @@ The potential for overwriting parameter values extends into the child component'
 > [!IMPORTANT]
 > Our general guidance is not to create components that directly write to their own parameters after the component is rendered for the first time.
 
-Consider the following faulty `Expander` component that:
+Consider the following `Expander` component that:
 
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).
@@ -1948,7 +1948,7 @@ The potential for overwriting parameter values extends into the child component'
 > [!IMPORTANT]
 > Our general guidance is not to create components that directly write to their own parameters after the component is rendered for the first time.
 
-Consider the following faulty `Expander` component that:
+Consider the following `Expander` component that:
 
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).
@@ -2933,7 +2933,7 @@ The potential for overwriting parameter values extends into the child component'
 > [!IMPORTANT]
 > Our general guidance is not to create components that directly write to their own parameters after the component is rendered for the first time.
 
-Consider the following faulty `Expander` component that:
+Consider the following `Expander` component that:
 
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -470,7 +470,17 @@ The `Expander` component is added to the following `ExpanderExample` parent comp
 
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/index/ExpanderExample.razor)]
 
-Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected. When <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in the parent, the `Expanded` parameter of the first child component is reset back to its initial value (`true`). The second `Expander` component's `Expanded` value isn't reset because no child content is rendered in the second component.
+Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected.
+
+If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed. Change detection behavior is covered in detail in the <xref:blazor/components/rendering#rendering-conventions-for-componentbase> article. The following is a summary of the behavior:
+
+* For several specific parameter types, Blazor rerenders the child component if it detects that any of the checked parameters have changed.
+* For all other parameter types, the framework doesn't know if parameter values are mutated, so Blazor ***must*** rerender the child component. Child content falls into this category of component parameters that trigger rerendering because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+
+For the `ExpanderExample` component:
+
+* The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
+* The second `Expander` component does ***not*** set child content. Therefore, no potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> exists. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
 
 To maintain state in the preceding scenario, use a *private field* in the `Expander` component to maintain its toggled state.
 
@@ -1891,7 +1901,17 @@ The `Expander` component is added to the following `ExpanderExample` parent comp
 
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Pages/index/ExpanderExample.razor)]
 
-Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected. When <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in the parent, the `Expanded` parameter of the first child component is reset back to its initial value (`true`). The second `Expander` component's `Expanded` value isn't reset because no child content is rendered in the second component.
+Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected.
+
+If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed. Change detection behavior is covered in detail in the <xref:blazor/components/rendering#rendering-conventions-for-componentbase> article. The following is a summary of the behavior:
+
+* For several specific parameter types, Blazor rerenders the child component if it detects that any of the checked parameters have changed.
+* For all other parameter types, the framework doesn't know if parameter values are mutated, so Blazor ***must*** rerender the child component. Child content falls into this category of component parameters that trigger rerendering because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+
+For the `ExpanderExample` component:
+
+* The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
+* The second `Expander` component does ***not*** set child content. Therefore, no potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> exists. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
 
 To maintain state in the preceding scenario, use a *private field* in the `Expander` component to maintain its toggled state.
 
@@ -2864,7 +2884,17 @@ The `Expander` component is added to the following `ExpanderExample` parent comp
 
 [!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Pages/index/ExpanderExample.razor)]
 
-Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected. When <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in the parent, the `Expanded` parameter of the first child component is reset back to its initial value (`true`). The second `Expander` component's `Expanded` value isn't reset because no child content is rendered in the second component.
+Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected.
+
+If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed. Change detection behavior is covered in detail in the <xref:blazor/components/rendering#rendering-conventions-for-componentbase> article. The following is a summary of the behavior:
+
+* For several specific parameter types, Blazor rerenders the child component if it detects that any of the checked parameters have changed.
+* For all other parameter types, the framework doesn't know if parameter values are mutated, so Blazor ***must*** rerender the child component. Child content falls into this category of component parameters that trigger rerendering because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+
+For the `ExpanderExample` component:
+
+* The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
+* The second `Expander` component does ***not*** set child content. Therefore, no potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> exists. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
 
 To maintain state in the preceding scenario, use a *private field* in the `Expander` component to maintain its toggled state.
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -431,6 +431,72 @@ Optional route parameters are supported. In the following example, the `text` op
 
 For information on catch-all route parameters (`{*pageRoute}`), which capture paths across multiple folder boundaries, see <xref:blazor/fundamentals/routing#catch-all-route-parameters>.
 
+## Child content
+
+Components can set the content of another component. The assigning component provides the content between the child component's opening and closing tags.
+
+In the following example, the `RenderFragmentChild` component has a `ChildContent` component parameter that represents a segment of the UI to render as a <xref:Microsoft.AspNetCore.Components.RenderFragment>. The position of `ChildContent` in the component's Razor markup is where the content is rendered in the final HTML output.
+
+`Shared/RenderFragmentChild.razor`:
+
+[!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/index/RenderFragmentChild.razor)]
+
+> [!IMPORTANT]
+> The property receiving the <xref:Microsoft.AspNetCore.Components.RenderFragment> content must be named `ChildContent` by convention.
+>
+> [Event callbacks](xref:blazor/components/event-handling#eventcallback) aren't supported for <xref:Microsoft.AspNetCore.Components.RenderFragment>.
+
+The following `RenderFragmentParent` component provides content for rendering the `RenderFragmentChild` by placing the content inside the child component's opening and closing tags.
+
+`Pages/RenderFragmentParent.razor`:
+
+[!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/index/RenderFragmentParent.razor)]
+
+Due to the way that Blazor renders child content, rendering components inside a [`for`](/dotnet/csharp/language-reference/keywords/for) loop requires a local index variable if the incrementing loop variable is used in the `RenderFragmentChild` component's content. The following example can be added to the preceding `RenderFragmentParent` component:
+
+```razor
+<h1>Three children with an index variable</h1>
+
+@for (int c = 0; c < 3; c++)
+{
+    var current = c;
+
+    <RenderFragmentChild>
+        Count: @current
+    </RenderFragmentChild>
+}
+```
+
+Alternatively, use a [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType> instead of a [`for`](/dotnet/csharp/language-reference/keywords/for) loop. The following example can be added to the preceding `RenderFragmentParent` component:
+
+```razor
+<h1>Second example of three children with an index variable</h1>
+
+@foreach (var c in Enumerable.Range(0,3))
+{
+    <RenderFragmentChild>
+        Count: @c
+    </RenderFragmentChild>
+}
+```
+
+> [!NOTE]
+> Assignment to a <xref:Microsoft.AspNetCore.Components.RenderFragment> delegate is only supported in Razor component files (`.razor`):
+> 
+> ```razor
+> private RenderFragment RenderWelcomeInfo = __builder =>
+> {
+>     <p>Welcome to your new app!</p>
+> };
+> ```
+>
+> For more information, see <xref:blazor/performance#define-reusable-renderfragments-in-code>.
+
+For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> can be used as a template for component UI, see the following articles:
+
+* <xref:blazor/components/templated-components>
+* <xref:blazor/performance#define-reusable-renderfragments-in-code>
+
 ## Overwritten parameters
 
 The Blazor framework generally imposes safe parent-to-child parameter assignment:
@@ -500,72 +566,6 @@ The following revised `Expander` component:
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/index/Expander.razor)]
 
 For two-way parent-child binding examples, see <xref:blazor/components/data-binding#binding-with-component-parameters>. For additional information, see [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599).
-
-## Child content
-
-Components can set the content of another component. The assigning component provides the content between the child component's opening and closing tags.
-
-In the following example, the `RenderFragmentChild` component has a `ChildContent` property that represents a segment of the UI to render as a <xref:Microsoft.AspNetCore.Components.RenderFragment>. The position of `ChildContent` in the component's Razor markup is where the content is rendered in the final HTML output.
-
-`Shared/RenderFragmentChild.razor`:
-
-[!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/index/RenderFragmentChild.razor)]
-
-> [!IMPORTANT]
-> The property receiving the <xref:Microsoft.AspNetCore.Components.RenderFragment> content must be named `ChildContent` by convention.
->
-> [Event callbacks](xref:blazor/components/event-handling#eventcallback) aren't supported for <xref:Microsoft.AspNetCore.Components.RenderFragment>.
-
-The following `RenderFragmentParent` component provides content for rendering the `RenderFragmentChild` by placing the content inside the child component's opening and closing tags.
-
-`Pages/RenderFragmentParent.razor`:
-
-[!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Pages/index/RenderFragmentParent.razor)]
-
-Due to the way that Blazor renders child content, rendering components inside a [`for`](/dotnet/csharp/language-reference/keywords/for) loop requires a local index variable if the incrementing loop variable is used in the `RenderFragmentChild` component's content. The following example can be added to the preceding `RenderFragmentParent` component:
-
-```razor
-<h1>Three children with an index variable</h1>
-
-@for (int c = 0; c < 3; c++)
-{
-    var current = c;
-
-    <RenderFragmentChild>
-        Count: @current
-    </RenderFragmentChild>
-}
-```
-
-Alternatively, use a [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType> instead of a [`for`](/dotnet/csharp/language-reference/keywords/for) loop. The following example can be added to the preceding `RenderFragmentParent` component:
-
-```razor
-<h1>Second example of three children with an index variable</h1>
-
-@foreach (var c in Enumerable.Range(0,3))
-{
-    <RenderFragmentChild>
-        Count: @c
-    </RenderFragmentChild>
-}
-```
-
-> [!NOTE]
-> Assignment to a <xref:Microsoft.AspNetCore.Components.RenderFragment> delegate is only supported in Razor component files (`.razor`):
-> 
-> ```razor
-> private RenderFragment RenderWelcomeInfo = __builder =>
-> {
->     <p>Welcome to your new app!</p>
-> };
-> ```
->
-> For more information, see <xref:blazor/performance#define-reusable-renderfragments-in-code>.
-
-For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> can be used as a template for component UI, see the following articles:
-
-* <xref:blazor/components/templated-components>
-* <xref:blazor/performance#define-reusable-renderfragments-in-code>
 
 ## Attribute splatting and arbitrary parameters
 
@@ -1864,6 +1864,72 @@ Optional route parameters are supported. In the following example, the `text` op
 
 For information on catch-all route parameters (`{*pageRoute}`), which capture paths across multiple folder boundaries, see <xref:blazor/fundamentals/routing#catch-all-route-parameters>.
 
+## Child content
+
+Components can set the content of another component. The assigning component provides the content between the child component's opening and closing tags.
+
+In the following example, the `RenderFragmentChild` component has a `ChildContent` component parameter that represents a segment of the UI to render as a <xref:Microsoft.AspNetCore.Components.RenderFragment>. The position of `ChildContent` in the component's Razor markup is where the content is rendered in the final HTML output.
+
+`Shared/RenderFragmentChild.razor`:
+
+[!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/index/RenderFragmentChild.razor)]
+
+> [!IMPORTANT]
+> The property receiving the <xref:Microsoft.AspNetCore.Components.RenderFragment> content must be named `ChildContent` by convention.
+>
+> [Event callbacks](xref:blazor/components/event-handling#eventcallback) aren't supported for <xref:Microsoft.AspNetCore.Components.RenderFragment>.
+
+The following `RenderFragmentParent` component provides content for rendering the `RenderFragmentChild` by placing the content inside the child component's opening and closing tags.
+
+`Pages/RenderFragmentParent.razor`:
+
+[!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Pages/index/RenderFragmentParent.razor)]
+
+Due to the way that Blazor renders child content, rendering components inside a [`for`](/dotnet/csharp/language-reference/keywords/for) loop requires a local index variable if the incrementing loop variable is used in the `RenderFragmentChild` component's content. The following example can be added to the preceding `RenderFragmentParent` component:
+
+```razor
+<h1>Three children with an index variable</h1>
+
+@for (int c = 0; c < 3; c++)
+{
+    var current = c;
+
+    <RenderFragmentChild>
+        Count: @current
+    </RenderFragmentChild>
+}
+```
+
+Alternatively, use a [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType> instead of a [`for`](/dotnet/csharp/language-reference/keywords/for) loop. The following example can be added to the preceding `RenderFragmentParent` component:
+
+```razor
+<h1>Second example of three children with an index variable</h1>
+
+@foreach (var c in Enumerable.Range(0,3))
+{
+    <RenderFragmentChild>
+        Count: @c
+    </RenderFragmentChild>
+}
+```
+
+> [!NOTE]
+> Assignment to a <xref:Microsoft.AspNetCore.Components.RenderFragment> delegate is only supported in Razor component files (`.razor`):
+> 
+> ```razor
+> private RenderFragment RenderWelcomeInfo = __builder =>
+> {
+>     <p>Welcome to your new app!</p>
+> };
+> ```
+>
+> For more information, see <xref:blazor/performance#define-reusable-renderfragments-in-code>.
+
+For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> can be used as a template for component UI, see the following articles:
+
+* <xref:blazor/components/templated-components>
+* <xref:blazor/performance#define-reusable-renderfragments-in-code>
+
 ## Overwritten parameters
 
 The Blazor framework generally imposes safe parent-to-child parameter assignment:
@@ -1933,72 +1999,6 @@ The following revised `Expander` component:
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/index/Expander.razor)]
 
 For additional information, see [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599).
-
-## Child content
-
-Components can set the content of another component. The assigning component provides the content between the child component's opening and closing tags.
-
-In the following example, the `RenderFragmentChild` component has a `ChildContent` property that represents a segment of the UI to render as a <xref:Microsoft.AspNetCore.Components.RenderFragment>. The position of `ChildContent` in the component's Razor markup is where the content is rendered in the final HTML output.
-
-`Shared/RenderFragmentChild.razor`:
-
-[!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/index/RenderFragmentChild.razor)]
-
-> [!IMPORTANT]
-> The property receiving the <xref:Microsoft.AspNetCore.Components.RenderFragment> content must be named `ChildContent` by convention.
->
-> [Event callbacks](xref:blazor/components/event-handling#eventcallback) aren't supported for <xref:Microsoft.AspNetCore.Components.RenderFragment>.
-
-The following `RenderFragmentParent` component provides content for rendering the `RenderFragmentChild` by placing the content inside the child component's opening and closing tags.
-
-`Pages/RenderFragmentParent.razor`:
-
-[!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Pages/index/RenderFragmentParent.razor)]
-
-Due to the way that Blazor renders child content, rendering components inside a [`for`](/dotnet/csharp/language-reference/keywords/for) loop requires a local index variable if the incrementing loop variable is used in the `RenderFragmentChild` component's content. The following example can be added to the preceding `RenderFragmentParent` component:
-
-```razor
-<h1>Three children with an index variable</h1>
-
-@for (int c = 0; c < 3; c++)
-{
-    var current = c;
-
-    <RenderFragmentChild>
-        Count: @current
-    </RenderFragmentChild>
-}
-```
-
-Alternatively, use a [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType> instead of a [`for`](/dotnet/csharp/language-reference/keywords/for) loop. The following example can be added to the preceding `RenderFragmentParent` component:
-
-```razor
-<h1>Second example of three children with an index variable</h1>
-
-@foreach (var c in Enumerable.Range(0,3))
-{
-    <RenderFragmentChild>
-        Count: @c
-    </RenderFragmentChild>
-}
-```
-
-> [!NOTE]
-> Assignment to a <xref:Microsoft.AspNetCore.Components.RenderFragment> delegate is only supported in Razor component files (`.razor`):
-> 
-> ```razor
-> private RenderFragment RenderWelcomeInfo = __builder =>
-> {
->     <p>Welcome to your new app!</p>
-> };
-> ```
->
-> For more information, see <xref:blazor/performance#define-reusable-renderfragments-in-code>.
-
-For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> can be used as a template for component UI, see the following articles:
-
-* <xref:blazor/components/templated-components>
-* <xref:blazor/performance#define-reusable-renderfragments-in-code>
 
 ## Attribute splatting and arbitrary parameters
 
@@ -2849,6 +2849,72 @@ Optional route parameters aren't supported, so two [`@page`][9] directives are a
 
 For information on catch-all route parameters (`{*pageRoute}`), which capture paths across multiple folder boundaries, see <xref:blazor/fundamentals/routing#catch-all-route-parameters>.
 
+## Child content
+
+Components can set the content of another component. The assigning component provides the content between the child component's opening and closing tags.
+
+In the following example, the `RenderFragmentChild` component has a `ChildContent` component parameter that represents a segment of the UI to render as a <xref:Microsoft.AspNetCore.Components.RenderFragment>. The position of `ChildContent` in the component's Razor markup is where the content is rendered in the final HTML output.
+
+`Shared/RenderFragmentChild.razor`:
+
+[!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/index/RenderFragmentChild.razor)]
+
+> [!IMPORTANT]
+> The property receiving the <xref:Microsoft.AspNetCore.Components.RenderFragment> content must be named `ChildContent` by convention.
+>
+> [Event callbacks](xref:blazor/components/event-handling#eventcallback) aren't supported for <xref:Microsoft.AspNetCore.Components.RenderFragment>.
+
+The following `RenderFragmentParent` component provides content for rendering the `RenderFragmentChild` by placing the content inside the child component's opening and closing tags.
+
+`Pages/RenderFragmentParent.razor`:
+
+[!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Pages/index/RenderFragmentParent.razor)]
+
+Due to the way that Blazor renders child content, rendering components inside a [`for`](/dotnet/csharp/language-reference/keywords/for) loop requires a local index variable if the incrementing loop variable is used in the `RenderFragmentChild` component's content. The following example can be added to the preceding `RenderFragmentParent` component:
+
+```razor
+<h1>Three children with an index variable</h1>
+
+@for (int c = 0; c < 3; c++)
+{
+    var current = c;
+
+    <RenderFragmentChild>
+        Count: @current
+    </RenderFragmentChild>
+}
+```
+
+Alternatively, use a [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType> instead of a [`for`](/dotnet/csharp/language-reference/keywords/for) loop. The following example can be added to the preceding `RenderFragmentParent` component:
+
+```razor
+<h1>Second example of three children with an index variable</h1>
+
+@foreach (var c in Enumerable.Range(0,3))
+{
+    <RenderFragmentChild>
+        Count: @c
+    </RenderFragmentChild>
+}
+```
+
+> [!NOTE]
+> Assignment to a <xref:Microsoft.AspNetCore.Components.RenderFragment> delegate is only supported in Razor component files (`.razor`):
+> 
+> ```razor
+> private RenderFragment RenderWelcomeInfo = __builder =>
+> {
+>     <p>Welcome to your new app!</p>
+> };
+> ```
+>
+> For more information, see <xref:blazor/performance#define-reusable-renderfragments-in-code>.
+
+For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> can be used as a template for component UI, see the following articles:
+
+* <xref:blazor/components/templated-components>
+* <xref:blazor/performance#define-reusable-renderfragments-in-code>
+
 ## Overwritten parameters
 
 The Blazor framework generally imposes safe parent-to-child parameter assignment:
@@ -2918,72 +2984,6 @@ The following revised `Expander` component:
 [!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/index/Expander.razor)]
 
 For additional information, see [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599).
-
-## Child content
-
-Components can set the content of another component. The assigning component provides the content between the child component's opening and closing tags.
-
-In the following example, the `RenderFragmentChild` component has a `ChildContent` property that represents a segment of the UI to render as a <xref:Microsoft.AspNetCore.Components.RenderFragment>. The position of `ChildContent` in the component's Razor markup is where the content is rendered in the final HTML output.
-
-`Shared/RenderFragmentChild.razor`:
-
-[!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/index/RenderFragmentChild.razor)]
-
-> [!IMPORTANT]
-> The property receiving the <xref:Microsoft.AspNetCore.Components.RenderFragment> content must be named `ChildContent` by convention.
->
-> [Event callbacks](xref:blazor/components/event-handling#eventcallback) aren't supported for <xref:Microsoft.AspNetCore.Components.RenderFragment>.
-
-The following `RenderFragmentParent` component provides content for rendering the `RenderFragmentChild` by placing the content inside the child component's opening and closing tags.
-
-`Pages/RenderFragmentParent.razor`:
-
-[!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Pages/index/RenderFragmentParent.razor)]
-
-Due to the way that Blazor renders child content, rendering components inside a [`for`](/dotnet/csharp/language-reference/keywords/for) loop requires a local index variable if the incrementing loop variable is used in the `RenderFragmentChild` component's content. The following example can be added to the preceding `RenderFragmentParent` component:
-
-```razor
-<h1>Three children with an index variable</h1>
-
-@for (int c = 0; c < 3; c++)
-{
-    var current = c;
-
-    <RenderFragmentChild>
-        Count: @current
-    </RenderFragmentChild>
-}
-```
-
-Alternatively, use a [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType> instead of a [`for`](/dotnet/csharp/language-reference/keywords/for) loop. The following example can be added to the preceding `RenderFragmentParent` component:
-
-```razor
-<h1>Second example of three children with an index variable</h1>
-
-@foreach (var c in Enumerable.Range(0,3))
-{
-    <RenderFragmentChild>
-        Count: @c
-    </RenderFragmentChild>
-}
-```
-
-> [!NOTE]
-> Assignment to a <xref:Microsoft.AspNetCore.Components.RenderFragment> delegate is only supported in Razor component files (`.razor`):
-> 
-> ```razor
-> private RenderFragment RenderWelcomeInfo = __builder =>
-> {
->     <p>Welcome to your new app!</p>
-> };
-> ```
->
-> For more information, see <xref:blazor/performance#define-reusable-renderfragments-in-code>.
-
-For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> can be used as a template for component UI, see the following articles:
-
-* <xref:blazor/components/templated-components>
-* <xref:blazor/performance#define-reusable-renderfragments-in-code>
 
 ## Attribute splatting and arbitrary parameters
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -543,8 +543,6 @@ If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is ca
 * For a group of parameter types that Blazor explicitly checks, Blazor rerenders a child component if it detects that any of the parameters have changed.
 * For unchecked parameter types, Blazor rerenders the child component *regardless of whether or not the parameters have changed*. Child content falls into this category of parameter types because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
 
-For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
-
 For the `ExpanderExample` component:
 
 * The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
@@ -566,6 +564,8 @@ The following revised `Expander` component:
 [!code-razor[](~/blazor/samples/6.0/BlazorSample_WebAssembly/Shared/index/Expander.razor)]
 
 For two-way parent-child binding examples, see <xref:blazor/components/data-binding#binding-with-component-parameters>. For additional information, see [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599).
+
+For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
 
 ## Attribute splatting and arbitrary parameters
 
@@ -1976,8 +1976,6 @@ If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is ca
 * For a group of parameter types that Blazor explicitly checks, Blazor rerenders a child component if it detects that any of the parameters have changed.
 * For unchecked parameter types, Blazor rerenders the child component *regardless of whether or not the parameters have changed*. Child content falls into this category of parameter types because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
 
-For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
-
 For the `ExpanderExample` component:
 
 * The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
@@ -1999,6 +1997,8 @@ The following revised `Expander` component:
 [!code-razor[](~/blazor/samples/5.0/BlazorSample_WebAssembly/Shared/index/Expander.razor)]
 
 For additional information, see [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599).
+
+For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
 
 ## Attribute splatting and arbitrary parameters
 
@@ -2961,8 +2961,6 @@ If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is ca
 * For a group of parameter types that Blazor explicitly checks, Blazor rerenders a child component if it detects that any of the parameters have changed.
 * For unchecked parameter types, Blazor rerenders the child component *regardless of whether or not the parameters have changed*. Child content falls into this category of parameter types because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
 
-For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
-
 For the `ExpanderExample` component:
 
 * The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
@@ -2984,6 +2982,8 @@ The following revised `Expander` component:
 [!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/Shared/index/Expander.razor)]
 
 For additional information, see [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599).
+
+For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
 
 ## Attribute splatting and arbitrary parameters
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -502,7 +502,7 @@ For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> c
 The Blazor framework generally imposes safe parent-to-child parameter assignment:
 
 * Parameters aren't overwritten unexpectedly.
-* Side-effects are minimized. For example, additional renders are avoided because they may create infinite rendering loops.
+* Side effects are minimized. For example, additional renders are avoided because they may create infinite rendering loops.
 
 A child component receives new parameter values that possibly overwrite existing values when the parent component rerenders. Accidentally overwriting parameter values in a child component often occurs when developing the component with one or more data-bound parameters and the developer writes directly to a parameter in the child:
 
@@ -556,7 +556,7 @@ The following revised `Expander` component:
 * Uses the private field to maintain its internal toggle state, which demonstrates how to avoid writing directly to a parameter.
 
 > [!NOTE]
-> The advice in this section extends to similar logic in component parameter `set` accessors, which can result in similar undesirable side-effects.
+> The advice in this section extends to similar logic in component parameter `set` accessors, which can result in similar undesirable side effects.
 
 `Shared/Expander.razor`:
 
@@ -1934,7 +1934,7 @@ For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> c
 The Blazor framework generally imposes safe parent-to-child parameter assignment:
 
 * Parameters aren't overwritten unexpectedly.
-* Side-effects are minimized. For example, additional renders are avoided because they may create infinite rendering loops.
+* Side effects are minimized. For example, additional renders are avoided because they may create infinite rendering loops.
 
 A child component receives new parameter values that possibly overwrite existing values when the parent component rerenders. Accidentally overwriting parameter values in a child component often occurs when developing the component with one or more data-bound parameters and the developer writes directly to a parameter in the child:
 
@@ -1988,7 +1988,7 @@ The following revised `Expander` component:
 * Uses the private field to maintain its internal toggle state, which demonstrates how to avoid writing directly to a parameter.
 
 > [!NOTE]
-> The advice in this section extends to similar logic in component parameter `set` accessors, which can result in similar undesirable side-effects.
+> The advice in this section extends to similar logic in component parameter `set` accessors, which can result in similar undesirable side effects.
 
 `Shared/Expander.razor`:
 
@@ -2918,7 +2918,7 @@ For information on how a <xref:Microsoft.AspNetCore.Components.RenderFragment> c
 The Blazor framework generally imposes safe parent-to-child parameter assignment:
 
 * Parameters aren't overwritten unexpectedly.
-* Side-effects are minimized. For example, additional renders are avoided because they may create infinite rendering loops.
+* Side effects are minimized. For example, additional renders are avoided because they may create infinite rendering loops.
 
 A child component receives new parameter values that possibly overwrite existing values when the parent component rerenders. Accidentally overwriting parameter values in a child component often occurs when developing the component with one or more data-bound parameters and the developer writes directly to a parameter in the child:
 
@@ -2972,7 +2972,7 @@ The following revised `Expander` component:
 * Uses the private field to maintain its internal toggle state, which demonstrates how to avoid writing directly to a parameter.
 
 > [!NOTE]
-> The advice in this section extends to similar logic in component parameter `set` accessors, which can result in similar undesirable side-effects.
+> The advice in this section extends to similar logic in component parameter `set` accessors, which can result in similar undesirable side effects.
 
 `Shared/Expander.razor`:
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -520,7 +520,7 @@ Consider the following `Expander` component that:
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).
 
-After the following `Expander` component demonstrates the incorrect approach for this scenario, a modified `Expander` component is shown to demonstrate the correct approach. The following examples can be placed in a local sample app to experience the behaviors described.
+After the following `Expander` component demonstrates an overwritten parameter, a modified `Expander` component is shown to demonstrate the correct approach for this scenario. The following examples can be placed in a local sample app to experience the behaviors described.
 
 `Shared/Expander.razor`:
 
@@ -1952,7 +1952,7 @@ Consider the following `Expander` component that:
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).
 
-After the following `Expander` component demonstrates the incorrect approach for this scenario, a modified `Expander` component is shown to demonstrate the correct approach. The following examples can be placed in a local sample app to experience the behaviors described.
+After the following `Expander` component demonstrates an overwritten parameter, a modified `Expander` component is shown to demonstrate the correct approach for this scenario. The following examples can be placed in a local sample app to experience the behaviors described.
 
 `Shared/Expander.razor`:
 
@@ -2936,7 +2936,7 @@ Consider the following `Expander` component that:
 * Renders child content.
 * Toggles showing child content with a component parameter (`Expanded`).
 
-After the following `Expander` component demonstrates the incorrect approach for this scenario, a modified `Expander` component is shown to demonstrate the correct approach. The following examples can be placed in a local sample app to experience the behaviors described.
+After the following `Expander` component demonstrates an overwritten parameter, a modified `Expander` component is shown to demonstrate the correct approach for this scenario. The following examples can be placed in a local sample app to experience the behaviors described.
 
 `Shared/Expander.razor`:
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -472,15 +472,17 @@ The `Expander` component is added to the following `ExpanderExample` parent comp
 
 Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected.
 
-If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed. Change detection behavior is covered in detail in the <xref:blazor/components/rendering#rendering-conventions-for-componentbase> article. The following is a summary of the behavior:
+If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed:
 
-* For several specific parameter types, Blazor rerenders the child component if it detects that any of the checked parameters have changed.
-* For all other parameter types, the framework doesn't know if parameter values are mutated, so Blazor ***must*** rerender the child component. Child content falls into this category of component parameters that trigger rerendering because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+* For a group of parameter types that Blazor explicitly checks, Blazor rerenders a child component if it detects that any of the parameters have changed.
+* For unchecked parameter types, Blazor rerenders the child component *regardless of whether or not the parameters have changed*. Child content falls into this category of parameter types because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+
+For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
 
 For the `ExpanderExample` component:
 
 * The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
-* The second `Expander` component does ***not*** set child content. Therefore, no potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> exists. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
+* The second `Expander` component doesn't set child content. Therefore, a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> doesn't exist. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
 
 To maintain state in the preceding scenario, use a *private field* in the `Expander` component to maintain its toggled state.
 
@@ -1903,15 +1905,17 @@ The `Expander` component is added to the following `ExpanderExample` parent comp
 
 Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected.
 
-If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed. Change detection behavior is covered in detail in the <xref:blazor/components/rendering#rendering-conventions-for-componentbase> article. The following is a summary of the behavior:
+If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed:
 
-* For several specific parameter types, Blazor rerenders the child component if it detects that any of the checked parameters have changed.
-* For all other parameter types, the framework doesn't know if parameter values are mutated, so Blazor ***must*** rerender the child component. Child content falls into this category of component parameters that trigger rerendering because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+* For a group of parameter types that Blazor explicitly checks, Blazor rerenders a child component if it detects that any of the parameters have changed.
+* For unchecked parameter types, Blazor rerenders the child component *regardless of whether or not the parameters have changed*. Child content falls into this category of parameter types because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+
+For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
 
 For the `ExpanderExample` component:
 
 * The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
-* The second `Expander` component does ***not*** set child content. Therefore, no potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> exists. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
+* The second `Expander` component doesn't set child content. Therefore, a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> doesn't exist. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
 
 To maintain state in the preceding scenario, use a *private field* in the `Expander` component to maintain its toggled state.
 
@@ -2886,15 +2890,17 @@ The `Expander` component is added to the following `ExpanderExample` parent comp
 
 Initially, the `Expander` components behave independently when their `Expanded` properties are toggled. The child components maintain their states as expected.
 
-If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed. Change detection behavior is covered in detail in the <xref:blazor/components/rendering#rendering-conventions-for-componentbase> article. The following is a summary of the behavior:
+If <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, the Blazor framework rerenders child components if their parameters might have changed:
 
-* For several specific parameter types, Blazor rerenders the child component if it detects that any of the checked parameters have changed.
-* For all other parameter types, the framework doesn't know if parameter values are mutated, so Blazor ***must*** rerender the child component. Child content falls into this category of component parameters that trigger rerendering because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+* For a group of parameter types that Blazor explicitly checks, Blazor rerenders a child component if it detects that any of the parameters have changed.
+* For unchecked parameter types, Blazor rerenders the child component *regardless of whether or not the parameters have changed*. Child content falls into this category of parameter types because child content is of type <xref:Microsoft.AspNetCore.Components.RenderFragment>, which is a delegate that refers to other mutable objects.
+
+For more information on change detection, inlcuding information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.
 
 For the `ExpanderExample` component:
 
 * The first `Expander` component sets child content in a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment>, so a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component automatically rerenders the component and potentially overwrites the value of `Expanded` to its intitial value of `true`.
-* The second `Expander` component does ***not*** set child content. Therefore, no potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> exists. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
+* The second `Expander` component doesn't set child content. Therefore, a potentially mutable <xref:Microsoft.AspNetCore.Components.RenderFragment> doesn't exist. A call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> in the parent component doesn't automatically rerender the child component, so the component's `Expanded` value isn't overwritten.
 
 To maintain state in the preceding scenario, use a *private field* in the `Expander` component to maintain its toggled state.
 

--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -24,7 +24,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 * After applying an updated set of [parameters](xref:blazor/components/data-binding#binding-with-component-parameters) from a parent component.
 * After applying an updated value for a [cascading parameter](xref:blazor/components/cascading-values-and-parameters).
 * After notification of an event and invoking one of its own [event handlers](xref:blazor/components/event-handling).
-* After a call to its own <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> method (see <xref:blazor/components/lifecycle#state-changes-statehaschanged>).
+* After a call to its own <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> method (see <xref:blazor/components/lifecycle#state-changes-statehaschanged>). For guidance on how to prevent overwriting child component parameters when <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, see <xref:blazor/components/index#overwritten-parameters>.
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
@@ -126,7 +126,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 * After applying an updated set of [parameters](xref:blazor/components/data-binding#binding-with-component-parameters) from a parent component.
 * After applying an updated value for a [cascading parameter](xref:blazor/components/cascading-values-and-parameters).
 * After notification of an event and invoking one of its own [event handlers](xref:blazor/components/event-handling).
-* After a call to its own <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> method (see <xref:blazor/components/lifecycle#state-changes-statehaschanged>).
+* After a call to its own <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> method (see <xref:blazor/components/lifecycle#state-changes-statehaschanged>). For guidance on how to prevent overwriting child component parameters when <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, see <xref:blazor/components/index#overwritten-parameters>.
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 
@@ -232,7 +232,7 @@ By default, Razor components inherit from the <xref:Microsoft.AspNetCore.Compone
 * After applying an updated set of [parameters](xref:blazor/components/data-binding#binding-with-component-parameters) from a parent component.
 * After applying an updated value for a [cascading parameter](xref:blazor/components/cascading-values-and-parameters).
 * After notification of an event and invoking one of its own [event handlers](xref:blazor/components/event-handling).
-* After a call to its own <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> method (see <xref:blazor/components/lifecycle#state-changes-statehaschanged>).
+* After a call to its own <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> method (see <xref:blazor/components/lifecycle#state-changes-statehaschanged>). For guidance on how to prevent overwriting child component parameters when <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called in a parent component, see <xref:blazor/components/index#overwritten-parameters>.
 
 Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> skip rerenders due to parameter updates if either of the following are true:
 


### PR DESCRIPTION
Fixes #23704

Thanks @omuleanu! :rocket:

Referenced content:

https://docs.microsoft.com/aspnet/core/blazor/components/rendering#rendering-conventions-for-componentbase

The updates to the *Overwritten parameters* section doesn't try to list the explicit parameters that are checked because that's subject to change over time. I think it best to refer to the reference source to harden the doc. Devs can then 👀 the exact list of param types checked for any given release, and the PU is free to change the list at any time without breaking the doc.

I'm moving the *Overwritten parameters* one section lower, below the *Child content* section. The *Child content* section introduces the `RenderFragment`, so that should appear first.

I'm also improving cross-links.

I considered moving the whole example from the Components overview to the newer Rendering topic, but change detection/rendering for state changes is a foundational concept for component parameters. I think it's important enough to leave here. The further details exist in the *Rendering* topic that devs will reach later in their reading (or via the cross-link that I'm adding).

**UPDATE**: Yikes! That was a lot of churn, but I think 🤔 I'm happy with it now.