### PR TITLE
Fixed incorrect lower case letter, and incorrect plural

### DIFF
--- a/aspnetcore/fundamentals/index.md
+++ b/aspnetcore/fundamentals/index.md
@@ -75,7 +75,7 @@ There are three different hosts:
 * .NET Generic Host
 * ASP.NET Core Web Host
 
-The .NET Minimal Host is recommended and used in all the ASP.NET Core templates. The Minimal and Generic hosts share many of the same interfaces and classes. The ASP.NET Core Web Host is available only for backward compatibility.
+The .NET Minimal Host is recommended and used in all the ASP.NET Core templates. The Minimal and Generic Host share many of the same interfaces and classes. The ASP.NET Core Web Host is available only for backward compatibility.
 
 The following example instantiates a WebApplication  Host:
 


### PR DESCRIPTION
Minimum Host and Generic House are proper nouns in the document like Jim Smith and Bob Smith are proper nouns. 

You would not say "Jim and Bob smiths" -- you'd say "Jim and Bob Smith" it should be "Minimal and Generic Host" not "Minimal and Generic hosts"



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->