### PR TITLE
Fix nullability annotation in TimedHostedService

### DIFF
--- a/aspnetcore/fundamentals/host/hosted-services/samples/6.0/BackgroundTasksSample/Services/TimedHostedService.cs
+++ b/aspnetcore/fundamentals/host/hosted-services/samples/6.0/BackgroundTasksSample/Services/TimedHostedService.cs
@@ -5,7 +5,7 @@ namespace BackgroundTasksSample.Services
     {
         private int executionCount = 0;
         private readonly ILogger<TimedHostedService> _logger;
-        private Timer _timer = null!;
+        private Timer? _timer = null;
 
         public TimedHostedService(ILogger<TimedHostedService> logger)
         {
@@ -16,7 +16,7 @@ namespace BackgroundTasksSample.Services
         {
             _logger.LogInformation("Timed Hosted Service running.");
 
-            _timer = new Timer(DoWork, null, TimeSpan.Zero, 
+            _timer = new Timer(DoWork, null, TimeSpan.Zero,
                 TimeSpan.FromSeconds(5));
 
             return Task.CompletedTask;


### PR DESCRIPTION
The `_timer` field should be nullable in this sample instead of using the null-forgiving operator.