### PR TITLE
Fix article description showing twice

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -11,9 +11,9 @@ uid: blazor/fundamentals/routing
 ---
 # ASP.NET Core Blazor routing and navigation
 
-:::moniker range=">= aspnetcore-6.0"
-
 This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create navigation links in Blazor apps.
+
+:::moniker range=">= aspnetcore-6.0"
 
 ## Route templates
 
@@ -661,8 +661,6 @@ For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndp
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create navigation links in Blazor apps.
-
 ## Route templates
 
 The <xref:Microsoft.AspNetCore.Components.Routing.Router> component enables routing to Razor components in a Blazor app. The <xref:Microsoft.AspNetCore.Components.Routing.Router> component is used in the `App` component of Blazor apps.
@@ -1087,8 +1085,6 @@ For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndp
 :::moniker-end
 
 :::moniker range="< aspnetcore-5.0"
-
-This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create navigation links in Blazor apps.
 
 ## Route templates
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -11,9 +11,9 @@ uid: blazor/fundamentals/routing
 ---
 # ASP.NET Core Blazor routing and navigation
 
-This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create a navigation links in Blazor apps.
-
 :::moniker range=">= aspnetcore-6.0"
+
+This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create navigation links in Blazor apps.
 
 ## Route templates
 
@@ -661,7 +661,7 @@ For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndp
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create a navigation links in Blazor apps.
+This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create navigation links in Blazor apps.
 
 ## Route templates
 
@@ -1088,7 +1088,7 @@ For information on configuring <xref:Microsoft.AspNetCore.Builder.RazorPagesEndp
 
 :::moniker range="< aspnetcore-5.0"
 
-This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create a navigation links in Blazor apps.
+This article explains how to manage request routing and how to use the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component to create navigation links in Blazor apps.
 
 ## Route templates
 


### PR DESCRIPTION
The article description shows twice when the selected moniker is < .net 6.
This moves all instances of the article description within moniker range selections, so there is only ever one description displayed.

Example incorrect behaviour:
![image](https://user-images.githubusercontent.com/37123271/171448555-6d2dd942-5b5a-4ed0-bef7-4c4611eb3161.png)

Also fix a typo in the article description to read "create navigation links in Blazor apps" rather than "create **a** navigation links in Blazor apps".