### PR TITLE
Clarify getting-started-with-swashbuckle.md

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -79,7 +79,15 @@ Enable the middleware for serving the generated JSON document and the Swagger UI
 
 :::code language="csharp" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Program.cs" id="snippet_Middleware" highlight="3,4":::
 
-The preceding code adds the Swagger middleware only if the current environment is set to Development. The `UseSwaggerUI` method call enables the [Static File Middleware](xref:fundamentals/static-files).
+The preceding code adds the Swagger middleware only if the current environment is set to Development. Pay attention that in .Net Core 6 the statement is 
+`if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Home/Error");
+}`
+
+so add call to UseSwagger and UseSwaggerUI bellow this statement if you are in development environment 
+
+The `UseSwaggerUI` method call enables the [Static File Middleware](xref:fundamentals/static-files).
 
 Launch the app and navigate to `https://localhost:<port>/swagger/v1/swagger.json`. The generated document describing the endpoints appears as shown in [OpenAPI specification (openapi.json)](xref:tutorials/web-api-help-pages-using-swagger#openapi-specification-openapijson).
 


### PR DESCRIPTION
The article is refering to .ASPNET CORE 6 version but the code snippet refers to older versions.
In Program.cs there is no 
if (app.Environment.IsDevelopment())
instead you can find the oposite statement
if (!app.Environment.IsDevelopment())
so someone can mistakenly insert 
app.UseSwagger();
app.UseSwaggerUI();
in wrong block statement.

Topic: [Get started with Swashbuckle and ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?view=aspnetcore-6.0&tabs=visual-studio)

Fixes #26033

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->