### PR TITLE
Update MvcMovie static references for .NET 6

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/6.0-completed/Views/Shared/_Layout.cshtml
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/6.0-completed/Views/Shared/_Layout.cshtml
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Movie App</title>
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 </head>
 <body>
@@ -40,8 +40,8 @@
             &copy; 2021 - Movie App - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
         </div>
     </footer>
-    <script src="~/lib/jquery/dist/jquery.min.js"></script>
-    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/lib/jquery/dist/jquery.js"></script>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/6.0-completed/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/6.0-completed/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,2 +1,2 @@
-﻿<script src="~/lib/jquery-validation/dist/jquery.validate.min.js"></script>
-<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"></script>
+﻿<script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
+<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Views/Shared/_Layout.cshtml
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Views/Shared/_Layout.cshtml
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Movie App</title>
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
 </head>
 <body>
@@ -40,8 +40,8 @@
             &copy; 2021 - Movie App - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
         </div>
     </footer>
-    <script src="~/lib/jquery/dist/jquery.min.js"></script>
-    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="~/lib/jquery/dist/jquery.js"></script>
+    <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -1,2 +1,2 @@
-﻿<script src="~/lib/jquery-validation/dist/jquery.validate.min.js"></script>
-<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"></script>
+﻿<script src="~/lib/jquery-validation/dist/jquery.validate.js"></script>
+<script src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.js"></script>


### PR DESCRIPTION

Fixes #26041

Update .NET 6 Bootstrap and jQuery static references since .NET 6 no longer ships min versions of libs.