### PR TITLE
links to workaround for app name change in .NET 6 /1

### DIFF
--- a/aspnetcore/includes/appname6.md
+++ b/aspnetcore/includes/appname6.md
@@ -1,0 +1,3 @@
+## Application name change
+
+ In .NET 6, <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> normalizes the content root path to end with a <xref:System.IO.Path.DirectorySeparatorChar>. Most apps migrating from <xref:Microsoft.Extensions.Hosting.HostBuilder> or  <xref:Microsoft.AspNetCore.Hosting.WebHostBuilder> won't have the same app name because they aren't normalized. For more information, see [SetApplicationName](xref:security/data-protection/configuration/overview#setapplicationname)

--- a/aspnetcore/migration/31-to-60.md
+++ b/aspnetcore/migration/31-to-60.md
@@ -202,6 +202,8 @@ For more information, see [Obsoleting DatabaseErrorPage middleware (dotnet/aspne
 
 [!INCLUDE[](~/includes/hosting-bundle.md)]
 
+[!INCLUDE[](~/includes/appname6.md)]
+
 ## Review breaking changes
 
 See the following resources:

--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -337,6 +337,8 @@ For more information on NRTs, the MSBuild `Nullable` property, and updating apps
 
 [!INCLUDE[](~/includes/hosting-bundle.md)]
 
+[!INCLUDE[](~/includes/appname6.md)]
+
 ## Additional resources
 
 * <xref:migration/50-to-60-samples>


### PR DESCRIPTION
Fixes #26023