### PR TITLE
.net 6 update of sharer app cookies /1

### DIFF
--- a/aspnetcore/security/cookie-sharing.md
+++ b/aspnetcore/security/cookie-sharing.md
@@ -27,7 +27,7 @@ In the examples that follow:
   * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action\<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
 * `DataProtectionProvider` requires the [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/) NuGet package:
   * In .NET Framework apps, add a package reference to [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/).
-* <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.SetApplicationName*> sets the common app name. For more information, see [SetApplicationName changes in .NET 6](xref:security/data-protection/configuration/overview#setapplicationname)
+* <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.SetApplicationName*> sets the common app name.
 
 ## Share authentication cookies with ASP.NET Core Identity
 
@@ -82,6 +82,8 @@ ASP.NET 4.x apps that use Katana Cookie Authentication Middleware can be configu
 When apps use the same Identity schema (same version of Identity), confirm that the Identity system for each app is pointed at the same user database. Otherwise, the identity system produces failures at runtime when it attempts to match the information in the authentication cookie against the information in its database.
 
 When the Identity schema is different among apps, usually because apps are using different Identity versions, sharing a common database based on the latest version of Identity isn't possible without remapping and adding columns in other app's Identity schemas. It's often more efficient to upgrade the other apps to use the latest Identity version so that a common database can be shared by the apps.
+
+[!INCLUDE[](~/includes/appname6.md)]
 
 ## Additional resources
 

--- a/aspnetcore/security/cookie-sharing.md
+++ b/aspnetcore/security/cookie-sharing.md
@@ -71,7 +71,7 @@ options.Cookie.Domain = ".contoso.com";
 
 For production deployments, configure the `DataProtectionProvider` to encrypt keys at rest with DPAPI or an X509Certificate. For more information, see <xref:security/data-protection/implementation/key-encryption-at-rest>. In the following example, a certificate thumbprint is provided to <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.ProtectKeysWithCertificate*>:
 
-[!code-csharp[](~/security/cookie-sharing/samples/WebCookieShare/Program.cs?name=snippet_dbp&highlight=7-8)]
+[!code-csharp[](~/security/cookie-sharing/samples/WebCookieShare/Program.cs?name=snippet_Encrypt&highlight=7-8)]
 
 ## Share authentication cookies between ASP.NET 4.x and ASP.NET Core apps
 
@@ -88,6 +88,10 @@ When the Identity schema is different among apps, usually because apps are using
 ## Additional resources
 
 * <xref:host-and-deploy/web-farm>
+* [A primer on OWIN cookie authentication middleware for the ASP.NET developer](https://brockallen.com/2013/10/24/a-primer-on-owin-cookie-authentication-middleware-for-the-asp-net-developer/) by [Brock Allen](https://brockallen.com/)
+* [OWIN Authentication Middleware Architecture](https://brockallen.com/2013/08/07/owin-authentication-middleware-architecture/) by [Brock Allen](https://brockallen.com/)
+* [Posts from the ‘OWIN / Katana’ Category](https://brockallen.com/category/owin-katana/) by [Brock Allen](https://brockallen.com/)
+
 :::moniker-end
 
 :::moniker range="< aspnetcore-6.0"

--- a/aspnetcore/security/cookie-sharing.md
+++ b/aspnetcore/security/cookie-sharing.md
@@ -20,15 +20,14 @@ In the examples that follow:
 
 * The authentication cookie name is set to a common value of `.AspNet.SharedCookie`.
 * The `AuthenticationType` is set to `Identity.Application` either explicitly or by default.
-* A common app name is used to enable the data protection system to share data protection keys (`SharedCookieApp`).
+* A common app name, `SharedCookieApp`, is used to enable the data protection system to share data protection keys.
 * `Identity.Application` is used as the authentication scheme. Whatever scheme is used, it must be used consistently *within and across* the shared cookie apps either as the default scheme or by explicitly setting it. The scheme is used when encrypting and decrypting cookies, so a consistent scheme must be used across apps.
 * A common [data protection key](xref:security/data-protection/implementation/key-management) storage location is used.
   * In ASP.NET Core apps, <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.PersistKeysToFileSystem*> is used to set the key storage location.
-  * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action\<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
+  * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action/<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
 * `DataProtectionProvider` requires the [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/) NuGet package:
-  * In ASP.NET Core 2.x apps, reference the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
   * In .NET Framework apps, add a package reference to [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/).
-* <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.SetApplicationName*> sets the common app name.
+* <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.SetApplicationName*> sets the common app name. For more information, see [SetApplicationName changes in .NET 6](xref:security/data-protection/configuration/overview#setapplicationname)
 
 ## Share authentication cookies with ASP.NET Core Identity
 
@@ -38,17 +37,9 @@ When using ASP.NET Core Identity:
 * Use the <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.ConfigureApplicationCookie*> extension method to set up the data protection service for cookies.
 * The default authentication type is `Identity.Application`.
 
-In `Startup.ConfigureServices`:
+In `Program.cs`:
 
-```csharp
-services.AddDataProtection()
-    .PersistKeysToFileSystem("{PATH TO COMMON KEY RING FOLDER}")
-    .SetApplicationName("SharedCookieApp");
-
-services.ConfigureApplicationCookie(options => {
-    options.Cookie.Name = ".AspNet.SharedCookie";
-});
-```
+[!code-csharp[](~/security/cookie-sharing/samples/WebCookieShare/Program.cs?name=snippet&highlight=7-13)]
 
 **Note:** The preceding instructions don't work with `ITicketStore` (`CookieAuthenticationOptions.SessionStore`).  For more information, see [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/21163).
 
@@ -129,7 +120,7 @@ In the examples that follow:
 * `Identity.Application` is used as the authentication scheme. Whatever scheme is used, it must be used consistently *within and across* the shared cookie apps either as the default scheme or by explicitly setting it. The scheme is used when encrypting and decrypting cookies, so a consistent scheme must be used across apps.
 * A common [data protection key](xref:security/data-protection/implementation/key-management) storage location is used.
   * In ASP.NET Core apps, <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.PersistKeysToFileSystem*> is used to set the key storage location.
-  * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action\<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
+  * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action/<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
 * `DataProtectionProvider` requires the [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/) NuGet package:
   * In ASP.NET Core 2.x apps, reference the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
   * In .NET Framework apps, add a package reference to [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/).

--- a/aspnetcore/security/cookie-sharing.md
+++ b/aspnetcore/security/cookie-sharing.md
@@ -24,7 +24,7 @@ In the examples that follow:
 * `Identity.Application` is used as the authentication scheme. Whatever scheme is used, it must be used consistently *within and across* the shared cookie apps either as the default scheme or by explicitly setting it. The scheme is used when encrypting and decrypting cookies, so a consistent scheme must be used across apps.
 * A common [data protection key](xref:security/data-protection/implementation/key-management) storage location is used.
   * In ASP.NET Core apps, <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.PersistKeysToFileSystem*> is used to set the key storage location.
-  * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action/<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
+  * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action\<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
 * `DataProtectionProvider` requires the [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/) NuGet package:
   * In .NET Framework apps, add a package reference to [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/).
 * <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.SetApplicationName*> sets the common app name. For more information, see [SetApplicationName changes in .NET 6](xref:security/data-protection/configuration/overview#setapplicationname)
@@ -47,19 +47,9 @@ In `Program.cs`:
 
 ## Share authentication cookies without ASP.NET Core Identity
 
-When using cookies directly without ASP.NET Core Identity, configure data protection and authentication in `Startup.ConfigureServices`. In the following example, the authentication type is set to `Identity.Application`:
+When using cookies directly without ASP.NET Core Identity, configure data protection and authentication. In the following example, the authentication type is set to `Identity.Application`:
 
-```csharp
-services.AddDataProtection()
-    .PersistKeysToFileSystem("{PATH TO COMMON KEY RING FOLDER}")
-    .SetApplicationName("SharedCookieApp");
-
-services.AddAuthentication("Identity.Application")
-    .AddCookie("Identity.Application", options =>
-    {
-        options.Cookie.Name = ".AspNet.SharedCookie";
-    });
-```
+[!code-csharp[](~/security/cookie-sharing/samples/WebCookieShare/Program.cs?name=snippet_swo&highlight=7-15)]
 
 [!INCLUDE[](~/includes/cookies-not-compressed.md)]
 
@@ -67,16 +57,7 @@ services.AddAuthentication("Identity.Application")
 
 An authentication cookie uses the [HttpRequest.PathBase](xref:Microsoft.AspNetCore.Http.HttpRequest.PathBase) as its default [Cookie.Path](xref:Microsoft.AspNetCore.Http.CookieBuilder.Path). If the app's cookie must be shared across different base paths, `Path` must be overridden:
 
-```csharp
-services.AddDataProtection()
-    .PersistKeysToFileSystem("{PATH TO COMMON KEY RING FOLDER}")
-    .SetApplicationName("SharedCookieApp");
-
-services.ConfigureApplicationCookie(options => {
-    options.Cookie.Name = ".AspNet.SharedCookie";
-    options.Cookie.Path = "/";
-});
-```
+[!code-csharp[](~/security/cookie-sharing/samples/WebCookieShare/Program.cs?name=snippet_dbp&highlight=7-15)]
 
 ## Share cookies across subdomains
 
@@ -90,10 +71,7 @@ options.Cookie.Domain = ".contoso.com";
 
 For production deployments, configure the `DataProtectionProvider` to encrypt keys at rest with DPAPI or an X509Certificate. For more information, see <xref:security/data-protection/implementation/key-encryption-at-rest>. In the following example, a certificate thumbprint is provided to <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.ProtectKeysWithCertificate*>:
 
-```csharp
-services.AddDataProtection()
-    .ProtectKeysWithCertificate("{CERTIFICATE THUMBPRINT}");
-```
+[!code-csharp[](~/security/cookie-sharing/samples/WebCookieShare/Program.cs?name=snippet_dbp&highlight=7-8)]
 
 ## Share authentication cookies between ASP.NET 4.x and ASP.NET Core apps
 
@@ -120,7 +98,7 @@ In the examples that follow:
 * `Identity.Application` is used as the authentication scheme. Whatever scheme is used, it must be used consistently *within and across* the shared cookie apps either as the default scheme or by explicitly setting it. The scheme is used when encrypting and decrypting cookies, so a consistent scheme must be used across apps.
 * A common [data protection key](xref:security/data-protection/implementation/key-management) storage location is used.
   * In ASP.NET Core apps, <xref:Microsoft.AspNetCore.DataProtection.DataProtectionBuilderExtensions.PersistKeysToFileSystem*> is used to set the key storage location.
-  * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action/<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
+  * In .NET Framework apps, Cookie Authentication Middleware uses an implementation of <xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider>. `DataProtectionProvider` provides data protection services for the encryption and decryption of authentication cookie payload data. The `DataProtectionProvider` instance is isolated from the data protection system used by other parts of the app. [DataProtectionProvider.Create(System.IO.DirectoryInfo, Action\<IDataProtectionBuilder>)](xref:Microsoft.AspNetCore.DataProtection.DataProtectionProvider.Create*) accepts a <xref:System.IO.DirectoryInfo> to specify the location for data protection key storage.
 * `DataProtectionProvider` requires the [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/) NuGet package:
   * In ASP.NET Core 2.x apps, reference the [Microsoft.AspNetCore.App metapackage](xref:fundamentals/metapackage-app).
   * In .NET Framework apps, add a package reference to [Microsoft.AspNetCore.DataProtection.Extensions](https://www.nuget.org/packages/Microsoft.AspNetCore.DataProtection.Extensions/).

--- a/aspnetcore/security/cookie-sharing/samples/WebCookieShare/Program.cs
+++ b/aspnetcore/security/cookie-sharing/samples/WebCookieShare/Program.cs
@@ -2,11 +2,22 @@
 #if NEVER
 #elif FIRST
 #region snippet1
+using Microsoft.AspNetCore.DataProtection;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(@"c:\PATH TO COMMON KEY RING FOLDER"))
+    .SetApplicationName("SharedCookieApp");
+
+builder.Services.ConfigureApplicationCookie(options => {
+    options.Cookie.Name = ".AspNet.SharedCookie";
+});
+
 var app = builder.Build();
+#endregion
 
 if (!app.Environment.IsDevelopment())
 {
@@ -24,5 +35,4 @@ app.UseAuthorization();
 app.MapRazorPages();
 
 app.Run();
-#endregion
 #endif

--- a/aspnetcore/security/cookie-sharing/samples/WebCookieShare/Program.cs
+++ b/aspnetcore/security/cookie-sharing/samples/WebCookieShare/Program.cs
@@ -1,7 +1,7 @@
-#define FIRST // FIRST
+#define Encrypt  // FIRST DBP SWO Encrypt
 #if NEVER
 #elif FIRST
-#region snippet1
+#region snippet
 using Microsoft.AspNetCore.DataProtection;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -35,4 +35,108 @@ app.UseAuthorization();
 app.MapRazorPages();
 
 app.Run();
+#elif SWO
+#region snippet_swo
+using Microsoft.AspNetCore.DataProtection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(@"c:\PATH TO COMMON KEY RING FOLDER"))
+    .SetApplicationName("SharedCookieApp");
+
+builder.Services.AddAuthentication("Identity.Application")
+    .AddCookie("Identity.Application", options =>
+    {
+        options.Cookie.Name = ".AspNet.SharedCookie";
+    });
+
+var app = builder.Build();
+#endregion
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();
+#elif DBP
+#region snippet_dbp
+using Microsoft.AspNetCore.DataProtection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+builder.Services.AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(@"c:\PATH TO COMMON KEY RING FOLDER"))
+    .SetApplicationName("SharedCookieApp");
+
+builder.Services.ConfigureApplicationCookie(options => {
+    options.Cookie.Name = ".AspNet.SharedCookie";
+    options.Cookie.Path = "/";
+});
+
+var app = builder.Build();
+#endregion
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();
+#elif Encrypt 
+#region snippet_Encrypt 
+using Microsoft.AspNetCore.DataProtection;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+builder.Services.AddDataProtection()
+    .ProtectKeysWithCertificate("{CERTIFICATE THUMBPRINT}");
+#endregion
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+
+app.UseRouting();
+
+app.UseAuthorization();
+
+app.MapRazorPages();
+
+app.Run();
+
 #endif


### PR DESCRIPTION
Fixes #26066
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/cookie-sharing?view=aspnetcore-6.0&branch=pr-en-us-26068)

Changes:

1. Created .NET 6 version
2. Replaced non working HTML `.PersistKeysToFileSystem("{PATH TO COMMON KEY RING FOLDER}")` with working code snippet `.PersistKeysToFileSystem(new DirectoryInfo(@"c:\PATH TO COMMON KEY RING FOLDER"))`
3. Added [In .NET 6, **Application name change** xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder normalizes the content root path to end with a xref:System.IO.Path.DirectorySeparatorChar.](https://review.docs.microsoft.com/en-us/aspnet/core/security/cookie-sharing?view=aspnetcore-6.0&branch=pr-en-us-26068#application-name-change)