### PR TITLE
Sync JS interop updates

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -5,7 +5,7 @@ description: Learn how to render globalized and localized content to users in di
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/09/2021
+ms.date: 06/09/2022
 uid: blazor/globalization-localization
 zone_pivot_groups: blazor-hosting-models
 ---
@@ -425,6 +425,9 @@ The `CultureSelector` component is placed in the `Shared` folder for use through
     }
 }
 ```
+
+> [!NOTE]
+> For more information on <xref:Microsoft.JSInterop.IJSInProcessRuntime>, see <xref:blazor/js-interop/call-javascript-from-dotnet#synchronous-js-interop-in-blazor-webassembly-apps>.
 
 Inside the closing tag of the `<main>` element in `Shared/MainLayout.razor`, add the `CultureSelector` component:
 
@@ -1303,6 +1306,9 @@ The following `CultureSelector` component shows how to set the user's culture se
 }
 ```
 
+> [!NOTE]
+> For more information on <xref:Microsoft.JSInterop.IJSInProcessRuntime>, see <xref:blazor/js-interop/call-javascript-from-dotnet#synchronous-js-interop-in-blazor-webassembly-apps>.
+
 Inside the closing `</div>` tag of the `<div class="main">` element in `Shared/MainLayout.razor`, add the `CultureSelector` component:
 
 ```razor
@@ -2094,6 +2100,9 @@ The following `CultureSelector` component shows how to set the user's culture se
     }
 }
 ```
+
+> [!NOTE]
+> For more information on <xref:Microsoft.JSInterop.IJSInProcessRuntime>, see <xref:blazor/js-interop/call-javascript-from-dotnet#synchronous-js-interop-in-blazor-webassembly-apps>.
 
 Inside the closing `</div>` tag of the `<div class="main">` element in `Shared/MainLayout.razor`, add the `CultureSelector` component:
 

--- a/aspnetcore/blazor/hybrid/reuse-razor-components.md
+++ b/aspnetcore/blazor/hybrid/reuse-razor-components.md
@@ -5,7 +5,7 @@ description: Learn how to author and organize Razor components for the web and a
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
 ms.custom: "mvc"
-ms.date: 05/23/2022
+ms.date: 06/09/2022
 uid: blazor/hybrid/reuse-razor-components
 ---
 # Reuse Razor components in ASP.NET Core Blazor Hybrid
@@ -24,7 +24,7 @@ In order to author Razor components that can seamlessly work across hosting mode
 
 * Place shared UI code in Razor class libraries (RCLs), which are containers designed to maintain reusable pieces of UI for use across different hosting models and platforms.
 * Implementations of unique features shouldn't exist in RCLs. Instead, the RCL should define abstractions (interfaces and base classes) that hosting models and platforms implement.
-* Only opt-in to unique features by hosting model or platform. For example, Blazor WebAssembly supports the use of <xref:Microsoft.JSInterop.IJSInProcessRuntime> in a component as an optimization, but only use it with a conditional cast and fallback implementation that relies on the universal <xref:Microsoft.JSInterop.IJSRuntime> abstraction that all hosting models and platforms support. For more information on <xref:Microsoft.JSInterop.IJSInProcessRuntime>, see <xref:blazor/performance#consider-the-use-of-synchronous-calls>.
+* Only opt-in to unique features by hosting model or platform. For example, Blazor WebAssembly supports the use of <xref:Microsoft.JSInterop.IJSInProcessRuntime> and <xref:Microsoft.JSInterop.IJSInProcessObjectReference> in a component as an optimization, but only use them with conditional casts and fallback implementations that rely on the universal <xref:Microsoft.JSInterop.IJSRuntime> and <xref:Microsoft.JSInterop.IJSObjectReference> abstractions that all hosting models and platforms support. For more information on <xref:Microsoft.JSInterop.IJSInProcessRuntime>, see <xref:blazor/js-interop/call-javascript-from-dotnet#synchronous-js-interop-in-blazor-webassembly-apps>. For more information on <xref:Microsoft.JSInterop.IJSInProcessObjectReference>, see <xref:blazor/js-interop/call-dotnet-from-javascript#synchronous-js-interop-in-blazor-webassembly-apps>.
 * As a general rule, use CSS for HTML styling in components. The most common case is for consistency in the look and feel of an app. In places where UI styles must differ across hosting models or platforms, use CSS to style the differences.
 * If some part of the UI requires additional or different content for a target hosting model or platform, the content can be encapsulated inside a component and rendered inside the RCL using [`DynamicComponent`](xref:blazor/components/dynamiccomponent). Additional UI can also be provided to components via <xref:Microsoft.AspNetCore.Components.RenderFragment> instances. For more information on <xref:Microsoft.AspNetCore.Components.RenderFragment>, see [Child content render fragments](xref:blazor/components/index#child-content-render-fragments) and [Render fragments for reusable rendering logic](xref:blazor/components/index#render-fragments-for-reusable-rendering-logic).
 

--- a/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-dotnet.md
+++ b/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-dotnet.md
@@ -1,0 +1,12 @@
+*This section only applies to Blazor WebAssembly apps.*
+
+JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, all JS interop calls must be asynchronous because they're sent over a network connection.
+
+If you know for certain that your app only ever runs on Blazor WebAssembly, you can choose to make synchronous JS interop calls. This has slightly less overhead than making asynchronous calls and can result in fewer render cycles because there's no intermediate state while awaiting results.
+
+To make a synchronous call from JavaScript to .NET in Blazor WebAssembly apps, use `DotNet.invokeMethod` instead of `DotNet.invokeMethodAsync`.
+
+Synchronous calls work if:
+
+* The app is running on Blazor WebAssembly, not Blazor Server.
+* The called function returns a value synchronously. The function isn't an `async` method and doesn't return a .NET <xref:System.Threading.Tasks.Task> or JavaScript [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise).

--- a/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
+++ b/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
@@ -1,0 +1,31 @@
+*This section only applies to Blazor WebAssembly apps.*
+
+JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, all JS interop calls must be asynchronous because they're sent over a network connection.
+
+If you know for certain that your app only ever runs on Blazor WebAssembly, you can choose to make synchronous JS interop calls. This has slightly less overhead than making asynchronous calls and can result in fewer render cycles because there's no intermediate state while awaiting results.
+
+To make a synchronous call from .NET to JavaScript in a Blazor WebAssembly app, cast <xref:Microsoft.JSInterop.IJSRuntime> to <xref:Microsoft.JSInterop.IJSInProcessRuntime> to make the JS interop call:
+
+```razor
+@inject IJSRuntime JS
+
+...
+
+@code {
+    protected override void HandleSomeEvent()
+    {
+        var jsInProcess = (IJSInProcessRuntime)JS;
+        var value = jsInProcess.Invoke<string>("javascriptFunctionIdentifier");
+    }
+}
+```
+
+When working with <xref:Microsoft.JSInterop.IJSObjectReference> in ASP.NET Core 5.0 or later Blazor WebAssembly apps, you can make a synchronous call by casting to <xref:Microsoft.JSInterop.IJSInProcessObjectReference>.
+
+```csharp
+private IJSInProcessObjectReference module;
+
+...
+
+module = await JS.InvokeAsync<IJSInProcessObjectReference>("import", "./scripts.js");
+```

--- a/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
+++ b/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
@@ -20,7 +20,7 @@ To make a synchronous call from .NET to JavaScript in a Blazor WebAssembly app, 
 }
 ```
 
-When working with <xref:Microsoft.JSInterop.IJSObjectReference> in ASP.NET Core 5.0 or later Blazor WebAssembly apps, you can make a synchronous call by casting to <xref:Microsoft.JSInterop.IJSInProcessObjectReference>.
+When working with <xref:Microsoft.JSInterop.IJSObjectReference> in ASP.NET Core 5.0 or later Blazor WebAssembly apps, you can use <xref:Microsoft.JSInterop.IJSInProcessObjectReference> synchronously instead:
 
 ```csharp
 private IJSInProcessObjectReference module;

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -5,7 +5,7 @@ description: Learn how to invoke .NET methods from JavaScript functions in Blazo
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc 
-ms.date: 11/09/2021
+ms.date: 06/09/2022
 uid: blazor/js-interop/call-dotnet-from-javascript
 ---
 # Call .NET methods from JavaScript functions in ASP.NET Core Blazor
@@ -24,7 +24,7 @@ For information on how to call JS functions from .NET, see <xref:blazor/js-inter
 
 ## Invoke a static .NET method
 
-To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`. Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
+To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` (synchronous for Blazor WebAssembly apps) or `DotNet.invokeMethodAsync` (asychronous for both Blazor Server and Blazor WebAssembly apps). Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
 
 In the following example:
 
@@ -36,9 +36,10 @@ In the following example:
 DotNet.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}', {ARGUMENTS});
 ```
 
-`DotNet.invokeMethod` returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
+`DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
 
-The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
+> [!IMPORTANT]
+> The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
 
 The .NET method must be public, static, and have the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute).
 
@@ -95,9 +96,9 @@ By default, the .NET method identifier for the JS call is the .NET method name, 
 [JSInvokable("DifferentMethodName")]
 ```
 
-In the call to `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
+In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
 
-* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');`
+* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 * `DotNet.invokeMethodAsync('BlazorSample', 'DifferentMethodName');`
 
 > [!NOTE]
@@ -120,7 +121,7 @@ In the call to `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`, call `Differ
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethod` or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethod` (Blazor WebAssembly only) or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:
@@ -583,6 +584,10 @@ The following image shows the rendered `CallDotNetExample6` parent component aft
 
 ![Rendered 'CallDotNetExample6' component example](~/blazor/javascript-interoperability/call-dotnet-from-javascript/_static/component-example-6.png)
 
+## Synchronous JS interop in Blazor WebAssembly apps
+
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-dotnet.md)]
+
 ## Location of JavaScript
 
 Load JavaScript (JS) code using any of approaches described by the [JS interop overview article](xref:blazor/js-interop/index#location-of-javascript):
@@ -723,7 +728,7 @@ For information on how to call JS functions from .NET, see <xref:blazor/js-inter
 
 ## Invoke a static .NET method
 
-To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`. Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
+To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` (synchronous for Blazor WebAssembly apps) or `DotNet.invokeMethodAsync` (asychronous for both Blazor Server and Blazor WebAssembly apps). Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
 
 In the following example:
 
@@ -735,9 +740,10 @@ In the following example:
 DotNet.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}', {ARGUMENTS});
 ```
 
-`DotNet.invokeMethod` returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
+`DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
 
-The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
+> [!IMPORTANT]
+> The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
 
 The .NET method must be public, static, and have the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute).
 
@@ -794,9 +800,9 @@ By default, the .NET method identifier for the JS call is the .NET method name, 
 [JSInvokable("DifferentMethodName")]
 ```
 
-In the call to `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
+In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
 
-* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');`
+* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 * `DotNet.invokeMethodAsync('BlazorSample', 'DifferentMethodName');`
 
 > [!NOTE]
@@ -819,7 +825,7 @@ In the call to `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`, call `Differ
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethod` or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethod` (Blazor WebAssembly only) or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:
@@ -1045,7 +1051,7 @@ For information on how to call JS functions from .NET, see <xref:blazor/js-inter
 
 ## Invoke a static .NET method
 
-To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`. Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
+To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` (synchronous for Blazor WebAssembly apps) or `DotNet.invokeMethodAsync` (asychronous for both Blazor Server and Blazor WebAssembly apps). Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
 
 In the following example:
 
@@ -1057,9 +1063,10 @@ In the following example:
 DotNet.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}', {ARGUMENTS});
 ```
 
-`DotNet.invokeMethod` returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
+`DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
 
-The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
+> [!IMPORTANT]
+> The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
 
 The .NET method must be public, static, and have the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute).
 
@@ -1116,9 +1123,9 @@ By default, the .NET method identifier for the JS call is the .NET method name, 
 [JSInvokable("DifferentMethodName")]
 ```
 
-In the call to `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
+In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
 
-* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');`
+* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 * `DotNet.invokeMethodAsync('BlazorSample', 'DifferentMethodName');`
 
 > [!NOTE]
@@ -1141,7 +1148,7 @@ In the call to `DotNet.invokeMethod` or `DotNet.invokeMethodAsync`, call `Differ
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethod` or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethod` (Blazor WebAssembly only) or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -24,7 +24,12 @@ For information on how to call JS functions from .NET, see <xref:blazor/js-inter
 
 ## Invoke a static .NET method
 
-To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` (synchronous for Blazor WebAssembly apps) or `DotNet.invokeMethodAsync` (asychronous for both Blazor Server and Blazor WebAssembly apps). Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
+To invoke a static .NET method from JavaScript (JS), use the JS functions:
+
+* `DotNet.invokeMethodAsync` (*Recommended*): Asynchronous for both Blazor Server and Blazor WebAssembly apps.
+* `DotNet.invokeMethod`: Synchronous for Blazor WebAssembly apps only.
+
+Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
 
 In the following example:
 
@@ -36,7 +41,7 @@ In the following example:
 DotNet.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}', {ARGUMENTS});
 ```
 
-`DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
+`DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
 
 > [!IMPORTANT]
 > The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
@@ -96,10 +101,10 @@ By default, the .NET method identifier for the JS call is the .NET method name, 
 [JSInvokable("DifferentMethodName")]
 ```
 
-In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
+In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAssembly only), call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
 
-* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 * `DotNet.invokeMethodAsync('BlazorSample', 'DifferentMethodName');`
+* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 
 > [!NOTE]
 > The `ReturnArrayAsync` method example in this section returns the result of a <xref:System.Threading.Tasks.Task> without the use of explicit C# [`async`](/dotnet/csharp/language-reference/keywords/async) and [`await`](/dotnet/csharp/language-reference/operators/await) keywords. Coding methods with [`async`](/dotnet/csharp/language-reference/keywords/async) and [`await`](/dotnet/csharp/language-reference/operators/await) is typical of methods that use the [`await`](/dotnet/csharp/language-reference/operators/await) keyword to return the value of asynchronous operations.
@@ -121,7 +126,7 @@ In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invoke
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethod` (Blazor WebAssembly only) or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethodAsync` or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:
@@ -728,7 +733,10 @@ For information on how to call JS functions from .NET, see <xref:blazor/js-inter
 
 ## Invoke a static .NET method
 
-To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` (synchronous for Blazor WebAssembly apps) or `DotNet.invokeMethodAsync` (asychronous for both Blazor Server and Blazor WebAssembly apps). Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
+To invoke a static .NET method from JavaScript (JS), use the JS functions:
+
+* `DotNet.invokeMethodAsync` (*Recommended*): Asynchronous for both Blazor Server and Blazor WebAssembly apps.
+* `DotNet.invokeMethod`: Synchronous for Blazor WebAssembly apps only.
 
 In the following example:
 
@@ -740,7 +748,7 @@ In the following example:
 DotNet.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}', {ARGUMENTS});
 ```
 
-`DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
+`DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
 
 > [!IMPORTANT]
 > The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
@@ -800,10 +808,10 @@ By default, the .NET method identifier for the JS call is the .NET method name, 
 [JSInvokable("DifferentMethodName")]
 ```
 
-In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
+In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAssembly only), call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
 
-* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 * `DotNet.invokeMethodAsync('BlazorSample', 'DifferentMethodName');`
+* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 
 > [!NOTE]
 > The `ReturnArrayAsync` method example in this section returns the result of a <xref:System.Threading.Tasks.Task> without the use of explicit C# [`async`](/dotnet/csharp/language-reference/keywords/async) and [`await`](/dotnet/csharp/language-reference/operators/await) keywords. Coding methods with [`async`](/dotnet/csharp/language-reference/keywords/async) and [`await`](/dotnet/csharp/language-reference/operators/await) is typical of methods that use the [`await`](/dotnet/csharp/language-reference/operators/await) keyword to return the value of asynchronous operations.
@@ -825,7 +833,7 @@ In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invoke
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethod` (Blazor WebAssembly only) or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethodAsync` or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:
@@ -1051,7 +1059,10 @@ For information on how to call JS functions from .NET, see <xref:blazor/js-inter
 
 ## Invoke a static .NET method
 
-To invoke a static .NET method from JavaScript (JS), use the JS functions `DotNet.invokeMethod` (synchronous for Blazor WebAssembly apps) or `DotNet.invokeMethodAsync` (asychronous for both Blazor Server and Blazor WebAssembly apps). Pass in the name of the assembly containing the method, the identifier of the static .NET method, and any arguments.
+To invoke a static .NET method from JavaScript (JS), use the JS functions:
+
+* `DotNet.invokeMethodAsync` (*Recommended*): Asynchronous for both Blazor Server and Blazor WebAssembly apps.
+* `DotNet.invokeMethod`: Synchronous for Blazor WebAssembly apps only.
 
 In the following example:
 
@@ -1063,7 +1074,7 @@ In the following example:
 DotNet.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}', {ARGUMENTS});
 ```
 
-`DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation. `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation.
+`DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
 
 > [!IMPORTANT]
 > The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
@@ -1123,10 +1134,10 @@ By default, the .NET method identifier for the JS call is the .NET method name, 
 [JSInvokable("DifferentMethodName")]
 ```
 
-In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invokeMethodAsync`, call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
+In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAssembly only), call `DifferentMethodName` to execute the `ReturnArrayAsync` .NET method:
 
-* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 * `DotNet.invokeMethodAsync('BlazorSample', 'DifferentMethodName');`
+* `DotNet.invokeMethod('BlazorSample', 'DifferentMethodName');` (Blazor WebAssembly only)
 
 > [!NOTE]
 > The `ReturnArrayAsync` method example in this section returns the result of a <xref:System.Threading.Tasks.Task> without the use of explicit C# [`async`](/dotnet/csharp/language-reference/keywords/async) and [`await`](/dotnet/csharp/language-reference/operators/await) keywords. Coding methods with [`async`](/dotnet/csharp/language-reference/keywords/async) and [`await`](/dotnet/csharp/language-reference/operators/await) is typical of methods that use the [`await`](/dotnet/csharp/language-reference/operators/await) keyword to return the value of asynchronous operations.
@@ -1148,7 +1159,7 @@ In the call to `DotNet.invokeMethod` (Blazor WebAssembly only) or `DotNet.invoke
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethod` (Blazor WebAssembly only) or `invokeMethodAsync` from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethodAsync` or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -5,7 +5,7 @@ description: Learn how to invoke JavaScript functions from .NET methods in Blazo
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/09/2021
+ms.date: 06/09/2022
 uid: blazor/js-interop/call-javascript-from-dotnet
 ---
 # Call JavaScript functions from .NET methods in ASP.NET Core Blazor
@@ -153,6 +153,10 @@ IJSRuntime JS { get; set; }
 
 [!INCLUDE[](~/blazor/includes/prerendering.md)]
 
+## Synchronous JS interop in Blazor WebAssembly apps
+
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-js.md)]
+
 ## Location of JavaScript
 
 Load JavaScript (JS) code using any of approaches described by the [JavaScript (JS) interoperability (interop) overview article](xref:blazor/js-interop/index#location-of-javascript):
@@ -205,7 +209,7 @@ In the preceding example:
 
 Dynamically importing a module requires a network request, so it can only be achieved asynchronously by calling <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A>.
 
-`IJSInProcessObjectReference` represents a reference to a JS object whose functions can be invoked synchronously.
+`IJSInProcessObjectReference` represents a reference to a JS object whose functions can be invoked synchronously in Blazor WebAssembly apps. For more information, see the [Synchronous JS interop in Blazor WebAssembly apps](#synchronous-js-interop-in-blazor-webassembly-apps) section.
 
 > [!NOTE]
 > When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the module's JS file using its stable static web asset path: `./_content/{PACKAGE ID}/{SCRIPT PATH AND FILENAME (.js)}`:
@@ -955,6 +959,10 @@ IJSRuntime JS { get; set; }
 
 [!INCLUDE[](~/blazor/includes/prerendering.md)]
 
+## Synchronous JS interop in Blazor WebAssembly apps
+
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-js.md)]
+
 ## Location of JavaScript
 
 Load JavaScript (JS) code using any of approaches described by the [JavaScript (JS) interoperability (interop) overview article](xref:blazor/js-interop/index#location-of-javascript):
@@ -1005,7 +1013,7 @@ In the preceding example:
 
 Dynamically importing a module requires a network request, so it can only be achieved asynchronously by calling <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A>.
 
-`IJSInProcessObjectReference` represents a reference to a JS object whose functions can be invoked synchronously.
+`IJSInProcessObjectReference` represents a reference to a JS object whose functions can be invoked synchronously in Blazor WebAssembly apps. For more information, see the [Synchronous JS interop in Blazor WebAssembly apps](#synchronous-js-interop-in-blazor-webassembly-apps) section.
 
 > [!NOTE]
 > When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the module's JS file using its stable static web asset path: `./_content/{PACKAGE ID}/{SCRIPT PATH AND FILENAME (.js)}`:
@@ -1568,6 +1576,10 @@ IJSRuntime JS { get; set; }
 ## Detect when a Blazor Server app is prerendering
 
 [!INCLUDE[](~/blazor/includes/prerendering.md)]
+
+## Synchronous JS interop in Blazor WebAssembly apps
+
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-js.md)]
 
 ## Location of JavaScript
 

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -5,7 +5,7 @@ description: Learn how to interact with JavaScript in Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/09/2021
+ms.date: 06/09/2022
 uid: blazor/js-interop/index
 ---
 # ASP.NET Core Blazor JavaScript interoperability (JS interop)
@@ -33,7 +33,12 @@ For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#ca
 
 ## Asynchronous JavaScript calls
 
-JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, JS interop calls must be asynchronous because they're sent over a network connection. For apps that exclusively adopt the Blazor WebAssembly hosting model, synchronous JS interop calls are supported. For more information, see <xref:blazor/performance?pivots=webassembly#consider-the-use-of-synchronous-calls>.
+JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, JS interop calls must be asynchronous because they're sent over a network connection. For apps that exclusively adopt the Blazor WebAssembly hosting model, synchronous JS interop calls are supported.
+
+For more information, see the following articles:
+
+* <xref:blazor/js-interop/call-javascript-from-dotnet#synchronous-js-interop-in-blazor-webassembly-apps>
+* <xref:blazor/js-interop/call-dotnet-from-javascript#synchronous-js-interop-in-blazor-webassembly-apps>
 
 ## Object serialization
 
@@ -257,7 +262,12 @@ For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#ca
 
 ## Asynchronous JavaScript calls
 
-JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, JS interop calls must be asynchronous because they're sent over a network connection. For apps that exclusively adopt the Blazor WebAssembly hosting model, synchronous JS interop calls are supported. For more information, see <xref:blazor/performance?pivots=webassembly#consider-the-use-of-synchronous-calls>.
+JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, JS interop calls must be asynchronous because they're sent over a network connection. For apps that exclusively adopt the Blazor WebAssembly hosting model, synchronous JS interop calls are supported.
+
+For more information, see the following articles:
+
+* <xref:blazor/js-interop/call-javascript-from-dotnet#synchronous-js-interop-in-blazor-webassembly-apps>
+* <xref:blazor/js-interop/call-dotnet-from-javascript#synchronous-js-interop-in-blazor-webassembly-apps>
 
 ## Object serialization
 
@@ -468,7 +478,9 @@ For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#ca
 
 ## Asynchronous JavaScript calls
 
-JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, JS interop calls must be asynchronous because they're sent over a network connection. For apps that exclusively adopt the Blazor WebAssembly hosting model, synchronous JS interop calls are supported. For more information, see <xref:blazor/performance?pivots=webassembly#consider-the-use-of-synchronous-calls>.
+JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, JS interop calls must be asynchronous because they're sent over a network connection. For apps that exclusively adopt the Blazor WebAssembly hosting model, synchronous JS interop calls are supported.
+
+For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#synchronous-js-interop-in-blazor-webassembly-apps>.
 
 ## Object serialization
 

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -5,7 +5,7 @@ description: Tips for increasing performance in ASP.NET Core Blazor apps and avo
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/09/2021
+ms.date: 06/09/2022
 uid: blazor/performance
 ---
 # ASP.NET Core Blazor performance best practices
@@ -653,38 +653,13 @@ For Blazor WebAssembly apps, rolling individual JS interop calls into a single c
 
 ### Consider the use of synchronous calls
 
-*This section only applies to Blazor WebAssembly apps.*
+#### Call JavaScript from .NET
 
-JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, all JS interop calls must be asynchronous because they're sent over a network connection.
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-js.md)]
 
-If you know for certain that your app only ever runs on Blazor WebAssembly, you can choose to make synchronous JS interop calls. This has slightly less overhead than making asynchronous calls and can result in fewer render cycles because there's no intermediate state while awaiting results.
+#### Call .NET from JavaScript
 
-To make a synchronous call from .NET to JavaScript in a Blazor WebAssembly app, cast <xref:Microsoft.JSInterop.IJSRuntime> to <xref:Microsoft.JSInterop.IJSInProcessRuntime> to make the JS interop call:
-
-```razor
-@inject IJSRuntime JS
-
-...
-
-@code {
-    protected override void HandleSomeEvent()
-    {
-        var jsInProcess = (IJSInProcessRuntime)JS;
-        var value = jsInProcess.Invoke<string>("javascriptFunctionIdentifier");
-    }
-}
-```
-
-When working with <xref:Microsoft.JSInterop.IJSObjectReference>, you can make a synchronous call by casting to <xref:Microsoft.JSInterop.IJSInProcessObjectReference>.
-
-To make a synchronous call from JavaScript to .NET, use `DotNet.invokeMethod` instead of `DotNet.invokeMethodAsync`.
-
-Synchronous calls work if:
-
-* The app is running on Blazor WebAssembly, not Blazor Server.
-* The called function returns a value synchronously. The function isn't an `async` method and doesn't return a .NET <xref:System.Threading.Tasks.Task> or JavaScript [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise).
-
-For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet>.
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-dotnet.md)]
 
 ### Consider the use of unmarshalled calls
 
@@ -1408,38 +1383,13 @@ For Blazor WebAssembly apps, rolling individual JS interop calls into a single c
 
 ### Consider the use of synchronous calls
 
-*This section only applies to Blazor WebAssembly apps.*
+#### Call JavaScript from .NET
 
-JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, all JS interop calls must be asynchronous because they're sent over a network connection.
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-js.md)]
 
-If you know for certain that your app only ever runs on Blazor WebAssembly, you can choose to make synchronous JS interop calls. This has slightly less overhead than making asynchronous calls and can result in fewer render cycles because there is no intermediate state while awaiting results.
+#### Call .NET from JavaScript
 
-To make a synchronous call from .NET to JavaScript, cast <xref:Microsoft.JSInterop.IJSRuntime> to <xref:Microsoft.JSInterop.IJSInProcessRuntime>:
-
-```razor
-@inject IJSRuntime JS
-
-...
-
-@code {
-    protected override void HandleSomeEvent()
-    {
-        var jsInProcess = (IJSInProcessRuntime)JS;
-        var value = jsInProcess.Invoke<string>("javascriptFunctionIdentifier");
-    }
-}
-```
-
-When working with <xref:Microsoft.JSInterop.IJSObjectReference>, you can make a synchronous call by casting to <xref:Microsoft.JSInterop.IJSInProcessObjectReference>.
-
-To make a synchronous call from JavaScript to .NET, use `DotNet.invokeMethod` instead of `DotNet.invokeMethodAsync`.
-
-Synchronous calls work if:
-
-* The app is running on Blazor WebAssembly, not Blazor Server.
-* The called function returns a value synchronously (it isn't an `async` method and doesn't return a .NET <xref:System.Threading.Tasks.Task> or JavaScript [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)).
-
-For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet>.
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-dotnet.md)]
 
 ### Consider the use of unmarshalled calls
 
@@ -2147,36 +2097,7 @@ For Blazor WebAssembly apps, rolling individual JS interop calls into a single c
 
 ### Consider the use of synchronous calls
 
-*This section only applies to Blazor WebAssembly apps.*
-
-JS interop calls are asynchronous by default, regardless of whether the called code is synchronous or asynchronous. Calls are asynchronous by default to ensure that components are compatible across both Blazor hosting models, Blazor Server and Blazor WebAssembly. On Blazor Server, all JS interop calls must be asynchronous because they're sent over a network connection.
-
-If you know for certain that your app only ever runs on Blazor WebAssembly, you can choose to make synchronous JS interop calls. This has slightly less overhead than making asynchronous calls and can result in fewer render cycles because there is no intermediate state while awaiting results.
-
-To make a synchronous call from .NET to JavaScript, cast <xref:Microsoft.JSInterop.IJSRuntime> to <xref:Microsoft.JSInterop.IJSInProcessRuntime>:
-
-```razor
-@inject IJSRuntime JS
-
-...
-
-@code {
-    protected override void HandleSomeEvent()
-    {
-        var jsInProcess = (IJSInProcessRuntime)JS;
-        var value = jsInProcess.Invoke<string>("javascriptFunctionIdentifier");
-    }
-}
-```
-
-To make a synchronous call from JavaScript to .NET, use `DotNet.invokeMethod` instead of `DotNet.invokeMethodAsync`.
-
-Synchronous calls work if:
-
-* The app is running on Blazor WebAssembly, not Blazor Server.
-* The called function returns a value synchronously (it isn't an `async` method and doesn't return a .NET <xref:System.Threading.Tasks.Task> or JavaScript [`Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise)).
-
-For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet>.
+[!INCLUDE[](~/blazor/includes/js-interop/synchronous-js-interop-call-js.md)]
 
 ## Minimize app download size
 


### PR DESCRIPTION
Addresses #24615

* Surface `IJSInProcessObjectReference` better. It was primarily covered way back in the *Performance* topic. This will centralize its coverage with the rest of JS interop in the JS interop node.
* Both the JS interop coverage and the performance articles use INCLUDE files to call out the synchronous options for WASM coverage. Because in the performance topic these sections sit SxS, there's a bit of duplicate text. Each section starts by explaining that WASM can use sync calls, not Server. Still tho, that language should stay in each INCLUDE because the files are used separately in the JS interop node topics on *calling JS* or *calling .NET* ... they aren't SxS in the JS node topics ... the dup text won't be seen by readers there. This is a reasonable compromise. I decided to go this way (with INCLUDES) instead of dropping the coverage from the perf topic and cross-linking to JS interop because I don't want to throw readers out of the perf topic to get reminded on these sync approaches.
* Also, a general clean-up of the language, such as placing the async examples and descriptions first because that's the favored approach to cover both hosting models and reminding readers each time the sync bits are mentioned that they only apply to WASM apps.
* Improve cross-linking.