### PR TITLE
[BrokenLinksH2] Fix path in link

### DIFF
--- a/aspnetcore/whats-new/dotnet-AspNetCore.Docs-2022-02-01.md
+++ b/aspnetcore/whats-new/dotnet-AspNetCore.Docs-2022-02-01.md
@@ -112,7 +112,7 @@ The following people contributed to the ASP.NET Core docs during this period. Th
 - [ericmutta](https://github.com/ericmutta) - Eric Mutta (1)
 - [eslamisepehr](https://github.com/eslamisepehr) - Sepehr Eslami (1)
 - [fscopel](https://github.com/fscopel) - Fabio Scopel (1)
-- [github-actions](https://github.com/github-actions) -  (1)
+- [github-actions](https://github.com/actions) -  (1)
 - [hjoab](https://github.com/hjoab) - Holger Otto André (1)
 - [karayanni](https://github.com/karayanni) - nader karayanni (1)
 - [KieranFoot](https://github.com/KieranFoot) - Kieran Foot (1)


### PR DESCRIPTION
**Global effort to fix broken links**

 @Rick-Anderson 

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!