### PR TITLE
Standardized on .NET 6 Host naming

### DIFF
--- a/aspnetcore/fundamentals/index.md
+++ b/aspnetcore/fundamentals/index.md
@@ -74,7 +74,7 @@ There are three different hosts:
 * [.NET Generic Host](xref:fundamentals/host/generic-host)
 * <xref:fundamentals/host/web-host>
 
-The .NET Minimal Host is recommended and used in all the ASP.NET Core templates. The Minimal and Generic Host share many of the same interfaces and classes. The ASP.NET Core Web Host is available only for backward compatibility.
+The .NET WebApplication Host is recommended and used in all the ASP.NET Core templates. The .NET WebApplication Host and .NET Generic Host share many of the same interfaces and classes. The ASP.NET Core Web Host is available only for backward compatibility.
 
 The following example instantiates a WebApplication  Host:
 


### PR DESCRIPTION
The bullet list contains .NET WebApplication Host but the paragraph below uses the terms .NET Minimal Host and Minimal Host. .NET WebApplication Host is the primary name used in .NET 6. The paragraph should match bullet list.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->