### PR TITLE
Repair broken link

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -1247,7 +1247,7 @@ items:
                   - name: Calling an ASP.NET Core 2.0 Web API from a WPF application using Azure AD V2
                     href: /samples/azure-samples/active-directory-dotnet-native-aspnetcore-v2/calling-an-aspnet-core-web-api-from-a-wpf-application-using-azure-ad-v2/
                   - name: Web API with Azure AD B2C
-                    href: https://azure.microsoft.com/resources/samples/active-directory-b2c-dotnetcore-webapi/
+                    href: /samples/azure-samples/active-directory-aspnetcore-webapp-openidconnect-v2/how-to-secure-a-web-api-built-with-aspnet-core-using-the-azure-ad-b2c/
           - name: Secure ASP.NET Core apps with Duende Identity Server
             href: https://docs.duendesoftware.com
           - name: Secure ASP.NET Core apps with IdentityServer4


### PR DESCRIPTION
Fixes #26128

It looks like this link for web API with B2C should be ...

**How to secure a Web API built with ASP.NET Core using the Azure AD B2C**
https://docs.microsoft.com/samples/azure-samples/active-directory-aspnetcore-webapp-openidconnect-v2/how-to-secure-a-web-api-built-with-aspnet-core-using-the-azure-ad-b2c/
