### PR TITLE
Blazor file downloads UE pass

### DIFF
--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -12,30 +12,25 @@ uid: blazor/file-downloads
 
 This article explains how to download files in Blazor Server and Blazor WebAssembly apps.
 
-Files can be downloaded from the app's own static assets or from any other location. When downloading files, Cross-Origin Resource Sharing (CORS) considerations apply. More information on CORS is in the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section later in this article.
+Files can be downloaded from the app's own static assets or from any other location. When downloading files, Cross-Origin Resource Sharing (CORS) considerations apply. For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
 
 > [!WARNING]
 > Always follow security best practices when allowing users to download files. For more information, see the [Security considerations](#security-considerations) section.
 
 ## Download from a stream
 
-The recommended approach for downloading files less than 250 MB in size uses [JavaScript (JS) interop](xref:blazor/js-interop/index) to receive the file's name with the file's data stream to trigger the client-side download. The `downloadFileFromStream` function, which is shown in the following example, is used in a Razor component later in this article.
+*This section applies to files that are typically up to 250 MB in size.*
+
+The recommended approach for downloading relatively small files (\< 250 MB) is to stream file content to a raw binary data buffer on the client with [JavaScript (JS) interop](xref:blazor/js-interop/index).
 
 > [!WARNING]
-> The approach in this section reads the file's content into an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). This approach loads the entire file into the client's memory, which can impair performance. For file downloads over 250 MB, we recommend following the guidance in the [Download from a URL](#download-from-a-url) section to download the file from a URL instead.
+> The approach in this section reads the file's content into a [JS `ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). This approach loads the entire file into the client's memory, which can impair performance. To download relatively large files (\>= 250 MB), we recommend following the guidance in the [Download from a URL](#download-from-a-url) section.
 
 The following `downloadFileFromStream` JS function performs the following steps:
 
 * Read the provided stream into an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 * Create a [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob) to wrap the `ArrayBuffer`.
 * Create an object URL to serve as the file's download address.
-
-The `fileName` and object `url` are passed to `triggerFileDownload`, which performs the following steps:
-
-* Create an [`HTMLAnchorElement`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement) (`<a>` element).
-* Assign the `url` and `fileName` for the download.
-* Trigger the download via `click`.
-* Remove the anchor (`<a>`) element.
 
 At this point, the file download is triggered and then the temporary object URL is revoked by calling [`revokeObjectURL`](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) on the URL. **This is an important step to ensure memory isn't leaked on the client.**
 
@@ -58,22 +53,29 @@ The following example component:
 * Uses native byte-streaming interop to ensure efficient transfer of the file to the client.
 * Has a method named `GetFileStream` to retrieve a <xref:System.IO.Stream> for the file that's downloaded to clients. Alternative approaches include retrieving a file from storage or generating a file dynamically in C# code. For this demonstration, the app creates a 50 KB file of random data from a new byte array (`new byte[]`). The bytes are wrapped with a <xref:System.IO.MemoryStream> to serve as the example's dynamically-generated binary file.
 * The `DownloadFileFromStream` method performs the following steps:
-  * Retrieves the <xref:System.IO.Stream> from `GetFileStream`.
+  * Retrieve the <xref:System.IO.Stream> from `GetFileStream`.
   * Specify a file name when file is saved on the user's machine. The following example names the file `quote.txt`.
-  * Wraps the <xref:System.IO.Stream> in a <xref:Microsoft.JSInterop.DotNetStreamReference>, which allows streaming the file data to the client.
-  * Invokes `downloadFileFromStream`, which is the JavaScript function shown earlier in this article that accepts the data on the client.
+  * Wrap the <xref:System.IO.Stream> in a <xref:Microsoft.JSInterop.DotNetStreamReference>, which allows streaming the file data to the client.
+  * Invoke the `downloadFileFromStream` JS function to accept the data on the client.
 
 :::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/file-downloads/FileDownload1.razor":::
 
 ## Download from a URL
 
-The recommended approach for downloading files less than 250 MB in size uses
+*This section applies to files that are relatively large, typically 250 MB or larger.*
 
-The example in this section uses a dummy log file named `quote.txt`, which is placed in a folder named `files` in the app's `wwwroot` folder:
+The example in this section uses a download file named `quote.txt`, which is placed in a folder named `files` in the app's web root (`wwwroot` folder). The use of the `files` folder is only for demonstration purposes. You can organize downloadable files in any folder layout within the web root (`wwwroot` folder) that you prefer, including serving them directly from the `wwwroot` folder.
 
-```wwwroot/files/quote.txt`:
+`wwwroot/files/quote.txt`:
 
 :::code language="text" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/wwwroot/files/quote.txt":::
+
+The following `triggerFileDownload` JS function performs the following steps:
+
+* Create an [`HTMLAnchorElement`](https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement) (`<a>` element).
+* Assign the file's name (`fileName`) and URL (`url`) for the download.
+* Trigger the download by firing a [`click` event](https://developer.mozilla.org/docs/Web/API/HTMLElement/click) on the anchor element.
+* Remove the anchor element.
 
 Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
 
@@ -89,16 +91,13 @@ Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `ww
 </script>
 ```
 
-In the following example component:
-
-* Downloads the file from the same origin (same domain) that the app uses. If the file download is attempted from a different origin (different domain), configure Cross-Origin Resource Sharing (CORS). For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section later in this article.
-* xxx
+The following example component downloads the file from the same origin (same domain) that the app uses. If the file download is attempted from a different origin (different domain), configure Cross-Origin Resource Sharing (CORS). For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
 
 :::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/file-downloads/FileDownload2.razor":::
 
 ## Cross-Origin Resource Sharing (CORS)
 
-Without taking further steps to enable cross-origin requests, downloading files won't pass [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS) checks made by the browser.
+Without taking further steps to enable [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS), downloading files won't pass CORS checks made by the browser.
 
 For more information on CORS with ASP.NET Core apps and other Microsoft products and services that host files for download, see the following resources:
 
@@ -108,8 +107,6 @@ For more information on CORS with ASP.NET Core apps and other Microsoft products
 * [Core Cloud Services - Set up CORS for your website and storage assets (Learn Module)](/learn/modules/set-up-cors-website-storage/)
 * [IIS CORS module Configuration Reference (IIS documentation)](/iis/extensions/cors-module/cors-module-configuration-reference)
 
-For more information on CORS with non-ASP.NET Core apps and non-Microsoft services, consult the external framework or service CORS documentation.
-
 ## Security considerations
 
 Use caution when providing users with the ability to download files from a server. Attackers may execute [denial of service (DOS)](/windows-hardware/drivers/ifs/denial-of-service) attacks, [API exploitation attacks](https://developer.mozilla.org/docs/Web/HTML/Element/a#security_and_privacy), or attempt to compromise networks and servers in other ways.
@@ -118,10 +115,11 @@ Security steps that reduce the likelihood of a successful attack are:
 
 * Download files from a dedicated file download area on the server, preferably from a non-system drive. Using a dedicated location makes it easier to impose security restrictions on downloadable files. Disable execute permissions on the file download area.
 * Verify that client-side checks are also performed on the server. Client-side checks are easy to circumvent.
+* Don't receive files from users or other untrusted sources and then make the files available for download without performing security checks on the files first. For more information, see <xref:mvc/models/file-uploads#security-considerations>.
 
 ## Additional resources
 
+* <xref:blazor/js-interop/index>
 * [`<a>`: The Anchor element: Security and privacy (MDN documentation)](https://developer.mozilla.org/docs/Web/HTML/Element/a#security_and_privacy)
 * <xref:blazor/file-uploads>
-* <xref:mvc/models/file-uploads#security-considerations>
 * <xref:blazor/forms-validation>

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -59,7 +59,7 @@ The following example component:
 * Has a method named `GetFileStream` to retrieve a <xref:System.IO.Stream> for the file that's downloaded to clients. Alternative approaches include retrieving a file from storage or generating a file dynamically in C# code. For this demonstration, the app creates a 50 KB file of random data from a new byte array (`new byte[]`). The bytes are wrapped with a <xref:System.IO.MemoryStream> to serve as the example's dynamically-generated binary file.
 * The `DownloadFileFromStream` method performs the following steps:
   * Retrieves the <xref:System.IO.Stream> from `GetFileStream`.
-  * Specify a file name when file is saved on the user's machine. The following example names the file `log.bin`.
+  * Specify a file name when file is saved on the user's machine. The following example names the file `quote.txt`.
   * Wraps the <xref:System.IO.Stream> in a <xref:Microsoft.JSInterop.DotNetStreamReference>, which allows streaming the file data to the client.
   * Invokes `downloadFileFromStream`, which is the JavaScript function shown earlier in this article that accepts the data on the client.
 
@@ -69,11 +69,11 @@ The following example component:
 
 The recommended approach for downloading files less than 250 MB in size uses
 
-The example in this section uses a dummy log file named `log.bin`, which is placed in a folder named `files` in the app's `wwwroot` folder:
+The example in this section uses a dummy log file named `quote.txt`, which is placed in a folder named `files` in the app's `wwwroot` folder:
 
-```wwwroot/files/log.bin`:
+```wwwroot/files/quote.txt`:
 
-:::code language="text" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/wwwroot/files/log.bin":::
+:::code language="text" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/wwwroot/files/quote.txt":::
 
 Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -5,14 +5,14 @@ description: Learn how to download files using Blazor Server and Blazor WebAssem
 monikerRange: '>= aspnetcore-6.0'
 ms.author: taparik
 ms.custom: mvc
-ms.date: 06/17/2022
+ms.date: 06/20/2022
 uid: blazor/file-downloads
 ---
 # ASP.NET Core Blazor file downloads
 
 This article explains how to download files in Blazor Server and Blazor WebAssembly apps.
 
-Files can be downloaded from the app's own static assets or from any other location. When downloading files, Cross-Origin Resource Sharing (CORS) considerations apply. For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
+Files can be downloaded from the app's own static assets or from any other location. When downloading files from a different origin than the app, Cross-Origin Resource Sharing (CORS) considerations apply. For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
 
 ## Security considerations
 
@@ -21,8 +21,8 @@ Use caution when providing users with the ability to download files from a serve
 Security steps that reduce the likelihood of a successful attack are:
 
 * Download files from a dedicated file download area on the server, preferably from a non-system drive. Using a dedicated location makes it easier to impose security restrictions on downloadable files. Disable execute permissions on the file download area.
-* Verify that client-side checks are also performed on the server. Client-side checks are easy to circumvent.
-* Don't receive files from users or other untrusted sources and then make the files available for download without performing security checks on the files first. For more information, see <xref:mvc/models/file-uploads#security-considerations>.
+* Client-side security checks are easy to circumvent by malicious users. Always perform client-side security checks on the server, too.
+* Don't receive files from users or other untrusted sources and then make the files available for immediate download without performing security checks on the files. For more information, see <xref:mvc/models/file-uploads#security-considerations>.
 
 ## Download from a stream
 
@@ -73,7 +73,7 @@ The following example component:
 
 *This section applies to files that are relatively large, typically 250 MB or larger.*
 
-The example in this section uses a download file named `quote.txt`, which is placed in a folder named `files` in the app's web root (`wwwroot` folder). The use of the `files` folder is only for demonstration purposes. You can organize downloadable files in any folder layout within the web root (`wwwroot` folder) that you prefer, including serving them directly from the `wwwroot` folder.
+The example in this section uses a download file named `quote.txt`, which is placed in a folder named `files` in the app's web root (`wwwroot` folder). The use of the `files` folder is only for demonstration purposes. You can organize downloadable files in any folder layout within the web root (`wwwroot` folder) that you prefer, including serving the files directly from the `wwwroot` folder.
 
 `wwwroot/files/quote.txt`:
 
@@ -102,13 +102,13 @@ Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `ww
 
 [!INCLUDE[](~/blazor/includes/js-location.md)]
 
-The following example component downloads the file from the same origin (same domain) that the app uses. If the file download is attempted from a different origin (different domain), configure Cross-Origin Resource Sharing (CORS). For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
+The following example component downloads the file from the same origin that the app uses. If the file download is attempted from a different origin, configure Cross-Origin Resource Sharing (CORS). For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
 
 :::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/file-downloads/FileDownload2.razor":::
 
 ## Cross-Origin Resource Sharing (CORS)
 
-Without taking further steps to enable [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS), downloading files won't pass CORS checks made by the browser.
+Without taking further steps to enable [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/docs/Web/HTTP/CORS) for files that don't have the same origin as the app, downloading files won't pass CORS checks made by the browser.
 
 For more information on CORS with ASP.NET Core apps and other Microsoft products and services that host files for download, see the following resources:
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -1,83 +1,30 @@
 ---
 title: ASP.NET Core Blazor file downloads
-author: TanayParikh
+author: guardrex
 description: Learn how to download files using Blazor Server and Blazor WebAssembly.
 monikerRange: '>= aspnetcore-6.0'
 ms.author: taparik
 ms.custom: mvc
-ms.date: 11/09/2021
+ms.date: 06/16/2022
 uid: blazor/file-downloads
 ---
 # ASP.NET Core Blazor file downloads
 
 This article explains how to download files in Blazor Server and Blazor WebAssembly apps.
 
-Files can be downloaded from the app's own static assets or from any other location. When downloading files, [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) considerations apply.
+Files can be downloaded from the app's own static assets or from any other location. When downloading files, Cross-Origin Resource Sharing (CORS) considerations apply. More information on CORS is in the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section later in this article.
 
 > [!WARNING]
 > Always follow security best practices when allowing users to download files. For more information, see the [Security considerations](#security-considerations) section.
 
-The following example demonstrates how to download a file. Native `byte[]` streaming interop is used to ensure efficient transfer to the client.
+## Download from a stream
 
-> [!IMPORTANT]
-> The example in this article pertains to downloading files that pass Cross-Origin Resource Sharing (CORS) checks. For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
+The recommended approach for downloading files less than 250 MB in size uses [JavaScript (JS) interop](xref:blazor/js-interop/index) to receive the file's name with the file's data stream to trigger the client-side download. The `downloadFileFromStream` function, which is shown in the following example, is used in a Razor component later in this article.
 
-In a Razor component (`.razor`), add [`@using`](xref:mvc/views/razor#using) and [`@inject`](xref:mvc/views/razor#inject) directives for the following:
+> [!WARNING]
+> The approach in this section reads the file's content into an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer). This approach loads the entire file into the client's memory, which can impair performance. For file downloads over 250 MB, we recommend following the guidance in the [Download from a URL](#download-from-a-url) section to download the file from a URL instead.
 
-* <xref:System.IO?displayProperty=fullName>
-* <xref:Microsoft.JSInterop.IJSRuntime?displayProperty=fullName>
-
-```razor
-@using System.IO
-@inject IJSRuntime JS
-```
-
-Add a button to trigger the file download:
-
-```razor
-<button @onclick="DownloadFileFromStream">
-    Download File From Stream
-</button>
-```
-
-Create a method that retrieves a <xref:System.IO.Stream> for the file that's downloaded to clients (`GetFileStream` in the following example). You may choose to retrieve a file from storage or dynamically generate a file.
-
-For this demonstration, the app creates a 50 KB file of random data from a new byte array (`new byte[]`). The bytes are wrapped with a <xref:System.IO.MemoryStream> to serve as the example's dynamically-generated binary file:
-
-```razor
-@code {
-    private Stream GetFileStream()
-    {
-        var randomBinaryData = new byte[50 * 1024];
-        var fileStream = new MemoryStream(randomBinaryData);
-
-        return fileStream;
-    }
-}
-```
-
-The following `DownloadFileFromStream` method performs the following steps:
-
-* Retrieves the <xref:System.IO.Stream> from `GetFileStream`.
-* Specify a file name when file is saved on the user's machine. The following example names the file `log.bin`.
-* Wraps the <xref:System.IO.Stream> in a <xref:Microsoft.JSInterop.DotNetStreamReference>, which allows streaming the file data to the client.
-* Invokes `downloadFileFromStream`, which is a JavaScript function that accepts the data on the client. The `downloadFileFromStream` function is shown later in this article.
-
-```razor
-@code {
-    private async Task DownloadFileFromStream()
-    {
-        var fileStream = GetFileStream();
-        var fileName = "log.bin";
-
-        using var streamRef = new DotNetStreamReference(stream: fileStream);
-
-        await JS.InvokeVoidAsync("downloadFileFromStream", fileName, streamRef);
-    }
-}
-```
-
-The JavaScript `downloadFileFromStream` function accepts the file name with the data stream and triggers the client-side download. The function performs the following steps:
+The following `downloadFileFromStream` JS function performs the following steps:
 
 * Read the provided stream into an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
 * Create a [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob) to wrap the `ArrayBuffer`.
@@ -92,47 +39,62 @@ The `fileName` and object `url` are passed to `triggerFileDownload`, which perfo
 
 At this point, the file download is triggered and then the temporary object URL is revoked by calling [`revokeObjectURL`](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL) on the URL. **This is an important step to ensure memory isn't leaked on the client.**
 
-```javascript
-async function downloadFileFromStream(fileName, contentStreamReference) {
-  const arrayBuffer = await contentStreamReference.arrayBuffer();
-  const blob = new Blob([arrayBuffer]);
-  const url = URL.createObjectURL(blob);
+Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
 
-  triggerFileDownload(fileName, url);
-
-  URL.revokeObjectURL(url);
-}
-
-function triggerFileDownload(fileName, url) {
-  const anchorElement = document.createElement('a');
-  anchorElement.href = url;
-  anchorElement.download = fileName ?? '';
-  anchorElement.click();
-  anchorElement.remove();
-}
+```html
+<script>
+  window.downloadFileFromStream = async (fileName, contentStreamReference) => {
+    const arrayBuffer = await contentStreamReference.arrayBuffer();
+    const blob = new Blob([arrayBuffer]);
+    const url = URL.createObjectURL(blob);
+    triggerFileDownload(fileName, url);
+    URL.revokeObjectURL(url);
+  }
+</script>
 ```
 
-In the preceding example, the call to `contentStreamReference.arrayBuffer` loads the entire file into client memory. For file downloads over 250 MB, we recommend downloading the file from a URL instead:
+The following example component:
 
-```razor
-<button @onclick="DownloadFileFromURL">
-    Download File From URL
-</button>
+* Uses native byte-streaming interop to ensure efficient transfer of the file to the client.
+* Has a method named `GetFileStream` to retrieve a <xref:System.IO.Stream> for the file that's downloaded to clients. Alternative approaches include retrieving a file from storage or generating a file dynamically in C# code. For this demonstration, the app creates a 50 KB file of random data from a new byte array (`new byte[]`). The bytes are wrapped with a <xref:System.IO.MemoryStream> to serve as the example's dynamically-generated binary file.
+* The `DownloadFileFromStream` method performs the following steps:
+  * Retrieves the <xref:System.IO.Stream> from `GetFileStream`.
+  * Specify a file name when file is saved on the user's machine. The following example names the file `log.bin`.
+  * Wraps the <xref:System.IO.Stream> in a <xref:Microsoft.JSInterop.DotNetStreamReference>, which allows streaming the file data to the client.
+  * Invokes `downloadFileFromStream`, which is the JavaScript function shown earlier in this article that accepts the data on the client.
 
-@code {
-    private async Task DownloadFileFromURL()
-    {
-        var fileURL = "{FILE URL}";
-        var fileName = "{FILE NAME}";
-        await JS.InvokeVoidAsync("triggerFileDownload", fileName, fileURL);
-    }
-}
+:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/file-downloads/FileDownload1.razor":::
+
+## Download from a URL
+
+The recommended approach for downloading files less than 250 MB in size uses
+
+The example in this section uses a dummy log file named `log0001.txt`, which is placed in a folder named `files` in the app's `wwwroot` folder:
+
+```wwwroot/files/log0001.txt`:
+
+:::code language="text" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/wwwroot/files/log0001.txt":::
+
+Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
+
+```html
+<script>
+  window.triggerFileDownload = (fileName, url) => {
+    const anchorElement = document.createElement('a');
+    anchorElement.href = url;
+    anchorElement.download = fileName ?? '';
+    anchorElement.click();
+    anchorElement.remove();
+  }
+</script>
 ```
 
-In the preceding example, replace the placeholders with the following values:
+In the following example component:
 
-* `{FILE URL}`: The URL of the file to download at the same origin (same domain) that the app uses. Example: `https://www.contoso.com/files/log0001.txt` for a text file physically located at the path `/wwwroot/files/` in the app and for an app that loads from `https://www.contoso.com`. For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
-* `{FILE NAME}`: The file name to use for the saved file. Example: `log-0001.txt`
+* Downloads the file from the same origin (same domain) that the app uses. If the file download is attempted from a different origin (different domain), configure Cross-Origin Resource Sharing (CORS). For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section later in this article.
+* xxx
+
+:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/file-downloads/FileDownload2.razor":::
 
 ## Cross-Origin Resource Sharing (CORS)
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -5,7 +5,7 @@ description: Learn how to download files using Blazor Server and Blazor WebAssem
 monikerRange: '>= aspnetcore-6.0'
 ms.author: taparik
 ms.custom: mvc
-ms.date: 06/16/2022
+ms.date: 06/17/2022
 uid: blazor/file-downloads
 ---
 # ASP.NET Core Blazor file downloads
@@ -69,11 +69,11 @@ The following example component:
 
 The recommended approach for downloading files less than 250 MB in size uses
 
-The example in this section uses a dummy log file named `log0001.txt`, which is placed in a folder named `files` in the app's `wwwroot` folder:
+The example in this section uses a dummy log file named `log.bin`, which is placed in a folder named `files` in the app's `wwwroot` folder:
 
-```wwwroot/files/log0001.txt`:
+```wwwroot/files/log.bin`:
 
-:::code language="text" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/wwwroot/files/log0001.txt":::
+:::code language="text" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/wwwroot/files/log.bin":::
 
 Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -55,6 +55,8 @@ Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `ww
 </script>
 ```
 
+[!INCLUDE[](~/blazor/includes/js-location.md)]
+
 The following example component:
 
 * Uses native byte-streaming interop to ensure efficient transfer of the file to the client.
@@ -97,6 +99,8 @@ Inside the closing `</body>` tag of `Pages/_Layout.razor` (Blazor Server) or `ww
   }
 </script>
 ```
+
+[!INCLUDE[](~/blazor/includes/js-location.md)]
 
 The following example component downloads the file from the same origin (same domain) that the app uses. If the file download is attempted from a different origin (different domain), configure Cross-Origin Resource Sharing (CORS). For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
 

--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -14,8 +14,15 @@ This article explains how to download files in Blazor Server and Blazor WebAssem
 
 Files can be downloaded from the app's own static assets or from any other location. When downloading files, Cross-Origin Resource Sharing (CORS) considerations apply. For more information, see the [Cross-Origin Resource Sharing (CORS)](#cross-origin-resource-sharing-cors) section.
 
-> [!WARNING]
-> Always follow security best practices when allowing users to download files. For more information, see the [Security considerations](#security-considerations) section.
+## Security considerations
+
+Use caution when providing users with the ability to download files from a server. Attackers may execute [denial of service (DOS)](/windows-hardware/drivers/ifs/denial-of-service) attacks, [API exploitation attacks](https://developer.mozilla.org/docs/Web/HTML/Element/a#security_and_privacy), or attempt to compromise networks and servers in other ways.
+
+Security steps that reduce the likelihood of a successful attack are:
+
+* Download files from a dedicated file download area on the server, preferably from a non-system drive. Using a dedicated location makes it easier to impose security restrictions on downloadable files. Disable execute permissions on the file download area.
+* Verify that client-side checks are also performed on the server. Client-side checks are easy to circumvent.
+* Don't receive files from users or other untrusted sources and then make the files available for download without performing security checks on the files first. For more information, see <xref:mvc/models/file-uploads#security-considerations>.
 
 ## Download from a stream
 
@@ -106,16 +113,6 @@ For more information on CORS with ASP.NET Core apps and other Microsoft products
 * [Cross-Origin Resource Sharing (CORS) support for Azure Storage (REST documentation)](/rest/api/storageservices/cross-origin-resource-sharing--cors--support-for-the-azure-storage-services)
 * [Core Cloud Services - Set up CORS for your website and storage assets (Learn Module)](/learn/modules/set-up-cors-website-storage/)
 * [IIS CORS module Configuration Reference (IIS documentation)](/iis/extensions/cors-module/cors-module-configuration-reference)
-
-## Security considerations
-
-Use caution when providing users with the ability to download files from a server. Attackers may execute [denial of service (DOS)](/windows-hardware/drivers/ifs/denial-of-service) attacks, [API exploitation attacks](https://developer.mozilla.org/docs/Web/HTML/Element/a#security_and_privacy), or attempt to compromise networks and servers in other ways.
-
-Security steps that reduce the likelihood of a successful attack are:
-
-* Download files from a dedicated file download area on the server, preferably from a non-system drive. Using a dedicated location makes it easier to impose security restrictions on downloadable files. Disable execute permissions on the file download area.
-* Verify that client-side checks are also performed on the server. Client-side checks are easy to circumvent.
-* Don't receive files from users or other untrusted sources and then make the files available for download without performing security checks on the files first. For more information, see <xref:mvc/models/file-uploads#security-considerations>.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/images.md
+++ b/aspnetcore/blazor/images.md
@@ -1,6 +1,6 @@
 ---
 title: Work with images in ASP.NET Core Blazor
-author: TanayParikh
+author: guardrex
 description: Learn how to work with images in ASP.NET Core Blazor apps.
 monikerRange: '>= aspnetcore-6.0'
 ms.author: taparik

--- a/aspnetcore/blazor/includes/js-location.md
+++ b/aspnetcore/blazor/includes/js-location.md
@@ -1,0 +1,2 @@
+> [!NOTE]
+> For general guidance on JS location and our recommendations for production apps, see <xref:blazor/js-interop/index#location-of-javascript>.


### PR DESCRIPTION
Addresses #24615

* Split the small file (< 250 MB) approach from the large file (> 250 MB) approach into a pair of sections.
* Phrasing updates.
* Cross-link improvements.
* Fully-working, cut-'n-paste examples.
* Reference snippet sample app code in the `dotnet/blazor-samples` repo.