### PR TITLE
Add launch profile config for setting pathbase

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -185,7 +185,21 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-The Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `launchUrl` and `commandLineArgs` properties in `launchSettings.json`:
+
+```json
+"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
+"commandLineArgs": "--pathbase=/{RELATIVE URL PATH (no trailing slash)}",
+```
+
+Using `CoolApp` as the example:
+
+```json
+"launchUrl": "CoolApp",
+"commandLineArgs": "--pathbase=/CoolApp",
+```
+
+Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
 ## Blazor Server `MapFallbackToPage` configuration
 

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -195,8 +195,8 @@ If you prefer to configure the app's launch profile to specify the `pathbase` au
 Using `CoolApp` as the example:
 
 ```json
-"launchUrl": "CoolApp",
 "commandLineArgs": "--pathbase=/CoolApp",
+"launchUrl": "CoolApp",
 ```
 
 Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
@@ -394,8 +394,8 @@ If you prefer to configure the app's launch profile to specify the `pathbase` au
 Using `CoolApp` as the example:
 
 ```json
-"launchUrl": "CoolApp",
 "commandLineArgs": "--pathbase=/CoolApp",
+"launchUrl": "CoolApp",
 ```
 
 Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
@@ -603,8 +603,8 @@ If you prefer to configure the app's launch profile to specify the `pathbase` au
 Using `CoolApp` as the example:
 
 ```json
-"launchUrl": "CoolApp",
 "commandLineArgs": "--pathbase=/CoolApp",
+"launchUrl": "CoolApp",
 ```
 
 Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -185,11 +185,11 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL:
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL (`launchUrl`):
 
 ```json
-"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
 "commandLineArgs": "--pathbase=/{RELATIVE URL PATH (no trailing slash)}",
+"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
 ```
 
 Using `CoolApp` as the example:
@@ -384,11 +384,11 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL:
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL (`launchUrl`):
 
 ```json
-"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
 "commandLineArgs": "--pathbase=/{RELATIVE URL PATH (no trailing slash)}",
+"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
 ```
 
 Using `CoolApp` as the example:
@@ -593,11 +593,11 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL:
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL (`launchUrl`):
 
 ```json
-"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
 "commandLineArgs": "--pathbase=/{RELATIVE URL PATH (no trailing slash)}",
+"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
 ```
 
 Using `CoolApp` as the example:

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -185,7 +185,7 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `launchUrl` and `commandLineArgs` properties in `launchSettings.json`:
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `launchUrl` and `commandLineArgs` properties in `Properties/launchSettings.json`. The following also configures the launch URL:
 
 ```json
 "launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
@@ -384,7 +384,21 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-The Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `launchUrl` and `commandLineArgs` properties in `Properties/launchSettings.json`. The following also configures the launch URL:
+
+```json
+"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
+"commandLineArgs": "--pathbase=/{RELATIVE URL PATH (no trailing slash)}",
+```
+
+Using `CoolApp` as the example:
+
+```json
+"launchUrl": "CoolApp",
+"commandLineArgs": "--pathbase=/CoolApp",
+```
+
+Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
 For additional third-party host support:
 
@@ -579,7 +593,21 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-The Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `launchUrl` and `commandLineArgs` properties in `Properties/launchSettings.json`. The following also configures the launch URL:
+
+```json
+"launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
+"commandLineArgs": "--pathbase=/{RELATIVE URL PATH (no trailing slash)}",
+```
+
+Using `CoolApp` as the example:
+
+```json
+"launchUrl": "CoolApp",
+"commandLineArgs": "--pathbase=/CoolApp",
+```
+
+Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
 For additional third-party host support:
 

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -185,7 +185,7 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `launchUrl` and `commandLineArgs` properties in `Properties/launchSettings.json`. The following also configures the launch URL:
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL:
 
 ```json
 "launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
@@ -384,7 +384,7 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `launchUrl` and `commandLineArgs` properties in `Properties/launchSettings.json`. The following also configures the launch URL:
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL:
 
 ```json
 "launchUrl": "{RELATIVE URL PATH (no trailing slash)}",
@@ -593,7 +593,7 @@ For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base hre
 dotnet run --pathbase=/CoolApp
 ```
 
-If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `launchUrl` and `commandLineArgs` properties in `Properties/launchSettings.json`. The following also configures the launch URL:
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL:
 
 ```json
 "launchUrl": "{RELATIVE URL PATH (no trailing slash)}",


### PR DESCRIPTION
Fixes #26170

Thanks @engineerTrooper! 🚀 ... *Great idea to add this!* Thanks again for the suggestion. I'd like to merge this quickly, but I'll leave it here for a few hours to give you a chance to look it over for any possible feedback.

Note that `launchBrowser` is already present in a profile config of an app created from a Blazor project template and set to `true`, so we don't need to call that property out.