### PR TITLE
docs: Fix Kubernetes example

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -223,6 +223,29 @@ Using separate readiness and liveness checks is useful in an environment such as
 
 The following example demonstrates a Kubernetes readiness probe configuration:
 
+:::moniker range=">= aspnetcore-6.0"
+
+```yaml
+spec:
+  template:
+  spec:
+    readinessProbe:
+      # an http probe
+      httpGet:
+        path: /healthz/ready
+        port: 80
+      # length of time to wait for a pod to initialize
+      # after pod startup, before applying health checking
+      initialDelaySeconds: 30
+      timeoutSeconds: 1
+    ports:
+      - containerPort: 80
+```
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-6.0"
+
 ```yaml
 spec:
   template:
@@ -239,6 +262,8 @@ spec:
     ports:
       - containerPort: 80
 ```
+
+:::moniker-end
 
 ## Distribute a health check library
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -223,8 +223,6 @@ Using separate readiness and liveness checks is useful in an environment such as
 
 The following example demonstrates a Kubernetes readiness probe configuration:
 
-:::moniker range=">= aspnetcore-6.0"
-
 ```yaml
 spec:
   template:
@@ -241,29 +239,6 @@ spec:
     ports:
       - containerPort: 80
 ```
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-6.0"
-
-```yaml
-spec:
-  template:
-  spec:
-    readinessProbe:
-      # an http probe
-      httpGet:
-        path: /health/ready
-        port: 80
-      # length of time to wait for a pod to initialize
-      # after pod startup, before applying health checking
-      initialDelaySeconds: 30
-      timeoutSeconds: 1
-    ports:
-      - containerPort: 80
-```
-
-:::moniker-end
 
 ## Distribute a health check library
 


### PR DESCRIPTION
Everywhere in the document, the _/health**z**_ endpoint is used (which, as I understand it, is the name by convention), and in the example for Kubernetes, just _/health_. I made changes to unify endpoints and get rid of misleadings.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->