### PR TITLE
Updates the salt hashing example in passwordhasher.cs for dotnet 6

### DIFF
--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -19,6 +19,6 @@ The package currently offers a method `KeyDerivation.Pbkdf2` which allows hashin
 
 3. The `KeyDerivation.Pbkdf2` method requires the caller to specify all parameters (salt, PRF, and iteration count). The `Rfc2898DeriveBytes` type provides default values for these.
 
-[!code-csharp[](password-hashing/samples/passwordhasher.cs)]
+[!code-csharp[](password-hashing/samples/5.x/passwordhasher.cs)]
 
 See the [source code](https://github.com/dotnet/AspNetCore/blob/main/src/Identity/Extensions.Core/src/PasswordHasher.cs) for ASP.NET Core Identity's `PasswordHasher` type for a real-world use case.

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/5.x/passwordhasher.cs
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/5.x/passwordhasher.cs
@@ -1,6 +1,6 @@
+using System;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Cryptography.KeyDerivation;
-#nullable disable
 
 public class Program
 {
@@ -11,7 +11,10 @@ public class Program
 
         // generate a 128-bit salt using a cryptographically strong random sequence of nonzero values
         byte[] salt = new byte[128 / 8];
-        RandomNumberGenerator.Create().GetNonZeroBytes(salt);
+        using (var rngCsp = new RNGCryptoServiceProvider())
+        {
+            rngCsp.GetNonZeroBytes(salt);
+        }
         Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
 
         // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
@@ -29,6 +32,7 @@ public class Program
  * SAMPLE OUTPUT
  *
  * Enter a password: Xtw9NMgx
- * Salt: SqSBFnfUBCRpH/yd9soRDQ==
- * Hashed: rWc4HTeqV7SA5eGWUEx7t4n5N8gyHgB4sVLTxtpsZNc=
+ * Salt: CGYzqeN4plZekNC88Umm1Q==
+ * Hashed: Gt9Yc4AiIvmsC1QQbe2RZsCIqvoYlst2xbz0Fs8aHnw=
  */
+ 

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
@@ -1,0 +1,34 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+#nullable disable
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.Write("Enter a password: ");
+        string password = Console.ReadLine();
+
+        // generate a 128-bit salt using a cryptographically strong random sequence of nonzero values
+        byte[] salt = new byte[128 / 8];
+        RandomNumberGenerator.Create().GetNonZeroBytes(salt);
+        Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
+
+        // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
+        string hashed = Convert.ToBase64String(KeyDerivation.Pbkdf2(
+            password: password,
+            salt: salt,
+            prf: KeyDerivationPrf.HMACSHA256,
+            iterationCount: 100000,
+            numBytesRequested: 256 / 8));
+        Console.WriteLine($"Hashed: {hashed}");
+    }
+}
+
+/*
+ * SAMPLE OUTPUT
+ *
+ * Enter a password: Xtw9NMgx
+ * Salt: CGYzqeN4plZekNC88Umm1Q==
+ * Hashed: Gt9Yc4AiIvmsC1QQbe2RZsCIqvoYlst2xbz0Fs8aHnw=
+ */

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/passwordhasher.cs
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/passwordhasher.cs
@@ -1,6 +1,6 @@
-using System;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+#nullable disable
 
 public class Program
 {
@@ -11,10 +11,7 @@ public class Program
 
         // generate a 128-bit salt using a cryptographically strong random sequence of nonzero values
         byte[] salt = new byte[128 / 8];
-        using (var rngCsp = new RNGCryptoServiceProvider())
-        {
-            rngCsp.GetNonZeroBytes(salt);
-        }
+        RandomNumberGenerator.Create().GetNonZeroBytes(salt);
         Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
 
         // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
@@ -32,6 +29,6 @@ public class Program
  * SAMPLE OUTPUT
  *
  * Enter a password: Xtw9NMgx
- * Salt: CGYzqeN4plZekNC88Umm1Q==
- * Hashed: Gt9Yc4AiIvmsC1QQbe2RZsCIqvoYlst2xbz0Fs8aHnw=
+ * Salt: SqSBFnfUBCRpH/yd9soRDQ==
+ * Hashed: rWc4HTeqV7SA5eGWUEx7t4n5N8gyHgB4sVLTxtpsZNc=
  */


### PR DESCRIPTION
Updates the salt hashing example in passwordhasher.cs for dotnet 6 using RandomNumberGenerator instead RNGCryptoServiceProvider (outdated).

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->