### PR TITLE
Global no-store/no-cache guidance

### DIFF
--- a/aspnetcore/performance/caching/response.md
+++ b/aspnetcore/performance/caching/response.md
@@ -97,7 +97,7 @@ The preceding code requires adding the Response Caching Middleware services <xre
 
 [!code-csharp[](response/samples/6.x/WebRC/Program.cs?name=snippet&highlight=4,13)]
 
-### NoStore and Location.None
+### `NoStore` and `Location.None`
 
 <xref:Microsoft.AspNetCore.Mvc.CacheProfile.NoStore> overrides most of the other properties. When this property is set to `true`, the `Cache-Control` header is set to `no-store`. If <xref:Microsoft.AspNetCore.Mvc.CacheProfile.Location> is set to `None`:
 
@@ -116,6 +116,22 @@ The preceding code includes the following headers in the response:
 Cache-Control: no-store,no-cache
 Pragma: no-cache
 ```
+
+To apply the <xref:Microsoft.AspNetCore.Mvc.ResponseCacheAttribute> to all of the app's MVC controller or Razor Pages page responses, add it with an [MVC filter](xref:mvc/controllers/filters) or [Razor Pages filter](xref:razor-pages/filter).
+
+In an MVC app:
+
+```csharp
+builder.Services.AddControllersWithViews().AddMvcOptions(options => 
+    options.Filters.Add(
+        new ResponseCacheAttribute
+        {
+            NoStore = true, 
+            Location = ResponseCacheLocation.None
+        }));
+```
+
+For an approach that applies to Razor Pages apps, see [Adding `ResponseCacheAttribute` to MVC global filter list does not apply to Razor Pages (dotnet/aspnetcore #18890)](https://github.com/dotnet/aspnetcore/issues/18890#issuecomment-584290537).
 
 ### Location and Duration
 
@@ -284,7 +300,7 @@ Cache-Control: public,max-age=30
 Vary: User-Agent
 ```
 
-### NoStore and Location.None
+### `NoStore` and `Location.None`
 
 <xref:Microsoft.AspNetCore.Mvc.CacheProfile.NoStore> overrides most of the other properties. When this property is set to `true`, the `Cache-Control` header is set to `no-store`. If <xref:Microsoft.AspNetCore.Mvc.CacheProfile.Location> is set to `None`:
 
@@ -303,6 +319,22 @@ The sample app returns the Cache2 page with the following headers:
 Cache-Control: no-store,no-cache
 Pragma: no-cache
 ```
+
+To apply the <xref:Microsoft.AspNetCore.Mvc.ResponseCacheAttribute> to all of the app's MVC controller or Razor Pages page responses, add it with an [MVC filter](xref:mvc/controllers/filters) or [Razor Pages filter](xref:razor-pages/filter).
+
+In an MVC app:
+
+```csharp
+services.AddMvc().AddMvcOptions(options => 
+    options.Filters.Add(
+        new ResponseCacheAttribute
+        {
+            NoStore = true, 
+            Location = ResponseCacheLocation.None
+        }));
+```
+
+For an approach that applies to Razor Pages apps, see [Adding `ResponseCacheAttribute` to MVC global filter list does not apply to Razor Pages (dotnet/aspnetcore #18890)](https://github.com/dotnet/aspnetcore/issues/18890#issuecomment-584290537).
 
 ### Location and Duration
 

--- a/aspnetcore/performance/caching/response.md
+++ b/aspnetcore/performance/caching/response.md
@@ -131,7 +131,7 @@ builder.Services.AddControllersWithViews().AddMvcOptions(options =>
         }));
 ```
 
-For an approach that applies to Razor Pages apps, see [Adding `ResponseCacheAttribute` to MVC global filter list does not apply to Razor Pages (dotnet/aspnetcore #18890)](https://github.com/dotnet/aspnetcore/issues/18890#issuecomment-584290537).
+For an approach that applies to Razor Pages apps, see [Adding `ResponseCacheAttribute` to MVC global filter list does not apply to Razor Pages (dotnet/aspnetcore #18890)](https://github.com/dotnet/aspnetcore/issues/18890#issuecomment-584290537). The example provided in the issue comment was written for apps targeting ASP.NET Core prior to the release of [Minimal APIs](xref:fundamentals/minimal-apis) at 6.0. For 6.0 or later apps, change the service registration in the example to `builder.Services.AddSingleton...` for `Program.cs`.
 
 ### Location and Duration
 

--- a/aspnetcore/performance/caching/response/samples/6.x/WebRC/Controllers/TimeController.cs
+++ b/aspnetcore/performance/caching/response/samples/6.x/WebRC/Controllers/TimeController.cs
@@ -15,7 +15,7 @@ public class TimeController : ControllerBase
     #region snippet2
     [Route("api/[controller]/ticks")]
     [HttpGet]
-    [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+    [ResponseCache(Location = ResponseCacheLocation.None, NoStore = true)]
     public ContentResult GetTimeTicks() => Content(
                       DateTime.Now.Ticks.ToString());
     #endregion


### PR DESCRIPTION
Fixes #26235

Thanks @xenophilios! :rocket:

Rick, a few points on this one ...

* If I've gone off the rails here, close this and take it over for a *better* PR than what I've set up here 🙈😄.
* The `Duration = 0` setting I think 🤔 is just a no-op in the scenario and can be removed/avoided.
* The RP approach is messy compared to the MVC approach ... *apparently*. It looks like something might be worked for 7.0 on [Make ResponseCacheMiddleware endpoint aware (dotnet/aspnetcore #37995)](https://github.com/dotnet/aspnetcore/issues/37995), so it might be good to have a follow-up 7.0 docs issue to make sure that this bit gets a 7.0 update if they make a change for MVC/RP/both.
* Although the "Razor Pages page responses" lingo isn't what I normally use, I think we must clarify that it's the page responses only from the RP app that get the attribute IIRC. Therefore, we should distinguish the app type ("RP") and the response type ("pages"), which also parallels the MVC language (i.e., "MVC controller").
* Head-check me on the `services.AddMvc().AddMvcOptions` piece for <6.0. I think that's right. *I can't compile that here on the new PC.* 😝 I haven't had the need (*yet*) to put 3.1/5.0 frameworks on here.
* I cross-link to https://github.com/dotnet/aspnetcore/issues/18890#issuecomment-584290537 for the exact PU example that Pranav provided at the time, but that's 3.1-era stuff. If there's any delta per the [Filter methods for Razor Pages](https://docs.microsoft.com/aspnet/core/razor-pages/filter) article, then I recommend that I make a change here to just link the Filters article instead of the PU issue comment. If we do that tho, we will have the reader work out the exact code for the global attribute approach on their own ... but that might be ok and is certainly preferable if the code shown by Pranav doesn't apply past 3.1.

  **_UPDATE_**: I just checked Pranav's code for 6.0 with Minimal APIs, and it's :+1: as he wrote it with an updated Minimal APIs registration in `Program.cs`. I think the cross-link with one more sentence will work there, so I'll add that sentence on the next commit.

  **_UPDATE_**: **Done!**