### PR TITLE
Fix xref link in anti-request-forgery.md

### DIFF
--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -117,7 +117,7 @@ Automatic generation of antiforgery tokens for HTML form elements can be disable
   :::code language="cshtml" source="anti-request-forgery/samples/6.x/AntiRequestForgerySample/Snippets/Views/Home/Index.cshtml" id="snippet_FormRemoveTagHelper":::
 
 > [!NOTE]
-> [Razor Pages](xref:razor-pages/index) are automatically protected from XSRF/CSRF. For more information, see [XSRF/CSRF and Razor Pages](xref:razor-pages/index#xsrf).
+> [Razor Pages](xref:razor-pages/index) are automatically protected from XSRF/CSRF. For more information, see [XSRF/CSRF and Razor Pages](xref:razor-pages/index#xsrfcsrf-and-razor-pages-1).
 
 The most common approach to defending against CSRF attacks is to use the *Synchronizer Token Pattern* (STP). STP is used when the user requests a page with form data:
 


### PR DESCRIPTION
The following xref link `xref:razor-pages/index#xsrf` points to the invalid link below:

> https://docs.microsoft.com/en-us/aspnet/core/razor-pages/?view=aspnetcore-5.0&tabs=visual-studio#xsrf

The xref link should be `xref:razor-pages/index#xsrfcsrf-and-razor-pages-1` in order to point to the valid link below:

> https://docs.microsoft.com/en-us/aspnet/core/razor-pages/?view=aspnetcore-5.0&tabs=visual-studio#xsrfcsrf-and-razor-pages-1

I've noticed that the xref link seems broken only for the ASP.NET Core 5.0 docs, so this fix may need tweaking to target just those docs (not sure how to do that at the moment).



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->