### PR TITLE
Updates the salt hashing example for .NET 6 /4

### DIFF
--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -11,7 +11,7 @@ uid: security/data-protection/consumer-apis/password-hashing
 
 The data protection code base includes a NuGet package [Microsoft.AspNetCore.Cryptography.KeyDerivation](https://www.nuget.org/packages/Microsoft.AspNetCore.Cryptography.KeyDerivation/) which contains cryptographic key derivation functions. This package is a standalone component and has no dependencies on the rest of the data protection system. It can be used completely independently. The source exists alongside the data protection code base as a convenience.
 
-The package currently offers a method `KeyDerivation.Pbkdf2` which allows hashing a password using the [PBKDF2 algorithm](https://tools.ietf.org/html/rfc2898#section-5.2). This API is very similar to the .NET Framework's existing <xref:System.Security.Cryptography.Rfc2898DeriveBytes>, but there are three important distinctions:
+The package currently offers a method [`KeyDerivation.Pbkdf2`](/dotnet/api/microsoft.aspnetcore.cryptography.keyderivation.keyderivation.pbkdf2) which allows hashing a password using the [PBKDF2 algorithm](https://tools.ietf.org/html/rfc2898#section-5.2). This API is very similar to the .NET Framework's existing <xref:System.Security.Cryptography.Rfc2898DeriveBytes>, but there are three important distinctions:
 
 1. The `KeyDerivation.Pbkdf2` method supports consuming multiple PRFs (currently `HMACSHA1`, `HMACSHA256`, and `HMACSHA512`), whereas the `Rfc2898DeriveBytes` type only supports `HMACSHA1`.
 

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -9,17 +9,13 @@ uid: security/data-protection/consumer-apis/password-hashing
 
 # Hash passwords in ASP.NET Core
 
-The data protection code base includes a NuGet package [Microsoft.AspNetCore.Cryptography.KeyDerivation](https://www.nuget.org/packages/Microsoft.AspNetCore.Cryptography.KeyDerivation/) which contains cryptographic key derivation functions. This package is a standalone component and has no dependencies on the rest of the data protection system. It can be used completely independently. The source exists alongside the data protection code base as a convenience.
-
-The package currently offers a method [`KeyDerivation.Pbkdf2`](/dotnet/api/microsoft.aspnetcore.cryptography.keyderivation.keyderivation.pbkdf2) which allows hashing a password using the [PBKDF2 algorithm](https://tools.ietf.org/html/rfc2898#section-5.2). This API is very similar to the .NET Framework's existing <xref:System.Security.Cryptography.Rfc2898DeriveBytes>, but there are three important distinctions:
-
-1. The `KeyDerivation.Pbkdf2` method supports consuming multiple PRFs (currently `HMACSHA1`, `HMACSHA256`, and `HMACSHA512`), whereas the `Rfc2898DeriveBytes` type only supports `HMACSHA1`.
-
-2. The `KeyDerivation.Pbkdf2` method detects the current operating system and attempts to choose the most optimized implementation of the routine, providing much better performance in certain cases. (On Windows 8, it offers around 10x the throughput of `Rfc2898DeriveBytes`.)
-
-3. The `KeyDerivation.Pbkdf2` method requires the caller to specify all parameters (salt, PRF, and iteration count). The `Rfc2898DeriveBytes` type provides default values for these.
+This article shows how to call the [`KeyDerivation.Pbkdf2`](/dotnet/api/microsoft.aspnetcore.cryptography.keyderivation.keyderivation.pbkdf2) method which allows hashing a password using the [PBKDF2 algorithm](https://tools.ietf.org/html/rfc2898#section-5.2).
 
 > [!WARNING]
+> The `KeyDerivation.Pbkdf2` API is a low-level cryptographic primitive and is intended to be used to integrate apps into an existing protocol or cryptographic system. `KeyDerivation.Pbkdf2` should not be used in new apps which support password based login and need to store hashed passwords in a datastore. New apps should use [`PasswordHasher`](/dotnet/api/microsoft.aspnetcore.identity.passwordhasher-1). For more information on `PasswordHasher`, see [Exploring the ASP.NET Core Identity PasswordHasher](https://andrewlock.net/exploring-the-asp-net-core-identity-passwordhasher/).
+
+The data protection code base includes a NuGet package [Microsoft.AspNetCore.Cryptography.KeyDerivation](https://www.nuget.org/packages/Microsoft.AspNetCore.Cryptography.KeyDerivation/) which contains cryptographic key derivation functions. This package is a standalone component and has no dependencies on the rest of the data protection system. It can be used independently. The source exists alongside the data protection code base as a convenience.
+
 > The following code shows how to use `KeyDerivation.Pbkdf2` to  generate a shared secret key. It should not be used to hash a password for storage in a datastore.
 
 :::moniker range=">= aspnetcore-6.0"

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -19,6 +19,8 @@ The data protection code base includes a NuGet package [Microsoft.AspNetCore.Cry
 > [!WARNING]
 > The following code shows how to use `KeyDerivation.Pbkdf2` to  generate a shared secret key. It should not be used to hash a password for storage in a datastore.
 
+<!-- See https://github.com/dotnet/AspNetCore.Docs/pull/26253#issuecomment-1187984822 for detailed reasoning -->
+
 :::moniker range=">= aspnetcore-6.0"
 
 [!code-csharp[](password-hashing/samples/6.x/passwordhasher.cs)]

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -9,7 +9,7 @@ uid: security/data-protection/consumer-apis/password-hashing
 
 # Hash passwords in ASP.NET Core
 
-The data protection code base includes a package *Microsoft.AspNetCore.Cryptography.KeyDerivation* which contains cryptographic key derivation functions. This package is a standalone component and has no dependencies on the rest of the data protection system. It can be used completely independently. The source exists alongside the data protection code base as a convenience.
+The data protection code base includes a NuGet package [Microsoft.AspNetCore.Cryptography.KeyDerivation](https://www.nuget.org/packages/Microsoft.AspNetCore.Cryptography.KeyDerivation/) which contains cryptographic key derivation functions. This package is a standalone component and has no dependencies on the rest of the data protection system. It can be used completely independently. The source exists alongside the data protection code base as a convenience.
 
 The package currently offers a method `KeyDerivation.Pbkdf2` which allows hashing a password using the [PBKDF2 algorithm](https://tools.ietf.org/html/rfc2898#section-5.2). This API is very similar to the .NET Framework's existing <xref:System.Security.Cryptography.Rfc2898DeriveBytes>, but there are three important distinctions:
 

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -19,6 +19,18 @@ The package currently offers a method `KeyDerivation.Pbkdf2` which allows hashin
 
 3. The `KeyDerivation.Pbkdf2` method requires the caller to specify all parameters (salt, PRF, and iteration count). The `Rfc2898DeriveBytes` type provides default values for these.
 
+:::moniker range=">= aspnetcore-6.0"
+
+[!code-csharp[](password-hashing/samples/6.x/passwordhasher.cs)]
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-6.0"
+
 [!code-csharp[](password-hashing/samples/5.x/passwordhasher.cs)]
 
+:::moniker-end
+
 See the [source code](https://github.com/dotnet/AspNetCore/blob/main/src/Identity/Extensions.Core/src/PasswordHasher.cs) for ASP.NET Core Identity's `PasswordHasher` type for a real-world use case.
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -16,6 +16,7 @@ This article shows how to call the [`KeyDerivation.Pbkdf2`](/dotnet/api/microsof
 
 The data protection code base includes a NuGet package [Microsoft.AspNetCore.Cryptography.KeyDerivation](https://www.nuget.org/packages/Microsoft.AspNetCore.Cryptography.KeyDerivation/) which contains cryptographic key derivation functions. This package is a standalone component and has no dependencies on the rest of the data protection system. It can be used independently. The source exists alongside the data protection code base as a convenience.
 
+> [!WARNING]
 > The following code shows how to use `KeyDerivation.Pbkdf2` to  generate a shared secret key. It should not be used to hash a password for storage in a datastore.
 
 :::moniker range=">= aspnetcore-6.0"

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing.md
@@ -19,6 +19,9 @@ The package currently offers a method [`KeyDerivation.Pbkdf2`](/dotnet/api/micro
 
 3. The `KeyDerivation.Pbkdf2` method requires the caller to specify all parameters (salt, PRF, and iteration count). The `Rfc2898DeriveBytes` type provides default values for these.
 
+> [!WARNING]
+> The following code shows how to use `KeyDerivation.Pbkdf2` to  generate a shared secret key. It should not be used to hash a password for storage in a datastore.
+
 :::moniker range=">= aspnetcore-6.0"
 
 [!code-csharp[](password-hashing/samples/6.x/passwordhasher.cs)]

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
@@ -1,22 +1,22 @@
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Cryptography.KeyDerivation;
-#nullable disable
 
 public class Program
 {
     public static void Main(string[] args)
     {
         Console.Write("Enter a password: ");
-        string password = Console.ReadLine();
+        string? password = Console.ReadLine();
 
-        // generate a 128-bit salt using a cryptographically strong random sequence of nonzero values
+        // Generate a 128-bit salt using a cryptographically strong
+        // random sequence of nonzero values.
         byte[] salt = new byte[128 / 8];
         RandomNumberGenerator.Create().GetNonZeroBytes(salt);
         Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
 
         // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
         string hashed = Convert.ToBase64String(KeyDerivation.Pbkdf2(
-            password: password,
+            password: password!,
             salt: salt,
             prf: KeyDerivationPrf.HMACSHA256,
             iterationCount: 100000,

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
@@ -7,7 +7,7 @@ string? password = Console.ReadLine();
 // Generate a 128-bit salt using a cryptographically strong
 // random sequence of nonzero values.
 byte[] salt = new byte[128 / 8];
-RandomNumberGenerator.Create().GetNonZeroBytes(salt);
+RandomNumberGenerator.Create().GetBytes(salt);
 Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
 
 // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
@@ -4,10 +4,9 @@ using System.Security.Cryptography;
 Console.Write("Enter a password: ");
 string? password = Console.ReadLine();
 
-// Generate a 128-bit salt using a cryptographically strong
-// random sequence of nonzero values.
-byte[] salt = new byte[128 / 8];
-RandomNumberGenerator.Create().GetBytes(salt);
+// Generate a 128-bit salt using a sequence of
+// cryptographically strong random bytes.
+byte[] salt = RandomNumberGenerator.GetBytes(128 / 8); // divide by 8 to convert bits to bytes
 Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
 
 // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/passwordhasher.cs
@@ -1,29 +1,24 @@
-using System.Security.Cryptography;
 using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+using System.Security.Cryptography;
 
-public class Program
-{
-    public static void Main(string[] args)
-    {
-        Console.Write("Enter a password: ");
-        string? password = Console.ReadLine();
+Console.Write("Enter a password: ");
+string? password = Console.ReadLine();
 
-        // Generate a 128-bit salt using a cryptographically strong
-        // random sequence of nonzero values.
-        byte[] salt = new byte[128 / 8];
-        RandomNumberGenerator.Create().GetNonZeroBytes(salt);
-        Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
+// Generate a 128-bit salt using a cryptographically strong
+// random sequence of nonzero values.
+byte[] salt = new byte[128 / 8];
+RandomNumberGenerator.Create().GetNonZeroBytes(salt);
+Console.WriteLine($"Salt: {Convert.ToBase64String(salt)}");
 
-        // derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
-        string hashed = Convert.ToBase64String(KeyDerivation.Pbkdf2(
-            password: password!,
-            salt: salt,
-            prf: KeyDerivationPrf.HMACSHA256,
-            iterationCount: 100000,
-            numBytesRequested: 256 / 8));
-        Console.WriteLine($"Hashed: {hashed}");
-    }
-}
+// derive a 256-bit subkey (use HMACSHA256 with 100,000 iterations)
+string hashed = Convert.ToBase64String(KeyDerivation.Pbkdf2(
+    password: password!,
+    salt: salt,
+    prf: KeyDerivationPrf.HMACSHA256,
+    iterationCount: 100000,
+    numBytesRequested: 256 / 8));
+
+Console.WriteLine($"Hashed: {hashed}");
 
 /*
  * SAMPLE OUTPUT

--- a/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/pwHash.csproj
+++ b/aspnetcore/security/data-protection/consumer-apis/password-hashing/samples/6.x/pwHash.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.6" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Completes PR #26233 which added [this pw hasher file](https://github.com/dotnet/AspNetCore.Docs/pull/26233/files#diff-1e2c12b88507dbd85457afb6e3edabb07e29a6e6f4ec918d794d1bc57b0a4b84)
Fixes #25786 
[Internal review URL](https://review.docs.microsoft.com/en-us/aspnet/core/security/data-protection/consumer-apis/password-hashing?view=aspnetcore-7.0&branch=pr-en-us-26253)

