### PR TITLE
Fix wrong Polly policy name

### DIFF
--- a/aspnetcore/fundamentals/http-requests.md
+++ b/aspnetcore/fundamentals/http-requests.md
@@ -276,7 +276,7 @@ An approach to managing regularly used policies is to define them once and regis
 
 In the preceding code:
 
-* Two policies, `Regular` and `Short`, are added to the Polly registry.
+* Two policies, `Regular` and `Long`, are added to the Polly registry.
 * <xref:Microsoft.Extensions.DependencyInjection.PollyHttpClientBuilderExtensions.AddPolicyHandlerFromRegistry%2A> configures individual named clients to use these policies from the Polly registry.
 
 For more information on `IHttpClientFactory` and Polly integrations, see the [Polly wiki](https://github.com/App-vNext/Polly/wiki/Polly-and-HttpClientFactory).


### PR DESCRIPTION
The policy name in the text was wrong.
It should be `Regular` and `Long`,
not `Regular` and `Short`.
Doc: https://docs.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-6.0#add-policies-from-the-polly-registry