### PR TITLE
Update signalr-blazor.md

### DIFF
--- a/aspnetcore/blazor/tutorials/signalr-blazor.md
+++ b/aspnetcore/blazor/tutorials/signalr-blazor.md
@@ -430,7 +430,7 @@ Create a `Hubs` (plural) folder and add the following `ChatHub` class (`Hubs/Cha
 
    ```csharp
    using Microsoft.AspNetCore.ResponseCompression;
-   using BlazorServerSignalRApp.Hubs;
+   using BlazorServerSignalRApp.Server.Hubs;
    ```
 
 1. Add Response Compression Middleware services to `Program.cs`:


### PR DESCRIPTION
Updating namespace 'using BlazorServerSignalRApp.Hubs;' to correct 'using BlazorServerSignalRApp.Server.Hubs;' to fix an error when building a project.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->