### PR TITLE
Removed spaces to make command one line

### DIFF
--- a/aspnetcore/blazor/security/includes/index-page-authentication.md
+++ b/aspnetcore/blazor/security/includes/index-page-authentication.md
@@ -1,6 +1,5 @@
 The Index page (`wwwroot/index.html`) page includes a script that defines the `AuthenticationService` in JavaScript. `AuthenticationService` handles the low-level details of the OIDC protocol. The app internally calls methods defined in the script to perform the authentication operations.
 
 ```html
-<script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/
-    AuthenticationService.js"></script>
+<script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
 ```


### PR DESCRIPTION
The existing script has a line break which prevents the script from working if copying directly. My change removed the spaces so the script is usable without editing.