### PR TITLE
Improve download from stream example

### DIFF
--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -76,6 +76,20 @@ The following example component:
 
 :::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/file-downloads/FileDownload1.razor":::
 
+For a component in a Blazor Server app that must return a <xref:System.IO.Stream> for a physical file, the component can call <xref:System.IO.File.OpenRead%2A?displayProperty=nameWithType>, as the following example demonstrates:
+
+```csharp
+private Stream GetFileStream()
+{
+    return File.OpenRead(@"{PATH}");
+}
+```
+
+In the preceding example, the `{PATH}` placeholder is the path to the file. The `@` prefix indicates that the string is a [*verbatim string literal*](/dotnet/csharp/programming-guide/strings/#verbatim-string-literals), which permits the use of backslashes (`\`) in a Windows OS path and embedded double-quotes (`""`) for a single quote in the path. Alternatively, avoid the string literal (`@`) and use either of the following approaches:
+
+* Use escaped backslashes (`\\`) and quotes (`\"`).
+* Use forward slashes (`/`) in the path, which are supported across platforms in ASP.NET Core apps, and escaped quotes (`\"`).
+
 ## Download from a URL
 
 *This section applies to files that are relatively large, typically 250 MB or larger.*


### PR DESCRIPTION
Fixes #26377

Thanks @frankleib! :rocket:

btw ... We're working on a build problem at the moment, which is why you see the 💥 down there :point_down:. We should have that cleared up shortly, then I'll merge this.

cc: @Rick-Anderson @wadepickett ... Here's another example of the 💥 ...

> File aspnetcore/blazor/file-downloads.md was deleted without redirection. To avoid broken links, add a redirection.

This topic has no versioned content. It's just for `monikerRange: '>= aspnetcore-6.0'`. It loads fine on the live doc set for the version selector ...

* https://docs.microsoft.com/en-us/aspnet/core/blazor/file-downloads?view=aspnetcore-7.0
* https://docs.microsoft.com/en-us/aspnet/core/blazor/file-downloads?view=aspnetcore-6.0

... and displays the correct banner earlier than that (e.g., https://docs.microsoft.com/en-us/aspnet/core/blazor/file-downloads?view=aspnetcore-5.0).