### PR TITLE
Provide additional Blazor WASM security guidance

### DIFF
--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -1192,6 +1192,30 @@ builder.Services.AddRemoteAuthentication<RemoteAuthenticationState, RemoteUserAc
     });
 ```
 
+The preceding example sets redirect URIs with a regular string literal. The following alternatives are available:
+
+* <xref:System.Uri.TryCreate%2A> using <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment.BaseAddress?displayProperty=nameWithType>:
+
+  ```csharp
+  Uri.TryCreate($"{builder.HostEnvironment.BaseAddress}authentication/login-callback", UriKind.Absolute, out var redirectUri);
+  options.RedirectUri = redirectUri;
+  ```
+  
+* [Host builder configuration](xref:blazor/fundamentals/configuration#host-builder-configuration):
+
+  ```csharp
+  options.RedirectUri = builder.Configuration["RedirectUri"];
+  ```
+  
+  `wwwroot/appsettings.json`:
+  
+  ```json
+  {
+    "RedirectUri": "https://localhost:5001/authentication/login-callback"
+  }
+  ```
+  
+
 ## Additional resources
 
 * <xref:blazor/security/webassembly/graph-api>
@@ -2379,6 +2403,29 @@ builder.Services.AddRemoteAuthentication<RemoteAuthenticationState, RemoteUserAc
     });
 ```
 
+The preceding example sets redirect URIs with a regular string literal. The following alternatives are available:
+
+* <xref:System.Uri.TryCreate%2A> using <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment.BaseAddress?displayProperty=nameWithType>:
+
+  ```csharp
+  Uri.TryCreate($"{builder.HostEnvironment.BaseAddress}authentication/login-callback", UriKind.Absolute, out var redirectUri);
+  options.RedirectUri = redirectUri;
+  ```
+  
+* [Host builder configuration](xref:blazor/fundamentals/configuration#host-builder-configuration):
+
+  ```csharp
+  options.RedirectUri = builder.Configuration["RedirectUri"];
+  ```
+  
+  `wwwroot/appsettings.json`:
+  
+  ```json
+  {
+    "RedirectUri": "https://localhost:5001/authentication/login-callback"
+  }
+  ```
+
 ## Additional resources
 
 * <xref:blazor/security/webassembly/graph-api>
@@ -3561,6 +3608,29 @@ builder.Services.AddRemoteAuthentication<RemoteAuthenticationState, RemoteUserAc
         options.ResponseMode = "...";
     });
 ```
+
+The preceding example sets redirect URIs with a regular string literal. The following alternatives are available:
+
+* <xref:System.Uri.TryCreate%2A> using <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment.BaseAddress?displayProperty=nameWithType>:
+
+  ```csharp
+  Uri.TryCreate($"{builder.HostEnvironment.BaseAddress}authentication/login-callback", UriKind.Absolute, out var redirectUri);
+  options.RedirectUri = redirectUri;
+  ```
+  
+* [Host builder configuration](xref:blazor/fundamentals/configuration#host-builder-configuration):
+
+  ```csharp
+  options.RedirectUri = builder.Configuration["RedirectUri"];
+  ```
+  
+  `wwwroot/appsettings.json`:
+  
+  ```json
+  {
+    "RedirectUri": "https://localhost:5001/authentication/login-callback"
+  }
+  ```
 
 ## Additional resources
 

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -1128,7 +1128,14 @@ export interface InteractiveAuthenticationRequest {
 };
 ```
 
-You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library.
+You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library. The following example demonstrates replacing the default `<script>` tag with one that loads a library named `CustomAuthenticationService.js` from the `wwwroot/js` folder.
+
+In `wwwroot/index.html` inside the closing `</body>` tag:
+
+```diff
+- <script src="_content/Microsoft.Authentication.WebAssembly.Msal/AuthenticationService.js"></script>
++ <script src="js/CustomAuthenticationService.js"></script>
+```
 
 For more information, see [`AuthenticationService.ts` in the `dotnet/aspnetcore` GitHub repository](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts).
 
@@ -2343,7 +2350,14 @@ export interface InteractiveAuthenticationRequest {
 };
 ```
 
-You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library.
+You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library. The following example demonstrates replacing the default `<script>` tag with one that loads a library named `CustomAuthenticationService.js` from the `wwwroot/js` folder.
+
+In `wwwroot/index.html` inside the closing `</body>` tag:
+
+```diff
+- <script src="_content/Microsoft.Authentication.WebAssembly.Msal/AuthenticationService.js"></script>
++ <script src="js/CustomAuthenticationService.js"></script>
+```
 
 For more information, see [`AuthenticationService.ts` in the `dotnet/aspnetcore` GitHub repository](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts).
 
@@ -3553,7 +3567,14 @@ export interface InteractiveAuthenticationRequest {
 };
 ```
 
-You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library.
+You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library. The following example demonstrates replacing the default `<script>` tag with one that loads a library named `CustomAuthenticationService.js` from the `wwwroot/js` folder.
+
+In `wwwroot/index.html` inside the closing `</body>` tag:
+
+```diff
+- <script src="_content/Microsoft.Authentication.WebAssembly.Msal/AuthenticationService.js"></script>
++ <script src="js/CustomAuthenticationService.js"></script>
+```
 
 For more information, see [`AuthenticationService.ts` in the `dotnet/aspnetcore` GitHub repository](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts).
 

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -1050,7 +1050,7 @@ The following subsections explain how to replace:
 Create a JavaScript library to handle your custom authentication details.
 
 > [!WARNING]
-> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
+> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%2A> and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.
@@ -1203,7 +1203,7 @@ builder.Services.AddRemoteAuthentication<RemoteAuthenticationState, RemoteUserAc
     });
 ```
 
-The preceding example sets redirect URIs with a regular string literal. The following alternatives are available:
+The preceding example sets redirect URIs with regular string literals. The following alternatives are available:
 
 * <xref:System.Uri.TryCreate%2A> using <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment.BaseAddress?displayProperty=nameWithType>:
 
@@ -2272,7 +2272,7 @@ The following subsections explain how to replace:
 Create a JavaScript library to handle your custom authentication details.
 
 > [!WARNING]
-> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
+> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%2A> and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.
@@ -2425,7 +2425,7 @@ builder.Services.AddRemoteAuthentication<RemoteAuthenticationState, RemoteUserAc
     });
 ```
 
-The preceding example sets redirect URIs with a regular string literal. The following alternatives are available:
+The preceding example sets redirect URIs with regular string literals. The following alternatives are available:
 
 * <xref:System.Uri.TryCreate%2A> using <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment.BaseAddress?displayProperty=nameWithType>:
 
@@ -3489,7 +3489,7 @@ The following subsections explain how to replace:
 Create a JavaScript library to handle your custom authentication details.
 
 > [!WARNING]
-> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
+> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%2A> and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.
@@ -3642,7 +3642,7 @@ builder.Services.AddRemoteAuthentication<RemoteAuthenticationState, RemoteUserAc
     });
 ```
 
-The preceding example sets redirect URIs with a regular string literal. The following alternatives are available:
+The preceding example sets redirect URIs with regular string literals. The following alternatives are available:
 
 * <xref:System.Uri.TryCreate%2A> using <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment.BaseAddress?displayProperty=nameWithType>:
 

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -1130,6 +1130,10 @@ export interface InteractiveAuthenticationRequest {
 
 You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library.
 
+For more information, see [`AuthenticationService.ts` in the `dotnet/aspnetcore` GitHub repository](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
 ### Replace the Microsoft Authentication Library for JavaScript (`MSAL.js`)
 
 If an app requires a custom version of the [Microsoft Authentication Library for JavaScript (`MSAL.js`)](https://www.npmjs.com/package/@azure/msal-browser), perform the following steps:
@@ -2341,6 +2345,10 @@ export interface InteractiveAuthenticationRequest {
 
 You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library.
 
+For more information, see [`AuthenticationService.ts` in the `dotnet/aspnetcore` GitHub repository](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
 ### Replace the Microsoft Authentication Library for JavaScript (`MSAL.js`)
 
 If an app requires a custom version of the [Microsoft Authentication Library for JavaScript (`MSAL.js`)](https://www.npmjs.com/package/@azure/msal-browser), perform the following steps:
@@ -3546,6 +3554,10 @@ export interface InteractiveAuthenticationRequest {
 ```
 
 You can import the library by removing the original `<script>` tag and adding a `<script>` tag that loads the custom library.
+
+For more information, see [`AuthenticationService.ts` in the `dotnet/aspnetcore` GitHub repository](https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly.Authentication/src/Interop/AuthenticationService.ts).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 ### Replace the Microsoft Authentication Library for JavaScript (`MSAL.js`)
 

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -1045,87 +1045,86 @@ The following subsections explain how to replace:
 * Any JavaScript `AuthenticationService` implementation.
 * The Microsoft Authentication Library for JavaScript (`MSAL.js`).
 
-> [!WARNING]
-> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
-
 ### Replace any JavaScript `AuthenticationService` implementation
 
-Create your on JavaScript (JS) library to handle your custom authentication details. The main contract follows, however be warned that it might change in future versions and is considered an
-implementation detail of the default RemoteAuthenticationService.
+Create a JavaScript library to handle your custom authentication details.
+
+> [!WARNING]
+> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.
 declare global {
-    interface Window { AuthenticationService: AuthenticationService }
+  interface Window { AuthenticationService: AuthenticationService }
 }
 
 export interface AuthenticationService {
-    // Init is called to initialize the AuthenticationService.
-    public static init(settings: UserManagerSettings & AuthorizeServiceSettings, logger: any) : Promise<void>;
+  // Init is called to initialize the AuthenticationService.
+  public static init(settings: UserManagerSettings & AuthorizeServiceSettings, logger: any) : Promise<void>;
 
-    // Gets the currently authenticated user.
-    public static getUser() : Promise<{[key: string] : string }>;
+  // Gets the currently authenticated user.
+  public static getUser() : Promise<{[key: string] : string }>;
 
-    // Tries to get an access token silently.
-    public static getAccessToken(options: AccessTokenRequestOptions) : Promise<AccessTokenResult>;
+  // Tries to get an access token silently.
+  public static getAccessToken(options: AccessTokenRequestOptions) : Promise<AccessTokenResult>;
 
-    // Tries to sign in the user or get an access token interactively.
-    public static signIn(context: AuthenticationContext) : Promise<AuthenticationResult>;
+  // Tries to sign in the user or get an access token interactively.
+  public static signIn(context: AuthenticationContext) : Promise<AuthenticationResult>;
 
-    // Handles the sign-in process when a redirect is used.
-    public static async completeSignIn(url: string) : Promise<AuthenticationResult>;
+  // Handles the sign-in process when a redirect is used.
+  public static async completeSignIn(url: string) : Promise<AuthenticationResult>;
 
-    // Signs the user out.
-    public static signOut(context: AuthenticationContext) : Promise<AuthenticationResult>;
+  // Signs the user out.
+  public static signOut(context: AuthenticationContext) : Promise<AuthenticationResult>;
 
-    // Handles the signout callback when a redirect is used.
-    public static async completeSignOut(url: string) : Promise<AuthenticationResult>;
+  // Handles the signout callback when a redirect is used.
+  public static async completeSignOut(url: string) : Promise<AuthenticationResult>;
 }
 
 // The rest of these interfaces match their C# definitions.
 
 export interface AccessTokenRequestOptions {
-    scopes: string[];
-    returnUrl: string;
+  scopes: string[];
+  returnUrl: string;
 }
 
 export interface AccessTokenResult {
-    status: AccessTokenResultStatus;
-    token?: AccessToken;
+  status: AccessTokenResultStatus;
+  token?: AccessToken;
 }
 
 export interface AccessToken {
-    value: string;
-    expires: Date;
-    grantedScopes: string[];
+  value: string;
+  expires: Date;
+  grantedScopes: string[];
 }
 
 export enum AccessTokenResultStatus {
-    Success = 'Success',
-    RequiresRedirect = 'RequiresRedirect'
+  Success = 'Success',
+  RequiresRedirect = 'RequiresRedirect'
 }
 
 export enum AuthenticationResultStatus {
-    Redirect = 'Redirect',
-    Success = 'Success',
-    Failure = 'Failure',
-    OperationCompleted = 'OperationCompleted'
+  Redirect = 'Redirect',
+  Success = 'Success',
+  Failure = 'Failure',
+  OperationCompleted = 'OperationCompleted'
 };
 
 export interface AuthenticationResult {
-    status: AuthenticationResultStatus;
-    state?: unknown;
-    message?: string;
+  status: AuthenticationResultStatus;
+  state?: unknown;
+  message?: string;
 }
 
 export interface AuthenticationContext {
-    state?: unknown;
-    interactiveRequest: InteractiveAuthenticationRequest;
+  state?: unknown;
+  interactiveRequest: InteractiveAuthenticationRequest;
 }
 
 export interface InteractiveAuthenticationRequest {
-    scopes?: string[];
-    additionalRequestParameters?: { [key: string]: any };
+  scopes?: string[];
+  additionalRequestParameters?: { [key: string]: any };
 };
 ```
 
@@ -2233,87 +2232,86 @@ The following subsections explain how to replace:
 * Any JavaScript `AuthenticationService` implementation.
 * The Microsoft Authentication Library for JavaScript (`MSAL.js`).
 
-> [!WARNING]
-> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
-
 ### Replace any JavaScript `AuthenticationService` implementation
 
-Create your on JavaScript (JS) library to handle your custom authentication details. The main contract follows, however be warned that it might change in future versions and is considered an
-implementation detail of the default RemoteAuthenticationService.
+Create a JavaScript library to handle your custom authentication details.
+
+> [!WARNING]
+> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.
 declare global {
-    interface Window { AuthenticationService: AuthenticationService }
+  interface Window { AuthenticationService: AuthenticationService }
 }
 
 export interface AuthenticationService {
-    // Init is called to initialize the AuthenticationService.
-    public static init(settings: UserManagerSettings & AuthorizeServiceSettings, logger: any) : Promise<void>;
+  // Init is called to initialize the AuthenticationService.
+  public static init(settings: UserManagerSettings & AuthorizeServiceSettings, logger: any) : Promise<void>;
 
-    // Gets the currently authenticated user.
-    public static getUser() : Promise<{[key: string] : string }>;
+  // Gets the currently authenticated user.
+  public static getUser() : Promise<{[key: string] : string }>;
 
-    // Tries to get an access token silently.
-    public static getAccessToken(options: AccessTokenRequestOptions) : Promise<AccessTokenResult>;
+  // Tries to get an access token silently.
+  public static getAccessToken(options: AccessTokenRequestOptions) : Promise<AccessTokenResult>;
 
-    // Tries to sign in the user or get an access token interactively.
-    public static signIn(context: AuthenticationContext) : Promise<AuthenticationResult>;
+  // Tries to sign in the user or get an access token interactively.
+  public static signIn(context: AuthenticationContext) : Promise<AuthenticationResult>;
 
-    // Handles the sign-in process when a redirect is used.
-    public static async completeSignIn(url: string) : Promise<AuthenticationResult>;
+  // Handles the sign-in process when a redirect is used.
+  public static async completeSignIn(url: string) : Promise<AuthenticationResult>;
 
-    // Signs the user out.
-    public static signOut(context: AuthenticationContext) : Promise<AuthenticationResult>;
+  // Signs the user out.
+  public static signOut(context: AuthenticationContext) : Promise<AuthenticationResult>;
 
-    // Handles the signout callback when a redirect is used.
-    public static async completeSignOut(url: string) : Promise<AuthenticationResult>;
+  // Handles the signout callback when a redirect is used.
+  public static async completeSignOut(url: string) : Promise<AuthenticationResult>;
 }
 
 // The rest of these interfaces match their C# definitions.
 
 export interface AccessTokenRequestOptions {
-    scopes: string[];
-    returnUrl: string;
+  scopes: string[];
+  returnUrl: string;
 }
 
 export interface AccessTokenResult {
-    status: AccessTokenResultStatus;
-    token?: AccessToken;
+  status: AccessTokenResultStatus;
+  token?: AccessToken;
 }
 
 export interface AccessToken {
-    value: string;
-    expires: Date;
-    grantedScopes: string[];
+  value: string;
+  expires: Date;
+  grantedScopes: string[];
 }
 
 export enum AccessTokenResultStatus {
-    Success = 'Success',
-    RequiresRedirect = 'RequiresRedirect'
+  Success = 'Success',
+  RequiresRedirect = 'RequiresRedirect'
 }
 
 export enum AuthenticationResultStatus {
-    Redirect = 'Redirect',
-    Success = 'Success',
-    Failure = 'Failure',
-    OperationCompleted = 'OperationCompleted'
+  Redirect = 'Redirect',
+  Success = 'Success',
+  Failure = 'Failure',
+  OperationCompleted = 'OperationCompleted'
 };
 
 export interface AuthenticationResult {
-    status: AuthenticationResultStatus;
-    state?: unknown;
-    message?: string;
+  status: AuthenticationResultStatus;
+  state?: unknown;
+  message?: string;
 }
 
 export interface AuthenticationContext {
-    state?: unknown;
-    interactiveRequest: InteractiveAuthenticationRequest;
+  state?: unknown;
+  interactiveRequest: InteractiveAuthenticationRequest;
 }
 
 export interface InteractiveAuthenticationRequest {
-    scopes?: string[];
-    additionalRequestParameters?: { [key: string]: any };
+  scopes?: string[];
+  additionalRequestParameters?: { [key: string]: any };
 };
 ```
 
@@ -3417,87 +3415,86 @@ The following subsections explain how to replace:
 * Any JavaScript `AuthenticationService` implementation.
 * The Microsoft Authentication Library for JavaScript (`MSAL.js`).
 
-> [!WARNING]
-> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
-
 ### Replace any JavaScript `AuthenticationService` implementation
 
-Create your on JavaScript (JS) library to handle your custom authentication details. The main contract follows, however be warned that it might change in future versions and is considered an
-implementation detail of the default RemoteAuthenticationService.
+Create a JavaScript library to handle your custom authentication details.
+
+> [!WARNING]
+> The guidance in this section is an implementation detail of of the default `RemoteAuthenticationService` and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.
 declare global {
-    interface Window { AuthenticationService: AuthenticationService }
+  interface Window { AuthenticationService: AuthenticationService }
 }
 
 export interface AuthenticationService {
-    // Init is called to initialize the AuthenticationService.
-    public static init(settings: UserManagerSettings & AuthorizeServiceSettings, logger: any) : Promise<void>;
+  // Init is called to initialize the AuthenticationService.
+  public static init(settings: UserManagerSettings & AuthorizeServiceSettings, logger: any) : Promise<void>;
 
-    // Gets the currently authenticated user.
-    public static getUser() : Promise<{[key: string] : string }>;
+  // Gets the currently authenticated user.
+  public static getUser() : Promise<{[key: string] : string }>;
 
-    // Tries to get an access token silently.
-    public static getAccessToken(options: AccessTokenRequestOptions) : Promise<AccessTokenResult>;
+  // Tries to get an access token silently.
+  public static getAccessToken(options: AccessTokenRequestOptions) : Promise<AccessTokenResult>;
 
-    // Tries to sign in the user or get an access token interactively.
-    public static signIn(context: AuthenticationContext) : Promise<AuthenticationResult>;
+  // Tries to sign in the user or get an access token interactively.
+  public static signIn(context: AuthenticationContext) : Promise<AuthenticationResult>;
 
-    // Handles the sign-in process when a redirect is used.
-    public static async completeSignIn(url: string) : Promise<AuthenticationResult>;
+  // Handles the sign-in process when a redirect is used.
+  public static async completeSignIn(url: string) : Promise<AuthenticationResult>;
 
-    // Signs the user out.
-    public static signOut(context: AuthenticationContext) : Promise<AuthenticationResult>;
+  // Signs the user out.
+  public static signOut(context: AuthenticationContext) : Promise<AuthenticationResult>;
 
-    // Handles the signout callback when a redirect is used.
-    public static async completeSignOut(url: string) : Promise<AuthenticationResult>;
+  // Handles the signout callback when a redirect is used.
+  public static async completeSignOut(url: string) : Promise<AuthenticationResult>;
 }
 
 // The rest of these interfaces match their C# definitions.
 
 export interface AccessTokenRequestOptions {
-    scopes: string[];
-    returnUrl: string;
+  scopes: string[];
+  returnUrl: string;
 }
 
 export interface AccessTokenResult {
-    status: AccessTokenResultStatus;
-    token?: AccessToken;
+  status: AccessTokenResultStatus;
+  token?: AccessToken;
 }
 
 export interface AccessToken {
-    value: string;
-    expires: Date;
-    grantedScopes: string[];
+  value: string;
+  expires: Date;
+  grantedScopes: string[];
 }
 
 export enum AccessTokenResultStatus {
-    Success = 'Success',
-    RequiresRedirect = 'RequiresRedirect'
+  Success = 'Success',
+  RequiresRedirect = 'RequiresRedirect'
 }
 
 export enum AuthenticationResultStatus {
-    Redirect = 'Redirect',
-    Success = 'Success',
-    Failure = 'Failure',
-    OperationCompleted = 'OperationCompleted'
+  Redirect = 'Redirect',
+  Success = 'Success',
+  Failure = 'Failure',
+  OperationCompleted = 'OperationCompleted'
 };
 
 export interface AuthenticationResult {
-    status: AuthenticationResultStatus;
-    state?: unknown;
-    message?: string;
+  status: AuthenticationResultStatus;
+  state?: unknown;
+  message?: string;
 }
 
 export interface AuthenticationContext {
-    state?: unknown;
-    interactiveRequest: InteractiveAuthenticationRequest;
+  state?: unknown;
+  interactiveRequest: InteractiveAuthenticationRequest;
 }
 
 export interface InteractiveAuthenticationRequest {
-    scopes?: string[];
-    additionalRequestParameters?: { [key: string]: any };
+  scopes?: string[];
+  additionalRequestParameters?: { [key: string]: any };
 };
 ```
 

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -1050,7 +1050,7 @@ The following subsections explain how to replace:
 Create a JavaScript library to handle your custom authentication details.
 
 > [!WARNING]
-> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%2A> and subject to change without notice in upcoming releases of ASP.NET Core.
+> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%603> and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.
@@ -2272,7 +2272,7 @@ The following subsections explain how to replace:
 Create a JavaScript library to handle your custom authentication details.
 
 > [!WARNING]
-> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%2A> and subject to change without notice in upcoming releases of ASP.NET Core.
+> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%603> and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.
@@ -3489,7 +3489,7 @@ The following subsections explain how to replace:
 Create a JavaScript library to handle your custom authentication details.
 
 > [!WARNING]
-> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%2A> and subject to change without notice in upcoming releases of ASP.NET Core.
+> The guidance in this section is an implementation detail of of the default <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.RemoteAuthenticationService%603> and subject to change without notice in upcoming releases of ASP.NET Core.
 
 ```typescript
 // .NET makes calls to an AuthenticationService object in the Window.


### PR DESCRIPTION
Fixes #26381
Fixes #26383

Javier ... It's best if you look this over. There are some deltas from your "provider options" issue on the PR ...

* I can't find a `WebAssemblyHostBuilder.BaseUri` property, but I think 🤔 that the redirect URIs can be built with `builder.HostEnvironment.BaseAddress`. It's probably also worth it to call out supplying the URIs via configuration.
* I can't find `Uri.Create`, so I placed a `Uri.TryCreate` approach on the PR.