### PR TITLE
Redirect users when content isn't found

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -76,6 +76,47 @@ In the `App` component, set custom content in the <xref:Microsoft.AspNetCore.Com
 
 Arbitrary items are supported as content of the `<NotFound>` tags, such as other interactive components. To apply a default layout to <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> content, see <xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component>.
 
+To redirect users when content isn't found, Blazor WebAssembly apps can:
+
+* Inject a [Navigation Manager](#uri-and-navigation-state-helpers) into the `App` component:
+
+  ```razor
+  @inject NavigationManager NavigationManager
+  ```
+
+* Call <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> with the destination. The following example navigates to the default component, typically the `Index` component (`Pages/Index.razor`):
+
+  ```razor
+  <NotFound>
+      @{ NavigationManager.NavigateTo("/", false); }
+  </NotFound>
+  ```
+  
+To redirect users in a Blazor Server app, calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> directly in the `App` component results in a <xref:Microsoft.AspNetCore.Components.NavigationException> during debugging, which is thrown during prerendering. To avoid the exception, call for the navigation in [`OnAfterRender`](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync) of a custom redirect component.
+
+The following Blazor Server example navigates users to the app's default component, typically the `Index` component:
+
+* Create a `RedirectUsers` component (`Shared/RedirectUsers.razor`):
+
+  ```razor
+  @inject NavigationManager NavigationManager
+
+  @code {
+      protected override void OnAfterRender(bool firstRender)
+      {
+          NavigationManager.NavigateTo("/", false);
+      }
+  }
+  ```
+
+* In the `App` component (`App.razor`), place the custom redirect component in `<NotFound>` child content:
+
+  ```razor
+  <NotFound>
+      <RedirectUsers />
+  </NotFound>
+  ```
+
 ## Route to components from multiple assemblies
 
 Use the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> parameter to specify additional assemblies for the <xref:Microsoft.AspNetCore.Components.Routing.Router> component to consider when searching for routable components. Additional assemblies are scanned in addition to the assembly specified to `AppAssembly`. In the following example, `Component1` is a routable component defined in a referenced [component class library](xref:blazor/components/class-libraries). The following <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> example results in routing support for `Component1`.
@@ -704,6 +745,47 @@ In the `App` component, set custom content in the <xref:Microsoft.AspNetCore.Com
 
 Arbitrary items are supported as content of the `<NotFound>` tags, such as other interactive components. To apply a default layout to <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> content, see <xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component>.
 
+To redirect users when content isn't found, Blazor WebAssembly apps can:
+
+* Inject a [Navigation Manager](#uri-and-navigation-state-helpers) into the `App` component:
+
+  ```razor
+  @inject NavigationManager NavigationManager
+  ```
+
+* Call <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> with the destination. The following example navigates to the default component, typically the `Index` component (`Pages/Index.razor`):
+
+  ```razor
+  <NotFound>
+      @{ NavigationManager.NavigateTo("/", false); }
+  </NotFound>
+  ```
+  
+To redirect users in a Blazor Server app, calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> directly in the `App` component results in a <xref:Microsoft.AspNetCore.Components.NavigationException> during debugging, which is thrown during prerendering. To avoid the exception, call for the navigation in [`OnAfterRender`](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync) of a custom redirect component.
+
+The following Blazor Server example navigates users to the app's default component, typically the `Index` component:
+
+* Create a `RedirectUsers` component (`Shared/RedirectUsers.razor`):
+
+  ```razor
+  @inject NavigationManager NavigationManager
+
+  @code {
+      protected override void OnAfterRender(bool firstRender)
+      {
+          NavigationManager.NavigateTo("/", false);
+      }
+  }
+  ```
+
+* In the `App` component (`App.razor`), place the custom redirect component in `<NotFound>` child content:
+
+  ```razor
+  <NotFound>
+      <RedirectUsers />
+  </NotFound>
+  ```
+
 ## Route to components from multiple assemblies
 
 Use the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> parameter to specify additional assemblies for the <xref:Microsoft.AspNetCore.Components.Routing.Router> component to consider when searching for routable components. Additional assemblies are scanned in addition to the assembly specified to `AppAssembly`. In the following example, `Component1` is a routable component defined in a referenced [component class library](xref:blazor/components/class-libraries). The following <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> example results in routing support for `Component1`.
@@ -1126,6 +1208,47 @@ In the `App` component, set custom content in the <xref:Microsoft.AspNetCore.Com
 [!code-razor[](~/blazor/samples/3.1/BlazorSample_WebAssembly/routing/App2.razor?highlight=5-8)]
 
 Arbitrary items are supported as content of the `<NotFound>` tags, such as other interactive components. To apply a default layout to <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> content, see <xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component>.
+
+To redirect users when content isn't found, Blazor WebAssembly apps can:
+
+* Inject a [Navigation Manager](#uri-and-navigation-state-helpers) into the `App` component:
+
+  ```razor
+  @inject NavigationManager NavigationManager
+  ```
+
+* Call <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> with the destination. The following example navigates to the default component, typically the `Index` component (`Pages/Index.razor`):
+
+  ```razor
+  <NotFound>
+      @{ NavigationManager.NavigateTo("/", false); }
+  </NotFound>
+  ```
+  
+To redirect users in a Blazor Server app, calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> directly in the `App` component results in a <xref:Microsoft.AspNetCore.Components.NavigationException> during debugging, which is thrown during prerendering. To avoid the exception, call for the navigation in [`OnAfterRender`](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync) of a custom redirect component.
+
+The following Blazor Server example navigates users to the app's default component, typically the `Index` component:
+
+* Create a `RedirectUsers` component (`Shared/RedirectUsers.razor`):
+
+  ```razor
+  @inject NavigationManager NavigationManager
+
+  @code {
+      protected override void OnAfterRender(bool firstRender)
+      {
+          NavigationManager.NavigateTo("/", false);
+      }
+  }
+  ```
+
+* In the `App` component (`App.razor`), place the custom redirect component in `<NotFound>` child content:
+
+  ```razor
+  <NotFound>
+      <RedirectUsers />
+  </NotFound>
+  ```
 
 ## Route to components from multiple assemblies
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -117,6 +117,12 @@ The following Blazor Server example navigates users to the app's default compone
   </NotFound>
   ```
 
+If the Blazor Server navigation is to an MVC controller or Razor Pages page, set `forceLoad` to `true` to force the browser to make a request to the server for the resource. In the following example, the `Index` MVC view is requested:
+
+```csharp
+NavigationManager.NavigateTo("/Home/Index", true);
+```
+
 ## Route to components from multiple assemblies
 
 Use the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> parameter to specify additional assemblies for the <xref:Microsoft.AspNetCore.Components.Routing.Router> component to consider when searching for routable components. Additional assemblies are scanned in addition to the assembly specified to `AppAssembly`. In the following example, `Component1` is a routable component defined in a referenced [component class library](xref:blazor/components/class-libraries). The following <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> example results in routing support for `Component1`.
@@ -786,6 +792,12 @@ The following Blazor Server example navigates users to the app's default compone
   </NotFound>
   ```
 
+If the Blazor Server navigation is to an MVC controller or Razor Pages page, set `forceLoad` to `true` to force the browser to make a request to the server for the resource. In the following example, the `Index` MVC view is requested:
+
+```csharp
+NavigationManager.NavigateTo("/Home/Index", true);
+```
+
 ## Route to components from multiple assemblies
 
 Use the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> parameter to specify additional assemblies for the <xref:Microsoft.AspNetCore.Components.Routing.Router> component to consider when searching for routable components. Additional assemblies are scanned in addition to the assembly specified to `AppAssembly`. In the following example, `Component1` is a routable component defined in a referenced [component class library](xref:blazor/components/class-libraries). The following <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies> example results in routing support for `Component1`.
@@ -1249,6 +1261,12 @@ The following Blazor Server example navigates users to the app's default compone
       <RedirectUsers />
   </NotFound>
   ```
+
+If the Blazor Server navigation is to an MVC controller or Razor Pages page, set `forceLoad` to `true` to force the browser to make a request to the server for the resource. In the following example, the `Index` MVC view is requested:
+
+```csharp
+NavigationManager.NavigateTo("/Home/Index", true);
+```
 
 ## Route to components from multiple assemblies
 


### PR DESCRIPTION
Fixes #26415

[Internal Review Topic (links to section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-3.1&branch=pr-en-us-26420#provide-custom-content-when-content-isnt-found) ... scroll down to the bottom of the *Provide custom content when content isn't found* section that loads via this link.

### RE: Redirect users when content isn't found

Thanks @dirkesquire! :rocket:

Steve ... a couple of points (one from me, one from @dirkesquire) ...

* Your [PU discussion (dotnet/aspnetcore #13582)](https://github.com/dotnet/aspnetcore/issues/13582#issuecomment-527383363) left me with the impression that using a custom redirect component and calling for navigation in its `OnAfterRender` would be a sane approach to avoiding the `NavigationException` in Blazor Server apps during debugging, noting that ...
  * Seems like it would be fine for production.
  * Doesn't check `firstRender` because there isn't a double event call, seemingly because it navigates on the prerender ... a short-circuit.

* From Dirk ......

  > Drawing from inspiration from the React world, specifically React-Router, you have not only a NavigationManager you can invoke functions on but there is also a built in element `<Navigate>` element that I think would make sense here which I was kinda expecting you might mention (if it existed - but I take it it doesn't). This would avoid the user having to 'roll their own' `<RedirectToUser>` element.
  >
  > This is the type of solution I would expect:
  >
  > ```razor
  > <NotFound>
  >     <Navigate to="/" />
  > </NotFound>
  > ```
  >
  > I am of course happy building my own Navigate page as it is quite easy, but I think it would be a beneficial addition to the framework.

  So, I told Dirk on the issue that if you're interested that he should open it on the PU repo as a request but that you might say 'nah' to that here and save him the trouble.