### PR TITLE
Tryparse with dynamic format provider supplied from client

### DIFF
--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseAPI/Models/Culture.cs
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseAPI/Models/Culture.cs
@@ -7,21 +7,18 @@ namespace BindTryParseAPI.Models
 
         public Culture(string displayName)
         {
-            if (string.IsNullOrEmpty(displayName))
-                throw new ArgumentNullException(nameof(displayName));
-
             DisplayName = displayName;
         }
 
-        public static bool TryParse(string? value, out Culture? result)
+        public static bool TryParse(string? value, out Culture? culture)
         {
-            if (value is null)
+            if (string.IsNullOrEmpty(value))
             {
-                result = default;
+                culture = default;
                 return false;
             }
 
-            result = new Culture(value);
+            culture = new Culture(value);
             return true;
         }
     }

--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseAPI/Models/DateRange.cs
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseAPI/Models/DateRange.cs
@@ -6,27 +6,29 @@ namespace BindTryParseAPI.Models
         public DateOnly? From { get; }
         public DateOnly? To { get; }
 
-        public DateRange(string from, string to)
+        public DateRange(DateOnly fromDate, DateOnly toDate)
         {
-            if (string.IsNullOrEmpty(from))
-                throw new ArgumentNullException(nameof(from));
-            if (string.IsNullOrEmpty(to))
-                throw new ArgumentNullException(nameof(to));
-
-            From = DateOnly.Parse(from);
-            To = DateOnly.Parse(to);
+            From = fromDate;
+            To = toDate;
         }
 
-        public static bool TryParse(string? value, IFormatProvider? provider, out DateRange? result)
+        public static bool TryParse(string? value, IFormatProvider? provider, out DateRange? dateRange)
         {
             if (string.IsNullOrEmpty(value) || value.Split('-').Length != 2)
             {
-                result = default;
+                dateRange = default;
                 return false;
             }
 
             var range = value.Split('-');
-            result = new DateRange(range[0], range[1]);
+
+            if (!DateOnly.TryParse(range[0], provider, out var fromDate) || !DateOnly.TryParse(range[1], provider, out var toDate))
+            {
+                dateRange = default;
+                return false;
+            }
+
+            dateRange = new DateRange(fromDate, toDate);
             return true;
         }
     }

--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Controllers/WeatherForecastController.cs
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Controllers/WeatherForecastController.cs
@@ -36,7 +36,7 @@ namespace BindTryParseMVC.Controllers
 
         // GET /WeatherForecast/Range?range=07/12/2022-07/14/2022
         // <snippet_1>
-        public IActionResult Range(DateRange? range)
+        public IActionResult Range(DateRange range)
         {
             var weatherForecasts = Enumerable
                 .Range(1, 5).Select(index => new WeatherForecast
@@ -59,9 +59,8 @@ namespace BindTryParseMVC.Controllers
         }
         // </snippet_1>
 
-        // GET /WeatherForecast/RangeWithFormatter?culture=en-GB&range=07/12/2022-07/14/2022
-        // <snippet_2>
-        public IActionResult RangeWithFormatter(Culture culture, string? range)
+        // GET /WeatherForecast/GetByRangeWithCulture?culture=en-GB&range=07/12/2022-07/14/2022
+        public IActionResult RangeWithCulture(Culture culture, string range)
         {
             if (!DateRange.TryParse(range, new CultureInfo(culture?.DisplayName ?? "en-US"), out var dateRange))
                return View("Error", $"Invalid date range {range} for culture {culture?.DisplayName}");

--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Controllers/WeatherForecastController.cs
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Controllers/WeatherForecastController.cs
@@ -58,5 +58,33 @@ namespace BindTryParseMVC.Controllers
             return View("Index", weatherForecasts);
         }
         // </snippet_1>
+
+        // GET /WeatherForecast/RangeWithFormatter?culture=en-GB&range=07/12/2022-07/14/2022
+        // <snippet_2>
+        public IActionResult RangeWithFormatter(Culture culture, string? range)
+        {
+            if (!DateRange.TryParse(range, new CultureInfo(culture?.DisplayName ?? "en-US"), out var dateRange))
+               return View("Error", $"Invalid date range {range} for culture {culture?.DisplayName}");
+
+            var weatherForecasts = Enumerable
+                .Range(1, 5).Select(index => new WeatherForecast
+                {
+                    Date = DateTime.Now.AddDays(index),
+                    TemperatureC = Random.Shared.Next(-20, 55),
+                    Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+                })
+                .Where(wf => DateOnly.FromDateTime(wf.Date) >= (dateRange?.From ?? DateOnly.MinValue)
+                          && DateOnly.FromDateTime(wf.Date) <= (dateRange?.To ?? DateOnly.MaxValue))
+                .Select(wf => new WeatherForecastViewModel
+                {
+                    Date = wf.Date.ToString(new CultureInfo(culture?.DisplayName ?? "en-US")),
+                    TemperatureC = wf.TemperatureC,
+                    TemperatureF = wf.TemperatureF,
+                    Summary = wf.Summary
+                });
+
+            return View("Index", weatherForecasts);
+        }
+        // </snippet_2>
     }
 }

--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Models/Culture.cs
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Models/Culture.cs
@@ -7,21 +7,18 @@ namespace BindTryParseMVC.Models
 
         public Culture(string displayName)
         {
-            if (string.IsNullOrEmpty(displayName))
-                throw new ArgumentNullException(nameof(displayName));
-
             DisplayName = displayName;
         }
-
-        public static bool TryParse(string? value, out Culture? result)
+        
+        public static bool TryParse(string? value, out Culture? culture)
         {
-            if (value is null)
+            if (string.IsNullOrEmpty(value))
             {
-                result = default;
+                culture = default;
                 return false;
             }
 
-            result = new Culture(value);
+            culture = new Culture(value);
             return true;
         }
     }

--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Models/DateRange.cs
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Models/DateRange.cs
@@ -15,7 +15,7 @@ namespace BindTryParseMVC.Models
             To = toDate;
         }
 
-        public static bool TryParse(string? value, IFormatProvider? provider, out DateRange? dateRange)
+        public static bool TryParse(string? value, IFormatProvider? provider, out DateRange dateRange)
         {
             if (string.IsNullOrEmpty(value) || value.Split('-').Length != 2)
             {

--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Models/DateRange.cs
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Models/DateRange.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System;
+
 namespace BindTryParseMVC.Models
 {
     // <snippet>
@@ -6,27 +9,29 @@ namespace BindTryParseMVC.Models
         public DateOnly? From { get; }
         public DateOnly? To { get; }
 
-        public DateRange(string from, string to)
+        public DateRange(DateOnly fromDate, DateOnly toDate)
         {
-            if (string.IsNullOrEmpty(from))
-                throw new ArgumentNullException(nameof(from));
-            if (string.IsNullOrEmpty(to))
-                throw new ArgumentNullException(nameof(to));
-
-            From = DateOnly.Parse(from);
-            To = DateOnly.Parse(to);
+            From = fromDate;
+            To = toDate;
         }
 
-        public static bool TryParse(string? value, IFormatProvider? provider, out DateRange? result)
+        public static bool TryParse(string? value, IFormatProvider? provider, out DateRange? dateRange)
         {
             if (string.IsNullOrEmpty(value) || value.Split('-').Length != 2)
             {
-                result = default;
+                dateRange = default;
+                return false;
+            }
+            
+            var range = value.Split('-');
+
+            if (!DateOnly.TryParse(range[0], provider, out var fromDate) || !DateOnly.TryParse(range[1], provider, out var toDate))
+            {
+                dateRange = default;
                 return false;
             }
 
-            var range = value.Split('-');
-            result = new DateRange(range[0], range[1]);
+            dateRange = new DateRange(fromDate, toDate);
             return true;
         }
     }

--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Models/DateRange.cs
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Models/DateRange.cs
@@ -1,6 +1,3 @@
-using System.Globalization;
-using System;
-
 namespace BindTryParseMVC.Models
 {
     // <snippet>
@@ -15,7 +12,7 @@ namespace BindTryParseMVC.Models
             To = toDate;
         }
 
-        public static bool TryParse(string? value, IFormatProvider? provider, out DateRange dateRange)
+        public static bool TryParse(string? value, IFormatProvider? provider, out DateRange? dateRange)
         {
             if (string.IsNullOrEmpty(value) || value.Split('-').Length != 2)
             {

--- a/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Views/WeatherForecast/Error.cshtml
+++ b/aspnetcore/mvc/controllers/bind-tryparse/7.0-samples/BindUsingTryParse/BindTryParseMVC/Views/WeatherForecast/Error.cshtml
@@ -1,0 +1,7 @@
+@model string
+@{
+    ViewData["Title"] = "Error";
+}
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">@Model</h2>


### PR DESCRIPTION
Fixes https://github.com/dotnet/AspNetCore.Docs/issues/26434

@Rick-Anderson I've modified the sample to make the snippets more meaningful and compact.

* `/WeatherForecast?culture=en-GB` can be called with or without the `culture=en-GB`
* `/WeatherForecast/Range?range=07/12/2022-07/14/2022`, here dateRange is a required field
* `/WeatherForecast/GetByRangeWithCulture?culture=en-GB&range=07/12/2022-07/14/2022`, both culture and range is required (but the range is in a string format, we make the call `DateRange.TryParse(range, new CultureInfo(culture?.DisplayName ?? "en-US"), out var dateRange)` inside the controller to validate the parameter based on the culture privided by the client

These three examples should suffice for using both,

`public static bool TryParse(string value, T out result);`
`public static bool TryParse(string value, IFormatProvider provider, T out result);`

