### PR TITLE
Create 7.0-SDK.md

### DIFF
--- a/aspnetcore/includes/7.0-SDK.md
+++ b/aspnetcore/includes/7.0-SDK.md
@@ -1,0 +1,1 @@
+[.NET 7.0 SDK](https://dotnet.microsoft.com/download/dotnet/7.0)


### PR DESCRIPTION
We'll need this one, and it's live today for use at ...

https://dotnet.microsoft.com/download/dotnet/7.0

I'm just putting this one up for now. It's one that I need for a Blazor topic. I think some of the others are in use in Blazor topics, but I'll need to work further to discover which ones if I create new PRs myself for them ... or just wait until they're all created by another doc :cat2:.