### PR TITLE
Dev/Prod SQL code for VS Mac to .NET 6

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -179,7 +179,7 @@ For more information, see [dotnet-aspnet-codegenerator](xref:fundamentals/tools/
 
 The `appsettings.json` file is updated with the connection string used to connect to a local database.
 
-[!INCLUDE[](~/includes/RP/sqlitedev.md)]
+[!INCLUDE[](~/includes/DevProdSQLite.md)]
 
 ---
 


### PR DESCRIPTION
Updated the SQL Lite+Development / SQL Server+Production switching code to use Program.cs per the new .NET 6 minimal hosting model

Fixes #26582
