### PR TITLE
improve text readability.

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-2.1.md
+++ b/aspnetcore/release-notes/aspnetcore-2.1.md
@@ -13,7 +13,8 @@ This article highlights the most significant changes in ASP.NET Core 2.1, with l
 
 ## SignalR
 
-SignalR has been rewritten for ASP.NET Core 2.1. ASP.NET Core SignalR includes a number of improvements:
+SignalR has been rewritten for ASP.NET Core 2.1.
+ASP.NET Core SignalR includes a number of improvements:
 
 * A simplified scale-out model.
 * A new JavaScript client with no jQuery dependency.

--- a/aspnetcore/release-notes/aspnetcore-2.1.md
+++ b/aspnetcore/release-notes/aspnetcore-2.1.md
@@ -14,6 +14,7 @@ This article highlights the most significant changes in ASP.NET Core 2.1, with l
 ## SignalR
 
 SignalR has been rewritten for ASP.NET Core 2.1.
+
 ASP.NET Core SignalR includes a number of improvements:
 
 * A simplified scale-out model.


### PR DESCRIPTION
Hello,

I was just browsing through our docs and came upon this statement:

"SignalR has been rewritten for ASP.NET Core 2.1. ASP.NET Core SignalR includes a number of improvements:"

It took me some time to parse and understand why we have the "ASP.NET Core" syntax mentioned consecutively.
I would propose a line break after the first phrase - it makes the content easier to understand and read.

Please let me know if you have any issues with this PR.
You can also reach out to me on Teams (aolariu).

Thanks!