### PR TITLE
MSBuild properties for hosted deployment options

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -204,7 +204,7 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     dotnet publish -c Release
     ```
     
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
   
     ```dotnetcli
     dotnet publish -c Release \p:RuntimeIdentifier={RID}
@@ -1043,7 +1043,7 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     dotnet publish -c Release
     ```
     
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
   
     ```dotnetcli
     dotnet publish -c Release \p:RuntimeIdentifier={RID}
@@ -1760,7 +1760,7 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     dotnet publish -c Release
     ```
     
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
   
     ```dotnetcli
     dotnet publish -c Release \p:RuntimeIdentifier={RID}

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -179,18 +179,18 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file or rely upon a Visual Studio publish profile (`.pubxml `) with the property set to `false` by default, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
   <SelfContained>false</SelfContained>
   ```
   
   > [!NOTE]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
   
 * Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
 
-  * Option 1: Set the RID in the in the **`Server`** project's project file:
+  * Option 1: Set the RID in the in the **`Server`** project's project file or via a Visual Studio publish profile (`.pubxml`) **Target Runtime**:
   
     ```xml
     <RuntimeIdentifier>{RID}</RuntimeIdentifier>
@@ -198,13 +198,17 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     
     In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
     
-    Publish the app in the Release configuration from the **`Server`** project:
+    Publish the app in the Release configuration from the **`Server`** project or publish the app from Visual Studio in the **Release** configuration.
+    
+    Using the .NET CLI:
     
     ```dotnetcli
     dotnet publish -c Release
     ```
     
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project.
+  
+    Using the .NET CLI:
   
     ```dotnetcli
     dotnet publish -c Release /p:RuntimeIdentifier={RID}
@@ -212,7 +216,10 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     
     In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
 
-For more information, see [.NET application publishing overview](/dotnet/core/deploying/).
+For more information, see the following articles:
+
+* [.NET application publishing overview](/dotnet/core/deploying/)
+* <xref:host-and-deploy/index>
 
 ## Hosted deployment with multiple Blazor WebAssembly apps
 
@@ -1018,18 +1025,18 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file or rely upon a Visual Studio publish profile (`.pubxml `) with the property set to `false` by default, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
   <SelfContained>false</SelfContained>
   ```
   
   > [!NOTE]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
   
 * Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
 
-  * Option 1: Set the RID in the in the **`Server`** project's project file:
+  * Option 1: Set the RID in the in the **`Server`** project's project file or via a Visual Studio publish profile (`.pubxml`) **Target Runtime**:
   
     ```xml
     <RuntimeIdentifier>{RID}</RuntimeIdentifier>
@@ -1037,13 +1044,17 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     
     In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
     
-    Publish the app in the Release configuration from the **`Server`** project:
+    Publish the app in the Release configuration from the **`Server`** project or publish the app from Visual Studio in the **Release** configuration.
+    
+    Using the .NET CLI:
     
     ```dotnetcli
     dotnet publish -c Release
     ```
     
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project.
+  
+    Using the .NET CLI:
   
     ```dotnetcli
     dotnet publish -c Release /p:RuntimeIdentifier={RID}
@@ -1051,7 +1062,10 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     
     In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
 
-For more information, see [.NET application publishing overview](/dotnet/core/deploying/).
+For more information, see the following articles:
+
+* [.NET application publishing overview](/dotnet/core/deploying/)
+* <xref:host-and-deploy/index>
 
 ## Hosted deployment with multiple Blazor WebAssembly apps
 
@@ -1735,18 +1749,18 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file or rely upon a Visual Studio publish profile (`.pubxml `) with the property set to `false` by default, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
   <SelfContained>false</SelfContained>
   ```
   
   > [!NOTE]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
   
 * Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
 
-  * Option 1: Set the RID in the in the **`Server`** project's project file:
+  * Option 1: Set the RID in the in the **`Server`** project's project file or via a Visual Studio publish profile (`.pubxml`) **Target Runtime**:
   
     ```xml
     <RuntimeIdentifier>{RID}</RuntimeIdentifier>
@@ -1754,13 +1768,17 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     
     In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
     
-    Publish the app in the Release configuration from the **`Server`** project:
+    Publish the app in the Release configuration from the **`Server`** project or publish the app from Visual Studio in the **Release** configuration.
+    
+    Using the .NET CLI:
     
     ```dotnetcli
     dotnet publish -c Release
     ```
     
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project.
+  
+    Using the .NET CLI:
   
     ```dotnetcli
     dotnet publish -c Release /p:RuntimeIdentifier={RID}
@@ -1768,7 +1786,10 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
     
     In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
 
-For more information, see [.NET application publishing overview](/dotnet/core/deploying/).
+For more information, see the following articles:
+
+* [.NET application publishing overview](/dotnet/core/deploying/)
+* <xref:host-and-deploy/index>
 
 ## Hosted deployment with multiple Blazor WebAssembly apps
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -181,7 +181,7 @@ When publishing a hosted Blazor WebAssembly app, some of the options passed to t
 
 The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
 
-Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
+Normally, such a deployment is created with the following .NET CLI command that uses the runtime option (`-r|--runtime`) with the `--no-self-contained` option, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
 
 ```dotnetcli
 dotnet publish -r {RID} --no-self-contained
@@ -1010,7 +1010,7 @@ When publishing a hosted Blazor WebAssembly app, some of the options passed to t
 
 The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
 
-Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
+Normally, such a deployment is created with the following .NET CLI command that uses the runtime option (`-r|--runtime`) with the `--no-self-contained` option, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
 
 ```dotnetcli
 dotnet publish -r {RID} --no-self-contained
@@ -1715,7 +1715,7 @@ When publishing a hosted Blazor WebAssembly app, some of the options passed to t
 
 The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
 
-Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
+Normally, such a deployment is created with the following .NET CLI command that uses the runtime option (`-r|--runtime`) with the `--no-self-contained` option, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
 
 ```dotnetcli
 dotnet publish -r {RID} --no-self-contained

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -179,7 +179,7 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure the deployment for [self-contained](/dotnet/core/deploying/#publish-self-contained) by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
   <SelfContained>false</SelfContained>
@@ -1018,7 +1018,7 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure the deployment for [self-contained](/dotnet/core/deploying/#publish-self-contained) by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
   <SelfContained>false</SelfContained>
@@ -1735,7 +1735,7 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure the deployment for [self-contained](/dotnet/core/deploying/#publish-self-contained) by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
   <SelfContained>false</SelfContained>

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -207,7 +207,7 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
   * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
   
     ```dotnetcli
-    dotnet publish -c Release \p:RuntimeIdentifier={RID}
+    dotnet publish -c Release /p:RuntimeIdentifier={RID}
     ```
     
     In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
@@ -1046,7 +1046,7 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
   * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
   
     ```dotnetcli
-    dotnet publish -c Release \p:RuntimeIdentifier={RID}
+    dotnet publish -c Release /p:RuntimeIdentifier={RID}
     ```
     
     In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
@@ -1763,7 +1763,7 @@ To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable f
   * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project:
   
     ```dotnetcli
-    dotnet publish -c Release \p:RuntimeIdentifier={RID}
+    dotnet publish -c Release /p:RuntimeIdentifier={RID}
     ```
     
     In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -175,6 +175,35 @@ For more information, see the following articles:
 * Deployment to Azure App Service: <xref:tutorials/publish-to-azure-webapp-using-vs>
 * Blazor project templates: <xref:blazor/project-structure>
 
+## Use MSBuild properties for hosted deployment options that apply to all projects
+
+When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
+
+The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as both a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
+
+Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
+
+```dotnetcli
+dotnet publish -r {RID} --no-self-contained
+```
+
+For a hosted Blazor WebAssembly app, use of the preceding command results in a runtime error because the options apply to all of the solution's projects unconditionally. This is a current limitation of the .NET CLI/MSBuild pipeline. To resolve the problem, adopt ***either*** of the following approaches:
+
+* Specify the options as MSBuild properties in the `dotnet publish` command:
+
+  ```dotnetcli
+  dotnet publish /p:RuntimeIdentifier={RID} /p:SelfContained=false
+  ```
+
+* Specify the options as MSBuild properties in the **`Server`** project's project file (`.csproj`):
+
+  ```xml
+  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
+  <SelfContained>false</SelfContained>
+  ```
+
+For more information, see [.NET application publishing overview](/dotnet/core/deploying/).
+
 ## Hosted deployment with multiple Blazor WebAssembly apps
 
 For more information, see <xref:blazor/host-and-deploy/multiple-hosted-webassembly>.
@@ -975,6 +1004,33 @@ For more information, see the following articles:
 * Deployment to Azure App Service: <xref:tutorials/publish-to-azure-webapp-using-vs>
 * Blazor project templates: <xref:blazor/project-structure>
 
+## Use MSBuild properties for hosted deployment options that apply to all projects
+
+When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
+
+The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as both a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
+
+Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
+
+```dotnetcli
+dotnet publish -r {RID} --no-self-contained
+```
+
+For a hosted Blazor WebAssembly app, use of the preceding command results in a runtime error because the options apply to all of the solution's projects unconditionally. This is a current limitation of the .NET CLI/MSBuild pipeline. To resolve the problem, adopt ***either*** of the following approaches:
+
+* Specify the options as MSBuild properties in the `dotnet publish` command:
+
+  ```dotnetcli
+  dotnet publish /p:RuntimeIdentifier={RID} /p:SelfContained=false
+  ```
+
+* Specify the options as MSBuild properties in the **`Server`** project's project file (`.csproj`):
+
+  ```xml
+  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
+  <SelfContained>false</SelfContained>
+  ```
+
 ## Hosted deployment with multiple Blazor WebAssembly apps
 
 For more information, see <xref:blazor/host-and-deploy/multiple-hosted-webassembly>.
@@ -1652,6 +1708,33 @@ For more information, see the following articles:
 * ASP.NET Core app hosting and deployment: <xref:host-and-deploy/index>
 * Deployment to Azure App Service: <xref:tutorials/publish-to-azure-webapp-using-vs>
 * Blazor project templates: <xref:blazor/project-structure>
+
+## Use MSBuild properties for hosted deployment options that apply to all projects
+
+When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
+
+The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as both a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
+
+Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
+
+```dotnetcli
+dotnet publish -r {RID} --no-self-contained
+```
+
+For a hosted Blazor WebAssembly app, use of the preceding command results in a runtime error because the options apply to all of the solution's projects unconditionally. This is a current limitation of the .NET CLI/MSBuild pipeline. To resolve the problem, adopt ***either*** of the following approaches:
+
+* Specify the options as MSBuild properties in the `dotnet publish` command:
+
+  ```dotnetcli
+  dotnet publish /p:RuntimeIdentifier={RID} /p:SelfContained=false
+  ```
+
+* Specify the options as MSBuild properties in the **`Server`** project's project file (`.csproj`):
+
+  ```xml
+  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
+  <SelfContained>false</SelfContained>
+  ```
 
 ## Hosted deployment with multiple Blazor WebAssembly apps
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -179,7 +179,7 @@ For more information, see the following articles:
 
 When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
 
-The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as both a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
+The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
 
 Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
 
@@ -1008,7 +1008,7 @@ For more information, see the following articles:
 
 When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
 
-The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as both a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
+The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
 
 Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
 
@@ -1713,7 +1713,7 @@ For more information, see the following articles:
 
 When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
 
-The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as both a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
+The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
 
 Normally, such a deployment is created with the following .NET CLI command, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -175,32 +175,42 @@ For more information, see the following articles:
 * Deployment to Azure App Service: <xref:tutorials/publish-to-azure-webapp-using-vs>
 * Blazor project templates: <xref:blazor/project-structure>
 
-## Use MSBuild properties for hosted deployment options that apply to all projects
+## Hosted deployment of a framework-dependent executable for a specific platform
 
-When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
+To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
-
-Normally, such a deployment is created with the following .NET CLI command that uses the runtime option (`-r|--runtime`) with the `--no-self-contained` option, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
-
-```dotnetcli
-dotnet publish -r {RID} --no-self-contained
-```
-
-For a hosted Blazor WebAssembly app, use of the preceding command results in a runtime error because the options apply to all of the solution's projects unconditionally. This is a current limitation of the .NET CLI/MSBuild pipeline. To resolve the problem, adopt ***either*** of the following approaches:
-
-* Specify the options as MSBuild properties in the `dotnet publish` command:
-
-  ```dotnetcli
-  dotnet publish /p:RuntimeIdentifier={RID} /p:SelfContained=false
-  ```
-
-* Specify the options as MSBuild properties in the **`Server`** project's project file (`.csproj`):
+* Configure the deployment for [self-contained](/dotnet/core/deploying/#publish-self-contained) by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
-  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
   <SelfContained>false</SelfContained>
   ```
+  
+  > [!NOTE]
+  > The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  
+* Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+
+  * Option 1: Set the RID in the in the **`Server`** project's project file:
+  
+    ```xml
+    <RuntimeIdentifier>{RID}</RuntimeIdentifier>
+    ```
+    
+    In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+    
+    Publish the app in the Release configuration from the **`Server`** project:
+    
+    ```dotnetcli
+    dotnet publish -c Release
+    ```
+    
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
+  
+    ```dotnetcli
+    dotnet publish -c Release \p:RuntimeIdentifier={RID}
+    ```
+    
+    In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
 
 For more information, see [.NET application publishing overview](/dotnet/core/deploying/).
 
@@ -1004,32 +1014,44 @@ For more information, see the following articles:
 * Deployment to Azure App Service: <xref:tutorials/publish-to-azure-webapp-using-vs>
 * Blazor project templates: <xref:blazor/project-structure>
 
-## Use MSBuild properties for hosted deployment options that apply to all projects
+## Hosted deployment of a framework-dependent executable for a specific platform
 
-When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
+To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
-
-Normally, such a deployment is created with the following .NET CLI command that uses the runtime option (`-r|--runtime`) with the `--no-self-contained` option, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
-
-```dotnetcli
-dotnet publish -r {RID} --no-self-contained
-```
-
-For a hosted Blazor WebAssembly app, use of the preceding command results in a runtime error because the options apply to all of the solution's projects unconditionally. This is a current limitation of the .NET CLI/MSBuild pipeline. To resolve the problem, adopt ***either*** of the following approaches:
-
-* Specify the options as MSBuild properties in the `dotnet publish` command:
-
-  ```dotnetcli
-  dotnet publish /p:RuntimeIdentifier={RID} /p:SelfContained=false
-  ```
-
-* Specify the options as MSBuild properties in the **`Server`** project's project file (`.csproj`):
+* Configure the deployment for [self-contained](/dotnet/core/deploying/#publish-self-contained) by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
-  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
   <SelfContained>false</SelfContained>
   ```
+  
+  > [!NOTE]
+  > The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  
+* Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+
+  * Option 1: Set the RID in the in the **`Server`** project's project file:
+  
+    ```xml
+    <RuntimeIdentifier>{RID}</RuntimeIdentifier>
+    ```
+    
+    In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+    
+    Publish the app in the Release configuration from the **`Server`** project:
+    
+    ```dotnetcli
+    dotnet publish -c Release
+    ```
+    
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
+  
+    ```dotnetcli
+    dotnet publish -c Release \p:RuntimeIdentifier={RID}
+    ```
+    
+    In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+
+For more information, see [.NET application publishing overview](/dotnet/core/deploying/).
 
 ## Hosted deployment with multiple Blazor WebAssembly apps
 
@@ -1709,32 +1731,44 @@ For more information, see the following articles:
 * Deployment to Azure App Service: <xref:tutorials/publish-to-azure-webapp-using-vs>
 * Blazor project templates: <xref:blazor/project-structure>
 
-## Use MSBuild properties for hosted deployment options that apply to all projects
+## Hosted deployment of a framework-dependent executable for a specific platform
 
-When publishing a hosted Blazor WebAssembly app, some of the options passed to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) result in runtime errors because the option applies to all of the solution's projects unconditionally, both the **`Client`** and the **`Server`** projects in a hosted deployment. Options that exhibit this behavior must be specified using the MSBuild property in the `dotnet publish` command or specified in the **`Server`** project's project file to scope the property correctly.
+To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-The [Runtime Identifier (RID)](/dotnet/core/rid-catalog) falls into this category of options. Consider the following example, where the developer plans to publish a hosted WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained).
-
-Normally, such a deployment is created with the following .NET CLI command that uses the runtime option (`-r|--runtime`) with the `--no-self-contained` option, where the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog):
-
-```dotnetcli
-dotnet publish -r {RID} --no-self-contained
-```
-
-For a hosted Blazor WebAssembly app, use of the preceding command results in a runtime error because the options apply to all of the solution's projects unconditionally. This is a current limitation of the .NET CLI/MSBuild pipeline. To resolve the problem, adopt ***either*** of the following approaches:
-
-* Specify the options as MSBuild properties in the `dotnet publish` command:
-
-  ```dotnetcli
-  dotnet publish /p:RuntimeIdentifier={RID} /p:SelfContained=false
-  ```
-
-* Specify the options as MSBuild properties in the **`Server`** project's project file (`.csproj`):
+* Configure the deployment for [self-contained](/dotnet/core/deploying/#publish-self-contained) by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
 
   ```xml
-  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
   <SelfContained>false</SelfContained>
   ```
+  
+  > [!NOTE]
+  > The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  
+* Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+
+  * Option 1: Set the RID in the in the **`Server`** project's project file:
+  
+    ```xml
+    <RuntimeIdentifier>{RID}</RuntimeIdentifier>
+    ```
+    
+    In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+    
+    Publish the app in the Release configuration from the **`Server`** project:
+    
+    ```dotnetcli
+    dotnet publish -c Release
+    ```
+    
+  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
+  
+    ```dotnetcli
+    dotnet publish -c Release \p:RuntimeIdentifier={RID}
+    ```
+    
+    In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+
+For more information, see [.NET application publishing overview](/dotnet/core/deploying/).
 
 ## Hosted deployment with multiple Blazor WebAssembly apps
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -179,14 +179,17 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file or rely upon a Visual Studio publish profile (`.pubxml `) with the property set to `false` by default, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment using either of the following approaches:
+
+  * Place the `<SelfContained>` MSBuild property in the **`Server`** project's project file set to `false`.
+  * Use a Visual Studio publish profile (`.pubxml `) with the property set to `false`, which is the default setting for a generated publish profile.
 
   ```xml
   <SelfContained>false</SelfContained>
   ```
   
-  > [!NOTE]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  > [!IMPORTANT]
+  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
   
 * Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
 
@@ -1025,14 +1028,17 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file or rely upon a Visual Studio publish profile (`.pubxml `) with the property set to `false` by default, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment using either of the following approaches:
+
+  * Place the `<SelfContained>` MSBuild property in the **`Server`** project's project file set to `false`.
+  * Use a Visual Studio publish profile (`.pubxml `) with the property set to `false`, which is the default setting for a generated publish profile.
 
   ```xml
   <SelfContained>false</SelfContained>
   ```
   
-  > [!NOTE]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  > [!IMPORTANT]
+  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
   
 * Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
 
@@ -1749,14 +1755,17 @@ For more information, see the following articles:
 
 To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in the **`Server`** project's project file or rely upon a Visual Studio publish profile (`.pubxml `) with the property set to `false` by default, ***not*** by passing the `--no-self-contained` option to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish):
+* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment using either of the following approaches:
+
+  * Place the `<SelfContained>` MSBuild property in the **`Server`** project's project file set to `false`.
+  * Use a Visual Studio publish profile (`.pubxml `) with the property set to `false`, which is the default setting for a generated publish profile.
 
   ```xml
   <SelfContained>false</SelfContained>
   ```
   
-  > [!NOTE]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be passed to the `dotnet publish` command as `/p:SelfContained=false`.
+  > [!IMPORTANT]
+  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
   
 * Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -177,47 +177,62 @@ For more information, see the following articles:
 
 ## Hosted deployment of a framework-dependent executable for a specific platform
 
-To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
+To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained) use the following guidance based on the tooling in use.
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment using either of the following approaches:
+### Visual Studio
 
-  * Place the `<SelfContained>` MSBuild property in the **`Server`** project's project file set to `false`.
-  * Use a Visual Studio publish profile (`.pubxml `) with the property set to `false`, which is the default setting for a generated publish profile.
+By default, a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment is configured for a generated publish profile (`.pubxml`). Confirm that the **`Server`** project's publish profile contains the `<SelfContained>` MSBuild property set to `false`.
 
+In the `.pubxml` publish profile file in the **`Server`** project's `Properties` folder:
+
+```xml
+<SelfContained>false</SelfContained>
+```
+
+Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using the **Target Runtime** setting in the **Settings** area of the **Publish** UI, which generates the `<RuntimeIdentifier>` MSBuild property in the publish profile:
+  
+```xml
+<RuntimeIdentifier>{RID}</RuntimeIdentifier>
+```
+
+In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+
+Publish the **`Server`** project in the **Release** configuration.
+
+### .NET CLI
+
+Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in a `<PropertyGroup>` in the **`Server`** project's project file set to `false`:
+
+```xml
+<SelfContained>false</SelfContained>
+```
+
+> [!IMPORTANT]
+> The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
+  
+Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+
+* Option 1: Set the RID in a `<PropertyGroup>` in the **`Server`** project's project file:
+  
   ```xml
-  <SelfContained>false</SelfContained>
+  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
   ```
+    
+  In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
   
-  > [!IMPORTANT]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
-  
-* Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+  Publish the app in the Release configuration from the **`Server`** project:
+    
+  ```dotnetcli
+   dotnet publish -c Release
+  ```
 
-  * Option 1: Set the RID in the in the **`Server`** project's project file or via a Visual Studio publish profile (`.pubxml`) **Target Runtime**:
+* Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
   
-    ```xml
-    <RuntimeIdentifier>{RID}</RuntimeIdentifier>
-    ```
+  ```dotnetcli
+  dotnet publish -c Release /p:RuntimeIdentifier={RID}
+  ```
     
-    In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
-    
-    Publish the app in the Release configuration from the **`Server`** project or publish the app from Visual Studio in the **Release** configuration.
-    
-    Using the .NET CLI:
-    
-    ```dotnetcli
-    dotnet publish -c Release
-    ```
-    
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project.
-  
-    Using the .NET CLI:
-  
-    ```dotnetcli
-    dotnet publish -c Release /p:RuntimeIdentifier={RID}
-    ```
-    
-    In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+  In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
 
 For more information, see the following articles:
 
@@ -1026,47 +1041,62 @@ For more information, see the following articles:
 
 ## Hosted deployment of a framework-dependent executable for a specific platform
 
-To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
+To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained) use the following guidance based on the tooling in use.
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment using either of the following approaches:
+### Visual Studio
 
-  * Place the `<SelfContained>` MSBuild property in the **`Server`** project's project file set to `false`.
-  * Use a Visual Studio publish profile (`.pubxml `) with the property set to `false`, which is the default setting for a generated publish profile.
+By default, a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment is configured for a generated publish profile (`.pubxml`). Confirm that the **`Server`** project's publish profile contains the `<SelfContained>` MSBuild property set to `false`.
 
+In the `.pubxml` publish profile file in the **`Server`** project's `Properties` folder:
+
+```xml
+<SelfContained>false</SelfContained>
+```
+
+Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using the **Target Runtime** setting in the **Settings** area of the **Publish** UI, which generates the `<RuntimeIdentifier>` MSBuild property in the publish profile:
+  
+```xml
+<RuntimeIdentifier>{RID}</RuntimeIdentifier>
+```
+
+In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+
+Publish the **`Server`** project in the **Release** configuration.
+
+### .NET CLI
+
+Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in a `<PropertyGroup>` in the **`Server`** project's project file set to `false`:
+
+```xml
+<SelfContained>false</SelfContained>
+```
+
+> [!IMPORTANT]
+> The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
+  
+Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+
+* Option 1: Set the RID in a `<PropertyGroup>` in the **`Server`** project's project file:
+  
   ```xml
-  <SelfContained>false</SelfContained>
+  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
   ```
+    
+  In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
   
-  > [!IMPORTANT]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
-  
-* Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+  Publish the app in the Release configuration from the **`Server`** project:
+    
+  ```dotnetcli
+   dotnet publish -c Release
+  ```
 
-  * Option 1: Set the RID in the in the **`Server`** project's project file or via a Visual Studio publish profile (`.pubxml`) **Target Runtime**:
+* Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
   
-    ```xml
-    <RuntimeIdentifier>{RID}</RuntimeIdentifier>
-    ```
+  ```dotnetcli
+  dotnet publish -c Release /p:RuntimeIdentifier={RID}
+  ```
     
-    In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
-    
-    Publish the app in the Release configuration from the **`Server`** project or publish the app from Visual Studio in the **Release** configuration.
-    
-    Using the .NET CLI:
-    
-    ```dotnetcli
-    dotnet publish -c Release
-    ```
-    
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project.
-  
-    Using the .NET CLI:
-  
-    ```dotnetcli
-    dotnet publish -c Release /p:RuntimeIdentifier={RID}
-    ```
-    
-    In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+  In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
 
 For more information, see the following articles:
 
@@ -1753,47 +1783,62 @@ For more information, see the following articles:
 
 ## Hosted deployment of a framework-dependent executable for a specific platform
 
-To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained):
+To deploy a hosted Blazor WebAssembly app as a [framework-dependent executable for a specific platform](/dotnet/core/deploying/#publish-framework-dependent) (not self-contained) use the following guidance based on the tooling in use.
 
-* Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment using either of the following approaches:
+### Visual Studio
 
-  * Place the `<SelfContained>` MSBuild property in the **`Server`** project's project file set to `false`.
-  * Use a Visual Studio publish profile (`.pubxml `) with the property set to `false`, which is the default setting for a generated publish profile.
+By default, a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment is configured for a generated publish profile (`.pubxml`). Confirm that the **`Server`** project's publish profile contains the `<SelfContained>` MSBuild property set to `false`.
 
+In the `.pubxml` publish profile file in the **`Server`** project's `Properties` folder:
+
+```xml
+<SelfContained>false</SelfContained>
+```
+
+Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using the **Target Runtime** setting in the **Settings** area of the **Publish** UI, which generates the `<RuntimeIdentifier>` MSBuild property in the publish profile:
+  
+```xml
+<RuntimeIdentifier>{RID}</RuntimeIdentifier>
+```
+
+In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+
+Publish the **`Server`** project in the **Release** configuration.
+
+### .NET CLI
+
+Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in a `<PropertyGroup>` in the **`Server`** project's project file set to `false`:
+
+```xml
+<SelfContained>false</SelfContained>
+```
+
+> [!IMPORTANT]
+> The `SelfContained` property must be placed in the **`Server`** project's project file. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
+  
+Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+
+* Option 1: Set the RID in a `<PropertyGroup>` in the **`Server`** project's project file:
+  
   ```xml
-  <SelfContained>false</SelfContained>
+  <RuntimeIdentifier>{RID}</RuntimeIdentifier>
   ```
+    
+  In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
   
-  > [!IMPORTANT]
-  > The `SelfContained` property must be placed in the **`Server`** project's project file or the Visual Studio publish profile. The property can't be set correctly with the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) using the `--no-self-contained` option or the MSBuild property `/p:SelfContained=false`.
-  
-* Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using ***either*** of the following approaches:
+  Publish the app in the Release configuration from the **`Server`** project:
+    
+  ```dotnetcli
+   dotnet publish -c Release
+  ```
 
-  * Option 1: Set the RID in the in the **`Server`** project's project file or via a Visual Studio publish profile (`.pubxml`) **Target Runtime**:
+* Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option:
   
-    ```xml
-    <RuntimeIdentifier>{RID}</RuntimeIdentifier>
-    ```
+  ```dotnetcli
+  dotnet publish -c Release /p:RuntimeIdentifier={RID}
+  ```
     
-    In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
-    
-    Publish the app in the Release configuration from the **`Server`** project or publish the app from Visual Studio in the **Release** configuration.
-    
-    Using the .NET CLI:
-    
-    ```dotnetcli
-    dotnet publish -c Release
-    ```
-    
-  * Option 2: Pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) as the MSBuild property (`/p:RuntimeIdentifier`), ***not*** with the `-r|--runtime` option. Publish the app from the **`Server`** project.
-  
-    Using the .NET CLI:
-  
-    ```dotnetcli
-    dotnet publish -c Release /p:RuntimeIdentifier={RID}
-    ```
-    
-    In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
+  In the preceding command, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
 
 For more information, see the following articles:
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -199,6 +199,9 @@ In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifi
 
 Publish the **`Server`** project in the **Release** configuration.
 
+> [!NOTE]
+> It's possible to publish an app with publish profile settings using the .NET CLI by passing `/p:PublishProfile={PROFILE}` to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish), where the `{PROFILE}` placeholder is the profile. For more information, see the *Publish profiles* and *Folder publish example* sections in the <xref:host-and-deploy/visual-studio-publish-profiles#publish-profiles> article. If you pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) and not in the publish profile, use the MSBuild property (`/p:RuntimeIdentifier`) with the command, ***not*** with the `-r|--runtime` option.
+
 ### .NET CLI
 
 Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in a `<PropertyGroup>` in the **`Server`** project's project file set to `false`:
@@ -1063,6 +1066,9 @@ In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifi
 
 Publish the **`Server`** project in the **Release** configuration.
 
+> [!NOTE]
+> It's possible to publish an app with publish profile settings using the .NET CLI by passing `/p:PublishProfile={PROFILE}` to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish), where the `{PROFILE}` placeholder is the profile. For more information, see the *Publish profiles* and *Folder publish example* sections in the <xref:host-and-deploy/visual-studio-publish-profiles#publish-profiles> article. If you pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) and not in the publish profile, use the MSBuild property (`/p:RuntimeIdentifier`) with the command, ***not*** with the `-r|--runtime` option.
+
 ### .NET CLI
 
 Configure a [self-contained](/dotnet/core/deploying/#publish-self-contained) deployment by placing the `<SelfContained>` MSBuild property in a `<PropertyGroup>` in the **`Server`** project's project file set to `false`:
@@ -1804,6 +1810,9 @@ Set the [Runtime Identifier (RID)](/dotnet/core/rid-catalog) using the **Target 
 In the preceding configuration, the `{RID}` placeholder is the [Runtime Identifier (RID)](/dotnet/core/rid-catalog).
 
 Publish the **`Server`** project in the **Release** configuration.
+
+> [!NOTE]
+> It's possible to publish an app with publish profile settings using the .NET CLI by passing `/p:PublishProfile={PROFILE}` to the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish), where the `{PROFILE}` placeholder is the profile. For more information, see the *Publish profiles* and *Folder publish example* sections in the <xref:host-and-deploy/visual-studio-publish-profiles#publish-profiles> article. If you pass the RID in the [`dotnet publish` command](/dotnet/core/tools/dotnet-publish) and not in the publish profile, use the MSBuild property (`/p:RuntimeIdentifier`) with the command, ***not*** with the `-r|--runtime` option.
 
 ### .NET CLI
 


### PR DESCRIPTION
Fixes #26619

@yugabe ... Are you free to take a look 👀 at this?

btw -- You'll see three copies of the section. You only need to look at the first because they're identical. We duplicate them to cover different release versions in the same article.

The new section for the WASM deployment doc seeks to address both the general scenario for any given MSBuild property that's applied to both projects of a hosted WASM solution and specifically for your use case scenario (framework-dependent executable for a specific platform), which I show as the example.

You (and Javier) didn't state that there was a limitation on the self-contained deployment option (as `false`) to the project file. You did state that ...

> Disabling SCD from the CLI breaks the build altogether.

... but you may have meant by way of `--no-self-contained`, which seems like it would 💥 based on Javier's explanation. I came away with the impression that `SelfContained` can also be stated as an MSBuild option (`/p:`) in a similar fashion to the RID to meet your needs ...

```dotnetcli
dotnet publish /p:RuntimeIdentifier={RID} /p:SelfContained=false
```

However, let me know if you tried that in your testing and it failed. If so, then we'll need to figure that out as an additional complication here. I may need to work on this a bit further with Javier's help. I'm trying to avoid pinging him due to the high .NET 7 product unit workload at this time. If this all looks good, then we can proceed. I'll take further reader feedback on it.