### PR TITLE
fix: `props` is initialized but never used

### DIFF
--- a/aspnetcore/security/authentication/social/additional-claims/samples/6.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/aspnetcore/security/authentication/social/additional-claims/samples/6.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable disable
 
@@ -266,7 +266,7 @@ namespace WebGoogOauth.Areas.Identity.Pages.Account
                             return RedirectToPage("./RegisterConfirmation", new { Email = Input.Email });
                         }
 
-                        await _signInManager.SignInAsync(user, isPersistent: false, info.LoginProvider);
+                        await _signInManager.SignInAsync(user, props, info.LoginProvider);
                         return LocalRedirect(returnUrl);
                     }
                 }


### PR DESCRIPTION
The `props` variable which holds the authentication tokens from the external provider, is initialized in line 247 but never actually used. Changed line 269 to use it.

Fixes #26651
