### PR TITLE
fix: `props` is initialized but never used

### DIFF
--- a/aspnetcore/security/authentication/social/additional-claims.md
+++ b/aspnetcore/security/authentication/social/additional-claims.md
@@ -88,7 +88,7 @@ When `OnPostConfirmationAsync` executes, store the access token ([ExternalLoginI
 
 The sample app saves the access token in `OnPostConfirmationAsync` (new user registration) and `OnGetCallbackAsync` (previously registered user) in `Account/ExternalLogin.cshtml.cs`:
 
-[!code-csharp[](additional-claims/samples/6.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs?name=snippet_OnPostConfirmationAsync&highlight=49-53)]
+[!code-csharp[](additional-claims/samples/6.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs?name=snippet_OnPostConfirmationAsync&highlight=49-53,73)]
 
 > [!NOTE]
 > For information on passing tokens to the Razor components of a Blazor Server app, see <xref:blazor/security/server/additional-scenarios#pass-tokens-to-a-blazor-server-app>.

--- a/aspnetcore/security/authentication/social/additional-claims/samples/6.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/aspnetcore/security/authentication/social/additional-claims/samples/6.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -266,7 +266,7 @@ namespace WebGoogOauth.Areas.Identity.Pages.Account
                             return RedirectToPage("./RegisterConfirmation", new { Email = Input.Email });
                         }
 
-                        await _signInManager.SignInAsync(user, isPersistent: false, info.LoginProvider);
+                        await _signInManager.SignInAsync(user, props, info.LoginProvider);
                         return LocalRedirect(returnUrl);
                     }
                 }

--- a/aspnetcore/security/authentication/social/additional-claims/samples/6.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
+++ b/aspnetcore/security/authentication/social/additional-claims/samples/6.x/ClaimsSample/Areas/Identity/Pages/Account/ExternalLogin.cshtml.cs
@@ -246,7 +246,7 @@ namespace WebGoogOauth.Areas.Identity.Pages.Account
                         // using Microsoft.AspNetCore.Authentication;
                         var props = new AuthenticationProperties();
                         props.StoreTokens(info.AuthenticationTokens);
-                        props.IsPersistent = true;
+                        props.IsPersistent = false;
 
                         var userId = await _userManager.GetUserIdAsync(user);
                         var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);


### PR DESCRIPTION
The `props` variable which holds the authentication tokens from the external provider, is initialized in line 247 but never actually used. Changed line 269 to use it.

Fixes #26651
