### PR TITLE
Use relative cross-link to Azure doc

### DIFF
--- a/aspnetcore/test/troubleshoot-azure-iis.md
+++ b/aspnetcore/test/troubleshoot-azure-iis.md
@@ -853,7 +853,7 @@ For more information, see <xref:host-and-deploy/iis/logging-and-diagnostics#enha
 When an app responds slowly or hangs on a request, see the following articles:
 
 * [Troubleshoot slow web app performance issues in Azure App Service](/azure/app-service/app-service-web-troubleshoot-performance-degradation)
-* [Use Crash Diagnoser Site Extension to Capture Dump for Intermittent Exception issues or performance issues on Azure Web App](https://docs.microsoft.com/azure/app-service/troubleshoot-performance-degradation)
+* [Use Crash Diagnoser Site Extension to Capture Dump for Intermittent Exception issues or performance issues on Azure Web App](/azure/app-service/troubleshoot-performance-degradation)
 
 ### Monitoring blades
 


### PR DESCRIPTION
FYI @Rick-Anderson ... This came up on a build report for a Blazor code example that I was fixing on another PR ...

> aspnetcore/test/troubleshoot-azure-iis.md
>
> Absolute link 'https://docs.microsoft.com/azure/app-service/troubleshoot-performance-degradation' will be broken in isolated environments. Replace with a relative link.

Patching it up here. 🏃