### PR TITLE
Non-Development static files for Blazor Server

### DIFF
--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -16,6 +16,8 @@ This article explains [ASP.NET Core environments](xref:fundamentals/environments
 
 > [!IMPORTANT]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
+>
+> For Blazor Server app configuration for static files in environments other than the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment during development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), see <xref:blazor/fundamentals/static-files#static-files-in-non-development-environments-for-blazor-server-apps>.
 
 When running an app locally, the environment defaults to `Development`. When the app is published, the environment defaults to `Production`.
 
@@ -154,6 +156,8 @@ The <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEn
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
+>
+> For Blazor Server app configuration for static files in environments other than the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment during development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), see <xref:blazor/fundamentals/static-files#static-files-in-non-development-environments-for-blazor-server-apps>.
 
 When running an app locally, the environment defaults to `Development`. When the app is published, the environment defaults to `Production`.
 
@@ -292,6 +296,8 @@ The <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEn
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
+>
+> For Blazor Server app configuration for static files in environments other than the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment during development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), see <xref:blazor/fundamentals/static-files#static-files-in-non-development-environments-for-blazor-server-apps>.
 
 When running an app locally, the environment defaults to `Development`. When the app is published, the environment defaults to `Production`.
 
@@ -403,6 +409,8 @@ The <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEn
 
 > [!IMPORTANT]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
+>
+> For Blazor Server app configuration for static files in environments other than the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment during development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), see <xref:blazor/fundamentals/static-files#static-files-in-non-development-environments-for-blazor-server-apps>.
 
 When running an app locally, the environment defaults to `Development`. When the app is published, the environment defaults to `Production`.
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -296,8 +296,6 @@ The <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEn
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
->
-> For Blazor Server app configuration for static files in environments other than the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment during development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), see <xref:blazor/fundamentals/static-files#static-files-in-non-development-environments-for-blazor-server-apps>.
 
 When running an app locally, the environment defaults to `Development`. When the app is published, the environment defaults to `Production`.
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -296,6 +296,8 @@ The <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEn
 
 > [!NOTE]
 > This topic applies to Blazor WebAssembly. For general guidance on ASP.NET Core app configuration, which describes the approaches to use for Blazor Server apps, see <xref:fundamentals/environments>.
+>
+> For Blazor Server app configuration for static files in environments other than the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment during development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), see <xref:blazor/fundamentals/static-files#static-files-in-non-development-environments-for-blazor-server-apps>.
 
 When running an app locally, the environment defaults to `Development`. When the app is published, the environment defaults to `Production`.
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -145,18 +145,20 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 
 In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`.
 
-<!--
-
 > [!WARNING]
-> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it by testing for non-`Production` environments (`xxxxxxxx`) to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.AspNetCore.Hosting.HostingEnvironmentExtensions.IsStaging%2A>.
+> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it by testing for non-`Production` environments to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment.
 
--->
 
 ```csharp
 Host.CreateDefaultBuilder(args)
     .ConfigureWebHostDefaults(webBuilder =>
     {
-        webBuilder.UseStaticWebAssets();
+        if (webBuilder.GetSetting(WebHostDefaults.EnvironmentKey) == 
+            Environments.Staging)
+        {
+            webBuilder.UseStaticWebAssets();
+        }
+
         webBuilder.UseStartup<Startup>();
     });
 ```
@@ -266,28 +268,6 @@ app.UseStaticFiles("/static");
 ```
 
 For more information, see <xref:fundamentals/static-files>.
-
-## Static files in non-`Development` environments for Blazor Server apps
-
-*This section applies to Blazor Server apps.*
-
-In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`.
-
-<!--
-
-> [!WARNING]
-> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it by testing for non-`Production` environments (`xxxxxxxx`) to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.AspNetCore.Hosting.HostingEnvironmentExtensions.IsStaging%2A>.
-
--->
-
-```csharp
-Host.CreateDefaultBuilder(args)
-    .ConfigureWebHostDefaults(webBuilder =>
-    {
-        webBuilder.UseStaticWebAssets();
-        webBuilder.UseStartup<Startup>();
-    });
-```
 
 ## Static web asset base path
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -140,11 +140,12 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`:
 
 ```csharp
-Host.ConfigureWebHostDefaults(webBuilder =>
-{
-    webBuilder.UseStaticWebAssets();    
-    webBuilder.UseStartup<Startup>();
-})
+Host.CreateDefaultBuilder(args)
+    .ConfigureWebHostDefaults(webBuilder =>
+    {
+        webBuilder.UseStaticWebAssets();
+        webBuilder.UseStartup<Startup>();
+    });
 ```
 
 ## Static web asset base path
@@ -252,6 +253,21 @@ app.UseStaticFiles("/static");
 ```
 
 For more information, see <xref:fundamentals/static-files>.
+
+## Static files in non-`Development` environments for Blazor Server apps
+
+*This section applies to Blazor Server apps.*
+
+In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`:
+
+```csharp
+Host.CreateDefaultBuilder(args)
+    .ConfigureWebHostDefaults(webBuilder =>
+    {
+        webBuilder.UseStaticWebAssets();
+        webBuilder.UseStartup<Startup>();
+    });
+```
 
 ## Static web asset base path
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -26,10 +26,16 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 
 *This section applies to Blazor Server apps.*
 
-In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> in `Program.cs`:
+In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> in `Program.cs`.
+
+> [!WARNING]
+> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it after testing for non-`Production` environments (for example, `!builder.Environment.IsProduction()`) to prevent activating the feature in production, as it serves files from separate locations on disk *other than from the project*. The example in this section checks for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsStaging%2A>.
 
 ```csharp
-builder.WebHost.UseStaticWebAssets();
+if (builder.Environment.IsStaging())
+{
+    builder.WebHost.UseStaticWebAssets();
+}
 ```
 
 ## Static web asset base path
@@ -137,7 +143,14 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 
 *This section applies to Blazor Server apps.*
 
-In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`:
+In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`.
+
+<!--
+
+> [!WARNING]
+> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it by testing for non-`Production` environments (`xxxxxxxx`) to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.AspNetCore.Hosting.HostingEnvironmentExtensions.IsStaging%2A>.
+
+-->
 
 ```csharp
 Host.CreateDefaultBuilder(args)
@@ -258,7 +271,14 @@ For more information, see <xref:fundamentals/static-files>.
 
 *This section applies to Blazor Server apps.*
 
-In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`:
+In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`.
+
+<!--
+
+> [!WARNING]
+> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it by testing for non-`Production` environments (`xxxxxxxx`) to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.AspNetCore.Hosting.HostingEnvironmentExtensions.IsStaging%2A>.
+
+-->
 
 ```csharp
 Host.CreateDefaultBuilder(args)

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -29,7 +29,7 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 In Blazor Server apps run locally, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> in `Program.cs`.
 
 > [!WARNING]
-> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** to prevent activating the feature in production, as it serves files from separate locations on disk *other than from the project*. The example in this section checks for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsStaging%2A>.
+> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** to prevent activating the feature in production, as it serves files from separate locations on disk *other than from the project* if called in a production environment. The example in this section checks for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsStaging%2A>.
 
 ```csharp
 if (builder.Environment.IsStaging())
@@ -146,7 +146,7 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 In Blazor Server apps run locally, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`.
 
 > [!WARNING]
-> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment.
+> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project* if called in a production environment. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment.
 
 
 ```csharp

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -26,7 +26,7 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 
 *This section applies to Blazor Server apps.*
 
-In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> in `Program.cs`.
+In Blazor Server apps run locally, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> in `Program.cs`.
 
 > [!WARNING]
 > Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it after testing for non-`Production` environments (for example, `!builder.Environment.IsProduction()`) to prevent activating the feature in production, as it serves files from separate locations on disk *other than from the project*. The example in this section checks for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsStaging%2A>.
@@ -143,7 +143,7 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 
 *This section applies to Blazor Server apps.*
 
-In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`.
+In Blazor Server apps run locally, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`.
 
 > [!WARNING]
 > Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it by testing for non-`Production` environments to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment.

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -29,7 +29,7 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 In Blazor Server apps run locally, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> in `Program.cs`.
 
 > [!WARNING]
-> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it after testing for non-`Production` environments (for example, `!builder.Environment.IsProduction()`) to prevent activating the feature in production, as it serves files from separate locations on disk *other than from the project*. The example in this section checks for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsStaging%2A>.
+> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** to prevent activating the feature in production, as it serves files from separate locations on disk *other than from the project*. The example in this section checks for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment by calling <xref:Microsoft.Extensions.Hosting.HostEnvironmentEnvExtensions.IsStaging%2A>.
 
 ```csharp
 if (builder.Environment.IsStaging())
@@ -146,7 +146,7 @@ Configure Static File Middleware to serve static assets to clients by calling <x
 In Blazor Server apps run locally, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`.
 
 > [!WARNING]
-> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** or call it by testing for non-`Production` environments to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment.
+> Call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> for the ***exact environment*** to prevent activating the feature in production, as it serves files from separate locations on disk *other than the project*. The example in this section checks explicitly for the <xref:Microsoft.Extensions.Hosting.Environments.Staging> environment.
 
 
 ```csharp

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -22,6 +22,16 @@ For more information on *solutions* in sections that apply to hosted Blazor WebA
 
 Configure Static File Middleware to serve static assets to clients by calling <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> in the app's request processing pipeline. For more information, see <xref:fundamentals/static-files>.
 
+## Static files in non-`Development` environments for Blazor Server apps
+
+*This section applies to Blazor Server apps.*
+
+In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> in `Program.cs`:
+
+```csharp
+builder.WebHost.UseStaticWebAssets();
+```
+
 ## Static web asset base path
 
 *This section applies to standalone Blazor WebAssembly apps and hosted Blazor WebAssembly solutions.*
@@ -122,6 +132,20 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
 *This section applies to Blazor Server apps and the `**Server**` app of a hosted Blazor WebAssembly solution.*
 
 Configure Static File Middleware to serve static assets to clients by calling <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> in the app's request processing pipeline. For more information, see <xref:fundamentals/static-files>.
+
+## Static files in non-`Development` environments for Blazor Server apps
+
+*This section applies to Blazor Server apps.*
+
+In Blazor Server apps, static web assets are only enabled by default in the <xref:Microsoft.Extensions.Hosting.Environments.Development> environment. To enable static files for environments other than <xref:Microsoft.Extensions.Hosting.Environments.Development> during local development and testing (for example, <xref:Microsoft.Extensions.Hosting.Environments.Staging>), call <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderExtensions.UseStaticWebAssets%2A> on the <xref:Microsoft.AspNetCore.Hosting.IWebHostBuilder> in `Program.cs`:
+
+```csharp
+Host.ConfigureWebHostDefaults(webBuilder =>
+{
+    webBuilder.UseStaticWebAssets();    
+    webBuilder.UseStartup<Startup>();
+})
+```
 
 ## Static web asset base path
 


### PR DESCRIPTION
Fixes #26751

[Internal Review Topic (links to 7.0 section)](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?view=aspnetcore-7.0&branch=pr-en-us-26759#static-files-in-non-development-environments-for-blazor-server-apps)

cc: @captainsafia ... Idk if you want to look 👀 at this given your participation in the PU discussion. I'll ping Halter for review; but of course, you're very welcome to help me with this. I didn't see a final summary set of suggestions for *all versions*, including 3.1 (which I think is the same as 5.0), at the end of the PU discussions **_from the PU engineers_**.

Thanks @KurtP20! 🚀 

cc: @voroninp ... I see that you asked about documenting this on [another PU issue](https://github.com/dotnet/aspnetcore/issues/43110). It's being worked on here for the docs.

I'm using a modified version of your, @KurtP20, approach for 5.0 ...

```csharp
Host.CreateDefaultBuilder(args)
    .ConfigureWebHostDefaults(webBuilder =>
    {
        if (webBuilder.GetSetting(WebHostDefaults.EnvironmentKey) == Environments.Staging)
        {
            webBuilder.UseStaticWebAssets();
        }

        webBuilder.UseStartup<Startup>();
    });
```

**❓for the PU: _Can I copy that approach back for 3.1 coverage on this, or should I just go with 5.0 and later coverage?_**

For 6.0 or later, the new guidance goes with ...

```csharp
if (builder.Environment.IsStaging())
{
    builder.WebHost.UseStaticWebAssets();
}
```

The PU discussions and the PR related to this docs PR ...

* https://github.com/dotnet/aspnetcore/issues/39596#issuecomment-1015279408
* https://github.com/dotnet/aspnetcore/issues/38212
* https://github.com/dotnet/aspnetcore/pull/41182
* https://github.com/dotnet/aspnetcore/issues/43110