### PR TITLE
Blazor WASM Options configuration guidance

### DIFF
--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -235,6 +235,21 @@ Configuration files are cached for offline use. With [Progressive Web Applicatio
 
 For more information on how background updates are handled by PWAs, see <xref:blazor/progressive-web-app#background-updates>.
 
+## Options configuration
+
+[Options configuration](xref:fundamentals/configuration/options) for Blazor WebAssembly apps requires adding a package reference for the [`Microsoft.Extensions.Options.ConfigurationExtensions`](https://www.nuget.org/packages/Microsoft.Extensions.Options.ConfigurationExtensions) NuGet package.
+
+[!INCLUDE[](~/includes/package-reference.md)]
+
+Example:
+
+```csharp
+builder.Services.Configure<MyOptions>(
+    builder.Configuration.GetSection("MyOptions"));
+```
+
+Not all of the ASP.NET Core Options features are supported in Razor components. For example, <xref:Microsoft.Extensions.Options.IOptionsSnapshot%601> and <xref:Microsoft.Extensions.Options.IOptionsMonitor%601> configuration is supported, but recomputing option values for these interfaces aren't supported outside of reloading the app by either requesting the app in a new browser tab or selecting the browser's reload button. Merely calling [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes-statehaschanged) doesn't update snapshot or monitored option values when the underlying configuration changes.
+
 :::moniker-end
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
@@ -467,6 +482,21 @@ Configuration files are cached for offline use. With [Progressive Web Applicatio
 
 For more information on how background updates are handled by PWAs, see <xref:blazor/progressive-web-app#background-updates>.
 
+## Options configuration
+
+[Options configuration](xref:fundamentals/configuration/options) for Blazor WebAssembly apps requires adding a package reference for the [`Microsoft.Extensions.Options.ConfigurationExtensions`](https://www.nuget.org/packages/Microsoft.Extensions.Options.ConfigurationExtensions) NuGet package.
+
+[!INCLUDE[](~/includes/package-reference.md)]
+
+Example:
+
+```csharp
+builder.Services.Configure<MyOptions>(
+    builder.Configuration.GetSection("MyOptions"));
+```
+
+Not all of the ASP.NET Core Options features are supported in Razor components. For example, <xref:Microsoft.Extensions.Options.IOptionsSnapshot%601> and <xref:Microsoft.Extensions.Options.IOptionsMonitor%601> configuration is supported, but recomputing option values for these interfaces aren't supported outside of reloading the app by either requesting the app in a new browser tab or selecting the browser's reload button. Merely calling [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes-statehaschanged) doesn't update snapshot or monitored option values when the underlying configuration changes.
+
 :::moniker-end
 
 :::moniker range="< aspnetcore-5.0"
@@ -698,5 +728,20 @@ Configuration files are cached for offline use. With [Progressive Web Applicatio
 * The PWA's `service-worker.js` and `service-worker-assets.js` files must be rebuilt on compilation, which signal to the app on the user's next online visit that the app has been redeployed.
 
 For more information on how background updates are handled by PWAs, see <xref:blazor/progressive-web-app#background-updates>.
+
+## Options configuration
+
+[Options configuration](xref:fundamentals/configuration/options) for Blazor WebAssembly apps requires adding a package reference for the [`Microsoft.Extensions.Options.ConfigurationExtensions`](https://www.nuget.org/packages/Microsoft.Extensions.Options.ConfigurationExtensions) NuGet package.
+
+[!INCLUDE[](~/includes/package-reference.md)]
+
+Example:
+
+```csharp
+builder.Services.Configure<MyOptions>(
+    builder.Configuration.GetSection("MyOptions"));
+```
+
+Not all of the ASP.NET Core Options features are supported in Razor components. For example, <xref:Microsoft.Extensions.Options.IOptionsSnapshot%601> and <xref:Microsoft.Extensions.Options.IOptionsMonitor%601> configuration is supported, but recomputing option values for these interfaces aren't supported outside of reloading the app by either requesting the app in a new browser tab or selecting the browser's reload button. Merely calling [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes-statehaschanged) doesn't update snapshot or monitored option values when the underlying configuration changes.
 
 :::moniker-end


### PR DESCRIPTION
Fixes #26439

Thanks @dougclutter! :rocket: ... I managed to reach this during this period before the first .NET 7 release candidate comes out 🏃 .

Pinging Hao for a remark on Options for Razor components. TL;DR from the issue, I can ask here ...

* I didn't test **_every_** Options scenario, but I know that basic config will work. General `IOptions<T>` and named options work as expected. From looking at a product unit issue, it looks like `IPostConfigureOptions` works as it should. 
* Configuration for Options (setting the initial values) can be provided by merely adding a package reference for `Microsoft.Extensions.Options.ConfigurationExtensions` to a WASM app.
* However, the framework doesn't wire up snapshot and monitoring features of Options. All that I can state thus far in the Blazor *Configuration* topic is that there's a lack of support for snapshot and monitored options features. I found an intriguing issue at https://github.com/dotnet/aspnetcore/issues/20092, where you said, "and then only modified if change notifications are setup," that I thought might make the Options recompute features work, but I didn't have any luck tinkering around with a WASM app getting something like Isaac's example code to work.

... so should we go with what's on this PR, or do you have alternative language for what I'm stating here? For example, is there a known way to make snapshot/monitored options recompute **_on the client_** if the `appsettings.json` file were to be changed there?