### PR TITLE
Blazor IIS and subapp hosting

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -53,11 +53,23 @@ Publish locations:
 
 The assets in the folder are deployed to the web server. Deployment might be a manual or automated process depending on the development tools in use.
 
-## IIS Application Pools
+## IIS
+
+To host a Blazor app in IIS, see the following resources:
+
+* IIS hosting
+  * <xref:tutorials/publish-to-iis>
+  * <xref:host-and-deploy/iis/index>
+* <xref:blazor/host-and-deploy/server> (Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) and Azure App Service)
+* IIS sub-application hosting
+  * Follow the guidance in the [App base path](#app-base-path) section for the Blazor app prior to publishing the app. The examples use an app base path of `/CoolApp`.
+  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app takes on a virtual path of the sub-app folder name. For an app that should be hosted with an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site in IIS Manager and the sub-app takes on a virtual path of `/CoolApp`.
 
 Sharing an app pool among ASP.NET Core apps isn't supported, including for Blazor apps. Use one app pool per app when hosting with IIS, and avoid the use of IIS's [virtual directories](/iis/get-started/planning-your-iis-architecture/understanding-sites-applications-and-virtual-directories-on-iis#virtual-directories) for hosting multiple apps.
 
-One or more Blazor WebAssembly apps hosted by an ASP.NET Core app, known as a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly), are supported for ***one*** app pool. However, we don't recommend or support assigning a single app pool to multiple hosted Blazor WebAssembly solutions or in sub-app hosting scenarios. For more information, see <xref:host-and-deploy/iis/advanced#sub-applications>.
+One or more Blazor WebAssembly apps hosted by an ASP.NET Core app, known as a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly), are supported for ***one*** app pool. However, we don't recommend or support assigning a single app pool to multiple hosted Blazor WebAssembly solutions or in sub-app hosting scenarios.
+
+For more information on *solutions*, see <xref:blazor/tooling#visual-studio-solution-file-sln>.
 
 For more information on *solutions*, see <xref:blazor/tooling#visual-studio-solution-file-sln>.
 
@@ -149,7 +161,7 @@ In other hosting scenarios, such as GitHub Pages and IIS sub-apps, the app base 
     }
     ```
     
-    For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>.
+    For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>. For additional information on Blazor app base paths and hosting, see [`<base href="/" />` or base-tag alternative for Blazor MVC integration (dotnet/aspnetcore #43191)](https://github.com/dotnet/aspnetcore/issues/43191#issuecomment-1212156106).
 
 > [!NOTE]
 > When using <xref:Microsoft.AspNetCore.Builder.WebApplication> (see <xref:migration/50-to-60#new-hosting-model>), [`app.UseRouting`](xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A) must be called after `UsePathBase` so that the routing middleware can observe the modified path before matching routes. Otherwise, routes are matched before the path is rewritten by `UsePathBase` as described in the [Middleware Ordering](xref:fundamentals/middleware/index#order) and [Routing](xref:fundamentals/routing) articles.
@@ -201,7 +213,7 @@ Using `CoolApp` as the example:
 
 Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
-For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>.
+For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>. For additional information on Blazor app base paths and hosting, see [`<base href="/" />` or base-tag alternative for Blazor MVC integration (dotnet/aspnetcore #43191)](https://github.com/dotnet/aspnetcore/issues/43191#issuecomment-1212156106).
 
 ## Blazor Server `MapFallbackToPage` configuration
 
@@ -280,11 +292,21 @@ Publish locations:
 
 The assets in the folder are deployed to the web server. Deployment might be a manual or automated process depending on the development tools in use.
 
-## IIS Application Pools
+## IIS
+
+To host a Blazor app in IIS, see the following resources:
+
+* IIS hosting
+  * <xref:tutorials/publish-to-iis>
+  * <xref:host-and-deploy/iis/index>
+* <xref:blazor/host-and-deploy/server> (Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) and Azure App Service)
+* IIS sub-application hosting
+  * Follow the guidance in the [App base path](#app-base-path) section for the Blazor app prior to publishing the app. The examples use an app base path of `/CoolApp`.
+  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app takes on a virtual path of the sub-app folder name. For an app that should be hosted with an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site in IIS Manager and the sub-app takes on a virtual path of `/CoolApp`.
 
 Sharing an app pool among ASP.NET Core apps isn't supported, including for Blazor apps. Use one app pool per app when hosting with IIS, and avoid the use of IIS's [virtual directories](/iis/get-started/planning-your-iis-architecture/understanding-sites-applications-and-virtual-directories-on-iis#virtual-directories) for hosting multiple apps.
 
-One or more Blazor WebAssembly apps hosted by an ASP.NET Core app, known as a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly), are supported for ***one*** app pool. However, we don't recommend or support assigning a single app pool to multiple hosted Blazor WebAssembly solutions or in sub-app hosting scenarios. For more information, see <xref:host-and-deploy/iis/advanced#sub-applications>.
+One or more Blazor WebAssembly apps hosted by an ASP.NET Core app, known as a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly), are supported for ***one*** app pool. However, we don't recommend or support assigning a single app pool to multiple hosted Blazor WebAssembly solutions or in sub-app hosting scenarios.
 
 For more information on *solutions*, see <xref:blazor/tooling#visual-studio-solution-file-sln>.
 
@@ -374,7 +396,7 @@ In other hosting scenarios, such as GitHub Pages and IIS sub-apps, the app base 
     }
     ```
     
-    For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>.
+    For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>. For additional information on Blazor app base paths and hosting, see [`<base href="/" />` or base-tag alternative for Blazor MVC integration (dotnet/aspnetcore #43191)](https://github.com/dotnet/aspnetcore/issues/43191#issuecomment-1212156106).
 
 For a Blazor WebAssembly app with a non-root relative URL path (for example, `<base href="/CoolApp/">`), the app fails to find its resources *when run locally*. To overcome this problem during local development and testing, you can supply a *path base* argument that matches the `href` value of the `<base>` tag at runtime. **Don't include a trailing slash.** To pass the path base argument when running the app locally, execute the `dotnet run` command from the app's directory with the `--pathbase` option:
 
@@ -404,7 +426,7 @@ Using `CoolApp` as the example:
 
 Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
-For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>.
+For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>. For additional information on Blazor app base paths and hosting, see [`<base href="/" />` or base-tag alternative for Blazor MVC integration (dotnet/aspnetcore #43191)](https://github.com/dotnet/aspnetcore/issues/43191#issuecomment-1212156106).
 
 For additional third-party host support:
 
@@ -493,11 +515,21 @@ Publish locations:
 
 The assets in the folder are deployed to the web server. Deployment might be a manual or automated process depending on the development tools in use.
 
-## IIS Application Pools
+## IIS
+
+To host a Blazor app in IIS, see the following resources:
+
+* IIS hosting
+  * <xref:tutorials/publish-to-iis>
+  * <xref:host-and-deploy/iis/index>
+* <xref:blazor/host-and-deploy/server> (Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) and Azure App Service)
+* IIS sub-application hosting
+  * Follow the guidance in the [App base path](#app-base-path) section for the Blazor app prior to publishing the app. The examples use an app base path of `/CoolApp`.
+  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app takes on a virtual path of the sub-app folder name. For an app that should be hosted with an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site in IIS Manager and the sub-app takes on a virtual path of `/CoolApp`.
 
 Sharing an app pool among ASP.NET Core apps isn't supported, including for Blazor apps. Use one app pool per app when hosting with IIS, and avoid the use of IIS's [virtual directories](/iis/get-started/planning-your-iis-architecture/understanding-sites-applications-and-virtual-directories-on-iis#virtual-directories) for hosting multiple apps.
 
-One or more Blazor WebAssembly apps hosted by an ASP.NET Core app, known as a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly), are supported for ***one*** app pool. However, we don't recommend or support assigning a single app pool to multiple hosted Blazor WebAssembly solutions or in sub-app hosting scenarios. For more information, see <xref:host-and-deploy/iis/advanced#sub-applications>.
+One or more Blazor WebAssembly apps hosted by an ASP.NET Core app, known as a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly), are supported for ***one*** app pool. However, we don't recommend or support assigning a single app pool to multiple hosted Blazor WebAssembly solutions or in sub-app hosting scenarios.
 
 For more information on *solutions*, see <xref:blazor/tooling#visual-studio-solution-file-sln>.
 
@@ -587,7 +619,7 @@ In other hosting scenarios, such as GitHub Pages and IIS sub-apps, the app base 
     }
     ```
     
-    For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>.
+    For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>. For additional information on Blazor app base paths and hosting, see [`<base href="/" />` or base-tag alternative for Blazor MVC integration (dotnet/aspnetcore #43191)](https://github.com/dotnet/aspnetcore/issues/43191#issuecomment-1212156106).
 
 For a Blazor WebAssembly app with a non-root relative URL path (for example, `<base href="/CoolApp/">`), the app fails to find its resources *when run locally*. To overcome this problem during local development and testing, you can supply a *path base* argument that matches the `href` value of the `<base>` tag at runtime. **Don't include a trailing slash.** To pass the path base argument when running the app locally, execute the `dotnet run` command from the app's directory with the `--pathbase` option:
 
@@ -617,7 +649,7 @@ Using `CoolApp` as the example:
 
 Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
-For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>.
+For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>. For additional information on Blazor app base paths and hosting, see [`<base href="/" />` or base-tag alternative for Blazor MVC integration (dotnet/aspnetcore #43191)](https://github.com/dotnet/aspnetcore/issues/43191#issuecomment-1212156106).
 
 For additional third-party host support:
 

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -60,10 +60,10 @@ To host a Blazor app in IIS, see the following resources:
 * IIS hosting
   * <xref:tutorials/publish-to-iis>
   * <xref:host-and-deploy/iis/index>
-* <xref:blazor/host-and-deploy/server> (Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) and Azure App Service)
+* <xref:blazor/host-and-deploy/server>: Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) running Windows OS and Azure App Service
 * IIS sub-application hosting
   * Follow the guidance in the [App base path](#app-base-path) section for the Blazor app prior to publishing the app. The examples use an app base path of `/CoolApp`.
-  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app takes on a virtual path of the sub-app folder name. For an app that should be hosted with an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site in IIS Manager and the sub-app takes on a virtual path of `/CoolApp`.
+  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app's folder path under the root site becomes the virtual path of the sub-app. For an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site and the sub-app takes on a virtual path of `/CoolApp`.
 
 Sharing an app pool among ASP.NET Core apps isn't supported, including for Blazor apps. Use one app pool per app when hosting with IIS, and avoid the use of IIS's [virtual directories](/iis/get-started/planning-your-iis-architecture/understanding-sites-applications-and-virtual-directories-on-iis#virtual-directories) for hosting multiple apps.
 
@@ -299,10 +299,10 @@ To host a Blazor app in IIS, see the following resources:
 * IIS hosting
   * <xref:tutorials/publish-to-iis>
   * <xref:host-and-deploy/iis/index>
-* <xref:blazor/host-and-deploy/server> (Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) and Azure App Service)
+* <xref:blazor/host-and-deploy/server>: Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) running Windows OS and Azure App Service
 * IIS sub-application hosting
   * Follow the guidance in the [App base path](#app-base-path) section for the Blazor app prior to publishing the app. The examples use an app base path of `/CoolApp`.
-  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app takes on a virtual path of the sub-app folder name. For an app that should be hosted with an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site in IIS Manager and the sub-app takes on a virtual path of `/CoolApp`.
+  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app's folder path under the root site becomes the virtual path of the sub-app. For an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site and the sub-app takes on a virtual path of `/CoolApp`.
 
 Sharing an app pool among ASP.NET Core apps isn't supported, including for Blazor apps. Use one app pool per app when hosting with IIS, and avoid the use of IIS's [virtual directories](/iis/get-started/planning-your-iis-architecture/understanding-sites-applications-and-virtual-directories-on-iis#virtual-directories) for hosting multiple apps.
 
@@ -522,10 +522,10 @@ To host a Blazor app in IIS, see the following resources:
 * IIS hosting
   * <xref:tutorials/publish-to-iis>
   * <xref:host-and-deploy/iis/index>
-* <xref:blazor/host-and-deploy/server> (Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) and Azure App Service)
+* <xref:blazor/host-and-deploy/server>: Blazor Server apps running on IIS, including IIS with Azure Virtual Machines (VMs) running Windows OS and Azure App Service
 * IIS sub-application hosting
   * Follow the guidance in the [App base path](#app-base-path) section for the Blazor app prior to publishing the app. The examples use an app base path of `/CoolApp`.
-  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app takes on a virtual path of the sub-app folder name. For an app that should be hosted with an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site in IIS Manager and the sub-app takes on a virtual path of `/CoolApp`.
+  * Follow the sub-application configuration guidance in <xref:host-and-deploy/iis/advanced#sub-applications>. The sub-app's folder path under the root site becomes the virtual path of the sub-app. For an app base path of `/CoolApp`, the Blazor app is placed in a folder named `CoolApp` under the root site and the sub-app takes on a virtual path of `/CoolApp`.
 
 Sharing an app pool among ASP.NET Core apps isn't supported, including for Blazor apps. Use one app pool per app when hosting with IIS, and avoid the use of IIS's [virtual directories](/iis/get-started/planning-your-iis-architecture/understanding-sites-applications-and-virtual-directories-on-iis#virtual-directories) for hosting multiple apps.
 


### PR DESCRIPTION
Fixes #26667

Follow-up to #26733.

Thanks @LarsOutzen! :rocket: ... I wasn't able to repro a problem with our current app base path guidance. I tested with both the base path tag (`<base>`) and the `UsePathBase` call, and they both worked for a Blazor Server sub-app. Other than the earlier PR to move the call for adding `UsePathBase` **_first_**, I don't have further changes at this time on the app base path piece.

Idk if you ever got it working in your Umbraco CMS scenario or other IIS config scenario. Perhaps, Umbraco has/had an influence or perhaps your IIS config or steps didn't work out. I also linked the [PU issue remarks that Javier made](https://github.com/dotnet/aspnetcore/issues/43191#issuecomment-1212156106) on that other issue at the bottom of the *App base path* section because that might be helpful to devs in edge cases ... other servers ... 3rd party hosting ... etc. I'm not going to write that up into a formal topic at this time. I'll continue to take feedback tho, and I might decide to do something with his remarks in '23 ... time permitting 🏃‍♂️😅 and if devs report on-going trouble 😈. 

What I **_don't like_** about our current coverage is that it's a bit scatter-🧠😄 on layout. This PR seeks to fix things up ...
 
* The general Blazor IIS guidance will appear in the *Host and Deploy* overview.
* The external IIS docs are cross-linked.
* The app base path section is cross-linked.
* The bits specific to Blazor Server are cross-linked.
* The bullets for the cross-linked content are in the order that the dev should follow.