### PR TITLE
ServerReady event /8

### DIFF
--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -10,7 +10,7 @@ uid: fundamentals/startup
 ---
 # App startup in ASP.NET Core
 
-By [Kirk Larkin](https://twitter.com/serpent5) and [Rick Anderson](https://twitter.com/RickAndMSFT)
+By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 :::moniker range=">= aspnetcore-7.0"
 

--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -12,7 +12,26 @@ uid: fundamentals/startup
 
 By [Kirk Larkin](https://twitter.com/serpent5) and [Rick Anderson](https://twitter.com/RickAndMSFT)
 
-:::moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-7.0"
+
+ASP.NET Core apps created with the web templates contain the application startup code in the `Program.cs` file.
+
+The following app startup code supports:
+
+* [Razor Pages](xref:tutorials/razor-pages/razor-pages-start)
+* [MVC controllers with views](xref:tutorials/first-mvc-app/start-mvc)
+* [Web API with controllers](xref:tutorials/first-web-api)
+* [Minimal APIs](xref:tutorials/min-web-api)
+
+[!code-csharp[](~/fundamentals/startup/6.0_samples/WebAll/Program.cs?name=snippet)]
+
+Apps using [EventSource](/dotnet/api/system.diagnostics.tracing.eventsource) can measure the startup time to understand and optimize startup performance. The [`ServerReady`](https://source.dot.net/#Microsoft.AspNetCore.Hosting/Internal/HostingEventSource.cs,76) event in <xref:Microsoft.AspNetCore.Hosting?displayProperty=fullName> represents the point where the server is ready to respond to requests.
+
+For more information on application startup, see <xref:fundamentals/index>.
+
+:::moniker-end
+
+:::moniker range="> aspnetcore-6.0"
 
 ASP.NET Core apps created with the web templates contain the application startup code in the `Program.cs` file.
 

--- a/aspnetcore/fundamentals/startup.md
+++ b/aspnetcore/fundamentals/startup.md
@@ -31,7 +31,7 @@ For more information on application startup, see <xref:fundamentals/index>.
 
 :::moniker-end
 
-:::moniker range="> aspnetcore-6.0"
+:::moniker range="= aspnetcore-6.0"
 
 ASP.NET Core apps created with the web templates contain the application startup code in the `Program.cs` file.
 

--- a/aspnetcore/release-notes/aspnetcore-7.0.md
+++ b/aspnetcore/release-notes/aspnetcore-7.0.md
@@ -193,6 +193,10 @@ Profiling on high core machines on .NET 6 showed significant contention in one o
 
 In .NET 7, Kestrel's memory pool is partitioned the same way as its I/O queue, which leads to much lower contention and higher throughput on high core machines. On the 80 core ARM64 VMs, we're seeing over 500% improvement in responses per second (RPS) in the TechEmpower plaintext benchmark.  On 48 Core AMD VMs, the improvement is nearly 100% in our HTTPS JSON benchmark.
 
+### `ServerReady` event to measure startup time
+
+Apps using [EventSource](/dotnet/api/system.diagnostics.tracing.eventsource) can measure the startup time to understand and optimize startup performance. The new [`ServerReady`](https://source.dot.net/#Microsoft.AspNetCore.Hosting/Internal/HostingEventSource.cs,76) event in <xref:Microsoft.AspNetCore.Hosting?displayProperty=fullName> represents the point where the server is ready to respond to requests.
+
 ## Server
 
 ### New ServerReady event for measuring startup time


### PR DESCRIPTION
Fixes #26846

Internal review URLs
* [What's new](https://review.docs.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-7.0?view=aspnetcore-7.0&branch=pr-en-us-26847#serverready-event-to-measure-startup-time)
* [Startup](https://review.docs.microsoft.com/en-us/aspnet/core/fundamentals/startup?view=aspnetcore-7.0&branch=pr-en-us-26847)