### PR TITLE
[BULK UPDATE] DocuTune - Fix build validation issues: docs-link-absolute (part 3)

### DIFF
--- a/aspnetcore/whats-new/index.yml
+++ b/aspnetcore/whats-new/index.yml
@@ -34,7 +34,7 @@ landingContent:
       url: https://github.com/dotnet/docs/blob/main/styleguide/labels-projects.md
   - linkListType: concept
     links:
-    - text: Microsoft docs contributor guide
+    - text: Contributor guide
       url: /contribute
     - text: ASP.NET Core docs contributor guide
       url: https://github.com/dotnet/AspNetCore.Docs/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
**Global effort to fix build validation errors**

The Microsoft Skilling team is fixing build validation errors and specific brand inconsistencies in Microsoft technical documentation for the rest of FY23 Q1. This will help address various accessibility, security, and usability issues. This PR was generated using DocuTune. It includes only targeted fixes and minor formatting adjustments.

DocuTune PRs improve quality of technical content by finding and automatically correcting a broad set of issues only where the correction is suitable. Please review within five business days and merge or comment in the PR with any changes you'd like to see. Thank you!

CorrelationId: 0df9c2d6-63f8-4d1e-8b57-b33611a06514
InitiativeId: docutune-build-validation-issues-2022-05
PointOfContact: Alex Buck
