### PR TITLE
Update static-files.md & its code samples.

### DIFF
--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -192,7 +192,7 @@ If no default-named file exists in the *MyStaticFiles* directory, `https://<host
 
 ![Static files list](static-files/_static/db2.png)
 
-<xref:Microsoft.AspNetCore.Builder.DefaultFilesExtensions.UseDefaultFiles*> and <xref:Microsoft.AspNetCore.Builder.DirectoryBrowserExtensions.UseDirectoryBrowser*> perform a client-side redirect from the target URI without a trailing `/`  to the target URI with a trailing `/`. For example, from `https://<hostname>/StaticFiles` to `https://<hostname>/StaticFiles/`. Relative URLs within the *StaticFiles* directory are invalid without a trailing slash (`/`). This behavior could be disabled by `RedirectToAppendTrailingSlash` option of `DefaultFilesOptions`.
+<xref:Microsoft.AspNetCore.Builder.DefaultFilesExtensions.UseDefaultFiles*> and <xref:Microsoft.AspNetCore.Builder.DirectoryBrowserExtensions.UseDirectoryBrowser*> perform a client-side redirect from the target URI without a trailing `/`  to the target URI with a trailing `/`. For example, from `https://<hostname>/StaticFiles` to `https://<hostname>/StaticFiles/`. Relative URLs within the *StaticFiles* directory are invalid without a trailing slash (`/`); alternatively, use the <xref:Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions.RedirectToAppendTrailingSlash> option of <xref:Microsoft.AspNetCore.Builder.DefaultFilesOptions>
 
 ## FileExtensionContentTypeProvider
 

--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -160,7 +160,7 @@ The following code enables the serving of static files, the default file, and di
 <!--  app.UseFileServer(enableDirectoryBrowsing: true); returns the default HTML doc before the default Razor Page - ie, / returns the default HTML file, not Pages/Index.cshtml --
 But when using app.UseDefaultFiles();, I need to comment out Pages/Index.cshtml or / returns  Pages/Index.cshtml, not the default HTML file.
 -->
-[!code-csharp[](~/fundamentals/static-files/samples/6.x/StaticFilesSample/Program.cs?name=snippet_ufs2&highlight=16)] 
+[!code-csharp[](~/fundamentals/static-files/samples/6.x/StaticFilesSample/Program.cs?name=snippet_ufs2&highlight=6,18)] 
 
 Consider the following directory hierarchy:
 
@@ -192,7 +192,7 @@ If no default-named file exists in the *MyStaticFiles* directory, `https://<host
 
 ![Static files list](static-files/_static/db2.png)
 
-<xref:Microsoft.AspNetCore.Builder.DefaultFilesExtensions.UseDefaultFiles*> and <xref:Microsoft.AspNetCore.Builder.DirectoryBrowserExtensions.UseDirectoryBrowser*> perform a client-side redirect from the target URI without a trailing `/`  to the target URI with a trailing `/`. For example, from `https://<hostname>/StaticFiles` to `https://<hostname>/StaticFiles/`. Relative URLs within the *StaticFiles* directory are invalid without a trailing slash (`/`).
+<xref:Microsoft.AspNetCore.Builder.DefaultFilesExtensions.UseDefaultFiles*> and <xref:Microsoft.AspNetCore.Builder.DirectoryBrowserExtensions.UseDirectoryBrowser*> perform a client-side redirect from the target URI without a trailing `/`  to the target URI with a trailing `/`. For example, from `https://<hostname>/StaticFiles` to `https://<hostname>/StaticFiles/`. Relative URLs within the *StaticFiles* directory are invalid without a trailing slash (`/`). This behavior could be disabled by `RedirectToAppendTrailingSlash` option of `DefaultFilesOptions`.
 
 ## FileExtensionContentTypeProvider
 

--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -192,7 +192,7 @@ If no default-named file exists in the *MyStaticFiles* directory, `https://<host
 
 ![Static files list](static-files/_static/db2.png)
 
-<xref:Microsoft.AspNetCore.Builder.DefaultFilesExtensions.UseDefaultFiles*> and <xref:Microsoft.AspNetCore.Builder.DirectoryBrowserExtensions.UseDirectoryBrowser*> perform a client-side redirect from the target URI without a trailing `/`  to the target URI with a trailing `/`. For example, from `https://<hostname>/StaticFiles` to `https://<hostname>/StaticFiles/`. Relative URLs within the *StaticFiles* directory are invalid without a trailing slash (`/`); alternatively, use the <xref:Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions.RedirectToAppendTrailingSlash> option of <xref:Microsoft.AspNetCore.Builder.DefaultFilesOptions>
+<xref:Microsoft.AspNetCore.Builder.DefaultFilesExtensions.UseDefaultFiles*> and <xref:Microsoft.AspNetCore.Builder.DirectoryBrowserExtensions.UseDirectoryBrowser*> perform a client-side redirect from the target URI without a trailing `/`  to the target URI with a trailing `/`. For example, from `https://<hostname>/StaticFiles` to `https://<hostname>/StaticFiles/`. Relative URLs within the *StaticFiles* directory are invalid without a trailing slash (`/`) unless the <xref:Microsoft.AspNetCore.StaticFiles.Infrastructure.SharedOptions.RedirectToAppendTrailingSlash> option of <xref:Microsoft.AspNetCore.Builder.DefaultFilesOptions> is used.
 
 ## FileExtensionContentTypeProvider
 

--- a/aspnetcore/fundamentals/static-files/samples/6.x/StaticFilesSample/Program.cs
+++ b/aspnetcore/fundamentals/static-files/samples/6.x/StaticFilesSample/Program.cs
@@ -230,6 +230,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
 builder.Services.AddControllersWithViews();
 
+builder.Services.AddDirectoryBrowser();
+
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
This PR updated two things about static files in ASP.NET Core:
1. Update code sample about `enableDirectoryBrowsing` parameter of `UseFileServer`. `AddDirectoryBrowser` is supposed to be called when the `EnableDirectoryBrowsing` property value is true.
2. According to [this issue](https://github.com/dotnet/aspnetcore/issues/2449), trailing `/` redirect could be disable with `RedirectToAppendTrailingSlash`.