### PR TITLE
gRPC multithreading example

### DIFF
--- a/aspnetcore/grpc/services.md
+++ b/aspnetcore/grpc/services.md
@@ -328,7 +328,7 @@ A gRPC call ends on the server once the gRPC method exits. The following argumen
 
 If a gRPC method starts background tasks that use these types, it must complete the tasks before the gRPC method exits. Continuing to use the context, stream reader, or stream writer after the gRPC method exists causes errors and unpredictable behavior.
 
-The following method could write to the response stream after the method has finished:
+In the following example, the server streaming method could write to the response stream after the call has finished:
 
 ```csharp
 public override async Task StreamingFromServer(ExampleRequest request,
@@ -347,7 +347,7 @@ public override async Task StreamingFromServer(ExampleRequest request,
 }
 ```
 
-The solution is to await the write task before exiting the method:
+The solution in this example is to await the write task before exiting the method:
 
 ```csharp
 public override async Task StreamingFromServer(ExampleRequest request,

--- a/aspnetcore/grpc/services.md
+++ b/aspnetcore/grpc/services.md
@@ -328,6 +328,46 @@ A gRPC call ends on the server once the gRPC method exits. The following argumen
 
 If a gRPC method starts background tasks that use these types, it must complete the tasks before the gRPC method exits. Continuing to use the context, stream reader, or stream writer after the gRPC method exists causes errors and unpredictable behavior.
 
+The following method could write to the response stream after the method has finished:
+
+```csharp
+public override async Task StreamingFromServer(ExampleRequest request,
+    IServerStreamWriter<ExampleResponse> responseStream, ServerCallContext context)
+{
+    _ = Task.Run(async () =>
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            await responseStream.WriteAsync(new ExampleResponse());
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+    });
+
+    // Perform other work.
+}
+```
+
+The solution is to await the write task before exiting the method:
+
+```csharp
+public override async Task StreamingFromServer(ExampleRequest request,
+    IServerStreamWriter<ExampleResponse> responseStream, ServerCallContext context)
+{
+    var writeTask = Task.Run(async () =>
+    {
+        for (var i = 0; i < 5; i++)
+        {
+            await responseStream.WriteAsync(new ExampleResponse());
+            await Task.Delay(TimeSpan.FromSeconds(1));
+        }
+    });
+
+    // Perform other work.
+
+    await writeTask;
+}
+```
+
 ## Additional resources
 
 * <xref:grpc/basics>

--- a/aspnetcore/grpc/services.md
+++ b/aspnetcore/grpc/services.md
@@ -343,11 +343,11 @@ public override async Task StreamingFromServer(ExampleRequest request,
         }
     });
 
-    // Perform other work.
+    await PerformLongRunningWorkAsync();
 }
 ```
 
-The solution in this example is to await the write task before exiting the method:
+The solution is to await the write task before exiting the method:
 
 ```csharp
 public override async Task StreamingFromServer(ExampleRequest request,
@@ -362,7 +362,7 @@ public override async Task StreamingFromServer(ExampleRequest request,
         }
     });
 
-    // Perform other work.
+    await PerformLongRunningWorkAsync();
 
     await writeTask;
 }

--- a/aspnetcore/grpc/services.md
+++ b/aspnetcore/grpc/services.md
@@ -347,7 +347,7 @@ public override async Task StreamingFromServer(ExampleRequest request,
 }
 ```
 
-The solution is to await the write task before exiting the method:
+For the previous example, the solution is to await the write task before exiting the method:
 
 ```csharp
 public override async Task StreamingFromServer(ExampleRequest request,


### PR DESCRIPTION
gRPC multithreading example