### PR TITLE
remove very unsafe link to bad-crook-site

### DIFF
--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -16,6 +16,20 @@ By [Fiyaz Hasan](https://twitter.com/FiyazBinHasan), [Rick Anderson](https://twi
 
 Cross-site request forgery (also known as XSRF or CSRF) is an attack against web-hosted apps whereby a malicious web app can influence the interaction between a client browser and a web app that trusts that browser. These attacks are possible because web browsers send some types of authentication tokens automatically with every request to a website. This form of exploit is also known as a *one-click attack* or *session riding* because the attack takes advantage of the user's previously authenticated session.
 
+An example of a CSRF attack:
+
+1. A user signs into `www.good-banking-site.com` using forms authentication. The server authenticates the user and issues a response that includes an authentication cookie. The site is vulnerable to attack because it trusts any request that it receives with a valid authentication cookie.
+1. The user visits a malicious site, `www.example.com`.
+
+   The malicious site, `www.example.com`, contains an HTML form similar to the following example:
+
+   :::code language="html" source="anti-request-forgery/samples_snapshot/vulnerable-form.html":::
+
+   Notice that the form's `action` posts to the vulnerable site, not to the malicious site. This is the "cross-site" part of CSRF.
+
+1. The user selects the submit button. The browser makes the request and automatically includes the authentication cookie for the requested domain, `www.good-banking-site.com`.
+1. The request runs on the `www.good-banking-site.com` server with the user's authentication context and can perform any action that an authenticated user is allowed to perform.
+
 In addition to the scenario where the user selects the button to submit the form, the malicious site could:
 
 * Run a script that automatically submits the form.

--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -16,20 +16,6 @@ By [Fiyaz Hasan](https://twitter.com/FiyazBinHasan), [Rick Anderson](https://twi
 
 Cross-site request forgery (also known as XSRF or CSRF) is an attack against web-hosted apps whereby a malicious web app can influence the interaction between a client browser and a web app that trusts that browser. These attacks are possible because web browsers send some types of authentication tokens automatically with every request to a website. This form of exploit is also known as a *one-click attack* or *session riding* because the attack takes advantage of the user's previously authenticated session.
 
-An example of a CSRF attack:
-
-1. A user signs into `www.good-banking-site.com` using forms authentication. The server authenticates the user and issues a response that includes an authentication cookie. The site is vulnerable to attack because it trusts any request that it receives with a valid authentication cookie.
-1. The user visits a malicious site, `www.bad-crook-site.com`.
-
-   The malicious site, `www.bad-crook-site.com`, contains an HTML form similar to the following example:
-
-   :::code language="html" source="anti-request-forgery/samples_snapshot/vulnerable-form.html":::
-
-   Notice that the form's `action` posts to the vulnerable site, not to the malicious site. This is the "cross-site" part of CSRF.
-
-1. The user selects the submit button. The browser makes the request and automatically includes the authentication cookie for the requested domain, `www.good-banking-site.com`.
-1. The request runs on the `www.good-banking-site.com` server with the user's authentication context and can perform any action that an authenticated user is allowed to perform.
-
 In addition to the scenario where the user selects the button to submit the form, the malicious site could:
 
 * Run a script that automatically submits the form.

--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -18,17 +18,17 @@ Cross-site request forgery (also known as XSRF or CSRF) is an attack against web
 
 An example of a CSRF attack:
 
-1. A user signs into `www.good-banking-site.com` using forms authentication. The server authenticates the user and issues a response that includes an authentication cookie. The site is vulnerable to attack because it trusts any request that it receives with a valid authentication cookie.
-1. The user visits a malicious site, `www.example.com`.
+1. A user signs into `www.good-banking-site.example.com` using forms authentication. The server authenticates the user and issues a response that includes an authentication cookie. The site is vulnerable to attack because it trusts any request that it receives with a valid authentication cookie.
+1. The user visits a malicious site, `www.bad-crook-site.example.com`.
 
-   The malicious site, `www.example.com`, contains an HTML form similar to the following example:
+   The malicious site, `www.bad-crook-site.example.com`, contains an HTML form similar to the following example:
 
    :::code language="html" source="anti-request-forgery/samples_snapshot/vulnerable-form.html":::
 
    Notice that the form's `action` posts to the vulnerable site, not to the malicious site. This is the "cross-site" part of CSRF.
 
-1. The user selects the submit button. The browser makes the request and automatically includes the authentication cookie for the requested domain, `www.good-banking-site.com`.
-1. The request runs on the `www.good-banking-site.com` server with the user's authentication context and can perform any action that an authenticated user is allowed to perform.
+1. The user selects the submit button. The browser makes the request and automatically includes the authentication cookie for the requested domain, `www.good-banking-site.example.com`.
+1. The request runs on the `www.good-banking-site.example.com` server with the user's authentication context and can perform any action that an authenticated user is allowed to perform.
 
 In addition to the scenario where the user selects the button to submit the form, the malicious site could:
 
@@ -285,17 +285,17 @@ Cross-site request forgery (also known as XSRF or CSRF) is an attack against web
 
 An example of a CSRF attack:
 
-1. A user signs into `www.good-banking-site.com` using forms authentication. The server authenticates the user and issues a response that includes an authentication cookie. The site is vulnerable to attack because it trusts any request that it receives with a valid authentication cookie.
-1. The user visits a malicious site, `www.bad-crook-site.com`.
+1. A user signs into `www.good-banking-site.example.com` using forms authentication. The server authenticates the user and issues a response that includes an authentication cookie. The site is vulnerable to attack because it trusts any request that it receives with a valid authentication cookie.
+1. The user visits a malicious site, `www.bad-crook-site.example.com`.
 
-   The malicious site, `www.bad-crook-site.com`, contains an HTML form similar to the following example:
+   The malicious site, `www.bad-crook-site.example.com`, contains an HTML form similar to the following example:
 
    :::code language="html" source="anti-request-forgery/samples_snapshot/vulnerable-form.html":::
 
    Notice that the form's `action` posts to the vulnerable site, not to the malicious site. This is the "cross-site" part of CSRF.
 
-1. The user selects the submit button. The browser makes the request and automatically includes the authentication cookie for the requested domain, `www.good-banking-site.com`.
-1. The request runs on the `www.good-banking-site.com` server with the user's authentication context and can perform any action that an authenticated user is allowed to perform.
+1. The user selects the submit button. The browser makes the request and automatically includes the authentication cookie for the requested domain, `www.good-banking-site.example.com`.
+1. The request runs on the `www.good-banking-site.example.com` server with the user's authentication context and can perform any action that an authenticated user is allowed to perform.
 
 In addition to the scenario where the user selects the button to submit the form, the malicious site could:
 
@@ -537,17 +537,17 @@ Cross-site request forgery (also known as XSRF or CSRF) is an attack against web
 
 An example of a CSRF attack:
 
-1. A user signs into `www.good-banking-site.com` using forms authentication. The server authenticates the user and issues a response that includes an authentication cookie. The site is vulnerable to attack because it trusts any request that it receives with a valid authentication cookie.
-1. The user visits a malicious site, `www.bad-crook-site.com`.
+1. A user signs into `www.good-banking-site.example.com` using forms authentication. The server authenticates the user and issues a response that includes an authentication cookie. The site is vulnerable to attack because it trusts any request that it receives with a valid authentication cookie.
+1. The user visits a malicious site, `www.bad-crook-site.example.com`.
 
-   The malicious site, `www.bad-crook-site.com`, contains an HTML form similar to the following example:
+   The malicious site, `www.bad-crook-site.example.com`, contains an HTML form similar to the following example:
 
    :::code language="html" source="anti-request-forgery/samples_snapshot/vulnerable-form.html":::
 
    Notice that the form's `action` posts to the vulnerable site, not to the malicious site. This is the "cross-site" part of CSRF.
 
-1. The user selects the submit button. The browser makes the request and automatically includes the authentication cookie for the requested domain, `www.good-banking-site.com`.
-1. The request runs on the `www.good-banking-site.com` server with the user's authentication context and can perform any action that an authenticated user is allowed to perform.
+1. The user selects the submit button. The browser makes the request and automatically includes the authentication cookie for the requested domain, `www.good-banking-site.example.com`.
+1. The request runs on the `www.good-banking-site.example.com` server with the user's authentication context and can perform any action that an authenticated user is allowed to perform.
 
 In addition to the scenario where the user selects the button to submit the form, the malicious site could:
 


### PR DESCRIPTION
The link to bad-crook-site is very unsafe. Nobody should click that ever. Not sure why you are linking to there, but it's an actual scam site with explicit porn ads on it.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->