### PR TITLE
Routing features (loc changes, NavigationLock)

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1980,7 +1980,7 @@ For additional example code, see the [`NavigationManagerComponent` in the `Basic
 
 To facilitate the control of navigation events in a Razor component, use the `NavigationLock` component. After the `NavigationLock` component is rendered, it intercepts navigation events.
 
-In the following `NavigationLockExample` component:
+In the following `NavLock` component:
 
 * `ConfirmExternalNavigation` sets a browser dialog to prompt the user to either confirm or cancel the external navigation. The default value is `false`. An attempt to follow the link to Microsoft's website must be confirmed by the user before the navigation to `https://www.microsoft.com` succeeds.
 * `OnBeforeInternalNavigation` sets a callback to be invoked when an internal navigation event occurs. `PreventNavigation` is called to prevent naviation from occurring if the user declines to confirm the navigation via a [JavaScript (JS) interop call](xref:blazor/js-interop/call-javascript-from-dotnet) that spawns the [JS `confirm` dialog](https://developer.mozilla.org/docs/Web/API/Window/confirm).

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1951,7 +1951,7 @@ In the following example, a location changing handler is registered for navigati
 </p>
 
 @code {
-    private IDisposable registration;
+    private IDisposable? registration;
 
     protected override void OnInitialized()
     {

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1955,7 +1955,7 @@ In the following example, a location changing handler is registered for navigati
 
     protected override void OnInitialized()
     {
-        var registration = 
+        registration = 
             NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
     }
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1583,7 +1583,7 @@ NavigationManager.NavigateTo("/path", new NavigationOptions
 });
 ```
 
-For more information on obtaining the state associated with the target history entry while handling location changes, see the [Handle location changes in a component](#handle-location-changes-in-a-component) section.
+For more information on obtaining the state associated with the target history entry while handling location changes, see the [Handle (prevent) location changes](#handle-prevent-location-changes) section.
 
 ## Query strings
 
@@ -1920,7 +1920,7 @@ In the following `App` component example:
 > [!NOTE]
 > Not throwing if the cancellation token in <xref:Microsoft.AspNetCore.Components.Routing.NavigationContext> is canceled can result in unintended behavior, such as rendering a component from a previous navigation.
 
-## Handle location changes in a component
+## Handle (prevent) location changes
 
 `RegisterLocationChangingHandler` registers a handler to process incoming navigation events. The handler's context provided by `LocationChangingContext` includes the following properties:
 
@@ -1930,7 +1930,10 @@ In the following `App` component example:
 * `CancellationToken`: Gets a <xref:System.Threading.CancellationToken> to determine if the navigation was canceled, for example, to determine if the user triggered a different navigation.
 * `PreventNavigation`: Called to prevent the navigation from continuing.
 
-A component can register multiple location changing handlers. Navigations invoke all of the location changing handlers registered across the entire app (across multiple components), and any internal navigation executes them all in parallel. In addition to <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invoking the handlers, selecting internal links (those that point to URLs under the app's base path) and navigating using the forward/back buttons also invoke the handlers.
+A component can register multiple location changing handlers. Navigations invoke all of the location changing handlers registered across the entire app (across multiple components), and any internal navigation executes them all in parallel. In addition to <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> handlers are invoked:
+
+* When selecting internal links, which are links that point to URLs under the app's base path.
+* When navigating using the forward and back buttons in a browser.
 
 Handlers are only executed for internal navigations within the app. If the user selects a link that navigates to a different site or changes the address bar to a different site manually, location changing handlers aren't executed.
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1583,7 +1583,7 @@ NavigationManager.NavigateTo("/path", new NavigationOptions
 });
 ```
 
-For more information on obtaining the state associated with the target history entry while handling location changes, see the [Handle (prevent) location changes](#handle-prevent-location-changes) section.
+For more information on obtaining the state associated with the target history entry while handling location changes, see the [Handle/prevent location changes](#handleprevent-location-changes) section.
 
 ## Query strings
 
@@ -1920,7 +1920,7 @@ In the following `App` component example:
 > [!NOTE]
 > Not throwing if the cancellation token in <xref:Microsoft.AspNetCore.Components.Routing.NavigationContext> is canceled can result in unintended behavior, such as rendering a component from a previous navigation.
 
-## Handle (prevent) location changes
+## Handle/prevent location changes
 
 `RegisterLocationChangingHandler` registers a handler to process incoming navigation events. The handler's context provided by `LocationChangingContext` includes the following properties:
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1930,14 +1930,14 @@ In the following `App` component example:
 * `CancellationToken`: Gets a <xref:System.Threading.CancellationToken> to determine if the navigation was canceled, for example, to determine if the user triggered a different navigation.
 * `PreventNavigation`: Called to prevent the navigation from continuing.
 
-A component can register multiple location changing handlers. Navigations invoke all of the location changing handlers registered across the entire app (across multiple components), and any internal navigation executes them all in parallel. In addition to <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> handlers are invoked:
+A component can register multiple location changing handlers in its [`OnAfterRender` or `OnAfterRenderAsync` methods](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync). Navigations invoke all of the location changing handlers registered across the entire app (across multiple components), and any internal navigation executes them all in parallel. In addition to <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> handlers are invoked:
 
 * When selecting internal links, which are links that point to URLs under the app's base path.
 * When navigating using the forward and back buttons in a browser.
 
 Handlers are only executed for internal navigations within the app. If the user selects a link that navigates to a different site or changes the address bar to a different site manually, location changing handlers aren't executed.
 
-[Dispose registered handlers](xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable) to unregister them.
+Implement <xref:System.IDisposable> and dispose registered handlers to unregister them. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
 In the following example, a location changing handler is registered for navigation events. Note that the component implements `IDisposable` and disposes the handler in its `Dispose` method.
 
@@ -1994,12 +1994,17 @@ For additional example code, see the [`NavigationManagerComponent` in the `Basic
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-To facilitate the control of navigation events in a Razor component, use the `NavigationLock` component. As long as the `NavigationLock` component is rendered, it intercepts navigation events. Handlers associated with `NavigationLock` components are disposed automatically when the component is disposed.
+To facilitate the control of navigation events in a Razor component, use the `NavigationLock` component. As long as the `NavigationLock` component is rendered, it intercepts navigation events.
+
+`NavigationLock` parameters:
+
+* `ConfirmExternalNavigation` sets a browser dialog to prompt the user to either confirm or cancel external navigation. The default value is `false`. Displaying the confirmation dialog requires initial user interaction with the page before triggering external navigation with the URL in the browser's address bar. For more information on the interaction requirement, see [Window: `beforeunload` event (MDN documentation)](https://developer.mozilla.org/docs/Web/API/Window/beforeunload_event).
+* `OnBeforeInternalNavigation` sets a callback for internal navigation events.
 
 In the following `NavLock` component:
 
-* `ConfirmExternalNavigation` sets a browser dialog to prompt the user to either confirm or cancel the external navigation. The default value is `false`. An attempt to follow the link to Microsoft's website must be confirmed by the user before the navigation to `https://www.microsoft.com` succeeds.
-* `OnBeforeInternalNavigation` sets a callback to be invoked when an internal navigation event occurs. `PreventNavigation` is called to prevent naviation from occurring if the user declines to confirm the navigation via a [JavaScript (JS) interop call](xref:blazor/js-interop/call-javascript-from-dotnet) that spawns the [JS `confirm` dialog](https://developer.mozilla.org/docs/Web/API/Window/confirm).
+* An attempt to follow the link to Microsoft's website must be confirmed by the user before the navigation to `https://www.microsoft.com` succeeds.
+* `PreventNavigation` is called to prevent naviation from occurring if the user declines to confirm the navigation via a [JavaScript (JS) interop call](xref:blazor/js-interop/call-javascript-from-dotnet) that spawns the [JS `confirm` dialog](https://developer.mozilla.org/docs/Web/API/Window/confirm).
 
 `Pages/NavLock.razor`:
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1930,15 +1930,16 @@ In the following `App` component example:
 * `CancellationToken`: Gets a <xref:System.Threading.CancellationToken> to determine if the navigation was canceled, for example, to determine if the user triggered a different navigation.
 * `PreventNavigation`: Called to prevent the navigation from continuing.
 
-A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invokes all of the registered handlers. Registered handlers are automatically disposed by the Navigation Manager when the component is disposed.
+A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invokes all of the registered handlers. [Dispose registered handlers](xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable) to avoid memory leaks.
 
-In the following example, a location changing handler is registered for navigation events. 
+In the following example, a location changing handler is registered for navigation events. Note that the component implements `IDisposable` and disposes the handler in its `Dispose` method.
 
 `Pages/NavHandler.razor`:
 
 ```razor
 @page "/nav-handler"
 @inject NavigationManager NavigationManager
+@implements IDisposable
 
 <p>
     <button @onclick="NavigationManager.NavigateTo("/")">
@@ -1950,9 +1951,12 @@ In the following example, a location changing handler is registered for navigati
 </p>
 
 @code {
+    private 
+
     protected override void OnInitialized()
     {
-        NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
+        var registration = 
+            NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
     }
 
     private async ValueTask OnLocationChanging(LocationChangingContext context)
@@ -1962,6 +1966,8 @@ In the following example, a location changing handler is registered for navigati
             context.PreventNavigation();
         }
     }
+
+    public void Dispose() => registration?.Dispose();
 }
 ```
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1930,7 +1930,7 @@ In the following `App` component example:
 * `CancellationToken`: Gets a <xref:System.Threading.CancellationToken> to determine if the navigation was canceled, for example, to determine if the user triggered a different navigation.
 * `PreventNavigation`: Called to prevent the navigation from continuing.
 
-A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invokes all of the registered handlers.
+A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invokes all of the registered handlers. Registered handlers are automatically disposed by the Navigation Manager when the component is disposed.
 
 In the following example, a location changing handler is registered for navigation events. 
 
@@ -1978,7 +1978,7 @@ For additional example code, see the [`NavigationManagerComponent` in the `Basic
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-To facilitate the control of navigation events in a Razor component, use the `NavigationLock` component. After the `NavigationLock` component is rendered, it intercepts navigation events.
+To facilitate the control of navigation events in a Razor component, use the `NavigationLock` component. After the `NavigationLock` component is rendered, it intercepts navigation events. Handlers associated with `NavigationLock` components are disposed automatically when the component is disposed.
 
 In the following `NavLock` component:
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1543,7 +1543,121 @@ Use <xref:Microsoft.AspNetCore.Components.NavigationManager> to manage URIs and 
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.LocationChanged> | An event that fires when the navigation location has changed. For more information, see the [Location changes](#location-changes) section. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri%2A> | Converts a relative URI into an absolute URI. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.ToBaseRelativePath%2A> | Given a base URI (for example, a URI previously returned by <xref:Microsoft.AspNetCore.Components.NavigationManager.BaseUri>), converts an absolute URI into a URI relative to the base URI prefix. |
+| `RegisterLocationChangingHandler` | Registers a handler to process incoming navigation events. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameter%2A> | Returns a URI constructed by updating <xref:Microsoft.AspNetCore.Components.NavigationManager.Uri?displayProperty=nameWithType> with a single parameter added, updated, or removed. For more information, see the [Query strings](#query-strings) section. |
+
+In the following example, a location changing handler is registered for navigation events. Note that calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> always invokes any location changing handlers that exist.
+
+`Pages/NavHandler.razor`:
+
+```razor
+@page "/nav-handler"
+@inject NavigationManager NavigationManager
+
+<p>
+    <button @onclick="NavigationManager.NavigateTo("/")">
+        Home (Allowed)
+    </button>
+    <button @onclick="NavigationManager.NavigateTo("/counter")">
+        Counter (Prevented)
+    </button>
+</p>
+
+@code {
+    protected override void OnInitialized()
+    {
+        NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
+    }
+
+    private async ValueTask OnLocationChanging(LocationChangingContext context)
+    {
+        if (context.TargetLocation == "counter")
+        {
+            context.PreventNavigation();
+        }
+    }
+}
+```
+
+`LocationChangingContext` properties:
+
+* `TargetLocation`: Obtain the target location.
+* `HistoryEntryState`: The state associated with the target history entry.
+* `IsNavigationIntercepted`: Whether the navigation was intercepted from a link.
+* `CancellationToken`: Gets a <xref:System.Threading.CancellationToken> to determine if the navigation was canceled, for example, to determine if the user triggered a different navigation.
+* `PreventNavigation`: Called to prevent the navigation from continuing.
+
+Pass `NavigationOptions` to <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> to control the following behaviors:
+
+* `ForceLoad`: Bypass client-side routing and force the browser to load the new page from the server, whether or not the URI is handled by the client-side router. The default value is `false`.
+* `ReplaceHistoryEntry`: Replace the current entry in the history stack. If `false`, append the new entry to the history stack. The default value is `false`.
+* `HistoryEntryState`: Gets or sets the state to append to the history entry.
+
+```csharp
+NavigationManager.NavigateTo("/path", new NavigationOptions
+{
+    HistoryEntryState = "Navigation state",
+});
+```
+
+Since internal navigation can be canceled asynchronously, multiple overlapping navigations may occur. For example, the user is rapidly clicking the back button on a page or clicking multiple links before a navigation is determined. The following is a summary of the asynchronous navigation logic:
+
+* If any location changing handlers are registered, all navigations are initially reverted, then replayed if the navigation isn't canceled.
+* If overlapping navigation requests are made, the latest request always cancels earlier requests, which means the following:
+  * The app may treat multiple back and forward button clicks as a single click.
+  * If the user clicks multiple links before the navigation completes, the last link clicked determines the navigation.
+
+For more information, see the following components in the `BasicTestApp` (`dotnet/aspnetcore` reference source):
+
+* [`NavigationManagerComponent`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/RouterTest/NavigationManagerComponent.razor)
+* [`ConfigurableNavigationLock`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/RouterTest/ConfigurableNavigationLock.razor)
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+## Intercept location changes in a component
+
+The `NavigationLock` component is used to intercept navigation events:
+
+* The component only takes effect after it's rendered, just like any other Razor component.
+* It's possible for the suer to bypass interception of the navigation because the user navigated away before the component had a chance to render.
+
+In the following `NavigationLockExample` component:
+
+* `OnBeforeInternalNavigation` sets a callback to be invoked when an internal navigation event occurs. `PreventNavigation` is called to prevent naviation from occurring if the user declines to confirm the navigation via a [JavaScript (JS) interop call](xref:blazor/js-interop/call-javascript-from-dotnet) that spawns the [JS `confirm` dialog](https://developer.mozilla.org/docs/Web/API/Window/confirm).
+* `ConfirmExternalNavigation` sets a browser dialog to prompt the user to either confirm or cancel the external navigation. The default value is `false`.
+
+`Pages/NavLock.razor`:
+
+```razor
+@page "/nav-lock"
+@inject IJSRuntime JSRuntime
+@inject NavigationManager NavigationManager
+
+<p>
+    <button @onclick="Navigate">Navigate</button>
+</p>
+
+<NavigationLock OnBeforeInternalNavigation="OnBeforeInternalNavigation" 
+    ConfirmExternalNavigation="true" />
+
+@code {
+    private void Navigate()
+    {
+        NavigationManager.NavigateTo("/");
+    }
+
+    private async Task OnBeforeInternalNavigation(LocationChangingContext context)
+    {
+        var isConfirmed = await JSRuntime.InvokeAsync<bool>("confirm", 
+            "Are you sure you want to navigate to the Index page?");
+
+        if (!isConfirmed)
+        {
+            context.PreventNavigation();
+        }
+    }
+}
+```
 
 ## Location changes
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1960,10 +1960,13 @@ In the following example, a location changing handler is registered for navigati
 @code {
     private IDisposable? registration;
 
-    protected override void OnInitialized()
+    protected override void OnAfterRender(bool firstRender)
     {
-        registration = 
-            NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
+        if (firstRender)
+        {
+            registration = 
+                NavigationManager.RegisterLocationChangingHandler(OnLocationChanging);
+        }
     }
 
     private async ValueTask OnLocationChanging(LocationChangingContext context)

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1583,7 +1583,7 @@ NavigationManager.NavigateTo("/path", new NavigationOptions
 });
 ```
 
-For more information on the history stack, see the [Handle location changes in a component](#handle-location-changes-in-a-component) section.
+For more information on obtaining the state associated with the target history entry while handling location changes, see the [Handle location changes in a component](#handle-location-changes-in-a-component) section.
 
 ## Query strings
 
@@ -1922,7 +1922,7 @@ In the following `App` component example:
 
 ## Handle location changes in a component
 
-`RegisterLocationChangingHandler` registers a handler to process incoming navigation events. The handler's context (`LocationChangingContext`) provides the following properties:
+`RegisterLocationChangingHandler` registers a handler to process incoming navigation events. The handler's context provided by `LocationChangingContext` includes the following properties:
 
 * `TargetLocation`: Gets the target location.
 * `HistoryEntryState`: Gets the state associated with the target history entry.
@@ -1930,7 +1930,7 @@ In the following `App` component example:
 * `CancellationToken`: Gets a <xref:System.Threading.CancellationToken> to determine if the navigation was canceled, for example, to determine if the user triggered a different navigation.
 * `PreventNavigation`: Called to prevent the navigation from continuing.
 
-A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> always invokes all of the registered handlers.
+A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invokes all of the registered handlers.
 
 In the following example, a location changing handler is registered for navigation events. 
 
@@ -1965,7 +1965,7 @@ In the following example, a location changing handler is registered for navigati
 }
 ```
 
-Since internal navigation can be canceled asynchronously, multiple overlapping navigations may occur. For example, multiple handler calls may occur when the user rapidly selects the back button on a page or selects multiple links before a navigation is determined. The following is a summary of the asynchronous navigation logic:
+Since internal navigation can be canceled asynchronously, multiple overlapping calls to registered handlers may occur. For example, multiple handler calls may occur when the user rapidly selects the back button on a page or selects multiple links before a navigation is executed. The following is a summary of the asynchronous navigation logic:
 
 * If any location changing handlers are registered, all navigations are initially reverted, then replayed if the navigation isn't canceled.
 * If overlapping navigation requests are made, the latest request always cancels earlier requests, which means the following:

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1951,7 +1951,7 @@ In the following example, a location changing handler is registered for navigati
 </p>
 
 @code {
-    private 
+    private IDisposable registration;
 
     protected override void OnInitialized()
     {

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1930,7 +1930,7 @@ In the following `App` component example:
 * `CancellationToken`: Gets a <xref:System.Threading.CancellationToken> to determine if the navigation was canceled, for example, to determine if the user triggered a different navigation.
 * `PreventNavigation`: Called to prevent the navigation from continuing.
 
-A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invokes all of the registered handlers. [Dispose registered handlers](xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable) to avoid memory leaks.
+A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invokes all of the registered handlers. [Dispose registered handlers](xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable) to unregister them.
 
 In the following example, a location changing handler is registered for navigation events. Note that the component implements `IDisposable` and disposes the handler in its `Dispose` method.
 
@@ -1984,7 +1984,7 @@ For additional example code, see the [`NavigationManagerComponent` in the `Basic
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-To facilitate the control of navigation events in a Razor component, use the `NavigationLock` component. After the `NavigationLock` component is rendered, it intercepts navigation events. Handlers associated with `NavigationLock` components are disposed automatically when the component is disposed.
+To facilitate the control of navigation events in a Razor component, use the `NavigationLock` component. As long as the `NavigationLock` component is rendered, it intercepts navigation events. Handlers associated with `NavigationLock` components are disposed automatically when the component is disposed.
 
 In the following `NavLock` component:
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1543,7 +1543,7 @@ Use <xref:Microsoft.AspNetCore.Components.NavigationManager> to manage URIs and 
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.LocationChanged> | An event that fires when the navigation location has changed. For more information, see the [Location changes](#location-changes) section. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri%2A> | Converts a relative URI into an absolute URI. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManager.ToBaseRelativePath%2A> | Given a base URI (for example, a URI previously returned by <xref:Microsoft.AspNetCore.Components.NavigationManager.BaseUri>), converts an absolute URI into a URI relative to the base URI prefix. |
-| [`RegisterLocationChangingHandler`](#handle-location-changes-in-a-component) | Registers a handler to process incoming navigation events. Calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> always invokes the handler. |
+| [`RegisterLocationChangingHandler`](#handleprevent-location-changes) | Registers a handler to process incoming navigation events. Calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> always invokes the handler. |
 | <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameter%2A> | Returns a URI constructed by updating <xref:Microsoft.AspNetCore.Components.NavigationManager.Uri?displayProperty=nameWithType> with a single parameter added, updated, or removed. For more information, see the [Query strings](#query-strings) section. |
 
 ## Location changes

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -226,7 +226,7 @@ The following component:
   * The `HandleLocationChanged` method is unhooked when `Dispose` is called by the framework. Unhooking the method permits garbage collection of the component.
   * The logger implementation logs the following information when the button is selected:
 
-    > `BlazorSample.Pages.Navigate: Information: URL of new location: https://localhost:5001/counter`
+    > :::no-loc text="BlazorSample.Pages.Navigate: Information: URL of new location: https://localhost:{PORT}/counter":::
 
 `Pages/Navigate.razor`:
 
@@ -863,7 +863,7 @@ The following component:
   * The `HandleLocationChanged` method is unhooked when `Dispose` is called by the framework. Unhooking the method permits garbage collection of the component.
   * The logger implementation logs the following information when the button is selected:
 
-    > `BlazorSample.Pages.Navigate: Information: URL of new location: https://localhost:5001/counter`
+    > :::no-loc text="BlazorSample.Pages.Navigate: Information: URL of new location: https://localhost:5001/counter":::
 
 `Pages/Navigate.razor`:
 
@@ -1247,7 +1247,7 @@ The following component:
   * The `HandleLocationChanged` method is unhooked when `Dispose` is called by the framework. Unhooking the method permits garbage collection of the component.
   * The logger implementation logs the following information when the button is selected:
 
-    > `BlazorSample.Pages.Navigate: Information: URL of new location: https://localhost:5001/counter`
+    > :::no-loc text="BlazorSample.Pages.Navigate: Information: URL of new location: https://localhost:5001/counter":::
 
 `Pages/Navigate.razor`:
 
@@ -1560,7 +1560,7 @@ The following component:
   * The `HandleLocationChanged` method is unhooked when `Dispose` is called by the framework. Unhooking the method permits garbage collection of the component.
   * The logger implementation logs the following information when the button is selected:
 
-    > `BlazorSample.Pages.Navigate: Information: URL of new location: https://localhost:{PORT}/counter`
+    > :::no-loc text="BlazorSample.Pages.Navigate: Information: URL of new location: https://localhost:{PORT}/counter":::
 
 `Pages/Navigate.razor`:
 
@@ -1939,7 +1939,7 @@ Handlers are only executed for internal navigations within the app. If the user 
 
 Implement <xref:System.IDisposable> and dispose registered handlers to unregister them. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
-In the following example, a location changing handler is registered for navigation events. Note that the component implements `IDisposable` and disposes the handler in its `Dispose` method.
+In the following example, a location changing handler is registered for navigation events.
 
 `Pages/NavHandler.razor`:
 
@@ -2004,7 +2004,7 @@ To facilitate the control of navigation events in a Razor component, use the `Na
 In the following `NavLock` component:
 
 * An attempt to follow the link to Microsoft's website must be confirmed by the user before the navigation to `https://www.microsoft.com` succeeds.
-* `PreventNavigation` is called to prevent naviation from occurring if the user declines to confirm the navigation via a [JavaScript (JS) interop call](xref:blazor/js-interop/call-javascript-from-dotnet) that spawns the [JS `confirm` dialog](https://developer.mozilla.org/docs/Web/API/Window/confirm).
+* `PreventNavigation` is called to prevent navigation from occurring if the user declines to confirm the navigation via a [JavaScript (JS) interop call](xref:blazor/js-interop/call-javascript-from-dotnet) that spawns the [JS `confirm` dialog](https://developer.mozilla.org/docs/Web/API/Window/confirm).
 
 `Pages/NavLock.razor`:
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1930,7 +1930,11 @@ In the following `App` component example:
 * `CancellationToken`: Gets a <xref:System.Threading.CancellationToken> to determine if the navigation was canceled, for example, to determine if the user triggered a different navigation.
 * `PreventNavigation`: Called to prevent the navigation from continuing.
 
-A component can register multiple location changing handlers, and calling <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invokes all of the registered handlers. [Dispose registered handlers](xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable) to unregister them.
+A component can register multiple location changing handlers. Navigations invoke all of the location changing handlers registered across the entire app (across multiple components), and any internal navigation executes them all in parallel. In addition to <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A> invoking the handlers, selecting internal links (those that point to URLs under the app's base path) and navigating using the forward/back buttons also invoke the handlers.
+
+Handlers are only executed for internal navigations within the app. If the user selects a link that navigates to a different site or changes the address bar to a different site manually, location changing handlers aren't executed.
+
+[Dispose registered handlers](xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable) to unregister them.
 
 In the following example, a location changing handler is registered for navigation events. Note that the component implements `IDisposable` and disposes the handler in its `Dispose` method.
 


### PR DESCRIPTION
Addresses #26364

Internal Review Topic (links to sections):

* [*Handle location changes in a component*](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-7.0&branch=pr-en-us-26919#handle-location-changes-in-a-component)
* [*Navigation options*](https://review.docs.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-7.0&branch=pr-en-us-26919#navigation-options)

## 💥🚑🚒🚓  

**_Ignore the doc build failure. We'll figure that out separately._**

## Notes

*These are numbered to facilitate easy feedback responses.*

1. I take access to the API after RC1 is released, so this is untested locally. I may have wonky bits 💥 at this point due to that.
1. Structure/layout of the content on the PR:
   * The nav options are covered early ... right next to the early, existing `NavigateTo` coverage.
   * The existing content on handling loc changes at the `Router` level should probably be covered first, as it's broader, app-level behavior.
   * The new section for handling loc changes in components follows.
1. The coverage seeks to address the most common use cases. Do we need to expand for additional anticipated common use cases? It's best if you shoot the code example(s) to me for what you have in mind. Either you or I can set up code as *fully-working/cut-'n-paste examples*. I recommend we take that approach as much as possible.
1. I cross-link the `BasicTestApp` examples but don't think we want to show something like these in general coverage. Devs can explore them (and try them locally) if they wish after following the links.
1. It looks like handler disposal is automatic. Even if that's correct, is there anything in particular to call out beyond what I say in the text about it?
1. Outside of the nice `ConfirmExternalNavigation` feature, what's better about using `NavigationLock` over just registering a handler and not using the `NavigationLock` component?
1. Per MS style guidelines, we describe 'selected' buttons, not 'clicked' buttons.