### PR TITLE
Fix example for nested purposes with user input

### DIFF
--- a/aspnetcore/security/data-protection/consumer-apis/purpose-strings.md
+++ b/aspnetcore/security/data-protection/consumer-apis/purpose-strings.md
@@ -34,7 +34,7 @@ Since the purposes parameter to `CreateProtector` is a string array, the above c
 >
 >For example, consider a component Contoso.Messaging.SecureMessage which is responsible for storing secure messages. If the secure messaging component were to call `CreateProtector([ username ])`, then a malicious user might create an account with username "Contoso.Security.BearerToken" in an attempt to get the component to call `CreateProtector([ "Contoso.Security.BearerToken" ])`, thus inadvertently causing the secure messaging system to mint payloads that could be perceived as authentication tokens.
 >
->A better purposes chain for the messaging component would be `CreateProtector([ "Contoso.Messaging.SecureMessage", "User: username" ])`, which provides proper isolation.
+>A better purposes chain for the messaging component would be `CreateProtector([ "Contoso.Messaging.SecureMessage", $"User: {username}" ])`, which provides proper isolation.
 
 The isolation provided by and behaviors of `IDataProtectionProvider`, `IDataProtector`, and purposes are as follows:
 


### PR DESCRIPTION
The warning about user input and using nested purposes to provide isolation uses a constant string instead of the actual user input.

Fixes #26930


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->