### PR TITLE
use xunit exception assertions in grpc integration test sample

### DIFF
--- a/aspnetcore/grpc/test-services/sample/Tests/Server/IntegrationTests/MockedGreeterServiceTests.cs
+++ b/aspnetcore/grpc/test-services/sample/Tests/Server/IntegrationTests/MockedGreeterServiceTests.cs
@@ -66,23 +66,19 @@ namespace Tests.Server.IntegrationTests
         }
         #endregion
 
-        [Test]
+        [Fact]
         public async Task SayHelloUnaryTest_MockGreeter_Error()
         {
             // Arrange
             var client = new Tester.TesterClient(Channel);
 
             // Act
-            try
-            {
-                await client.SayHelloUnaryAsync(new HelloRequest { Name = "" });
-                Assert.Fail();
-            }
-            catch (RpcException ex)
-            {
-                // Assert
-                StringAssert.Contains("Name not provided.", ex.Status.Detail);
-            }
+            var exception = await Record.ExceptionAsync(async () =>
+                await client.SayHelloUnaryAsync(new HelloRequest { Name = "" }));
+
+            // Assert
+            Assert.IsType<RpcException>(exception);
+            Assert.Contains("Name not provided.", exception.Message);
         }
     }
 }

--- a/aspnetcore/grpc/test-services/sample/Tests/Server/IntegrationTests/MockedGreeterServiceTests.cs
+++ b/aspnetcore/grpc/test-services/sample/Tests/Server/IntegrationTests/MockedGreeterServiceTests.cs
@@ -73,11 +73,10 @@ namespace Tests.Server.IntegrationTests
             var client = new Tester.TesterClient(Channel);
 
             // Act
-            var exception = await Record.ExceptionAsync(async () =>
+            var exception = await Assert.ThrowsAsync<RpcException>(async () =>
                 await client.SayHelloUnaryAsync(new HelloRequest { Name = "" }));
 
             // Assert
-            Assert.IsType<RpcException>(exception);
             Assert.Contains("Name not provided.", exception.Message);
         }
     }


### PR DESCRIPTION
Fixes #26937

This test fails to build when using Visual Studio Code or a CodeSpace. This change makes use of xUnit's exception assertions that are already included in the .csproj to conduct the same test.