### PR TITLE
update custom provider code snippet

### DIFF
--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -723,7 +723,7 @@ services.Configure<RequestLocalizationOptions>(options =>
     options.AddInitialRequestCultureProvider(new CustomRequestCultureProvider(async context =>
     {
         // My custom request culture logic
-        return new ProviderCultureResult("en");
+        return await Task.FromResult(new ProviderCultureResult("en"));
     }));
 });
 ```

--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -352,7 +352,7 @@ services.Configure<RequestLocalizationOptions>(options =>
     options.AddInitialRequestCultureProvider(new CustomRequestCultureProvider(async context =>
     {
         // My custom request culture logic
-        return new ProviderCultureResult("en");
+        return await Task.FromResult(new ProviderCultureResult("en"));
     }));
 });
 ```


### PR DESCRIPTION
The code on line 355 lacks an awaiter despite being part of an async method, and triggers a warning for not being awaited in .NET 6. I settled on this implementation which eliminates the warning and functions properly. It seems like there should be some more code here to help with the async method, hence my proposed change. However, please let me know if I am incorrect or misunderstanding this code.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->