### PR TITLE
Address dotnet/docs #31084 - contradicting recommendations

### DIFF
--- a/aspnetcore/includes/combine-di6.md
+++ b/aspnetcore/includes/combine-di6.md
@@ -12,7 +12,4 @@ The remaining services are registered in a similar class. The following code use
 
 [!code-csharp[](~/fundamentals/configuration/index/samples/6.x/ConfigSample/program.cs?name=snippet3)]
 
-**_Note:_** Each `services.Add{GROUP_NAME}` extension method adds and potentially configures services. For example, <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddControllersWithViews%2A> adds the services MVC controllers with views require, and <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages%2A> adds the services Razor Pages requires. We recommend that apps follow the naming convention of creating extension methods in the <xref:Microsoft.Extensions.DependencyInjection?displayProperty=fullName> namespace. Creating extension methods in the `Microsoft.Extensions.DependencyInjection` namespace:
-
-* Encapsulates groups of service registrations.
-* Provides convenient [IntelliSense](/visualstudio/ide/using-intellisense) access to the service.
+**_Note:_** Each `services.Add{GROUP_NAME}` extension method adds and potentially configures services. For example, <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddControllersWithViews%2A> adds the services MVC controllers with views require, and <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddRazorPages%2A> adds the services Razor Pages requires.


### PR DESCRIPTION
The .NET docs formally recommend _not_ using the `Microsoft.Extensions.DependencyInjection` namespace, [.NET docs: Options pattern guidance for .NET library authors — Namespace guidance](https://docs.microsoft.com/dotnet/core/extensions/options-library-authors#namespace-guidance). The sentence being removed in this PR are a contradiction to the .NET docs recommendation.

This PR removes the recommendation to use namespaces owned by Microsoft. Otherwise, doing so has a good chance of colliding with our future additions in these namespaces.

Fixes dotnet/docs#31084