### PR TITLE
Clean up "In Program.cs" step

### DIFF
--- a/aspnetcore/blazor/tutorials/signalr-blazor.md
+++ b/aspnetcore/blazor/tutorials/signalr-blazor.md
@@ -447,13 +447,9 @@ Create a `Hubs` (plural) folder and add the following `ChatHub` class (`Hubs/Cha
 1. In `Program.cs`:
 
    * Use Response Compression Middleware at the top of the processing pipeline's configuration.
-   * Between the endpoints for mapping the Blazor hub and the client-side fallback, add an endpoint for the hub:
+   * Between the endpoints for mapping the Blazor hub and the client-side fallback, add an endpoint for the hub.
 
-     ```csharp
-     app.MapHub<ChatHub>("/chathub");
-     ```
-
-   :::code language="csharp" source="~/../blazor-samples/6.0/BlazorServerSignalRApp/Program.cs" id="snippet_Configure":::
+   :::code language="csharp" source="~/../blazor-samples/6.0/BlazorServerSignalRApp/Program.cs" id="snippet_Configure" highlight="1,17":::
 
 ## Add Razor component code for chat
 
@@ -2100,13 +2096,9 @@ Create a `Hubs` (plural) folder and add the following `ChatHub` class (`Hubs/Cha
 1. In `Program.cs`:
 
    * Use Response Compression Middleware at the top of the processing pipeline's configuration.
-   * Between the endpoints for mapping the Blazor hub and the client-side fallback, add an endpoint for the hub:
+   * Between the endpoints for mapping the Blazor hub and the client-side fallback, add an endpoint for the hub.
 
-     ```csharp
-     app.MapHub<ChatHub>("/chathub");
-     ```
-
-   :::code language="csharp" source="~/../blazor-samples/7.0/BlazorServerSignalRApp/Program.cs" id="snippet_Configure":::
+   :::code language="csharp" source="~/../blazor-samples/7.0/BlazorServerSignalRApp/Program.cs" id="snippet_Configure" highlight="1,16":::
 
 ## Add Razor component code for chat
 


### PR DESCRIPTION
Fixes  #27052

Thanks @d4shm1r! :rocket: This will use line highlights, so the text part can avoid individual code lines.

and btw ... There's a number difference of line 16 vs. line 17. That's because I removed a comment line from the `Program.cs` file that's normally in the project template. It moves up that highlight to line 16 in the 7.0 example.