### PR TITLE
Add an AddMyDependencyGroup extension method

### DIFF
--- a/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigSample/Options/MyConfigServiceCollectionExtensions.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/3.x/ConfigSample/Options/MyConfigServiceCollectionExtensions.cs
@@ -15,5 +15,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return services;
         }
+
+        public static IServiceCollection AddMyDependencyGroup(
+             this IServiceCollection services)
+        {
+            services.AddScoped<IMyDependency, MyDependency>();
+            services.AddScoped<IMyDependency2, MyDependency2>();
+
+            return services;
+        }
     }
 }

--- a/aspnetcore/fundamentals/configuration/index/samples/6.x/ConfigSample/Options/MyConfigServiceCollectionExtensions.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/6.x/ConfigSample/Options/MyConfigServiceCollectionExtensions.cs
@@ -15,5 +15,14 @@ namespace Microsoft.Extensions.DependencyInjection
 
             return services;
         }
+
+        public static IServiceCollection AddMyDependencyGroup(
+             this IServiceCollection services)
+        {
+            services.AddScoped<IMyDependency, MyDependency>();
+            services.AddScoped<IMyDependency2, MyDependency2>();
+
+            return services;
+        }
     }
 }


### PR DESCRIPTION
Fixes #27095

The code in `snippet3` of [Program.cs](https://github.com/dotnet/AspNetCore.Docs/blob/3057fe3e950d41d39d55b45d7545acdba63defed/aspnetcore/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs#L99) in the configuration fundamentals section makes a call to a non-existent extension method called `AddMyDependencyGroup`, this PR adds that extension method.

