### PR TITLE
Clarify AddEntityFrameworkStores behavior

### DIFF
--- a/aspnetcore/security/authentication/customize-identity-model.md
+++ b/aspnetcore/security/authentication/customize-identity-model.md
@@ -292,6 +292,8 @@ The context is used to configure the model in two ways:
 
 When overriding `OnModelCreating`, `base.OnModelCreating` should be called first; the overriding configuration should be called next. EF Core generally has a last-one-wins policy for configuration. For example, if the `ToTable` method for an entity type is called first with one table name and then again later with a different table name, the table name in the second call is used.
 
+NOTE: If the `DbContext` for your app does not derive from `IdentityDbContext`, `AddEntityFrameworkStores` potentially will not infer the correct POCO types, for TUserClaim, TUserLogin, TUserToken, you should directly add your stores via `services.AddScoped<IUser/RoleStore<TUser>, UserStore<...>>` with the correct types.
+
 ### Custom user data
 
 <!--

--- a/aspnetcore/security/authentication/customize-identity-model.md
+++ b/aspnetcore/security/authentication/customize-identity-model.md
@@ -292,7 +292,7 @@ The context is used to configure the model in two ways:
 
 When overriding `OnModelCreating`, `base.OnModelCreating` should be called first; the overriding configuration should be called next. EF Core generally has a last-one-wins policy for configuration. For example, if the `ToTable` method for an entity type is called first with one table name and then again later with a different table name, the table name in the second call is used.
 
-NOTE: If the `DbContext` for your app does not derive from `IdentityDbContext`, `AddEntityFrameworkStores` potentially will not infer the correct POCO types, for TUserClaim, TUserLogin, TUserToken, you should directly add your stores via `services.AddScoped<IUser/RoleStore<TUser>, UserStore<...>>` with the correct types.
+***NOTE***: If the `DbContext` doesn't derive from `IdentityDbContext`, `AddEntityFrameworkStores` may not infer the correct POCO types for `TUserClaim`, `TUserLogin`, and `TUserToken`. If `AddEntityFrameworkStores` doesn't infer the correct POCO types, a workaround is to directly add the correct types via `services.AddScoped<IUser/RoleStore<TUser>` and `UserStore<...>>`.
 
 ### Custom user data
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/12511

Clarify AddEntityFrameworkStores behavior and workaround when not using a derived IdentityDbContext