### PR TITLE
Update Blazor Hybrid prereq

### DIFF
--- a/aspnetcore/blazor/hybrid/tutorials/maui.md
+++ b/aspnetcore/blazor/hybrid/tutorials/maui.md
@@ -5,7 +5,7 @@ description: Build a .NET MAUI Blazor app step-by-step.
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/23/2022
+ms.date: 09/29/2022
 uid: blazor/hybrid/tutorials/maui
 ---
 # Build a .NET MAUI Blazor app
@@ -20,16 +20,16 @@ This tutorial shows you how to build and run a .NET MAUI Blazor app. You learn h
 ## Prerequisites
 
 * [Supported platforms (.NET MAUI documentation)](/dotnet/maui/supported-platforms)
-* [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/) with the **.NET Multi-platform App UI development** workload.
+* [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with the **.NET Multi-platform App UI development** workload.
 * [Microsoft Edge `WebView2`](https://developer.microsoft.com/microsoft-edge/webview2/): `WebView2` is required on Windows when running a native app. When developing .NET MAUI Blazor apps and only running them in Visual Studio's emulators, `WebView2` isn't required.
 * [Enable hardware acceleration](/dotnet/maui/android/emulator/hardware-acceleration) to improve the performance of the Android emulator.
 
 > [!NOTE]
-> Blazor Hybrid has reached General Availability (GA) and is fully supported for production workloads. Visual Studio and Visual Studio for Mac are in prerelease for working on Blazor Hybrid apps and may be modified before final release. We recommend keeping Visual Studio 2022 Preview updated for the best tooling experience.
+> Blazor Hybrid has reached General Availability (GA) and is fully supported for production workloads. Visual Studio for Mac is in prerelease for working on Blazor Hybrid apps and may be modified before final release. We recommend keeping Visual Studio 2022 updated for the best tooling experience.
 
 ## Create a .NET MAUI Blazor app
 
-Launch Visual Studio 2022 Preview.
+Launch Visual Studio 2022.
 
 In the Start Window, select **Create a new project**:
 

--- a/aspnetcore/blazor/hybrid/tutorials/windows-forms.md
+++ b/aspnetcore/blazor/hybrid/tutorials/windows-forms.md
@@ -22,7 +22,7 @@ This tutorial shows you how to build and run a Windows Forms Blazor app. You lea
 * [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with the **.NET desktop development** workload
 
 > [!NOTE]
-> Blazor Hybrid has reached General Availability (GA) and is fully supported for production workloads. Visual Studio for Mac are in prerelease for working on Blazor Hybrid apps and may be modified before final release. We recommend keeping Visual Studio 2022 updated for the best tooling experience.
+> Blazor Hybrid has reached General Availability (GA) and is fully supported for production workloads. Visual Studio for Mac is in prerelease for working on Blazor Hybrid apps and may be modified before final release. We recommend keeping Visual Studio 2022 updated for the best tooling experience.
 
 ## Visual Studio workload
 

--- a/aspnetcore/blazor/hybrid/tutorials/windows-forms.md
+++ b/aspnetcore/blazor/hybrid/tutorials/windows-forms.md
@@ -19,10 +19,10 @@ This tutorial shows you how to build and run a Windows Forms Blazor app. You lea
 ## Prerequisites
 
 * [Supported platforms (Windows Forms documentation)](/dotnet/desktop/winforms/overview/)
-* [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/) with the **.NET desktop development** workload
+* [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with the **.NET desktop development** workload
 
 > [!NOTE]
-> Blazor Hybrid has reached General Availability (GA) and is fully supported for production workloads. Visual Studio and Visual Studio for Mac are in prerelease for working on Blazor Hybrid apps and may be modified before final release. We recommend keeping Visual Studio 2022 Preview updated for the best tooling experience.
+> Blazor Hybrid has reached General Availability (GA) and is fully supported for production workloads. Visual Studio for Mac are in prerelease for working on Blazor Hybrid apps and may be modified before final release. We recommend keeping Visual Studio 2022 updated for the best tooling experience.
 
 ## Visual Studio workload
 
@@ -32,7 +32,7 @@ If the **.NET desktop development** workload isn't installed, use the Visual Stu
 
 ## Create a Windows Forms Blazor project
 
-Start Visual Studio 2022 Preview.
+Start Visual Studio 2022.
 
 In the Start Window, select **Create a new project**:
 

--- a/aspnetcore/blazor/hybrid/tutorials/wpf.md
+++ b/aspnetcore/blazor/hybrid/tutorials/wpf.md
@@ -20,10 +20,10 @@ This tutorial shows you how to build and run a WPF Blazor app. You learn how to:
 ## Prerequisites
 
 * [Supported platforms (WPF documentation)](/dotnet/desktop/wpf/overview/)
-* [Visual Studio 2022 Preview](https://visualstudio.microsoft.com/vs/preview/) with the **.NET desktop development** workload
+* [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) with the **.NET desktop development** workload
 
 > [!NOTE]
-> Blazor Hybrid has reached General Availability (GA) and is fully supported for production workloads. Visual Studio and Visual Studio for Mac are in prerelease for working on Blazor Hybrid apps and may be modified before final release. We recommend keeping Visual Studio 2022 Preview updated for the best tooling experience.
+> Blazor Hybrid has reached General Availability (GA) and is fully supported for production workloads. Visual Studio for Mac is in prerelease for working on Blazor Hybrid apps and may be modified before final release. We recommend keeping Visual Studio 2022 updated for the best tooling experience.
 
 ## Visual Studio workload
 
@@ -33,7 +33,7 @@ If the **.NET desktop development** workload isn't installed, use the Visual Stu
 
 ## Create a WPF Blazor project
 
-Start Visual Studio 2022 Preview.
+Start Visual Studio 2022.
 
 In the Start Window, select **Create a new project**:
 


### PR DESCRIPTION
Fixes  #27131

~This PR only updates the MAUI tutorial. The Windows Forms and WPF tutorials still call for preview. I'm 👂 if they need to change in the same way.~

Nevermind ... I just picked up on the "**for Blazor Hybrid**" part of your issue title. I'll update the other two now. **_Done!_** 👍

I've set up ...

**Remove VS4Mac prerelease remark at 17.4 release**
https://github.com/dotnet/AspNetCore.Docs/issues/27133

... to track the VS4Mac update at 17.4.