### PR TITLE
Updates note for emitting Razor generated files

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -903,10 +903,10 @@ Rendered output:
 
 There are three directives that pertain to [Tag Helpers](xref:mvc/views/tag-helpers/intro).
 
-| Directive                                                                            | Function                                                                                   |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| [`@addTagHelper`](xref:mvc/views/tag-helpers/intro#add-helper-label)                 | Makes Tag Helpers available to a view.                                                     |
-| [`@removeTagHelper`](xref:mvc/views/tag-helpers/intro#remove-razor-directives-label) | Removes Tag Helpers previously added from a view.                                          |
+| Directive | Function |
+| --------- | -------- |
+| [`@addTagHelper`](xref:mvc/views/tag-helpers/intro#add-helper-label) | Makes Tag Helpers available to a view. |
+| [`@removeTagHelper`](xref:mvc/views/tag-helpers/intro#remove-razor-directives-label) | Removes Tag Helpers previously added from a view. |
 | [`@tagHelperPrefix`](xref:mvc/views/tag-helpers/intro#prefix-razor-directives-label) | Specifies a tag prefix to enable Tag Helper support and to make Tag Helper usage explicit. |
 
 ## Razor reserved keywords
@@ -948,13 +948,45 @@ C# Razor keywords must be double-escaped with `@(@C# Razor Keyword)` (for exampl
 
 ## Inspect the Razor C# class generated for a view
 
-The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By default, the generated code files are not emitted in recent versions of ASP.NET Core. To enable this, set the `EmitCompilerGeneratedFiles` directive in your `.csproj` file to `true`:
-```xml
-<PropertyGroup>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-</PropertyGroup>
+The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. When building a project, the Razor SDK generates an `obj/<build_configuration>/<target_framework_moniker>/Razor` directory in the project root. The directory structure within the `Razor` directory mirrors the project's directory structure.
+
+Consider the following directory structure in an ASP.NET Core Razor Pages project:
+
 ```
-When building the project, the Razor SDK generates an `obj/<build_configuration>/net6.0/generated/` directory in the project root. Its subdirectory contains the emitted Razor page code files.
+ Areas/
+   Admin/
+     Pages/
+       Index.cshtml
+       Index.cshtml.cs
+ Pages/
+   Shared/
+     _Layout.cshtml
+   _ViewImports.cshtml
+   _ViewStart.cshtml
+   Index.cshtml
+   Index.cshtml.cs
+  ```
+
+Building the project in *Debug* configuration yields the following `obj` directory:
+
+```
+ obj/
+   Debug/
+     netcoreapp2.1/
+       Razor/
+         Areas/
+           Admin/
+             Pages/
+               Index.g.cshtml.cs
+         Pages/
+           Shared/
+             _Layout.g.cshtml.cs
+           _ViewImports.g.cshtml.cs
+           _ViewStart.g.cshtml.cs
+           Index.g.cshtml.cs
+```
+
+To view the generated class for `Pages/Index.cshtml`, open `obj/Debug/netcoreapp2.1/Razor/Pages/Index.g.cshtml.cs`.
 
 ## View lookups and case sensitivity
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -948,10 +948,26 @@ C# Razor keywords must be double-escaped with `@(@C# Razor Keyword)` (for exampl
 
 ## Inspect the Razor C# class generated for a view
 
+::: moniker range=">= aspnetcore-5.0"
+
+The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By default, the generated code files aren't emitted. To enable emitting the code files, set the `EmitCompilerGeneratedFiles` directive in the project file (`.csproj`) to `true`:
+
+```xml
+<PropertyGroup>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+</PropertyGroup>
+```
+
+When building the project, the Razor SDK generates an `obj/<build_configuration>/net6.0/generated/` directory in the project root. Its subdirectory contains the emitted Razor page code files.
+
+::: moniker-end
+
 ::: moniker range="< aspnetcore-5.0"
 
-The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. When building a project, the Razor SDK generates an `obj/<build_configuration>/<target_framework_moniker>/Razor` directory in the project root. The directory structure within the `Razor` directory mirrors the project's directory structure.
-Consider the following directory structure in an ASP.NET Core Razor Pages project:
+The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. When building a project, the Razor SDK generates an `obj/{BUILD CONFIGURATION}/{TARGET FRAMEWORK MONIKER}/Razor` directory in the project root. The directory structure within the `Razor` directory mirrors the project's directory structure.
+
+Consider the following directory structure in an ASP.NET Core Razor Pages 2.1 project:
+
 ```
  Areas/
    Admin/
@@ -965,8 +981,10 @@ Consider the following directory structure in an ASP.NET Core Razor Pages projec
    _ViewStart.cshtml
    Index.cshtml
    Index.cshtml.cs
-  ```
-Building the project in *Debug* configuration yields the following `obj` directory:
+```
+
+Building the project in `Debug` configuration yields the following `obj` directory:
+
 ```
  obj/
    Debug/
@@ -983,19 +1001,8 @@ Building the project in *Debug* configuration yields the following `obj` directo
            _ViewStart.g.cshtml.cs
            Index.g.cshtml.cs
 ```
+
 To view the generated class for `Pages/Index.cshtml`, open `obj/Debug/netcoreapp2.1/Razor/Pages/Index.g.cshtml.cs`.
-
-::: moniker-end
-
-::: moniker range=">= aspnetcore-5.0"
-
-The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By default, the generated code files are not emitted. To enable this, set the `EmitCompilerGeneratedFiles` directive in your `.csproj` file to `true`:
-```xml
-<PropertyGroup>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-</PropertyGroup>
-```
-When building the project, the Razor SDK generates an `obj/<build_configuration>/net6.0/generated/` directory in the project root. Its subdirectory contains the emitted Razor page code files.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -954,7 +954,7 @@ The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By def
 
 ```xml
 <PropertyGroup>
-    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 </PropertyGroup>
 ```
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -958,7 +958,7 @@ The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By def
 </PropertyGroup>
 ```
 
-When building the project, the Razor SDK generates an `obj/<build_configuration>/net6.0/generated/` directory in the project root. Its subdirectory contains the emitted Razor page code files.
+When building a 6.0 project (`net6.0`) in the `Debug` build configuration, the Razor SDK generates an `obj/Debug/net6.0/generated/` directory in the project root. Its subdirectory contains the emitted Razor page code files.
 
 ::: moniker-end
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -903,10 +903,10 @@ Rendered output:
 
 There are three directives that pertain to [Tag Helpers](xref:mvc/views/tag-helpers/intro).
 
-| Directive | Function |
-| --------- | -------- |
-| [`@addTagHelper`](xref:mvc/views/tag-helpers/intro#add-helper-label) | Makes Tag Helpers available to a view. |
-| [`@removeTagHelper`](xref:mvc/views/tag-helpers/intro#remove-razor-directives-label) | Removes Tag Helpers previously added from a view. |
+| Directive                                                                            | Function                                                                                   |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| [`@addTagHelper`](xref:mvc/views/tag-helpers/intro#add-helper-label)                 | Makes Tag Helpers available to a view.                                                     |
+| [`@removeTagHelper`](xref:mvc/views/tag-helpers/intro#remove-razor-directives-label) | Removes Tag Helpers previously added from a view.                                          |
 | [`@tagHelperPrefix`](xref:mvc/views/tag-helpers/intro#prefix-razor-directives-label) | Specifies a tag prefix to enable Tag Helper support and to make Tag Helper usage explicit. |
 
 ## Razor reserved keywords
@@ -948,45 +948,13 @@ C# Razor keywords must be double-escaped with `@(@C# Razor Keyword)` (for exampl
 
 ## Inspect the Razor C# class generated for a view
 
-The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. When building a project, the Razor SDK generates an `obj/<build_configuration>/<target_framework_moniker>/Razor` directory in the project root. The directory structure within the `Razor` directory mirrors the project's directory structure.
-
-Consider the following directory structure in an ASP.NET Core Razor Pages project:
-
+The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By default, the generated code files are not emitted in recent versions of ASP.NET Core. To enable this, set the `EmitCompilerGeneratedFiles` directive in your `.csproj` file to `true`:
+```xml
+<PropertyGroup>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+</PropertyGroup>
 ```
- Areas/
-   Admin/
-     Pages/
-       Index.cshtml
-       Index.cshtml.cs
- Pages/
-   Shared/
-     _Layout.cshtml
-   _ViewImports.cshtml
-   _ViewStart.cshtml
-   Index.cshtml
-   Index.cshtml.cs
-  ```
-
-Building the project in *Debug* configuration yields the following `obj` directory:
-
-```
- obj/
-   Debug/
-     netcoreapp2.1/
-       Razor/
-         Areas/
-           Admin/
-             Pages/
-               Index.g.cshtml.cs
-         Pages/
-           Shared/
-             _Layout.g.cshtml.cs
-           _ViewImports.g.cshtml.cs
-           _ViewStart.g.cshtml.cs
-           Index.g.cshtml.cs
-```
-
-To view the generated class for `Pages/Index.cshtml`, open `obj/Debug/netcoreapp2.1/Razor/Pages/Index.g.cshtml.cs`.
+When building the project, the Razor SDK generates an `obj/<build_configuration>/net6.0/generated/` directory in the project root. Its subdirectory contains the emitted Razor page code files.
 
 ## View lookups and case sensitivity
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -948,13 +948,56 @@ C# Razor keywords must be double-escaped with `@(@C# Razor Keyword)` (for exampl
 
 ## Inspect the Razor C# class generated for a view
 
-The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By default, the generated code files are not emitted in recent versions of ASP.NET Core. To enable this, set the `EmitCompilerGeneratedFiles` directive in your `.csproj` file to `true`:
+::: moniker range="< aspnetcore-5.0"
+
+The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. When building a project, the Razor SDK generates an `obj/<build_configuration>/<target_framework_moniker>/Razor` directory in the project root. The directory structure within the `Razor` directory mirrors the project's directory structure.
+Consider the following directory structure in an ASP.NET Core Razor Pages project:
+```
+ Areas/
+   Admin/
+     Pages/
+       Index.cshtml
+       Index.cshtml.cs
+ Pages/
+   Shared/
+     _Layout.cshtml
+   _ViewImports.cshtml
+   _ViewStart.cshtml
+   Index.cshtml
+   Index.cshtml.cs
+  ```
+Building the project in *Debug* configuration yields the following `obj` directory:
+```
+ obj/
+   Debug/
+     netcoreapp2.1/
+       Razor/
+         Areas/
+           Admin/
+             Pages/
+               Index.g.cshtml.cs
+         Pages/
+           Shared/
+             _Layout.g.cshtml.cs
+           _ViewImports.g.cshtml.cs
+           _ViewStart.g.cshtml.cs
+           Index.g.cshtml.cs
+```
+To view the generated class for `Pages/Index.cshtml`, open `obj/Debug/netcoreapp2.1/Razor/Pages/Index.g.cshtml.cs`.
+
+::: moniker-end
+
+::: moniker range=">= aspnetcore-5.0"
+
+The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By default, the generated code files are not emitted. To enable this, set the `EmitCompilerGeneratedFiles` directive in your `.csproj` file to `true`:
 ```xml
 <PropertyGroup>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
 </PropertyGroup>
 ```
 When building the project, the Razor SDK generates an `obj/<build_configuration>/net6.0/generated/` directory in the project root. Its subdirectory contains the emitted Razor page code files.
+
+::: moniker-end
 
 ## View lookups and case sensitivity
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -948,45 +948,13 @@ C# Razor keywords must be double-escaped with `@(@C# Razor Keyword)` (for exampl
 
 ## Inspect the Razor C# class generated for a view
 
-The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. When building a project, the Razor SDK generates an `obj/<build_configuration>/<target_framework_moniker>/Razor` directory in the project root. The directory structure within the `Razor` directory mirrors the project's directory structure.
-
-Consider the following directory structure in an ASP.NET Core Razor Pages project:
-
+The [Razor SDK](xref:razor-pages/sdk) handles compilation of Razor files. By default, the generated code files are not emitted in recent versions of ASP.NET Core. To enable this, set the `EmitCompilerGeneratedFiles` directive in your `.csproj` file to `true`:
+```xml
+<PropertyGroup>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+</PropertyGroup>
 ```
- Areas/
-   Admin/
-     Pages/
-       Index.cshtml
-       Index.cshtml.cs
- Pages/
-   Shared/
-     _Layout.cshtml
-   _ViewImports.cshtml
-   _ViewStart.cshtml
-   Index.cshtml
-   Index.cshtml.cs
-  ```
-
-Building the project in *Debug* configuration yields the following `obj` directory:
-
-```
- obj/
-   Debug/
-     netcoreapp2.1/
-       Razor/
-         Areas/
-           Admin/
-             Pages/
-               Index.g.cshtml.cs
-         Pages/
-           Shared/
-             _Layout.g.cshtml.cs
-           _ViewImports.g.cshtml.cs
-           _ViewStart.g.cshtml.cs
-           Index.g.cshtml.cs
-```
-
-To view the generated class for `Pages/Index.cshtml`, open `obj/Debug/netcoreapp2.1/Razor/Pages/Index.g.cshtml.cs`.
+When building the project, the Razor SDK generates an `obj/<build_configuration>/net6.0/generated/` directory in the project root. Its subdirectory contains the emitted Razor page code files.
 
 ## View lookups and case sensitivity
 


### PR DESCRIPTION
Updates the section 'Inspect the Razor C# class generated for a view' to reflect the behavior of recent versions that by default omit the generated source files. Adds information on how to re-enable it.

Since the directory structure that was shown in the previous version of the section has changed (in fact, all generated files now get dumped in one single directory instead of mirroring the original structure), I took the liberty of removing it.

(Fixes #26804)