### PR TITLE
Add links to port tunneling in VS

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/test-min-api.md
+++ b/aspnetcore/fundamentals/minimal-apis/test-min-api.md
@@ -19,5 +19,6 @@ The [sample code on GitHub](https://github.com/dotnet/AspNetCore.Docs.Samples/tr
 
 * [Basic authentication tests](https://github.com/blowdart/idunno.Authentication/tree/dev/test/idunno.Authentication.Basic.Test) is not a .NET repository but was written by a member of the .NET team. It provides examples of basic authentication testing.
 * [View or download sample code](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/fundamentals/minimal-apis/samples/MinApiTestsSample)
+* [Use port tunneling Visual Studio to debug web APIs](/connectors/custom-connectors/port-tunneling)
 * <xref:mvc/controllers/testing>
 * <xref:test/razor-pages-tests>

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -678,6 +678,8 @@ items:
         uid: web-api/advanced/conventions
       - name: Handle errors
         uid: web-api/handle-errors
+      - name: Port tunneling in VS to debug web APIs
+        href: /connectors/custom-connectors/port-tunneling
       - name: Test with HttpRepl
         items:
           - name: Overview
@@ -690,6 +692,8 @@ items:
         uid: fundamentals/minimal-apis
       - name: OpenAPI in Minimal API apps
         uid: fundamentals/minimal-apis/openapi
+      - name: Port tunneling in VS to debug web APIs
+        href: /connectors/custom-connectors/port-tunneling
       - name: Filters in Minimal API apps
         uid: fundamentals/minimal-apis/min-api-filters
       - name: Unit and integration tests
@@ -911,6 +915,8 @@ items:
         href: /azure/azure-monitor/app/snapshot-debugger?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
       - name: Snapshot debugging in Visual Studio
         href: /visualstudio/debugger/debug-live-azure-applications
+      - name: Port tunneling in VS to debug web APIs
+        href: /connectors/custom-connectors/port-tunneling
       - name: Load and stress testing
         uid: test/loadtests
       - name: Troubleshoot and debug

--- a/aspnetcore/web-api/index.md
+++ b/aspnetcore/web-api/index.md
@@ -284,6 +284,7 @@ The `[Consumes]` attribute is applied to both actions. The `PostJson` action han
 * <xref:web-api/advanced/formatting>
 * <xref:tutorials/web-api-help-pages-using-swagger>
 * <xref:mvc/controllers/routing>
+* [Use port tunneling Visual Studio to debug web APIs](/connectors/custom-connectors/port-tunneling)
 * [Create a web API with ASP.NET Core](/training/modules/build-web-api-aspnet-core/)
 
 :::moniker-end
@@ -590,6 +591,7 @@ The `[Consumes]` attribute is applied to both actions. The `PostJson` action han
 * <xref:web-api/advanced/formatting>
 * <xref:tutorials/web-api-help-pages-using-swagger>
 * <xref:mvc/controllers/routing>
+* [Use port tunneling Visual Studio to debug web APIs](/connectors/custom-connectors/port-tunneling)
 * [Create a web API with ASP.NET Core](/training/modules/build-web-api-aspnet-core/)
 
 :::moniker-end


### PR DESCRIPTION
Internal review URLs, link is under the following doc's. See the TOC

* [Handle errors in ASP.NET Core web APIs](https://review.learn.microsoft.com/en-us/aspnet/core/web-api/handle-errors?view=aspnetcore-7.0&branch=pr-en-us-27193)
* [OpenAPI support in minimal APIs - ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/openapi?view=aspnetcore-7.0&branch=pr-en-us-27193)
* [test node](https://review.learn.microsoft.com/en-us/aspnet/core/test/middleware?view=aspnetcore-7.0&branch=pr-en-us-27193)

<img width="188" alt="image" src="https://user-images.githubusercontent.com/3605364/193939699-139307f1-0499-42b7-9ab8-af2707fc396f.png">

