### PR TITLE
Changing route parameter name

### DIFF
--- a/aspnetcore/mvc/advanced/custom-model-binding/samples/2.x/CustomModelBindingSample/Controllers/BoundAuthorsController.cs
+++ b/aspnetcore/mvc/advanced/custom-model-binding/samples/2.x/CustomModelBindingSample/Controllers/BoundAuthorsController.cs
@@ -21,7 +21,7 @@ namespace CustomModelBindingSample.Controllers
         #endregion
 
         #region demo2
-        [HttpGet("get/{authorId}")]
+        [HttpGet("get/{author}")]
         public IActionResult Get(Author author)
         {
             if (author == null)

--- a/aspnetcore/mvc/advanced/custom-model-binding/samples/3.x/CustomModelBindingSample/Controllers/BoundAuthorsController.cs
+++ b/aspnetcore/mvc/advanced/custom-model-binding/samples/3.x/CustomModelBindingSample/Controllers/BoundAuthorsController.cs
@@ -21,7 +21,7 @@ namespace CustomModelBindingSample.Controllers
         #endregion
 
         #region snippet_Get
-        [HttpGet("get/{authorId}")]
+        [HttpGet("get/{author}")]
         public IActionResult Get(Author author)
         {
             if (author == null)


### PR DESCRIPTION
Related #10341

Updating the `route parameter name` to make the sample code functional, however, this code produces a bad OpenAPI documentation, and we should review it later.