### PR TITLE
Prevent disk caching of service-worker-assets.js

### DIFF
--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -190,6 +190,14 @@ The cache-first strategy is valuable because:
 
 * **It ensures correctness.** When building a cache of offline resources, the service worker uses content hashing to guarantee it has fetched a complete and self-consistent snapshot of resources at a single instant in time. This cache is then used as an atomic unit. There's no point asking the network for newer resources, since the only versions required are the ones already cached. Anything else risks inconsistency and incompatibility (for example, trying to use versions of .NET assemblies that weren't compiled together).
 
+If you must prevent disk caching of the service worker assets, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
+
+```html
+<script>
+  navigator.serviceWorker.register('/service-worker.js', {updateViaCache: 'none'});
+</script>
+```
+
 ### Background updates
 
 As a mental model, you can think of an offline-first PWA as behaving like a mobile app that can be installed. The app starts up immediately regardless of network connectivity, but the installed app logic comes from a point-in-time snapshot that might not be the latest version.
@@ -545,6 +553,14 @@ The cache-first strategy is valuable because:
 
 * **It ensures correctness.** When building a cache of offline resources, the service worker uses content hashing to guarantee it has fetched a complete and self-consistent snapshot of resources at a single instant in time. This cache is then used as an atomic unit. There's no point asking the network for newer resources, since the only versions required are the ones already cached. Anything else risks inconsistency and incompatibility (for example, trying to use versions of .NET assemblies that weren't compiled together).
 
+If you must prevent disk caching of the service worker assets, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
+
+```html
+<script>
+  navigator.serviceWorker.register('/service-worker.js', {updateViaCache: 'none'});
+</script>
+```
+
 ### Background updates
 
 As a mental model, you can think of an offline-first PWA as behaving like a mobile app that can be installed. The app starts up immediately regardless of network connectivity, but the installed app logic comes from a point-in-time snapshot that might not be the latest version.
@@ -898,6 +914,14 @@ The cache-first strategy is valuable because:
   This is why the browser's `navigator.onLine` API isn't reliable and shouldn't be depended upon.
 
 * **It ensures correctness.** When building a cache of offline resources, the service worker uses content hashing to guarantee it has fetched a complete and self-consistent snapshot of resources at a single instant in time. This cache is then used as an atomic unit. There's no point asking the network for newer resources, since the only versions required are the ones already cached. Anything else risks inconsistency and incompatibility (for example, trying to use versions of .NET assemblies that weren't compiled together).
+
+If you must prevent disk caching of the service worker assets, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
+
+```html
+<script>
+  navigator.serviceWorker.register('/service-worker.js', {updateViaCache: 'none'});
+</script>
+```
 
 ### Background updates
 

--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -190,7 +190,7 @@ The cache-first strategy is valuable because:
 
 * **It ensures correctness.** When building a cache of offline resources, the service worker uses content hashing to guarantee it has fetched a complete and self-consistent snapshot of resources at a single instant in time. This cache is then used as an atomic unit. There's no point asking the network for newer resources, since the only versions required are the ones already cached. Anything else risks inconsistency and incompatibility (for example, trying to use versions of .NET assemblies that weren't compiled together).
 
-If you must prevent disk caching of the service worker assets, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
+If you must prevent the browser from fetching `service-worker-assets.js` from its HTTP cache, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
 
 ```html
 <script>
@@ -553,7 +553,7 @@ The cache-first strategy is valuable because:
 
 * **It ensures correctness.** When building a cache of offline resources, the service worker uses content hashing to guarantee it has fetched a complete and self-consistent snapshot of resources at a single instant in time. This cache is then used as an atomic unit. There's no point asking the network for newer resources, since the only versions required are the ones already cached. Anything else risks inconsistency and incompatibility (for example, trying to use versions of .NET assemblies that weren't compiled together).
 
-If you must prevent disk caching of the service worker assets, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
+If you must prevent the browser from fetching `service-worker-assets.js` from its HTTP cache, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
 
 ```html
 <script>
@@ -915,7 +915,7 @@ The cache-first strategy is valuable because:
 
 * **It ensures correctness.** When building a cache of offline resources, the service worker uses content hashing to guarantee it has fetched a complete and self-consistent snapshot of resources at a single instant in time. This cache is then used as an atomic unit. There's no point asking the network for newer resources, since the only versions required are the ones already cached. Anything else risks inconsistency and incompatibility (for example, trying to use versions of .NET assemblies that weren't compiled together).
 
-If you must prevent disk caching of the service worker assets, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
+If you must prevent the browser from fetching `service-worker-assets.js` from its HTTP cache, for example to resolve temporary integrity check failures when deploying a new version of the service worker, update the service worker registration in `wwwroot/index.html` with [`updateViaCache`](https://developer.mozilla.org/docs/Web/API/ServiceWorkerRegistration/updateViaCache) set to 'none':
 
 ```html
 <script>


### PR DESCRIPTION
Fixes #27247

... ~**_BUT_** ... this needs to go ON HOLD until the PU resolves what's going on. There might have been a PU fix for the underlying problem, so they'll need to tell me what the workaround is supposed to solve in light of the PR that may have fixed it. Discussion is taking place on https://github.com/dotnet/aspnetcore/issues/39252.~

This coverage seems fine for now. There's a new PU issue to consider the change (`updateViaCache: 'none'`) ... among other things ... for the project template for .NET 8. I'll refactor the language here for .NET 8 docs if this becomes the default.

Cross-ref: https://github.com/dotnet/aspnetcore/issues/44635