### PR TITLE
advise user to set Nullable property to disable

### DIFF
--- a/aspnetcore/data/ef-mvc/crud.md
+++ b/aspnetcore/data/ef-mvc/crud.md
@@ -158,7 +158,23 @@ This is server-side validation that you get by default; in a later tutorial you'
 
 [!code-csharp[](intro/samples/cu/Controllers/StudentsController.cs?name=snippet_Create&highlight=8)]
 
-Change the date to a valid value and click **Create** to see the new student appear in the **Index** page.
+Change the date to a valid value and click **Create** showing that we still cannot not create the new object. We need to disable the setting in our project template for this. 
+
+Please open csproj and change this settings:
+
+```xml
+<Nullable>enable</Nullable>
+```
+
+To the **disable** value.
+
+```xml
+<Nullable>disable</Nullable>
+```
+
+This will be addressed by our team in future.
+
+You should now be able to click **Create** to see the new student appear in the **Index** page.
 
 ## Update the Edit page
 


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

This fix disables the `<Nullable>` setting and will allow the user to create and update database records in SQL Server Local DB. This works in ASP.NET 6 and was originally report by @savionlee in #24541 

So to recap the nullable property in .csproj has been changed from:

```xml
<Nullable>enable</Nullable>
```

```xml
<Nullable>disable</Nullable>
```

This is the correct branch.