### PR TITLE
Minimal APIS Optional Parameters example /products/two will return a 404 and not throw

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -496,7 +496,8 @@ The preceding code calls the method with a null product if no request body is se
 | --------- | -------------- |
 | `/products?pageNumber=3` | `3` returned |
 | `/products` | `1` returned |
-| `/products/two` | `BadHttpRequestException`: Failed to bind parameter `"Nullable<int> pageNumber"` from "two".|
+| `/products?pageNumber=two` | `BadHttpRequestException`: Failed to bind parameter `"Nullable<int> pageNumber"` from "two". |
+| `/products/two` | HTTP 404 error, no matching route |
 
 See the [Binding Failures](#bf) section for more information.
 
@@ -1340,7 +1341,8 @@ The preceding code calls the method with a null product if no request body is se
 | --------- | -------------- |
 | `/products?pageNumber=3` | `3` returned |
 | `/products` | `1` returned |
-| `/products/two` | `BadHttpRequestException`: Failed to bind parameter `"Nullable<int> pageNumber"` from "two".|
+| `/products?pageNumber=two` | `BadHttpRequestException`: Failed to bind parameter `"Nullable<int> pageNumber"` from "two". |
+| `/products/two` | HTTP 404 error, no matching route |
 
 See the [Binding Failures](#bf) section for more information.
 


### PR DESCRIPTION
In the example for [optional parameters](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-6.0#optional-parameters), the route registered is `app.MapGet("/products", (int? pageNumber) => $"Requesting page {pageNumber ?? 1}");`.

If you call the API with `/products/two` it will return a `404` and not throw an exception as the documentation indicates.

See the attached screenshots.

![image](https://user-images.githubusercontent.com/19230602/195403427-8919315f-6b65-478e-b4b7-1dbbb98a47e6.png)

![image](https://user-images.githubusercontent.com/19230602/195909265-3d37da29-51da-4973-b28f-90b11ef0706e.png)

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->