### PR TITLE
Thin the Blazor "JavaScript" names to "JS"

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -8,7 +8,7 @@ items:
       - name: About ASP.NET Core
         uid: index
       - name: Compare ASP.NET Core and ASP.NET
-        uid: fundamentals/choose-between-aspnet-and-aspnetcorehttps://github.com/dotnet/runtime/blob/main/src/mono/wasm/runtime/blazor
+        uid: fundamentals/choose-between-aspnet-and-aspnetcore
       - name: Compare .NET and .NET Framework
         href: /dotnet/standard/choosing-core-framework-server?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
   - name: Get started

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -459,7 +459,7 @@ items:
                 uid: blazor/js-interop/call-javascript-from-dotnet
               - name: Call .NET from JS
                 uid: blazor/js-interop/call-dotnet-from-javascript
-              - name: JS [JSImport]/[JSExport] interop
+              - name: [JSImport]/[JSExport] interop
                 uid: blazor/js-interop/import-export-interop
           - name: Call a web API
             uid: blazor/call-web-api

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -459,7 +459,7 @@ items:
                 uid: blazor/js-interop/call-javascript-from-dotnet
               - name: Call .NET from JS
                 uid: blazor/js-interop/call-dotnet-from-javascript
-              - name: [JSImport]/[JSExport] interop
+              - name: \[JSImport]/[JSExport] interop
                 uid: blazor/js-interop/import-export-interop
           - name: Call a web API
             uid: blazor/call-web-api

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -8,7 +8,7 @@ items:
       - name: About ASP.NET Core
         uid: index
       - name: Compare ASP.NET Core and ASP.NET
-        uid: fundamentals/choose-between-aspnet-and-aspnetcore
+        uid: fundamentals/choose-between-aspnet-and-aspnetcorehttps://github.com/dotnet/runtime/blob/main/src/mono/wasm/runtime/blazor
       - name: Compare .NET and .NET Framework
         href: /dotnet/standard/choosing-core-framework-server?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
   - name: Get started
@@ -455,9 +455,9 @@ items:
             items:
               - name: Overview
                 uid: blazor/js-interop/index
-              - name: Call JavaScript from .NET
+              - name: Call JS from .NET
                 uid: blazor/js-interop/call-javascript-from-dotnet
-              - name: Call .NET from JavaScript
+              - name: Call .NET from JS
                 uid: blazor/js-interop/call-dotnet-from-javascript
               - name: JS [JSImport]/[JSExport] interop
                 uid: blazor/js-interop/import-export-interop


### PR DESCRIPTION
The sub-node title for this group of topics is "JavaScript interop," and I've already merged the new JS interop article PR to use the name "JS [JSImport]/[JSExport] interop," so let's go with "JS" over "JavaScript" for each entry in this sub-node.

# 🤔

mmmmmmmmmm ...

Let's just go with "[JSImport]/[JSExport] interop" for that article.