### PR TITLE
Escape didn't work in name

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -459,7 +459,7 @@ items:
                 uid: blazor/js-interop/call-javascript-from-dotnet
               - name: Call .NET from JS
                 uid: blazor/js-interop/call-dotnet-from-javascript
-              - name: \[JSImport]/[JSExport] interop
+              - name: JSImport/JSExport interop
                 uid: blazor/js-interop/import-export-interop
           - name: Call a web API
             uid: blazor/call-web-api


### PR DESCRIPTION
Without an escape ...

```yaml
- name: [JSImport]/[JSExport] interop
```

... it breaks the build. With an escape (`\`), it shows it ...

![image](https://user-images.githubusercontent.com/1622880/197197166-da9ce10b-1965-4f9e-a9ed-7d64910c1bfe.png)

I'll strip the brackets off of the name. That's fine for this entry.

No giant rush to merge this to live. The presence of the backslash is trivial at the moment.