### PR TITLE
Can't retrieve scoped service correctly

### DIFF
--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -427,7 +427,8 @@ services
     })
     .AddCallCredentials(async (context, metadata, serviceProvider) =>
     {
-        var provider = serviceProvider.GetRequiredService<ITokenProvider>();
+        var scope = serviceProvider.CreateScope();
+        var provider = scope.ServiceProvider.GetRequiredService<ITokenProvider>();
         var token = await provider.GetTokenAsync();
         metadata.Add("Authorization", $"Bearer {token}");
     }));


### PR DESCRIPTION
GetService() method will simply throw an error if we try to get an scoped service on it. I change to call CreateScope() at first which fixes the problem.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->