### PR TITLE
Blazor SignalR configuration updates

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -268,7 +268,7 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
-When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example, based on the `Index` component in the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor), uses default values:
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -291,6 +291,11 @@ When changing the values of the server timeout (<xref:Microsoft.AspNetCore.Signa
 
 * The server timeout should be at least double the value assigned to the keep-alive interval.
 * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+
+For more information, see the *Global deployment and connection failures* sections of the following articles:
+
+* <xref:blazor/host-and-deploy/server#global-deployment-and-connection-failures>
+* <xref:blazor/host-and-deploy/webassembly#global-deployment-and-connection-failures>
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -646,7 +651,7 @@ The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroo
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
-When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example, based on the `Index` component in the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor), uses default values:
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -669,6 +674,11 @@ When changing the values of the server timeout (<xref:Microsoft.AspNetCore.Signa
 
 * The server timeout should be at least double the value assigned to the keep-alive interval.
 * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+
+For more information, see the *Global deployment and connection failures* sections of the following articles:
+
+* <xref:blazor/host-and-deploy/server#global-deployment-and-connection-failures>
+* <xref:blazor/host-and-deploy/webassembly#global-deployment-and-connection-failures>
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -1010,7 +1020,7 @@ The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroo
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
-When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example, based on the `Index` component in the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor), uses default values:
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -1033,6 +1043,11 @@ When changing the values of the server timeout (<xref:Microsoft.AspNetCore.Signa
 
 * The server timeout should be at least double the value assigned to the keep-alive interval.
 * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+
+For more information, see the *Global deployment and connection failures* sections of the following articles:
+
+* <xref:blazor/host-and-deploy/server#global-deployment-and-connection-failures>
+* <xref:blazor/host-and-deploy/webassembly#global-deployment-and-connection-failures>
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -1380,7 +1395,7 @@ When `autostart` is disabled, any aspect of the app that doesn't depend on the c
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
 
-## Configure SignalR server timeout and Keep-Alive on the client
+## Configure SignalR timeouts and Keep-Alive on the client
 
 Configure the following values for the client:
 
@@ -1407,7 +1422,7 @@ The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroo
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
-When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example, based on the `Index` component in the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor), uses default values:
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -1430,6 +1445,11 @@ When changing the values of the server timeout (<xref:Microsoft.AspNetCore.Signa
 
 * The server timeout should be at least double the value assigned to the keep-alive interval.
 * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+
+For more information, see the *Global deployment and connection failures* sections of the following articles:
+
+* <xref:blazor/host-and-deploy/server#global-deployment-and-connection-failures>
+* <xref:blazor/host-and-deploy/webassembly#global-deployment-and-connection-failures>
 
 ## Configure SignalR client logging (Blazor Server)
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -232,25 +232,14 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor Server app's SignalR circuit in the `Pages/_Layout.cshtml` file:
-
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Place a script that calls `Blazor.start` after the `blazor.server.js` script's `<script>` tag and inside the closing `</body>` tag.
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
 Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Layout.cshtml` file (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` or `blazor.webassembly.js` script.
 * Place a script that calls `Blazor.start` after the Blazor script is loaded and inside the closing `</body>` tag.
 
--->
-
 When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
 
 ## Configure SignalR server timeout and Keep-Alive on the client
 
@@ -266,16 +255,18 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 <script>
   Blazor.start({
     configureSignalR: function (builder) {
-      builder.serverTimeoutInMilliseconds = 30000;
-      builder.keepAliveIntervalInMilliseconds = 15000;
+      let c = builder.build();
+      c.serverTimeoutInMilliseconds = 30000;
+      c.keepAliveIntervalInMilliseconds = 15000;
+      builder.build = () => {
+        return c;
+      };
     }
-});
+  });
 </script>
 ```
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
-
--->
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -595,25 +586,14 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor Server app's SignalR circuit in the `Pages/_Host.cshtml` file:
-
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Place a script that calls `Blazor.start` after the `blazor.server.js` script's `<script>` tag and inside the closing `</body>` tag.
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
 Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` or `blazor.webassembly.js` script.
 * Place a script that calls `Blazor.start` after the Blazor script is loaded and inside the closing `</body>` tag.
 
--->
-
 When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
 
 ## Configure SignalR server timeout and Keep-Alive on the client
 
@@ -622,23 +602,25 @@ Configure the following values for the client:
 * `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds).
 * `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds).
 
-The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
+The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
 ```html
 <script src="_framework/blazor.{HOSTING MODEL}.js" autostart="false"></script>
 <script>
   Blazor.start({
     configureSignalR: function (builder) {
-      builder.serverTimeoutInMilliseconds = 30000;
-      builder.keepAliveIntervalInMilliseconds = 15000;
+      let c = builder.build();
+      c.serverTimeoutInMilliseconds = 30000;
+      c.keepAliveIntervalInMilliseconds = 15000;
+      builder.build = () => {
+        return c;
+      };
     }
-});
+  });
 </script>
 ```
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
-
--->
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -944,25 +926,14 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor Server app's SignalR circuit in the `Pages/_Host.cshtml` file:
-
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Place a script that calls `Blazor.start` after the `blazor.server.js` script's `<script>` tag and inside the closing `</body>` tag.
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
 Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` or `blazor.webassembly.js` script.
 * Place a script that calls `Blazor.start` after the Blazor script is loaded and inside the closing `</body>` tag.
 
--->
-
 When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
 
 ## Configure SignalR server timeout and Keep-Alive on the client
 
@@ -971,23 +942,25 @@ Configure the following values for the client:
 * `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds).
 * `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds).
 
-The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
+The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
 ```html
 <script src="_framework/blazor.{HOSTING MODEL}.js" autostart="false"></script>
 <script>
   Blazor.start({
     configureSignalR: function (builder) {
-      builder.serverTimeoutInMilliseconds = 30000;
-      builder.keepAliveIntervalInMilliseconds = 15000;
+      let c = builder.build();
+      c.serverTimeoutInMilliseconds = 30000;
+      c.keepAliveIntervalInMilliseconds = 15000;
+      builder.build = () => {
+        return c;
+      };
     }
-});
+  });
 </script>
 ```
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
-
--->
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -1326,25 +1299,14 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor Server app's SignalR circuit in the `Pages/_Host.cshtml` file:
-
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` script.
-* Place a script that calls `Blazor.start` after the `blazor.server.js` script's `<script>` tag and inside the closing `</body>` tag.
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
 Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
 
 * Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` or `blazor.webassembly.js` script.
 * Place a script that calls `Blazor.start` after the Blazor script is loaded and inside the closing `</body>` tag.
 
--->
-
 When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
 
 ## Configure SignalR server timeout and Keep-Alive on the client
 
@@ -1353,23 +1315,25 @@ Configure the following values for the client:
 * `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds).
 * `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds).
 
-The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
+The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
 ```html
 <script src="_framework/blazor.{HOSTING MODEL}.js" autostart="false"></script>
 <script>
   Blazor.start({
     configureSignalR: function (builder) {
-      builder.serverTimeoutInMilliseconds = 30000;
-      builder.keepAliveIntervalInMilliseconds = 15000;
+      let c = builder.build();
+      c.serverTimeoutInMilliseconds = 30000;
+      c.keepAliveIntervalInMilliseconds = 15000;
+      builder.build = () => {
+        return c;
+      };
     }
-});
+  });
 </script>
 ```
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
-
--->
 
 ## Configure SignalR client logging (Blazor Server)
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -245,8 +245,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds). The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds). The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
@@ -623,8 +623,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds). The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds). The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
@@ -987,8 +987,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds). The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds). The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
@@ -1384,8 +1384,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds). The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`)..
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds). The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -245,8 +245,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds). The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds). The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
@@ -268,7 +268,7 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
-When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout>, and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -286,6 +286,11 @@ protected override async Task OnInitializedAsync()
     await hubConnection.StartAsync();
 }
 ```
+
+When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+
+* The server timeout should be at least double the value assigned to the keep-alive interval.
+* The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -618,10 +623,10 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds). The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds). The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
-The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
+The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
 ```html
 <script src="_framework/blazor.{HOSTING MODEL}.js" autostart="false"></script>
@@ -641,7 +646,7 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
-When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout>, and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -659,6 +664,11 @@ protected override async Task OnInitializedAsync()
     await hubConnection.StartAsync();
 }
 ```
+
+When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+
+* The server timeout should be at least double the value assigned to the keep-alive interval.
+* The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -977,10 +987,10 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds). The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds). The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
-The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
+The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
 ```html
 <script src="_framework/blazor.{HOSTING MODEL}.js" autostart="false"></script>
@@ -1000,7 +1010,7 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
-When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout>, and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -1018,6 +1028,11 @@ protected override async Task OnInitializedAsync()
     await hubConnection.StartAsync();
 }
 ```
+
+When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+
+* The server timeout should be at least double the value assigned to the keep-alive interval.
+* The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -1369,10 +1384,10 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30,000 milliseconds (30 seconds). The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`)..
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15,000 milliseconds (15 seconds). The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
-The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
+The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
 ```html
 <script src="_framework/blazor.{HOSTING MODEL}.js" autostart="false"></script>
@@ -1392,7 +1407,7 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
-When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout>, and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
 
 ```csharp
 protected override async Task OnInitializedAsync()
@@ -1410,6 +1425,11 @@ protected override async Task OnInitializedAsync()
     await hubConnection.StartAsync();
 }
 ```
+
+When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+
+* The server timeout should be at least double the value assigned to the keep-alive interval.
+* The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
 ## Configure SignalR client logging (Blazor Server)
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -268,6 +268,25 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout>, and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+
+```csharp
+protected override async Task OnInitializedAsync()
+{
+    hubConnection = new HubConnectionBuilder()
+        .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+        .Build();
+
+    hubConnection.ServerTimeout = TimeSpan.FromSeconds(30);
+    hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
+    hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+    hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
+
+    await hubConnection.StartAsync();
+}
+```
+
 ## Configure SignalR client logging (Blazor Server)
 
 On the client builder, pass in the `configureSignalR` configuration object that calls `configureLogging` with the log level.
@@ -622,6 +641,25 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
 
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout>, and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+
+```csharp
+protected override async Task OnInitializedAsync()
+{
+    hubConnection = new HubConnectionBuilder()
+        .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+        .Build();
+
+    hubConnection.ServerTimeout = TimeSpan.FromSeconds(30);
+    hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
+    hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+    hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
+
+    await hubConnection.StartAsync();
+}
+```
+
 ## Configure SignalR client logging (Blazor Server)
 
 On the client builder, pass in the `configureSignalR` configuration object that calls `configureLogging` with the log level.
@@ -961,6 +999,25 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 ```
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
+
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout>, and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+
+```csharp
+protected override async Task OnInitializedAsync()
+{
+    hubConnection = new HubConnectionBuilder()
+        .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+        .Build();
+
+    hubConnection.ServerTimeout = TimeSpan.FromSeconds(30);
+    hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
+    hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+    hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
+
+    await hubConnection.StartAsync();
+}
+```
 
 ## Configure SignalR client logging (Blazor Server)
 
@@ -1334,6 +1391,25 @@ The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwr
 ```
 
 In the preceding markup, the `{HOSTING MODEL}` placeholder is either `server` for a Blazor Server app or `webassembly` for a Blazor WebAssembly app.
+
+When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout>, and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>. The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values:
+
+```csharp
+protected override async Task OnInitializedAsync()
+{
+    hubConnection = new HubConnectionBuilder()
+        .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+        .Build();
+
+    hubConnection.ServerTimeout = TimeSpan.FromSeconds(30);
+    hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
+    hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+    hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
+
+    await hubConnection.StartAsync();
+}
+```
 
 ## Configure SignalR client logging (Blazor Server)
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -245,8 +245,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the Keep-Alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Layout.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
@@ -287,10 +287,10 @@ protected override async Task OnInitializedAsync()
 }
 ```
 
-When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the Keep-Alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
 
-* The server timeout should be at least double the value assigned to the keep-alive interval.
-* The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+* The server timeout should be at least double the value assigned to the Keep-Alive interval.
+* The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
 For more information, see the *Global deployment and connection failures* sections of the following articles:
 
@@ -628,8 +628,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the Keep-Alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
@@ -670,10 +670,10 @@ protected override async Task OnInitializedAsync()
 }
 ```
 
-When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the Keep-Alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
 
-* The server timeout should be at least double the value assigned to the keep-alive interval.
-* The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+* The server timeout should be at least double the value assigned to the Keep-Alive interval.
+* The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
 For more information, see the *Global deployment and connection failures* sections of the following articles:
 
@@ -997,8 +997,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the Keep-Alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
@@ -1039,10 +1039,10 @@ protected override async Task OnInitializedAsync()
 }
 ```
 
-When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the Keep-Alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
 
-* The server timeout should be at least double the value assigned to the keep-alive interval.
-* The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+* The server timeout should be at least double the value assigned to the Keep-Alive interval.
+* The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
 For more information, see the *Global deployment and connection failures* sections of the following articles:
 
@@ -1399,8 +1399,8 @@ For more information, including how to initialize Blazor when the document is re
 
 Configure the following values for the client:
 
-* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the keep-alive interval (`keepAliveIntervalInMilliseconds`).
-* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The keep-alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
+* `serverTimeoutInMilliseconds`: The server timeout in milliseconds. If this timeout elapses without receiving any messages from the server, the connection is terminated with an error. The default timeout value is 30 seconds. The server timeout should be at least double the value assigned to the Keep-Alive interval (`keepAliveIntervalInMilliseconds`).
+* `keepAliveIntervalInMilliseconds`: Default interval at which to ping the server. This setting allows the server to detect hard disconnects, such as when a client unplugs their computer from the network. The ping occurs at most as often as the server pings. If the server pings every five seconds, assigning a value lower than `5000` (5 seconds) pings every five seconds. The default value is 15 seconds. The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout (`serverTimeoutInMilliseconds`).
 
 The following example for either `Pages/_Host.cshtml` (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly) uses default values:
 
@@ -1441,10 +1441,10 @@ protected override async Task OnInitializedAsync()
 }
 ```
 
-When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the Keep-Alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
 
-* The server timeout should be at least double the value assigned to the keep-alive interval.
-* The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+* The server timeout should be at least double the value assigned to the Keep-Alive interval.
+* The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
 For more information, see the *Global deployment and connection failures* sections of the following articles:
 

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -184,6 +184,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)
 * SignalR
   * [Blazor startup](xref:blazor/fundamentals/signalr#blazor-startup)
+  * [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
   * [Configure SignalR client logging](xref:blazor/fundamentals/signalr#configure-signalr-client-logging-blazor-server)
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
@@ -191,12 +192,6 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [Globalization and localization: Statically set the culture with `Blazor.start` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
-* [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
-
--->
 
 :::moniker-end
 
@@ -368,6 +363,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)
 * SignalR
   * [Blazor startup](xref:blazor/fundamentals/signalr#blazor-startup)
+  * [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
   * [Configure SignalR client logging](xref:blazor/fundamentals/signalr#configure-signalr-client-logging-blazor-server)
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
@@ -375,12 +371,6 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [Globalization and localization: Statically set the culture with `Blazor.start` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
-* [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
-
--->
 
 :::moniker-end
 
@@ -551,17 +541,12 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 * SignalR
   * [Blazor startup](xref:blazor/fundamentals/signalr#blazor-startup)
+  * [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
   * [Configure SignalR client logging](xref:blazor/fundamentals/signalr#configure-signalr-client-logging-blazor-server)
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
-* [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
-
--->
 
 :::moniker-end
 
@@ -780,6 +765,7 @@ To review the Blazor WebAssembly project template markup and styling for the def
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)
 * SignalR
   * [Blazor startup](xref:blazor/fundamentals/signalr#blazor-startup)
+  * [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
   * [Configure SignalR client logging](xref:blazor/fundamentals/signalr#configure-signalr-client-logging-blazor-server)
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
@@ -787,11 +773,5 @@ To review the Blazor WebAssembly project template markup and styling for the def
 * [Globalization and localization: Statically set the culture with `Blazor.start` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
-
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
-* [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
-
--->
 
 :::moniker-end

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -184,7 +184,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)
 * SignalR
   * [Blazor startup](xref:blazor/fundamentals/signalr#blazor-startup)
-  * [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
+  * [Configure SignalR timeouts and Keep-Alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client)
   * [Configure SignalR client logging](xref:blazor/fundamentals/signalr#configure-signalr-client-logging-blazor-server)
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
@@ -363,7 +363,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)
 * SignalR
   * [Blazor startup](xref:blazor/fundamentals/signalr#blazor-startup)
-  * [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
+  * [Configure SignalR timeouts and Keep-Alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client)
   * [Configure SignalR client logging](xref:blazor/fundamentals/signalr#configure-signalr-client-logging-blazor-server)
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
@@ -541,7 +541,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 * SignalR
   * [Blazor startup](xref:blazor/fundamentals/signalr#blazor-startup)
-  * [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
+  * [Configure SignalR timeouts and Keep-Alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client)
   * [Configure SignalR client logging](xref:blazor/fundamentals/signalr#configure-signalr-client-logging-blazor-server)
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
@@ -765,7 +765,7 @@ To review the Blazor WebAssembly project template markup and styling for the def
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)
 * SignalR
   * [Blazor startup](xref:blazor/fundamentals/signalr#blazor-startup)
-  * [Configure SignalR server timeout and keep alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client)
+  * [Configure SignalR timeouts and Keep-Alive on the client](xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client)
   * [Configure SignalR client logging](xref:blazor/fundamentals/signalr#configure-signalr-client-logging-blazor-server)
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -58,9 +58,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> are set to their default values and shown for demonstration purposes in case you need to change the value. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
   For a Blazor Server app in `Program.cs`:
 
@@ -69,7 +69,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       .AddHubOptions(options =>
       {
           options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-          options.HandshakeTimeout = TimeSpan.FromSeconds(30);
+          options.HandshakeTimeout = TimeSpan.FromSeconds(15);
           options.KeepAliveInterval = TimeSpan.FromSeconds(15);
       });
   ```
@@ -78,12 +78,12 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
 
 * **Client**
 
-  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30,000 milliseconds).
+  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds).
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> aren't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> don't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>, make sure that the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> on the server match the client settings.
+  > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value. A custom value of 60 seconds is used for the server timeout.
 
   In `Pages/_Layout.cshtml` of a Blazor Server app:
 
@@ -123,6 +123,11 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       await hubConnection.StartAsync();
   }
   ```
+
+  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+
+  * The server timeout should be at least double the value assigned to the keep-alive interval.
+  * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
 
@@ -847,9 +852,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> are set to their default values and shown for demonstration purposes in case you need to change the value. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
   For a Blazor Server app in `Program.cs`:
 
@@ -858,7 +863,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       .AddHubOptions(options =>
       {
           options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-          options.HandshakeTimeout = TimeSpan.FromSeconds(30);
+          options.HandshakeTimeout = TimeSpan.FromSeconds(15);
           options.KeepAliveInterval = TimeSpan.FromSeconds(15);
       });
   ```
@@ -867,12 +872,12 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
 
 * **Client**
 
-  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30,000 milliseconds).
+  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds).
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> aren't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> don't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>, make sure that the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> on the server match the client settings.
+  > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value. A custom value of 60 seconds is used for the server timeout.
 
   In `Pages/_Host.cshtml` of a Blazor Server app:
 
@@ -912,6 +917,11 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       await hubConnection.StartAsync();
   }
   ```
+
+  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+
+  * The server timeout should be at least double the value assigned to the keep-alive interval.
+  * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -45,8 +45,6 @@ A console warning appears if Long Polling is utilized:
 
 > :::no-loc text="Failed to connect via WebSockets, using the Long Polling fallback transport. This may be due to a VPN or proxy blocking the connection.":::
 
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
 Recommendations for global deployments to geographical data centers:
 
 * Deploy the app to the regions where most of the users reside.
@@ -60,7 +58,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> value is 50% or less of the timeout values and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
   >
   > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
@@ -80,30 +78,22 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
 
 * **Client**
 
-  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds`, default: 30,000 milliseconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
+  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30,000 milliseconds).
 
   > [!IMPORTANT]
-  > The `keepAliveIntervalInMilliseconds` isn't directly related to the reconnection UI appearing. The `keepAliveIntervalInMilliseconds` doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the `serverTimeoutInMilliseconds` can be increased and the `keepAliveIntervalInMilliseconds` can remain the same. The important consideration is that if you change the `keepAliveIntervalInMilliseconds`, make sure that the `keepAliveIntervalInMilliseconds` value is 50% or less of the timeout value and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> on the server matches the client setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> aren't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> don't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>, make sure that the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> on the server match the client settings.
   >
-  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
-  For a Blazor Server app in `Pages/_Layout.cshtml`:
+  In a Razor component after the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection> (`hubConnection`) is created:
 
-  ```html
-  <script src="_framework/blazor.server.js" autostart="false"></script>
-  <script>
-    Blazor.start({
-      configureSignalR: function (builder) {
-        builder.serverTimeoutInMilliseconds = 60000;
-        builder.keepAliveIntervalInMilliseconds = 15000;
-      }
-    });
-  </script>
+  ```csharp
+  hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
+  hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(30);
+  hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
   ```
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
-
--->
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
 
@@ -813,8 +803,6 @@ A console warning appears if Long Polling is utilized:
 
 > :::no-loc text="Failed to connect via WebSockets, using the Long Polling fallback transport. This may be due to a VPN or proxy blocking the connection.":::
 
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
 Recommendations for global deployments to geographical data centers:
 
 * Deploy the app to the regions where most of the users reside.
@@ -828,7 +816,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> value is 50% or less of the timeout values and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
   >
   > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
@@ -848,30 +836,22 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
 
 * **Client**
 
-  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds`, default: 30,000 milliseconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
+  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30,000 milliseconds).
 
   > [!IMPORTANT]
-  > The `keepAliveIntervalInMilliseconds` isn't directly related to the reconnection UI appearing. The `keepAliveIntervalInMilliseconds` doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the `serverTimeoutInMilliseconds` can be increased and the `keepAliveIntervalInMilliseconds` can remain the same. The important consideration is that if you change the `keepAliveIntervalInMilliseconds`, make sure that the `keepAliveIntervalInMilliseconds` value is 50% or less of the timeout value and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> on the server matches the client setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> aren't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> don't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>, make sure that the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> on the server match the client settings.
   >
-  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
-  For a Blazor Server app in `Pages/_Host.cshtml`:
+  In a Razor component after the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection> (`hubConnection`) is created:
 
-  ```html
-  <script src="_framework/blazor.server.js" autostart="false"></script>
-  <script>
-    Blazor.start({
-      configureSignalR: function (builder) {
-        builder.serverTimeoutInMilliseconds = 60000;
-        builder.keepAliveIntervalInMilliseconds = 15000;
-      }
-    });
-  </script>
+  ```csharp
+  hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
+  hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(30);
+  hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
   ```
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
-
--->
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -91,7 +91,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   In `Pages/_Layout.cshtml` of a Blazor Server app:
 
   ```html
-  <script src="_framework/blazor.webassembly.js" autostart="false"></script>
+  <script src="_framework/blazor.server.js" autostart="false"></script>
   <script>
     Blazor.start({
       configureSignalR: function (builder) {
@@ -881,10 +881,10 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   >
   > In the following example, a custom value of 60 seconds is used for the server timeout.
 
-  In `Pages/_Layout.cshtml` of a Blazor Server app:
+  In `Pages/_Host.cshtml` of a Blazor Server app:
 
   ```html
-  <script src="_framework/blazor.webassembly.js" autostart="false"></script>
+  <script src="_framework/blazor.server.js" autostart="false"></script>
   <script>
     Blazor.start({
       configureSignalR: function (builder) {

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -37,13 +37,17 @@ Each circuit uses approximately 250 KB of memory for a minimal *Hello World*-sty
 
 ## SignalR configuration
 
-Blazor Server apps use [ASP.NET Core SignalR](xref:signalr/introduction) to communicate with the browser. [SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply to Blazor Server apps.
+[SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply to Blazor apps that use SignalR.
+
+### Transports
 
 Blazor works best when using [WebSockets](xref:fundamentals/websockets) as the SignalR transport due to lower latency, better reliability, and improved [security](xref:signalr/security). [Long Polling](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md#long-polling-server-to-client-only) is used by SignalR when WebSockets isn't available or when the app is explicitly configured to use Long Polling. When deploying to Azure App Service, configure the app to use WebSockets in the Azure portal settings for the service. For details on configuring the app for Azure App Service, see the [SignalR publishing guidelines](xref:signalr/publish-to-azure-web-app).
 
 A console warning appears if Long Polling is utilized:
 
 > :::no-loc text="Failed to connect via WebSockets, using the Long Polling fallback transport. This may be due to a VPN or proxy blocking the connection.":::
+
+### Global deployment and connection failures
 
 Recommendations for global deployments to geographical data centers:
 
@@ -831,13 +835,17 @@ Each circuit uses approximately 250 KB of memory for a minimal *Hello World*-sty
 
 ## SignalR configuration
 
-Blazor Server apps use [ASP.NET Core SignalR](xref:signalr/introduction) to communicate with the browser. [SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply to Blazor Server apps.
+[SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply to Blazor apps that use SignalR.
+
+### Transports
 
 Blazor works best when using [WebSockets](xref:fundamentals/websockets) as the SignalR transport due to lower latency, better reliability, and improved [security](xref:signalr/security). [Long Polling](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md#long-polling-server-to-client-only) is used by SignalR when WebSockets isn't available or when the app is explicitly configured to use Long Polling. When deploying to Azure App Service, configure the app to use WebSockets in the Azure portal settings for the service. For details on configuring the app for Azure App Service, see the [SignalR publishing guidelines](xref:signalr/publish-to-azure-web-app).
 
 A console warning appears if Long Polling is utilized:
 
 > :::no-loc text="Failed to connect via WebSockets, using the Long Polling fallback transport. This may be due to a VPN or proxy blocking the connection.":::
+
+### Global deployment and connection failures
 
 Recommendations for global deployments to geographical data centers:
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -62,7 +62,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The Keep-Alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the Keep-Alive interval can remain the same. The important consideration is that if you change the Keep-Alive interval, make sure that the client timeout value is at least double the value of the Keep-Alive interval and that the Keep-Alive interval on the client matches the server setting.
   >
   > In the following example, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
@@ -84,7 +84,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds).
 
   > [!IMPORTANT]
-  > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
+  > The Keep-Alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The Keep-Alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the Keep-Alive interval can remain the same. The important consideration is that if you change the Keep-Alive interval, make sure that the timeout value is at least double the value of the Keep-Alive interval and that the Keep-Alive interval on the server matches the client setting.
   >
   > In the following example, a custom value of 60 seconds is used for the server timeout.
 
@@ -125,10 +125,10 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   }
   ```
 
-  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the Keep-Alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
 
-  * The server timeout should be at least double the value assigned to the keep-alive interval.
-  * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+  * The server timeout should be at least double the value assigned to the Keep-Alive interval.
+  * The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
@@ -857,7 +857,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The Keep-Alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the Keep-Alive interval can remain the same. The important consideration is that if you change the Keep-Alive interval, make sure that the client timeout value is at least double the value of the Keep-Alive interval and that the Keep-Alive interval on the client matches the server setting.
   >
   > In the following example, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
@@ -879,7 +879,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds).
 
   > [!IMPORTANT]
-  > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
+  > The Keep-Alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The Keep-Alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the Keep-Alive interval can remain the same. The important consideration is that if you change the Keep-Alive interval, make sure that the timeout value is at least double the value of the Keep-Alive interval and that the Keep-Alive interval on the server matches the client setting.
   >
   > In the following example, a custom value of 60 seconds is used for the server timeout.
 
@@ -920,10 +920,10 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   }
   ```
 
-  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the Keep-Alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
 
-  * The server timeout should be at least double the value assigned to the keep-alive interval.
-  * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+  * The server timeout should be at least double the value assigned to the Keep-Alive interval.
+  * The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -130,9 +130,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   * The server timeout should be at least double the value assigned to the Keep-Alive interval.
   * The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
-  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
-
-For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
+For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
 ## Azure SignalR Service
 
@@ -925,9 +923,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   * The server timeout should be at least double the value assigned to the Keep-Alive interval.
   * The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
-  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
-
-For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
+For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
 ## Azure SignalR Service
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -85,12 +85,43 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   >
   > In the following example, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
-  In a Razor component after the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection> (`hubConnection`) is created:
+  In `Pages/_Layout.cshtml` of a Blazor Server app:
+
+  ```html
+  <script src="_framework/blazor.webassembly.js" autostart="false"></script>
+  <script>
+    Blazor.start({
+      configureSignalR: function (builder) {
+        let c = builder.build();
+        c.serverTimeoutInMilliseconds = 60000;
+        c.keepAliveIntervalInMilliseconds = 15000;
+        builder.build = () => {
+          return c;
+        };
+      }
+    });
+  </script>
+  ```
+
+  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
+  
+  The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values for the handshake timeout and keep-alive interval with a custom value of 60 seconds for the server timeout:
 
   ```csharp
-  hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
-  hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(30);
-  hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+  protected override async Task OnInitializedAsync()
+  {
+      hubConnection = new HubConnectionBuilder()
+          .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+          .Build();
+
+      hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
+      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
+      hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+      hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
+
+      await hubConnection.StartAsync();
+  }
   ```
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
@@ -843,12 +874,43 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   >
   > In the following example, <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
-  In a Razor component after the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection> (`hubConnection`) is created:
+  In `Pages/_Host.cshtml` of a Blazor Server app:
+
+  ```html
+  <script src="_framework/blazor.webassembly.js" autostart="false"></script>
+  <script>
+    Blazor.start({
+      configureSignalR: function (builder) {
+        let c = builder.build();
+        c.serverTimeoutInMilliseconds = 60000;
+        c.keepAliveIntervalInMilliseconds = 15000;
+        builder.build = () => {
+          return c;
+        };
+      }
+    });
+  </script>
+  ```
+
+  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
+  
+  The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values for the handshake timeout and keep-alive interval with a custom value of 60 seconds for the server timeout:
 
   ```csharp
-  hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
-  hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(30);
-  hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+  protected override async Task OnInitializedAsync()
+  {
+      hubConnection = new HubConnectionBuilder()
+          .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+          .Build();
+
+      hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
+      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
+      hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+      hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
+
+      await hubConnection.StartAsync();
+  }
   ```
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -64,7 +64,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   > [!IMPORTANT]
   > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> are set to their default values and shown for demonstration purposes in case you need to change the value. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
+  > In the following example, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
   For a Blazor Server app in `Program.cs`:
 
@@ -73,8 +73,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       .AddHubOptions(options =>
       {
           options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-          options.HandshakeTimeout = TimeSpan.FromSeconds(15);
-          options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+          options.HandshakeTimeout = TimeSpan.FromSeconds(30);
       });
   ```
 
@@ -87,7 +86,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   > [!IMPORTANT]
   > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
   >
-  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value. A custom value of 60 seconds is used for the server timeout.
+  > In the following example, a custom value of 60 seconds is used for the server timeout.
 
   In `Pages/_Layout.cshtml` of a Blazor Server app:
 
@@ -98,7 +97,6 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       configureSignalR: function (builder) {
         let c = builder.build();
         c.serverTimeoutInMilliseconds = 60000;
-        c.keepAliveIntervalInMilliseconds = 15000;
         builder.build = () => {
           return c;
         };
@@ -107,9 +105,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   </script>
   ```
 
-  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
+  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
   
-  The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values for the handshake timeout and keep-alive interval with a custom value of 60 seconds for the server timeout:
+  The following example is based on the `Index` component in the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor). The server timeout is increased to 60 seconds, and the handshake timeout is increased to 30 seconds:
 
   ```csharp
   protected override async Task OnInitializedAsync()
@@ -119,8 +117,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
           .Build();
 
       hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
-      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
-      hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(30);
 
       hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
 
@@ -133,7 +130,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   * The server timeout should be at least double the value assigned to the keep-alive interval.
   * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
-  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
+  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
 
@@ -862,7 +859,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   > [!IMPORTANT]
   > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> are set to their default values and shown for demonstration purposes in case you need to change the value. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
+  > In the following example, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
   For a Blazor Server app in `Program.cs`:
 
@@ -871,8 +868,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       .AddHubOptions(options =>
       {
           options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-          options.HandshakeTimeout = TimeSpan.FromSeconds(15);
-          options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+          options.HandshakeTimeout = TimeSpan.FromSeconds(30);
       });
   ```
 
@@ -885,9 +881,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   > [!IMPORTANT]
   > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
   >
-  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value. A custom value of 60 seconds is used for the server timeout.
+  > In the following example, a custom value of 60 seconds is used for the server timeout.
 
-  In `Pages/_Host.cshtml` of a Blazor Server app:
+  In `Pages/_Layout.cshtml` of a Blazor Server app:
 
   ```html
   <script src="_framework/blazor.webassembly.js" autostart="false"></script>
@@ -896,7 +892,6 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       configureSignalR: function (builder) {
         let c = builder.build();
         c.serverTimeoutInMilliseconds = 60000;
-        c.keepAliveIntervalInMilliseconds = 15000;
         builder.build = () => {
           return c;
         };
@@ -905,9 +900,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   </script>
   ```
 
-  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
+  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
   
-  The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values for the handshake timeout and keep-alive interval with a custom value of 60 seconds for the server timeout:
+  The following example is based on the `Index` component in the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor). The server timeout is increased to 60 seconds, and the handshake timeout is increased to 30 seconds:
 
   ```csharp
   protected override async Task OnInitializedAsync()
@@ -917,8 +912,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
           .Build();
 
       hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
-      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
-      hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(30);
 
       hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
 
@@ -931,7 +925,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   * The server timeout should be at least double the value assigned to the keep-alive interval.
   * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
-  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
+  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -1022,6 +1022,27 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   </script>
   ```
 
+  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
+  
+  The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values for the handshake timeout and keep-alive interval with a custom value of 60 seconds for the server timeout:
+
+  ```csharp
+  protected override async Task OnInitializedAsync()
+  {
+      hubConnection = new HubConnectionBuilder()
+          .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+          .Build();
+
+      hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
+      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
+      hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+      hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
+
+      await hubConnection.StartAsync();
+  }
+  ```
+
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
@@ -3486,6 +3507,27 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       }
     });
   </script>
+  ```
+
+  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
+  
+  The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values for the handshake timeout and keep-alive interval with a custom value of 60 seconds for the server timeout:
+
+  ```csharp
+  protected override async Task OnInitializedAsync()
+  {
+      hubConnection = new HubConnectionBuilder()
+          .WithUrl(Navigation.ToAbsoluteUri("/chathub"))
+          .Build();
+
+      hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
+      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
+      hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+
+      hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
+
+      await hubConnection.StartAsync();
+  }
   ```
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -980,7 +980,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The Keep-Alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the Keep-Alive interval can remain the same. The important consideration is that if you change the Keep-Alive interval, make sure that the client timeout value is at least double the value of the Keep-Alive interval and that the Keep-Alive interval on the client matches the server setting.
   >
   > In the following example, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
@@ -1001,7 +1001,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds).
 
   > [!IMPORTANT]
-  > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
+  > The Keep-Alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The Keep-Alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the Keep-Alive interval can remain the same. The important consideration is that if you change the Keep-Alive interval, make sure that the timeout value is at least double the value of the Keep-Alive interval and that the Keep-Alive interval on the server matches the client setting.
   >
   > In the following example, a custom value of 60 seconds is used for the server timeout.
 
@@ -1042,10 +1042,10 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   }
   ```
 
-  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the Keep-Alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
 
-  * The server timeout should be at least double the value assigned to the keep-alive interval.
-  * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+  * The server timeout should be at least double the value assigned to the Keep-Alive interval.
+  * The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
@@ -3471,7 +3471,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The Keep-Alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the Keep-Alive interval can remain the same. The important consideration is that if you change the Keep-Alive interval, make sure that the client timeout value is at least double the value of the Keep-Alive interval and that the Keep-Alive interval on the client matches the server setting.
   >
   > In the following example, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
@@ -3492,7 +3492,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds).
 
   > [!IMPORTANT]
-  > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
+  > The Keep-Alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The Keep-Alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the Keep-Alive interval can remain the same. The important consideration is that if you change the Keep-Alive interval, make sure that the timeout value is at least double the value of the Keep-Alive interval and that the Keep-Alive interval on the server matches the client setting.
   >
   > In the following example, a custom value of 60 seconds is used for the server timeout.
 
@@ -3533,10 +3533,10 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   }
   ```
 
-  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the Keep-Alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
 
-  * The server timeout should be at least double the value assigned to the keep-alive interval.
-  * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
+  * The server timeout should be at least double the value assigned to the Keep-Alive interval.
+  * The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -1047,9 +1047,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   * The server timeout should be at least double the value assigned to the Keep-Alive interval.
   * The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
-  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
-
-For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
+For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
 :::moniker-end
 
@@ -3538,8 +3536,6 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   * The server timeout should be at least double the value assigned to the Keep-Alive interval.
   * The Keep-Alive interval should be less than or equal to half the value assigned to the server timeout.
 
-  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
-
-For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
+For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
 :::moniker-end

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -980,9 +980,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> are set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the values. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is set to a custom value of 60 seconds.
+  > In the following example, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
   For a hosted Blazor WebAssembly app in `Program.cs` of the **:::no-loc text="Server":::** project:
 
@@ -990,8 +990,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
    builder.Services.AddSignalR(options =>
    {
        options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-       options.HandshakeTimeout = TimeSpan.FromSeconds(15);
-       options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+       options.HandshakeTimeout = TimeSpan.FromSeconds(30);
    });
    ```
 
@@ -999,12 +998,12 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
 
 * **Client**
 
-  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
+  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds).
 
   > [!IMPORTANT]
   > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
   >
-  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value. A custom value of 60 seconds is used for the server timeout.
+  > In the following example, a custom value of 60 seconds is used for the server timeout.
 
   For a hosted Blazor WebAssembly app in `wwwroot/index.html` of the **:::no-loc text="Client":::** project:
 
@@ -1015,7 +1014,6 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       configureSignalR: function (builder) {
         let c = builder.build();
         c.serverTimeoutInMilliseconds = 60000;
-        c.keepAliveIntervalInMilliseconds = 15000;
         builder.build = () => {
           return c;
         };
@@ -1024,9 +1022,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   </script>
   ```
 
-  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
+  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
   
-  The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values for the handshake timeout and keep-alive interval with a custom value of 60 seconds for the server timeout:
+  The following example is based on the `Index` component in the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor). The server timeout is increased to 60 seconds, and the handshake timeout is increased to 30 seconds:
 
   ```csharp
   protected override async Task OnInitializedAsync()
@@ -1036,8 +1034,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
           .Build();
 
       hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
-      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
-      hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(30);
 
       hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
 
@@ -1050,7 +1047,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   * The server timeout should be at least double the value assigned to the keep-alive interval.
   * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
-  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
+  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
 
@@ -3474,9 +3471,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the client timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the client matches the server setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> are set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the values. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is set to a custom value of 60 seconds.
+  > In the following example, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is increased to 60 seconds, and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> is increased to 30 seconds.
 
   For a hosted Blazor WebAssembly app in `Program.cs` of the **:::no-loc text="Server":::** project:
 
@@ -3484,8 +3481,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
    builder.Services.AddSignalR(options =>
    {
        options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-       options.HandshakeTimeout = TimeSpan.FromSeconds(15);
-       options.KeepAliveInterval = TimeSpan.FromSeconds(15);
+       options.HandshakeTimeout = TimeSpan.FromSeconds(30);
    });
    ```
 
@@ -3493,12 +3489,12 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
 
 * **Client**
 
-  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
+  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds).
 
   > [!IMPORTANT]
   > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
   >
-  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value. A custom value of 60 seconds is used for the server timeout.
+  > In the following example, a custom value of 60 seconds is used for the server timeout.
 
   For a hosted Blazor WebAssembly app in `wwwroot/index.html` of the **:::no-loc text="Client":::** project:
 
@@ -3509,7 +3505,6 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       configureSignalR: function (builder) {
         let c = builder.build();
         c.serverTimeoutInMilliseconds = 60000;
-        c.keepAliveIntervalInMilliseconds = 15000;
         builder.build = () => {
           return c;
         };
@@ -3518,9 +3513,9 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   </script>
   ```
 
-  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds), <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds), and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
+  When creating a hub connection in a component, set the <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.HandshakeTimeout> (default: 15 seconds) on the built <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection>.
   
-  The following example based on the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor) uses default values for the handshake timeout and keep-alive interval with a custom value of 60 seconds for the server timeout:
+  The following example is based on the `Index` component in the [SignalR with Blazor tutorial](xref:blazor/tutorials/signalr-blazor). The server timeout is increased to 60 seconds, and the handshake timeout is increased to 30 seconds:
 
   ```csharp
   protected override async Task OnInitializedAsync()
@@ -3530,8 +3525,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
           .Build();
 
       hubConnection.ServerTimeout = TimeSpan.FromSeconds(60);
-      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(15);
-      hubConnection.KeepAliveInterval = TimeSpan.FromSeconds(15);
+      hubConnection.HandshakeTimeout = TimeSpan.FromSeconds(30);
 
       hubConnection.On<string, string>("ReceiveMessage", (user, message) => ...
 
@@ -3544,7 +3538,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   * The server timeout should be at least double the value assigned to the keep-alive interval.
   * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
-  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
+  For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-timeouts-and-keep-alive-on-the-client>.
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -997,12 +997,12 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
 
 * **Client**
 
-  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds`, default: 30,000 milliseconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
+  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
 
   > [!IMPORTANT]
-  > The `keepAliveIntervalInMilliseconds` isn't directly related to the reconnection UI appearing. The `keepAliveIntervalInMilliseconds` doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the `serverTimeoutInMilliseconds` can be increased and the `keepAliveIntervalInMilliseconds` can remain the same. The important consideration is that if you change the `keepAliveIntervalInMilliseconds`, make sure that the timeout value is at least double the value of the `keepAliveIntervalInMilliseconds` and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> on the server matches the client setting.
+  > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
   >
-  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value. A custom value of 60 seconds is used for the server timeout.
 
   For a hosted Blazor WebAssembly app in `wwwroot/index.html` of the **:::no-loc text="Client":::** project:
 
@@ -1042,6 +1042,11 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       await hubConnection.StartAsync();
   }
   ```
+
+  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+
+  * The server timeout should be at least double the value assigned to the keep-alive interval.
+  * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
 
@@ -3484,12 +3489,12 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
 
 * **Client**
 
-  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds`, default: 30,000 milliseconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
+  Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>, default: 30 seconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
 
   > [!IMPORTANT]
-  > The `keepAliveIntervalInMilliseconds` isn't directly related to the reconnection UI appearing. The `keepAliveIntervalInMilliseconds` doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the `serverTimeoutInMilliseconds` can be increased and the `keepAliveIntervalInMilliseconds` can remain the same. The important consideration is that if you change the `keepAliveIntervalInMilliseconds`, make sure that the timeout value is at least double the value of the `keepAliveIntervalInMilliseconds` and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> on the server matches the client setting.
+  > The keep-alive interval (`keepAliveIntervalInMilliseconds` or <xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>) isn't directly related to the reconnection UI appearing. The keep-alive interval doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the server timeout can be increased and the keep-alive interval can remain the same. The important consideration is that if you change the keep-alive interval, make sure that the timeout value is at least double the value of the keep-alive interval and that the keep-alive interval on the server matches the client setting.
   >
-  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value. A custom value of 60 seconds is used for the server timeout.
 
   For a hosted Blazor WebAssembly app in `wwwroot/index.html` of the **:::no-loc text="Client":::** project:
 
@@ -3529,6 +3534,11 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
       await hubConnection.StartAsync();
   }
   ```
+
+  When changing the values of the server timeout (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout>) or the keep-alive interval (<xref:Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval>:
+
+  * The server timeout should be at least double the value assigned to the keep-alive interval.
+  * The keep-alive interval should be less than or equal to half the value assigned to the server timeout.
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -289,7 +289,7 @@ To use a custom `web.config` file:
 
 If the SDK's `web.config` generation or transformation during publish either doesn't move the file to published assets in the `publish` folder or modifies the custom configuration in your custom `web.config` file, use any of the following approaches as needed to take full control of the process:
 
-* If the SDK doesn't generate the file, for example, in a standalone Blazor WebAssembly app at `/bin/Release/{TARGET FRAMEWORK}/publish/wwwroot` or `bin\Release\{TARGET FRAMEWORK}\browser-wasm\publish`, depending on which version of the SDK is used and where the `{TARGET FRAMEWORK}` placeholder is the target framework, set the `<PublishIISAssets>` property to `true` in the project file (`.csproj`). Usually for standalone WebAsssembly apps, this is the only required setting to move a custom `web.config` file and prevent transformation of the file by the SDK.
+* If the SDK doesn't generate the file, for example, in a standalone Blazor WebAssembly app at `/bin/Release/{TARGET FRAMEWORK}/publish/wwwroot` or `bin\Release\{TARGET FRAMEWORK}\browser-wasm\publish`, depending on which version of the SDK is used and where the `{TARGET FRAMEWORK}` placeholder is the target framework, set the `<PublishIISAssets>` property to `true` in the project file (`.csproj`). Usually for standalone WebAssembly apps, this is the only required setting to move a custom `web.config` file and prevent transformation of the file by the SDK.
 
   ```xml
   <PropertyGroup>
@@ -955,15 +955,17 @@ Again, disabling integrity checking means that you lose the safety guarantees of
 
 ## SignalR configuration
 
-*This section applies to hosted Blazor WebAssembly apps where the developer has implemented SignalR communication on their own.*
+[SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply to Blazor apps that use SignalR.
 
-When a developer has implemented [ASP.NET Core SignalR](xref:signalr/introduction) in a hosted Blazor WebAssembly app, [SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply.
+### Transport
 
 Blazor works best when using [WebSockets](xref:fundamentals/websockets) as the SignalR transport due to lower latency, better reliability, and improved [security](xref:signalr/security). [Long Polling](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md#long-polling-server-to-client-only) is used by SignalR when WebSockets isn't available or when the app is explicitly configured to use Long Polling. When deploying to Azure App Service, configure the app to use WebSockets in the Azure portal settings for the service. For details on configuring the app for Azure App Service, see the [SignalR publishing guidelines](xref:signalr/publish-to-azure-web-app).
 
 A console warning appears if Long Polling is utilized:
 
 > :::no-loc text="Failed to connect via WebSockets, using the Long Polling fallback transport. This may be due to a VPN or proxy blocking the connection.":::
+
+### Global deployment and connection failures
 
 Recommendations for global deployments to geographical data centers:
 
@@ -980,7 +982,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   > [!IMPORTANT]
   > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> are set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the values. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is set to a custom value of 60 seconds.
 
   For a hosted Blazor WebAssembly app in `Program.cs` of the **:::no-loc text="Server":::** project:
 
@@ -988,7 +990,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
    builder.Services.AddSignalR(options =>
    {
        options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-       options.HandshakeTimeout = TimeSpan.FromSeconds(30);
+       options.HandshakeTimeout = TimeSpan.FromSeconds(15);
        options.KeepAliveInterval = TimeSpan.FromSeconds(15);
    });
    ```
@@ -3447,15 +3449,17 @@ Again, disabling integrity checking means that you lose the safety guarantees of
 
 ## SignalR configuration
 
-*This section applies to hosted Blazor WebAssembly apps where the developer has implemented SignalR communication on their own.*
+[SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply to Blazor apps that use SignalR.
 
-When a developer has implemented [ASP.NET Core SignalR](xref:signalr/introduction) in a hosted Blazor WebAssembly app, [SignalR's hosting and scaling conditions](xref:signalr/publish-to-azure-web-app) apply.
+### Transports
 
 Blazor works best when using [WebSockets](xref:fundamentals/websockets) as the SignalR transport due to lower latency, better reliability, and improved [security](xref:signalr/security). [Long Polling](https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/docs/specs/TransportProtocols.md#long-polling-server-to-client-only) is used by SignalR when WebSockets isn't available or when the app is explicitly configured to use Long Polling. When deploying to Azure App Service, configure the app to use WebSockets in the Azure portal settings for the service. For details on configuring the app for Azure App Service, see the [SignalR publishing guidelines](xref:signalr/publish-to-azure-web-app).
 
 A console warning appears if Long Polling is utilized:
 
 > :::no-loc text="Failed to connect via WebSockets, using the Long Polling fallback transport. This may be due to a VPN or proxy blocking the connection.":::
+
+### Global deployment and connection failures
 
 Recommendations for global deployments to geographical data centers:
 
@@ -3472,7 +3476,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   > [!IMPORTANT]
   > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
   >
-  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
+  > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> are set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the values. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> is set to a custom value of 60 seconds.
 
   For a hosted Blazor WebAssembly app in `Program.cs` of the **:::no-loc text="Server":::** project:
 
@@ -3480,7 +3484,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
    builder.Services.AddSignalR(options =>
    {
        options.ClientTimeoutInterval = TimeSpan.FromSeconds(60);
-       options.HandshakeTimeout = TimeSpan.FromSeconds(30);
+       options.HandshakeTimeout = TimeSpan.FromSeconds(15);
        options.KeepAliveInterval = TimeSpan.FromSeconds(15);
    });
    ```

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -965,8 +965,6 @@ A console warning appears if Long Polling is utilized:
 
 > :::no-loc text="Failed to connect via WebSockets, using the Long Polling fallback transport. This may be due to a VPN or proxy blocking the connection.":::
 
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
 Recommendations for global deployments to geographical data centers:
 
 * Deploy the app to the regions where most of the users reside.
@@ -980,7 +978,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> value is 50% or less of the timeout values and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
   >
   > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
@@ -1002,7 +1000,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds`, default: 30,000 milliseconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
 
   > [!IMPORTANT]
-  > The `keepAliveIntervalInMilliseconds` isn't directly related to the reconnection UI appearing. The `keepAliveIntervalInMilliseconds` doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the `serverTimeoutInMilliseconds` can be increased and the `keepAliveIntervalInMilliseconds` can remain the same. The important consideration is that if you change the `keepAliveIntervalInMilliseconds`, make sure that the `keepAliveIntervalInMilliseconds` value is 50% or less of the timeout value and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> on the server matches the client setting.
+  > The `keepAliveIntervalInMilliseconds` isn't directly related to the reconnection UI appearing. The `keepAliveIntervalInMilliseconds` doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the `serverTimeoutInMilliseconds` can be increased and the `keepAliveIntervalInMilliseconds` can remain the same. The important consideration is that if you change the `keepAliveIntervalInMilliseconds`, make sure that the timeout value is at least double the value of the `keepAliveIntervalInMilliseconds` and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> on the server matches the client setting.
   >
   > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
@@ -1013,16 +1011,18 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   <script>
     Blazor.start({
       configureSignalR: function (builder) {
-        builder.serverTimeoutInMilliseconds = 60000;
-        builder.keepAliveIntervalInMilliseconds = 15000;
+        let c = builder.build();
+        c.serverTimeoutInMilliseconds = 60000;
+        c.keepAliveIntervalInMilliseconds = 15000;
+        builder.build = () => {
+          return c;
+        };
       }
     });
   </script>
   ```
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
-
--->
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
 
@@ -3431,8 +3431,6 @@ A console warning appears if Long Polling is utilized:
 
 > :::no-loc text="Failed to connect via WebSockets, using the Long Polling fallback transport. This may be due to a VPN or proxy blocking the connection.":::
 
-<!-- HOLD: WORKING ON https://github.com/dotnet/AspNetCore.Docs/issues/27320
-
 Recommendations for global deployments to geographical data centers:
 
 * Deploy the app to the regions where most of the users reside.
@@ -3446,7 +3444,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   At least double the maximum roundtrip time expected between the client and the server. Test, monitor, and revise the timeouts as needed. For the SignalR hub, set the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> (default: 30 seconds) and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> (default: 15 seconds). The following example assumes that <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> uses the default value of 15 seconds.
 
   > [!IMPORTANT]
-  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> value is 50% or less of the timeout values and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
+  > The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> isn't directly related to the reconnection UI appearing. The <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the <xref:Microsoft.AspNetCore.SignalR.HubOptions.ClientTimeoutInterval> and <xref:Microsoft.AspNetCore.SignalR.HubOptions.HandshakeTimeout> can be increased and the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> can remain the same. The important consideration is that if you change the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval>, make sure that the timeout value is at least double the value of the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> and that the `keepAliveIntervalInMilliseconds` on the client matches the server setting.
   >
   > In the following example, <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
@@ -3468,7 +3466,7 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   Typically, double the value used for the server's <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> to set the timeout for the client's server timeout (`serverTimeoutInMilliseconds`, default: 30,000 milliseconds). To configure the client, set the Blazor script's `autostart` attribute to `false` and configure the SignalR options in [`Blazor.start`](xref:blazor/fundamentals/startup).
 
   > [!IMPORTANT]
-  > The `keepAliveIntervalInMilliseconds` isn't directly related to the reconnection UI appearing. The `keepAliveIntervalInMilliseconds` doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the `serverTimeoutInMilliseconds` can be increased and the `keepAliveIntervalInMilliseconds` can remain the same. The important consideration is that if you change the `keepAliveIntervalInMilliseconds`, make sure that the `keepAliveIntervalInMilliseconds` value is 50% or less of the timeout value and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> on the server matches the client setting.
+  > The `keepAliveIntervalInMilliseconds` isn't directly related to the reconnection UI appearing. The `keepAliveIntervalInMilliseconds` doesn't necessarily need to be changed. If the reconnection UI appearance issue is due to timeouts, the `serverTimeoutInMilliseconds` can be increased and the `keepAliveIntervalInMilliseconds` can remain the same. The important consideration is that if you change the `keepAliveIntervalInMilliseconds`, make sure that the timeout value is at least double the value of the `keepAliveIntervalInMilliseconds` and that the <xref:Microsoft.AspNetCore.SignalR.HubOptions.KeepAliveInterval> on the server matches the client setting.
   >
   > In the following example, `keepAliveIntervalInMilliseconds` is set to the default value of 15 seconds and shown for demonstration purposes in case you need to change the value.
 
@@ -3479,16 +3477,18 @@ If a deployed app frequently displays the reconnection UI due to ping timeouts c
   <script>
     Blazor.start({
       configureSignalR: function (builder) {
-        builder.serverTimeoutInMilliseconds = 60000;
-        builder.keepAliveIntervalInMilliseconds = 15000;
+        let c = builder.build();
+        c.serverTimeoutInMilliseconds = 60000;
+        c.keepAliveIntervalInMilliseconds = 15000;
+        builder.build = () => {
+          return c;
+        };
       }
     });
   </script>
   ```
 
   For more information, see <xref:blazor/fundamentals/signalr#configure-signalr-server-timeout-and-keep-alive-on-the-client>.
-
--->
 
 For more information on SignalR configuration, see <xref:blazor/fundamentals/signalr>.
 


### PR DESCRIPTION
Fixes #27320

* I assume that a connection failure can also occur because the `ClientTimeoutInterval` isn't long enough on the server. I apply the same guidance to this as for the `ServerTimeout` on the client, namely that it should be at least double the keep-alive. I also say that when changing any of these on one side (server or client) that matching them on the other side (server or client) is sensible.
* When creating a new hub connection in a component, the `serverTimeoutInMilliseconds` / `keepAliveIntervalInMilliseconds` aren't reflected in `Microsoft.AspNetCore.SignalR.Client.HubConnection.ServerTimeout` / `Microsoft.AspNetCore.SignalR.Client.HubConnection.KeepAliveInterval`. AFAICT, they must be changed manually by the dev in the component where the hub connection is created. Therefore, I place client-side coverage for both the `Blazor.start` SignalR config and setting properties in a component on a created hub connection.