### PR TITLE
Matching type names of the sample server interceptors

### DIFF
--- a/aspnetcore/grpc/interceptors.md
+++ b/aspnetcore/grpc/interceptors.md
@@ -176,11 +176,11 @@ gRPC server interceptors intercept incoming RPC requests. They provide access to
 The following code presents an example of an intercepting an incoming unary RPC:
 
 ```csharp
-public class ServerLoggingInterceptor : Interceptor
+public class ServerLoggerInterceptor : Interceptor
 {
     private readonly ILogger _logger;
 
-    public ServerLoggingInterceptor(ILogger<ServerLoggingInterceptor> logger)
+    public ServerLoggerInterceptor(ILogger<ServerLoggerInterceptor> logger)
     {
         _logger = logger;
     }


### PR DESCRIPTION
Using ServerLoggerInterceptor everywhere in the document, because that is the type name also used by the samples, ie. when registering the interceptor to the services.

Fixes #27375