### PR TITLE
Fix variable name typo

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/min-api-filters/7samples/todo/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/min-api-filters/7samples/todo/Program.cs
@@ -117,7 +117,7 @@ app.MapPut("/todoitems/{id}", async (Todo inputTodo, int id, TodoDb db) =>
         {
             var todoParam = invocationContext.GetArgument<Todo>(0);
 
-            var validationError = Utilities.IsValid(tdparam);
+            var validationError = Utilities.IsValid(todoParam);
 
             if (!string.IsNullOrEmpty(validationError))
             {


### PR DESCRIPTION
It appears the wrong variable was used here. `tdparam` is declared elsewhere in the code. I believe IsValid should be using `todoParam` that is mentioned in the line above it.