### PR TITLE
Endpoint names are not inferred

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -329,7 +329,7 @@ Route handlers are methods that execute when the route matches. Route handlers c
 
 [!code-csharp[](minimal-apis/samples/WebMinAPIs/Program.cs?name=snippet_sm)]
 
-### Name endpoints and link generation
+### Named endpoints and link generation
 
 Endpoints can be given names in order to generate URLs to the endpoint. Using a named endpoint avoids having to hard code paths in an app:
 

--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -337,12 +337,6 @@ Routes can be given names in order to generate URLs to the route. Using a named 
 
 The preceding code displays `The link to the hello route is /hello` from the `/` endpoint.
 
-Route names are inferred from method names if specified:
-
-[!code-csharp[](minimal-apis/samples/WebMinAPIs/Program.cs?name=snippet_nr2)]
-
-**REVIEW**: `{linker.GetPathByName("Hi", values: null)}` is null in the preceding code.
-
 **NOTE**: Route names are case sensitive.
 
 Route names:

--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -329,17 +329,17 @@ Route handlers are methods that execute when the route matches. Route handlers c
 
 [!code-csharp[](minimal-apis/samples/WebMinAPIs/Program.cs?name=snippet_sm)]
 
-### Name routes and link generation
+### Name endpoints and link generation
 
-Routes can be given names in order to generate URLs to the route. Using a named route avoids having to hard code paths in an app:
+Endpoints can be given names in order to generate URLs to the endpoint. Using a named endpoint avoids having to hard code paths in an app:
 
 [!code-csharp[](minimal-apis/samples/WebMinAPIs/Program.cs?name=snippet_nr)]
 
-The preceding code displays `The link to the hello route is /hello` from the `/` endpoint.
+The preceding code displays `The link to the hello endpoint is /hello` from the `/` endpoint.
 
-**NOTE**: Route names are case sensitive.
+**NOTE**: Endpoint names are case sensitive.
 
-Route names:
+Endpoint names:
 
 * Must be globally unique.
 * Are used as the OpenAPI operation id when OpenAPI support is enabled. For more information, see [OpenAPI](xref:fundamentals/minimal-apis/openapi).


### PR DESCRIPTION
This was the behavior in some .NET 6 preview releases, but was reverted in .NET 6 RC 2 due to potential uniqueness issues given overloaded method groups: dotnet/aspnetcore#36518. This is why `{linker.GetPathByName("Hi", values: null)}` was null.

It's surprising that this REVIEW note stayed in the doc for over a year without anyone who knows about this noticing, but that's partially on me.

Also, these are technically "endpoint" names, not "route" names.
