### PR TITLE
Add HTTP/2 WebSockets to What's New in 7

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-7.0.md
+++ b/aspnetcore/release-notes/aspnetcore-7.0.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn about the new features in ASP.NET Core 7.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/19/2022
+ms.date: 11/01/2022
 uid: aspnetcore-7
 ---
 # What's new in ASP.NET Core 7.0 preview
@@ -460,6 +460,19 @@ One place where these improvements can be noticed is in gRPC, a popular RPC fram
 
 Changes were made in the HTTP/2 frame writing code that improves performance when there are multiple streams trying to write data on a single HTTP/2 connection. We now dispatch TLS work to the thread pool and more quickly release a write lock that other streams can acquire to write their data. The reduction in wait times can yield significant performance improvements in cases where there is contention for this write lock. A gRPC benchmark with 70 streams on a single connection (with TLS) showed a ~15% improvement in requests per second (RPS) with this change.
 
+### Http/2 WebSockets support
+
+.NET 7 introduces Websockets over HTTP/2 support for Kestrel, the SignalR JavaScript client, and SignalR with Blazor WebAssembly.
+
+Using WebSockets over HTTP/2 takes advantage of new features such as:
+
+* Header compression.
+* Multiplexing, which reduces the time and resources needed when making multiple requests to the server.
+
+These supported features are available in Kestrel on all HTTP/2 enabled platforms. The version negotiation is automatic in browsers and Kestrel, so no new APIs are needed.
+
+For more information, see [Http/2 WebSockets support](xref:fundamentals/websockets?view=aspnetcore-7.0#http2-websockets-support).
+
 ### Kestrel performance improvements on high core machines
 
 Kestrel uses <xref:System.Collections.Concurrent.ConcurrentQueue%601> for many purposes. One purpose is scheduling I/O operations in Kestrel's default Socket transport. Partitioning the `ConcurrentQueue` based on the associated socket reduces contention and increases throughput on machines with many CPU cores.
@@ -484,7 +497,7 @@ The [`ServerReady`](https://github.com/dotnet/aspnetcore/blob/v7.0.0-preview.5.2
 
 Shadow copying app assemblies to the [ASP.NET Core Module (ANCM)](xref:host-and-deploy/aspnet-core-module) for IIS can provide a better end user experience than stopping the app by deploying an [app offline file](xref:host-and-deploy/iis/app-offline).
 
-For more information, see [Shadow copying in IIS](xref:host-and-deploy/iis/advanced?view=aspnetcore-7.0#shadow-copy)
+For more information, see [Shadow copying in IIS](xref:host-and-deploy/iis/advanced?view=aspnetcore-7.0#shadow-copy).
 
 ## Miscellaneous
 
@@ -502,7 +515,7 @@ Here's an example of what the new output looks like:
 
 ![output for dotnet watch](~/release-notes/aspnetcore-7/static/dnwatch.png)
 
-See [this GitHub pull request](https://github.com/dotnet/sdk/pull/23318) for more information.
+For more information, see [this GitHub pull request](https://github.com/dotnet/sdk/pull/23318).
 
 ### Configure dotnet watch to always restart for rude edits
 


### PR DESCRIPTION
[Internal Review - New Section - Http/2 WebSockets support](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-7.0?view=aspnetcore-7.0&branch=pr-en-us-27466#http2-websockets-support)

Fixes #27442 