### PR TITLE
Switch minimal TOC titles and page titles

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/min-api-filters.md
+++ b/aspnetcore/fundamentals/minimal-apis/min-api-filters.md
@@ -1,7 +1,7 @@
 ---
-title: Filters in Minimal API applications
+title: Filters in Minimal API apps
 author: rick-anderson
-description: Use filters in Minimal API applications
+description: Use filters in Minimal API apps
 ms.author: riande
 ms.date: 8/11/2022
 monikerRange: '>= aspnetcore-7.0'

--- a/aspnetcore/fundamentals/minimal-apis/openapi.md
+++ b/aspnetcore/fundamentals/minimal-apis/openapi.md
@@ -1,5 +1,5 @@
 ---
-title: How to use OpenAPI in Minimal API applications
+title: How to use OpenAPI in Minimal API apps
 author: rick-anderson
 description: Learn how to use OpenAPI (Swagger and Swashbuckle) features of minimal APIs in ASP.NET Core.
 ms.author: riande
@@ -8,7 +8,7 @@ ms.date: 10/24/2022
 uid: fundamentals/minimal-apis/openapi
 ---
 
-# OpenAPI support in minimal APIs - ASP.NET Core
+# OpenAPI support in minimal API apps
 
 :::moniker range="= aspnetcore-6.0"
 

--- a/aspnetcore/fundamentals/minimal-apis/parameter-binding.md
+++ b/aspnetcore/fundamentals/minimal-apis/parameter-binding.md
@@ -8,6 +8,6 @@ ms.date: 10/31/2022
 uid: fundamentals/minimal-apis/parameter-binding
 ---
 
-# Parameter Binding
+# Parameter Binding in Minimal API apps
 
 [!INCLUDE [parameter-binding](includes/parameter-binding.md)]

--- a/aspnetcore/fundamentals/minimal-apis/route-handlers.md
+++ b/aspnetcore/fundamentals/minimal-apis/route-handlers.md
@@ -1,14 +1,14 @@
 ---
-title: Route handlers in Minimal API applications
+title: Route handlers in Minimal API apps
 author: rick-anderson
-description: Learn how to handle requests in Minimal API applications.
+description: Learn how to handle requests in Minimal API apps.
 ms.author: riande
 monikerRange: '>= aspnetcore-7.0'
 ms.date: 10/31/2022
 uid: fundamentals/minimal-apis/route-handlers
 ---
 
-# Route Handlers
+# Route Handlers in Minimal API apps
 
 A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapMethods%2A> where `{Verb}` is a camel-cased HTTP method like `Get`, `Post`, `Put` or `Delete`:
 

--- a/aspnetcore/fundamentals/minimal-apis/security.md
+++ b/aspnetcore/fundamentals/minimal-apis/security.md
@@ -25,7 +25,7 @@ There are two strategies for determining user access to resources in the authori
 
 In ASP.NET Core, both strategies are captured into an authorization requirement. The authorization service leverages authorization handlers to determine whether or not a particular user meets the authorization requirements applied onto a resource. 
 
-## Enabling authentication in minimal applications
+## Enabling authentication in minimal apps
 
 To enable authentication, call [`AddAuthentication`](/dotnet/api/microsoft.extensions.dependencyinjection.authenticationservicecollectionextensions.addauthentication) to register the required authentication services on the app's service provider.
 
@@ -130,7 +130,7 @@ var app = builder.Build();
 app.Run();
 ```
 
-## Configuring authorization policies in minimal applications
+## Configuring authorization policies in minimal apps
 
 Authentication is used to identify and validate the identity of users against an API. Authorization is used to validate and verify access to resources in an API and is facilitated by the `IAuthorizationService` registered by the `AddAuthorization` extension method. In the following scenario, a `/hello` resource is added that requires a user to present an `is_admin` claim with a `greetings_api` scope.
 

--- a/aspnetcore/fundamentals/minimal-apis/test-min-api.md
+++ b/aspnetcore/fundamentals/minimal-apis/test-min-api.md
@@ -1,7 +1,7 @@
 ---
-title: Test Minimal API applications
+title: Test Minimal API apps
 author: rick-anderson
-description: Unit and integration tests in Minimal API applications
+description: Unit and integration tests in Minimal API apps
 ms.author: riande
 ms.date: 9/30/2022
 monikerRange: '>= aspnetcore-7.0'

--- a/aspnetcore/fundamentals/minimal-apis/webapplication.md
+++ b/aspnetcore/fundamentals/minimal-apis/webapplication.md
@@ -1,5 +1,5 @@
 ---
-title: WebApplication and WebApplicationBuilder in Minimal API applications
+title: WebApplication and WebApplicationBuilder in Minimal API apps
 author: rick-anderson
 description: Learn about how to use WebApplication and WebApplicationBuilder.
 ms.author: riande
@@ -8,6 +8,6 @@ ms.date: 10/31/2022
 uid: fundamentals/minimal-apis/webapplication
 ---
 
-# WebApplication and WebApplicationBuilder
+# WebApplication and WebApplicationBuilder in Minimal API apps
 
 [!INCLUDE [WebApplication and WebApplicationBuilder](includes/webapplication.md)]

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -702,23 +702,23 @@ items:
         uid: fundamentals/minimal-apis
       - name: WebApplication and WebApplicationBuilder
         uid: fundamentals/minimal-apis/webapplication
-      - name: Route Handlers in Minimal API apps
+      - name: Route Handlers
         uid: fundamentals/minimal-apis/route-handlers
-      - name: Parameter binding in Minimal API apps
+      - name: Parameter binding
         uid: fundamentals/minimal-apis/parameter-binding
-      - name: Create responses in Minimal API apps
+      - name: Create responses
         uid: fundamentals/minimal-apis/responses
-      - name: OpenAPI in Minimal API apps
+      - name: OpenAPI
         uid: fundamentals/minimal-apis/openapi
       - name: Port tunneling in VS to debug web APIs
         href: /connectors/custom-connectors/port-tunneling
-      - name: Filters in Minimal API apps
+      - name: Filters
         uid: fundamentals/minimal-apis/min-api-filters
       - name: Unit and integration tests
         uid: fundamentals/minimal-apis/test-min-api
-      - name: Middleware in Minimal API apps
+      - name: Middleware
         uid: fundamentals/minimal-apis/middleware
-      - name: Handle errors in Minimal API apps
+      - name: Handle errors
         uid: fundamentals/minimal-apis/handle-errors
   - name: Real-time apps
     displayName: signalr


### PR DESCRIPTION
This PR switches minimal TOC titles and page titles for Minimal API apps. It also replaces references to "minimal applications" with "minimal apps".