### PR TITLE
Add config for Quest import

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
-          
+          issue: '-1'

--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,0 +1,34 @@
+name: "bulk quest import"
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "The reason for running the bulk import workflow"
+        required: true
+        default: "Initial import into Quest (Azure DevOps)"
+
+jobs:
+  bulk-import:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: "Print manual bulk import run reason"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "Reason: ${{ github.event.inputs.reason }}"
+
+      - name: bulk-sequester
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: bulk-sequester
+        uses: dotnet/docs-tools/actions/sequester@main
+        env:
+          ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
+          ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
+        with:
+          org: ${{ github.repository_owner }}
+          repo: ${{ github.repository }}
+          

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -1,0 +1,58 @@
+name: "quest import"
+on:
+  issues:
+    types:
+      [ labeled, closed, reopened, assigned, unassigned ]
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "The reason for running the workflow"
+        required: true
+        default: "Manual run"
+      issue:
+        description: "The issue number to manually test"
+        required: true
+
+jobs:
+  import:
+    # if: github.event.label.name == "reQUEST" || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+
+    steps:
+      - name: "Print manual run reason"
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          echo "Reason: ${{ github.event.inputs.reason }}"
+          echo "Issue number: ${{ github.event.inputs.issue }}"
+
+      # This step occurs when ran manually, passing the manual issue number input
+      - name: manual-sequester
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: manual-sequester
+        uses: dotnet/docs-tools/actions/sequester@main
+        env:
+          ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
+          ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
+        with:
+          org: ${{ github.repository_owner }}
+          repo: ${{ github.repository }}
+          issue: ${{ github.event.inputs.issue }}
+
+      # This step occurs automatically, passing the issue number from the event
+      - name: auto-sequester
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        id: auto-sequester
+        uses: dotnet/docs-tools/actions/sequester@main
+        env:
+          ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
+          ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
+        with:
+          org: ${{ github.repository_owner }}
+          repo: ${{ github.repository }}
+          issue: ${{ github.event.issue.number }}
+          

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -15,7 +15,12 @@ on:
 
 jobs:
   import:
-    # if: github.event.label.name == "reQUEST" || github.event_name == 'workflow_dispatch'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'reQUEST' ||
+      github.event.label.name == 'seQUESTered' ||
+      contains(github.event.issue.labels.*.name, 'reQUEST') ||
+      contains(github.event.issue.labels.*.name, 'seQUESTered')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/quest-config.json
+++ b/quest-config.json
@@ -1,0 +1,9 @@
+{
+    "AzureDevOps": {
+        "Org": "msft-skilling",
+        "Project": "Content",
+        "AreaPath": "Production\\Digital and App Innovation\\DotNet and more\\ASP.NET"
+    },
+    "ImportTriggerLabel": "reQUEST",
+    "ImportedLabel": "seQUESTered"
+}


### PR DESCRIPTION
This PR adds the configuration for the Quest import GitHub action.

Before merging this PR, follow the instructions [here](https://github.com/dotnet/docs-tools/tree/main/actions/sequester#installation-and-use) to create the API KEY secrets. Then, once this is installed, it will start updating work items.

Note: To import items in bulk, when those have already been labeled, you can run the `quest-bulk` action via the GitHub UI to import all issues already labeled.
