### PR TITLE
Corrected a typo at StartupMap.cs

### DIFF
--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupMap.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupMap.cs
@@ -24,7 +24,7 @@
 
         app.Run(async context =>
         {
-            await context.Response.WriteAsync("<p>Hello from non-Map delegate.</p>");
+            await context.Response.WriteAsync("Hello from non-Map delegate.");
         });
     }
 }

--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupMap.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupMap.cs
@@ -24,7 +24,7 @@
 
         app.Run(async context =>
         {
-            await context.Response.WriteAsync("Hello from non-Map delegate. <p>");
+            await context.Response.WriteAsync("<p>Hello from non-Map delegate.</p>");
         });
     }
 }

--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupMapWhen.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain/StartupMapWhen.cs
@@ -16,7 +16,7 @@
 
         app.Run(async context =>
         {
-            await context.Response.WriteAsync("Hello from non-Map delegate. <p>");
+            await context.Response.WriteAsync("Hello from non-Map delegate.");
         });
     }
 }

--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/ProgramMap.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/ProgramMap.cs
@@ -7,7 +7,7 @@ app.Map("/map2", HandleMapTest2);
 
 app.Run(async context =>
 {
-    await context.Response.WriteAsync("Hello from non-Map delegate. <p>");
+    await context.Response.WriteAsync("Hello from non-Map delegate.");
 });
 
 app.Run();

--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/ProgramMapWhen.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/ProgramMapWhen.cs
@@ -5,7 +5,7 @@ app.MapWhen(context => context.Request.Query.ContainsKey("branch"), HandleBranch
 
 app.Run(async context =>
 {
-    await context.Response.WriteAsync("Hello from non-Map delegate. <p>");
+    await context.Response.WriteAsync("Hello from non-Map delegate.");
 });
 
 app.Run();

--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/ProgramMultiSeg.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/ProgramMultiSeg.cs
@@ -5,7 +5,7 @@ app.Map("/map1/seg1", HandleMultiSeg);
 
 app.Run(async context =>
 {
-    await context.Response.WriteAsync("Hello from non-Map delegate. <p>");
+    await context.Response.WriteAsync("Hello from non-Map delegate.");
 });
 
 app.Run();

--- a/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/ProgramUseWhen.cs
+++ b/aspnetcore/fundamentals/middleware/index/snapshot/Chain60/ProgramUseWhen.cs
@@ -6,7 +6,7 @@ app.UseWhen(context => context.Request.Query.ContainsKey("branch"),
 
 app.Run(async context =>
 {
-    await context.Response.WriteAsync("Hello from non-Map delegate. <p>");
+    await context.Response.WriteAsync("Hello from non-Map delegate.");
 });
 
 app.Run();


### PR DESCRIPTION
I noticed a typo in an article on learn.microsoft.com. The tag was open, but not closed. I think it was supposed to use "Hello from non-Map delegate." inside the p tag.

If so, I suggest using this quick fix. Thanks!