### PR TITLE
Message size limit and prerendering state size

### DIFF
--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -936,7 +936,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting in prerrendered state.
+* Reduce the amount of data that you are putting into the prerrendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
@@ -1643,7 +1643,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting in prerrendered state.
+* Reduce the amount of data that you are putting into the prerrendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
@@ -2083,7 +2083,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting in prerrendered state.
+* Reduce the amount of data that you are putting into the prerrendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
@@ -2983,7 +2983,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting in prerrendered state.
+* Reduce the amount of data that you are putting into the prerrendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -936,7 +936,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting into the prerrendered state.
+* Reduce the amount of data that you are putting into the prerendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
@@ -1643,7 +1643,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting into the prerrendered state.
+* Reduce the amount of data that you are putting into the prerendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
@@ -2083,7 +2083,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting into the prerrendered state.
+* Reduce the amount of data that you are putting into the prerendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
@@ -2983,7 +2983,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting into the prerrendered state.
+* Reduce the amount of data that you are putting into the prerendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -926,6 +926,18 @@ By initializing components with the same state used during prerendering, any exp
 :::zone-end
 
 :::zone pivot="server"
+     
+## Prerendered state size and SignalR message size limit
+
+A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
+
+* The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
+* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+
+To resolve the problem, use ***either*** of the following approaches:
+
+* Reduce the amount of data that you are putting in prerrendered state.
+* Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
 
@@ -1622,6 +1634,18 @@ For more information, see <xref:blazor/components/index#namespaces>.
 
 :::zone pivot="server"
 
+## Prerendered state size and SignalR message size limit
+
+A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
+
+* The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
+* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+
+To resolve the problem, use ***either*** of the following approaches:
+
+* Reduce the amount of data that you are putting in prerrendered state.
+* Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
+
 ## Additional Blazor Server resources
 
 * [State management: Handle prerendering](xref:blazor/state-management#handle-prerendering)
@@ -2049,6 +2073,18 @@ When using a custom folder to hold the project's Razor components, add the names
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
 For more information, see <xref:blazor/components/index#namespaces>.
+
+## Prerendered state size and SignalR message size limit
+
+A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
+
+* The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
+* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+
+To resolve the problem, use ***either*** of the following approaches:
+
+* Reduce the amount of data that you are putting in prerrendered state.
+* Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
 
@@ -2937,6 +2973,18 @@ By initializing components with the same state used during prerendering, any exp
 :::zone-end
 
 :::zone pivot="server"
+
+## Prerendered state size and SignalR message size limit
+
+A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
+
+* The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
+* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+
+To resolve the problem, use ***either*** of the following approaches:
+
+* Reduce the amount of data that you are putting in prerrendered state.
+* Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional Blazor Server resources
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/persist-component-state.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/persist-component-state.md
@@ -96,6 +96,20 @@ In the following example:
 
 For more information and a complete example, see <xref:blazor/components/prerendering-and-integration#persist-prerendered-state>.
 
+## Prerendered state size and SignalR message size limit
+
+*This section only applies to Blazor Server apps.*
+
+A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
+
+* The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
+* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+
+To resolve the problem, use ***either*** of the following approaches:
+
+* Reduce the amount of data that you are putting into the prerrendered state.
+* Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
+
 ## Additional resources
 
 * <xref:Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper>

--- a/aspnetcore/mvc/views/tag-helpers/built-in/persist-component-state.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/persist-component-state.md
@@ -107,7 +107,7 @@ A large prerendered state size may exceed the SignalR circuit message size limit
 
 To resolve the problem, use ***either*** of the following approaches:
 
-* Reduce the amount of data that you are putting into the prerrendered state.
+* Reduce the amount of data that you are putting into the prerendered state.
 * Increase the [SignalR message size limit](xref:blazor/fundamentals/signalr#circuit-handler-options-for-blazor-server-apps). ***WARNING***: Increasing the limit may increase the risk of Denial of service (DoS) attacks.
 
 ## Additional resources


### PR DESCRIPTION
Fixes #27531

Thanks @Bouke! :rocket: ... I'll remain 👂 on your PU issue in case there's more to address. If so, I'll do that on a follow-up PR. This is ***NOT*** a good time to leave PRs lying around with the .NET 7 release and all of the docs work needed to activate the new release docs ... 😈 ***merge conflicts!*** 😈

I added the coverage both to the *Prendering* doc ***and*** in the *Persist component state* TH doc. That should surface it well.

I also included the exact client-side message about the circuit not initializing, which can help devs find this content via a string-based docs search.

Since most apps won't hit the limit  ... we hope 🤞🍀 and is consistent with the lack of issues generated on this particular error, here on the docs repo anyway, I'll hold off on placing this info into the *Fundamentals* > *SignalR* topic. If more feedback arrives on it 💥 in apps, I'll further expand this into that fundamentals topic.