### PR TITLE
[JSImport] global FN guidance

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
+++ b/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
@@ -5,10 +5,20 @@ description: Learn how to interact with JavaScript in Blazor WebAssembly apps us
 monikerRange: '= aspnetcore-7.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/08/2022
+ms.date: 11/10/2022
 uid: blazor/js-interop/import-export-interop
 ---
 # JavaScript `[JSImport]`/`[JSExport]` interop with ASP.NET Core Blazor
+
+<!--
+
+    AUTHOR NOTE: This topic is configured in metadata for ONLY the 7.0 release
+                 because I assume that this implementation of JS interop will
+                 be expanded to Blazor Server and will replace IJSRuntime-based
+                 JS interop. If so, this topic will disappear at 8.0 in favor
+                 of 8.0 JS interop docs adopting this API completely.
+
+-->
 
 This article explains how to interact with JavaScript (JS) in Blazor WebAssembly apps using JavaScript (JS) `[JSImport]`/`[JSExport]` interop API released with .NET 7.
 
@@ -119,6 +129,13 @@ The module name in the `[JSImport]` attribute and the call to load the module in
 ```csharp
 [JSImport("getMessage", 
     "Contoso.InteropServices.JavaScript.UserMessages.CallJavaScript1")]
+```
+
+Prefix a global function name with [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) and only pass the function name to the `[JSImport]` attribute. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
+
+```csharp
+[JSImport("globalThis.console.log")]
+internal static partial void Log([JSMarshalAs<JSType.String>] string message);
 ```
 
 Export scripts from a standard [JavaScript ES6 module](xref:blazor/js-interop/index#javascript-isolation-in-javascript-modules) either [collocated with a component](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js-collocated-with-a-component) or placed with other JavaScript static assets in a JS file (for example, `wwwroot/js/{FILENAME}.js`, where JS static assets are maintained in a folder named `js` in the app's `wwwroot` folder and the `{FILENAME}` placeholder is the filename).

--- a/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
+++ b/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
@@ -131,7 +131,7 @@ The module name in the `[JSImport]` attribute and the call to load the module in
     "Contoso.InteropServices.JavaScript.UserMessages.CallJavaScript1")]
 ```
 
-Functions accessible on the global namespace can be also imported by using the [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) prefix in the function name and by using the `[JSImport]` attribute without providing a module name. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
+Functions accessible on the global namespace can be imported by using the [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) prefix in the function name and by using the `[JSImport]` attribute without providing a module name. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
 
 ```csharp
 [JSImport("globalThis.console.log")]

--- a/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
+++ b/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
@@ -131,7 +131,7 @@ The module name in the `[JSImport]` attribute and the call to load the module in
     "Contoso.InteropServices.JavaScript.UserMessages.CallJavaScript1")]
 ```
 
-Prefix a global function name with [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) and only pass the function name to the `[JSImport]` attribute. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
+Functions accessible on the global namespace can be also imported by using the [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) prefix in the function name and by using the `[JSImport]` attribute without providing a module name. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
 
 ```csharp
 [JSImport("globalThis.console.log")]

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -5,7 +5,7 @@ description: Learn how to run .NET from JavaScript.
 monikerRange: '>= aspnetcore-7.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 10/26/2022
+ms.date: 11/10/2022
 uid: client-side/dotnet-interop
 ---
 # Run .NET from JavaScript
@@ -168,6 +168,13 @@ internal static partial string GetHRef();
 In the imported method signature, you can use .NET types for parameters and return values, which are marshalled automatically by the runtime. Use `JSMarshalAsAttribute<T>` to control how the imported method parameters are marshalled. For example, you might choose to marshal a `long` as <xref:System.Runtime.InteropServices.JavaScript.JSType.Number?displayProperty=nameWithType> or <xref:System.Runtime.InteropServices.JavaScript.JSType.BigInt?displayProperty=nameWithType>. You can pass <xref:System.Action>/<xref:System.Func%601> callbacks as parameters, which are marshalled as callable JS functions. You can pass both JS and managed object references, and they are marshaled as proxy objects, keeping the object alive across the boundary until the proxy is garbage collected. You can also import and export asynchronous methods with a <xref:System.Threading.Tasks.Task> result, which are marshaled as [JS promises](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise). Most of the marshalled types work in both directions, as parameters and as return values, on both imported and exported methods.
 
 [!INCLUDE[](~/blazor/includes/js-interop/7.0/import-export-interop-mappings.md)]
+
+Prefix a global function name with [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) and only pass the function name to the `[JSImport]` attribute. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
+
+```csharp
+[JSImport("globalThis.console.log")]
+internal static partial void Log([JSMarshalAs<JSType.String>] string message);
+```
 
 To export a .NET method so it can be called from JS, use the `JSExportAttribute`.
 

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -169,7 +169,7 @@ In the imported method signature, you can use .NET types for parameters and retu
 
 [!INCLUDE[](~/blazor/includes/js-interop/7.0/import-export-interop-mappings.md)]
 
-Prefix a global function name with [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) and only pass the function name to the `[JSImport]` attribute. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
+Functions accessible on the global namespace can be also imported by using the [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) prefix in the function name and by using the `[JSImport]` attribute without providing a module name. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
 
 ```csharp
 [JSImport("globalThis.console.log")]

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -169,7 +169,7 @@ In the imported method signature, you can use .NET types for parameters and retu
 
 [!INCLUDE[](~/blazor/includes/js-interop/7.0/import-export-interop-mappings.md)]
 
-Functions accessible on the global namespace can be also imported by using the [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) prefix in the function name and by using the `[JSImport]` attribute without providing a module name. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
+Functions accessible on the global namespace can be imported by using the [`globalThis`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/globalThis) prefix in the function name and by using the `[JSImport]` attribute without providing a module name. In the following example, [`console.log`](https://developer.mozilla.org/docs/Web/API/console/log) is prefixed with `globalThis`. The imported function is called by the C# `Log` method, which accepts a C# string message (`message`) and marshalls the C# string to a JS [`String`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String) for `console.log`:
 
 ```csharp
 [JSImport("globalThis.console.log")]


### PR DESCRIPTION
Fixes #27554

Thanks @yugabe! 🚀 

@pavelsavara ... It's not my intention here to use an example that's an already-imported global FN by the framework, but I only see `console.log` in a helper class for testing ...

https://github.com/dotnet/runtime/blob/main/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs#L17-L18

If it's only in test code there, the example on this PR should be fine unless you want to change it to something else. It would be easy for devs to play with this `Log` method they want to drop this into a local test app because `console.log` is already there.

***ALSO***, I modified the signature from `public` to `internal` ... head-check the 🦖 on that because I might have made a mistake there.

Otherwise, I'm not sure from the rest of your discussion with @yugabe if any further changes are required. If you want to add more, it's probably best if you shoot me a few text lines/snippet code with a tip on where to place it in the doc.

***Side Note***: You see me adding an `AUTHOR NOTE` at the top of the doc. This is just to remind everyone internally (**NOTE TO SELF** at least) about the strict versioning of this topic for 7.0, since I think this might become THE WAY to do JS interop at 8.0 everywhere and forever. If so, this topic will only appear in the ToC for 7.0 in favor of all of our JS interop coverage taking on the new API in 8.0 docs.