### PR TITLE
Test holiday Blazor automatic commenting

### DIFF
--- a/.github/workflows/holiday-blazor-comment.yml
+++ b/.github/workflows/holiday-blazor-comment.yml
@@ -1,0 +1,23 @@
+name: Add comment
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'Blazor'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@5adcb0bb0f9fb3f95ef05400558bdb3f329ee808
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            # This is a multi-line test comment
+            
+            A list:
+            
+            * With GitHub **Markdown** :sparkles:
+            * Item 2


### PR DESCRIPTION
As you know, I've had great success thus far with ✨ ***auto-magical*** ✨ new Blazor issue management with automatic labels, project assignment, and assignees ( 🦖 ***ME!*** 😄) per Andy's bits 🥇.

Now, I'd like to see if I can have ***automatic comments*** when a new Blazor issue is opened. *May the* 🙏***server gods*** 🙏 *bless me with this feature!* 😆

A problem that I always hit during the holidays is that I manually need to apply my *'I'm out for the holiday ... I'll get back to you ASAP here when I get back'* message to new issues. It would be super cool to have that message automatically applied along with the rest of the automatic issue config. If this works 🍀🤞 ... *and I think it will* ... I should be able to focus on my 🏖️ vacation with only one daily check-in for emergency bugs, which are very rare.

This PR adopts ...

* https://docs.github.com/en/actions/managing-issues-and-pull-requests/commenting-on-an-issue-when-a-label-is-added
* https://github.com/peter-evans/create-or-update-comment
* https://github.com/marketplace/actions/create-or-update-comment

I'm no rockstar when on implementing GH Actions, but I think we only need to place the file for it to ✨ ***Just Work!***&trade; ✨.

I did pin the Action via the latest SHA for 2.1.0 (`5adcb0bb0f9fb3f95ef05400558bdb3f329ee808`).

Shall I proceed with this test?

If so, I'll merge this ... open a new issue from a topic to test it ... and if working, fill-in my holiday message 🦃🎅🎆 and set the label check to `Blazor2` until we reach the 🦃 holiday. You can add a second `add-comment` for non-Blazor issues thereafter. 