### PR TITLE
Change SHA to version number

### DIFF
--- a/.github/workflows/holiday-blazor-comment.yml
+++ b/.github/workflows/holiday-blazor-comment.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     steps:
       - name: Add comment
-        uses: peter-evans/create-or-update-comment@5adcb0bb0f9fb3f95ef05400558bdb3f329ee808
+        uses: peter-evans/create-or-update-comment@v2.1.0
         with:
           issue-number: ${{ github.event.issue.number }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@Rick-Anderson ... I'm changing from pinning via the SHA to the version number, which I think is how **create-pull-request** is managed. I'm leaving the `token` in place just in case that's required. It's probably harmless if it isn't required. I'll monitor for a 💥 on that just in case.