### PR TITLE
Bundling and minification updates

### DIFF
--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -58,7 +58,7 @@ Original | Renamed
 
 ## Impact of bundling and minification
 
-The following table outlines differences between individually loading assets and using bundling and minification in a typical web app:
+The following table outlines differences between individually loading assets and using bundling and minification for a typical web app.
 
 Action | Without B/M | With B/M | Reduction
 --- | :---: | :---: | :---:

--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -31,14 +31,14 @@ Consider the following JavaScript function:
 
 ```javascript
 AddAltToImg = function (imageTagAndImageID, imageContext) {
-    ///<signature>
-    ///<summary> Adds an alt tab to the image
-    // </summary>
-    //<param name="imgElement" type="String">The image selector.</param>
-    //<param name="ContextForImage" type="String">The image context.</param>
-    ///</signature>
-    var imageElement = $(imageTagAndImageID, imageContext);
-    imageElement.attr('alt', imageElement.attr('id').replace(/ID/, ''));
+  ///<signature>
+  ///<summary> Adds an alt tab to the image
+  // </summary>
+  //<param name="imgElement" type="String">The image selector.</param>
+  //<param name="ContextForImage" type="String">The image context.</param>
+  ///</signature>
+  var imageElement = $(imageTagAndImageID, imageContext);
+  imageElement.attr('alt', imageElement.attr('id').replace(/ID/, ''));
 }
 ```
 
@@ -58,21 +58,23 @@ Original | Renamed
 
 ## Impact of bundling and minification
 
-The following table outlines differences between individually loading assets and using bundling and minification:
+The following table outlines differences between individually loading assets and using bundling and minification in a typical web app:
 
-Action | With B/M | Without B/M | Change
+Action | Without B/M | With B/M | Reduction
 --- | :---: | :---: | :---:
-File Requests  | 7   | 18     | 157%
-KB Transferred | 156 | 264.68 | 70%
-Load Time (ms) | 885 | 2360   | 167%
+File Requests | 18 | 7 | 61%
+Bytes Transferred (KB) | 265 | 156 | 41%
+Load Time (ms) | 2360 | 885 | 63%
 
-Browsers are fairly verbose regarding HTTP request headers. The total bytes sent metric saw a significant reduction when bundling. The load time shows a significant improvement, however this example ran locally. Greater performance gains are realized when using bundling and minification with assets transferred over a network.
+The load time improved, but this example ran locally. Greater performance gains are realized when using bundling and minification with assets transferred over a network.
+
+The test app used to generate the figures in the preceding table demonstrates typical improvements that might not apply to a given app. We recommend testing an app to determine if bundling and minification yields an improved load time.
 
 ## Choose a bundling and minification strategy
 
 ASP.NET Core is compatible with WebOptimizer, an open-source bundling and minification solution. For set up instructions and sample projects, see [WebOptimizer](https://github.com/ligershark/WebOptimizer). ASP.NET Core doesn't provide a native bundling and minification solution.
 
-Third-party tools, such as [Gulp](https://gulpjs.com) and [Webpack](https://webpack.js.org), provide workflow automation for bundling and minification, as well as linting and image optimization. By using design-time bundling and minification, the minified files are created prior to the app's deployment. Bundling and minifying before deployment provides the advantage of reduced server load. However, it's important to recognize that design-time bundling and minification increases build complexity and only works with static files.
+Third-party tools, such as [Gulp](https://gulpjs.com) and [Webpack](https://webpack.js.org), provide workflow automation for bundling and minification, as well as linting and image optimization. By using bundling and minification, the minified files are created prior to the app's deployment. Bundling and minifying before deployment provides the advantage of reduced server load. However, it's important to recognize that bundling and minification increases build complexity and only works with static files.
 
 ## Environment-based bundling and minification
 


### PR DESCRIPTION
Fixes #27508

Thanks @pluraltouch! 🚀 

Rick, I had a couple of minutes this morning to touch-up a few bits (downloading and installing Xcode on the MacBook ⏳😠) ...

* The impacts section with the right calcs (% reduction).
* I took out the word "significant," which has specific meaning in scientific contexts. I admit that we're only weakly within the bounds of "computer ***science***" here as a formal science because we aren't reporting the results of empirical investigation. However, I'd feel better if we don't use the word "significant" when referring directly to ***data***. That's kind'a 😨 if we ever have researchers looking at our docs. I checked the whole doc set on the use of the word. Of the ~30-40 times "significant" is used, this is the only spot where it's used to directly address presented data, so this is the only change that I recommend.
* Where "design time" appears, it's just an adjective. We can 🔪 that out and not be specific about when B&M is performed prior to deployment.

I ***didn't*** address the problem(s) with WebOptimizer for 6.0/7.0 reported on https://github.com/dotnet/AspNetCore.Docs/issues/27645, which was closed as a dup of https://github.com/dotnet/AspNetCore.Docs/issues/20808. If you'd like me to address that here and knock that issue out 🥊😵, let me know how you'd like it handled. Their issues are here 👉 https://github.com/ligershark/WebOptimizer/issues. I originally made a judgement about the level of support, but I don't really want to upset anyone 😄. I see that you labelled https://github.com/dotnet/AspNetCore.Docs/issues/20808 for Artak, so I could check with him to make a call on it ... I could bring it up in my next chat with him this Friday.

If you want to cut it out, the start of that section in the current doc appears as ...

> ASP.NET Core is compatible with WebOptimizer, an open-source bundling and minification solution. For set up instructions and sample projects, see \[WebOptimizer](https://github.com/ligershark/WebOptimizer). ASP.NET Core doesn't provide a native bundling and minification solution.
>
> Third-party tools, such as ...

What I'd do is just 🔪 that WebOptimizer bit out and move the last sentence of the first para to the second, so that section would start like this ...

> ASP.NET Core doesn't provide a native bundling and minification solution. Third-party tools, such as ...