### PR TITLE
Blazor loc shared resource approach

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -880,15 +880,15 @@ To create localization shared resources, adopt the following approach. For addit
 * Create a dummy class with an arbitrary class name. In the following example:
 
   * The app uses the `BlazorSample` namespace, and localization assets use the `BlazorSample.Localization` namespace.
-  * The dummy class is named `ComponentLocalization`.
+  * The dummy class is named `SharedResource`.
   * The class file is placed in a `Localization` folder at the root of the app.
 
-  `Localization/ComponentLocalization.cs`:
+  `Localization/SharedResource.cs`:
 
   ```csharp
   namespace BlazorSample.Localization
   {
-      public class ComponentLocalization
+      public class SharedResource
       {
       }
   }
@@ -896,29 +896,32 @@ To create localization shared resources, adopt the following approach. For addit
 
 * Create the shared resource files with a **Build Action** of `Embedded resource`. In the following example:
 
-  * The files are placed in the `Localization` folder with the dummy `ComponentLocalization` class (`Localization/ComponentLocalization.cs`).
+  * The files are placed in the `Localization` folder with the dummy `SharedResource` class (`Localization/SharedResource.cs`).
   * Name the resource files to match the name of the dummy class. The following example files include a default localization file and a file for Spanish (`es`) localization.
 
-  * `Localization/ComponentLocalization.resx`
-  * `Localization/ComponentLocalization.es.resx`
+  * `Localization/SharedResource.resx`
+  * `Localization/SharedResource.es.resx`
+
+  > [!NOTE]
+  > `Localization` is resource path that can be set via <xref:Microsoft.Extensions.Localization.LocalizationOptions>.
 
 * To reference the dummy class for an injected <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> in a Razor component, either place an [`@using`](xref:mvc/views/razor#using) directive for the localization namespace or include the localization namespace in the dummy class reference. In the following examples:
 
-  * The first example states the `Localization` namespace for the `ComponentLocalization` dummy class with an [`@using`](xref:mvc/views/razor#using) directive.
-  * The second example states the `ComponentLocalization` dummy class's namespace explicitly.
+  * The first example states the `Localization` namespace for the `SharedResource` dummy class with an [`@using`](xref:mvc/views/razor#using) directive.
+  * The second example states the `SharedResource` dummy class's namespace explicitly.
 
   In a Razor component, use ***either*** of the following approaches:
 
   ```razor
   @using Localization
-  @inject IStringLocalizer<ComponentLocalization> Loc
+  @inject IStringLocalizer<SharedResource> Loc
   ```
 
   ```razor
-  @inject IStringLocalizer<Localization.ComponentLocalization> Loc
+  @inject IStringLocalizer<Localization.SharedResource> Loc
   ```
 
-For additional guidance on using the preceding approach with <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizerFactory>, see <xref:fundamentals/localization#make-the-apps-content-localizable>.
+For additional guidance, see <xref:fundamentals/localization>.
 
 ## Additional resources
 
@@ -1800,6 +1803,56 @@ To further understand how the Blazor framework processes localization, see the [
 
 :::zone-end
 
+## Shared resources
+
+To create localization shared resources, adopt the following approach. For additional information, see the shared resources guidance in the <xref:fundamentals/localization#make-the-apps-content-localizable> article.
+
+* Create a dummy class with an arbitrary class name. In the following example:
+
+  * The app uses the `BlazorSample` namespace, and localization assets use the `BlazorSample.Localization` namespace.
+  * The dummy class is named `SharedResource`.
+  * The class file is placed in a `Localization` folder at the root of the app.
+
+  `Localization/SharedResource.cs`:
+
+  ```csharp
+  namespace BlazorSample.Localization
+  {
+      public class SharedResource
+      {
+      }
+  }
+  ```
+
+* Create the shared resource files with a **Build Action** of `Embedded resource`. In the following example:
+
+  * The files are placed in the `Localization` folder with the dummy `SharedResource` class (`Localization/SharedResource.cs`).
+  * Name the resource files to match the name of the dummy class. The following example files include a default localization file and a file for Spanish (`es`) localization.
+
+  * `Localization/SharedResource.resx`
+  * `Localization/SharedResource.es.resx`
+
+  > [!NOTE]
+  > `Localization` is resource path that can be set via <xref:Microsoft.Extensions.Localization.LocalizationOptions>.
+
+* To reference the dummy class for an injected <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> in a Razor component, either place an [`@using`](xref:mvc/views/razor#using) directive for the localization namespace or include the localization namespace in the dummy class reference. In the following examples:
+
+  * The first example states the `Localization` namespace for the `SharedResource` dummy class with an [`@using`](xref:mvc/views/razor#using) directive.
+  * The second example states the `SharedResource` dummy class's namespace explicitly.
+
+  In a Razor component, use ***either*** of the following approaches:
+
+  ```razor
+  @using Localization
+  @inject IStringLocalizer<SharedResource> Loc
+  ```
+
+  ```razor
+  @inject IStringLocalizer<Localization.SharedResource> Loc
+  ```
+
+For additional guidance, see <xref:fundamentals/localization>.
+
 ## Additional resources
 
 * [Set the app base path](xref:blazor/host-and-deploy/index#app-base-path)
@@ -2670,6 +2723,56 @@ To further understand how the Blazor framework processes localization, see the [
 
 :::zone-end
 
+## Shared resources
+
+To create localization shared resources, adopt the following approach. For additional information, see the shared resources guidance in the <xref:fundamentals/localization#make-the-apps-content-localizable> article.
+
+* Create a dummy class with an arbitrary class name. In the following example:
+
+  * The app uses the `BlazorSample` namespace, and localization assets use the `BlazorSample.Localization` namespace.
+  * The dummy class is named `SharedResource`.
+  * The class file is placed in a `Localization` folder at the root of the app.
+
+  `Localization/SharedResource.cs`:
+
+  ```csharp
+  namespace BlazorSample.Localization
+  {
+      public class SharedResource
+      {
+      }
+  }
+  ```
+
+* Create the shared resource files with a **Build Action** of `Embedded resource`. In the following example:
+
+  * The files are placed in the `Localization` folder with the dummy `SharedResource` class (`Localization/SharedResource.cs`).
+  * Name the resource files to match the name of the dummy class. The following example files include a default localization file and a file for Spanish (`es`) localization.
+
+  * `Localization/SharedResource.resx`
+  * `Localization/SharedResource.es.resx`
+
+  > [!NOTE]
+  > `Localization` is resource path that can be set via <xref:Microsoft.Extensions.Localization.LocalizationOptions>.
+
+* To reference the dummy class for an injected <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> in a Razor component, either place an [`@using`](xref:mvc/views/razor#using) directive for the localization namespace or include the localization namespace in the dummy class reference. In the following examples:
+
+  * The first example states the `Localization` namespace for the `SharedResource` dummy class with an [`@using`](xref:mvc/views/razor#using) directive.
+  * The second example states the `SharedResource` dummy class's namespace explicitly.
+
+  In a Razor component, use ***either*** of the following approaches:
+
+  ```razor
+  @using Localization
+  @inject IStringLocalizer<SharedResource> Loc
+  ```
+
+  ```razor
+  @inject IStringLocalizer<Localization.SharedResource> Loc
+  ```
+
+For additional guidance, see <xref:fundamentals/localization>.
+
 ## Additional resources
 
 * [Set the app base path](xref:blazor/host-and-deploy/index#app-base-path)
@@ -3453,6 +3556,56 @@ Add the namespace for <xref:Microsoft.Extensions.Localization?displayProperty=fu
 ```
 
 Optionally, add a menu item to the navigation in `Shared/NavMenu.razor` for the `CultureExample2` component.
+
+## Shared resources
+
+To create localization shared resources, adopt the following approach. For additional information, see the shared resources guidance in the <xref:fundamentals/localization#make-the-apps-content-localizable> article.
+
+* Create a dummy class with an arbitrary class name. In the following example:
+
+  * The app uses the `BlazorSample` namespace, and localization assets use the `BlazorSample.Localization` namespace.
+  * The dummy class is named `SharedResource`.
+  * The class file is placed in a `Localization` folder at the root of the app.
+
+  `Localization/SharedResource.cs`:
+
+  ```csharp
+  namespace BlazorSample.Localization
+  {
+      public class SharedResource
+      {
+      }
+  }
+  ```
+
+* Create the shared resource files with a **Build Action** of `Embedded resource`. In the following example:
+
+  * The files are placed in the `Localization` folder with the dummy `SharedResource` class (`Localization/SharedResource.cs`).
+  * Name the resource files to match the name of the dummy class. The following example files include a default localization file and a file for Spanish (`es`) localization.
+
+  * `Localization/SharedResource.resx`
+  * `Localization/SharedResource.es.resx`
+
+  > [!NOTE]
+  > `Localization` is resource path that can be set via <xref:Microsoft.Extensions.Localization.LocalizationOptions>.
+
+* To reference the dummy class for an injected <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> in a Razor component, either place an [`@using`](xref:mvc/views/razor#using) directive for the localization namespace or include the localization namespace in the dummy class reference. In the following examples:
+
+  * The first example states the `Localization` namespace for the `SharedResource` dummy class with an [`@using`](xref:mvc/views/razor#using) directive.
+  * The second example states the `SharedResource` dummy class's namespace explicitly.
+
+  In a Razor component, use ***either*** of the following approaches:
+
+  ```razor
+  @using Localization
+  @inject IStringLocalizer<SharedResource> Loc
+  ```
+
+  ```razor
+  @inject IStringLocalizer<Localization.SharedResource> Loc
+  ```
+
+For additional guidance, see <xref:fundamentals/localization>.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -873,6 +873,53 @@ To further understand how the Blazor framework processes localization, see the [
 
 :::zone-end
 
+## Shared resources
+
+To create localization shared resources, adopt the following approach. For additional information, see the shared resources guidance in the <xref:fundamentals/localization#make-the-apps-content-localizable> article.
+
+* Create a dummy class with an arbitrary class name. In the following example:
+
+  * The app uses the `BlazorSample` namespace, and localization assets use the `BlazorSample.Localization` namespace.
+  * The dummy class is named `ComponentLocalization`.
+  * The class file is placed in a `Localization` folder at the root of the app.
+
+  `Localization/ComponentLocalization.cs`:
+
+  ```csharp
+  namespace BlazorSample.Localization
+  {
+      public class ComponentLocalization
+      {
+      }
+  }
+  ```
+
+* Create the shared resource files with a **Build Action** of `Embedded resource`. In the following example:
+
+  * The files are placed in the `Localization` folder with the dummy `ComponentLocalization` class (`Localization/ComponentLocalization.cs`).
+  * Name the resource files to match the name of the dummy class. The following example files include a default localization file and a file for Spanish (`es`) localization.
+
+  * `Localization/ComponentLocalization.resx`
+  * `Localization/ComponentLocalization.es.resx`
+
+* To reference the dummy class for an injected <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> in a Razor component, either place an [`@using`](xref:mvc/views/razor#using) directive for the localization namespace or include the localization namespace in the dummy class reference. In the following examples:
+
+  * The first example states the `Localization` namespace for the `ComponentLocalization` dummy class with an [`@using`](xref:mvc/views/razor#using) directive.
+  * The second example states the `ComponentLocalization` dummy class's namespace explicitly.
+
+  In a Razor component, use ***either*** of the following approaches:
+
+  ```razor
+  @using Localization
+  @inject IStringLocalizer<ComponentLocalization> Loc
+  ```
+
+  ```razor
+  @inject IStringLocalizer<Localization.ComponentLocalization> Loc
+  ```
+
+For additional guidance on using the preceding approach with <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizerFactory>, see <xref:fundamentals/localization#make-the-apps-content-localizable>.
+
 ## Additional resources
 
 * [Set the app base path](xref:blazor/host-and-deploy/index#app-base-path)

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -875,7 +875,7 @@ To further understand how the Blazor framework processes localization, see the [
 
 ## Shared resources
 
-To create localization shared resources, adopt the following approach. For additional information, see the shared resources guidance in the <xref:fundamentals/localization#make-the-apps-content-localizable> article.
+To create localization shared resources, adopt the following approach.
 
 * Create a dummy class with an arbitrary class name. In the following example:
 
@@ -1805,7 +1805,7 @@ To further understand how the Blazor framework processes localization, see the [
 
 ## Shared resources
 
-To create localization shared resources, adopt the following approach. For additional information, see the shared resources guidance in the <xref:fundamentals/localization#make-the-apps-content-localizable> article.
+To create localization shared resources, adopt the following approach.
 
 * Create a dummy class with an arbitrary class name. In the following example:
 
@@ -2725,7 +2725,7 @@ To further understand how the Blazor framework processes localization, see the [
 
 ## Shared resources
 
-To create localization shared resources, adopt the following approach. For additional information, see the shared resources guidance in the <xref:fundamentals/localization#make-the-apps-content-localizable> article.
+To create localization shared resources, adopt the following approach.
 
 * Create a dummy class with an arbitrary class name. In the following example:
 
@@ -3559,7 +3559,7 @@ Optionally, add a menu item to the navigation in `Shared/NavMenu.razor` for the 
 
 ## Shared resources
 
-To create localization shared resources, adopt the following approach. For additional information, see the shared resources guidance in the <xref:fundamentals/localization#make-the-apps-content-localizable> article.
+To create localization shared resources, adopt the following approach.
 
 * Create a dummy class with an arbitrary class name. In the following example:
 


### PR DESCRIPTION
Fixes #27594

Thanks @AlessandroMartinelli! :rocket:

@hishamco, I think we should have a tidbit on this in the Blazor loc doc. If we merely cross-link to the main doc set for this, it's just a bit too cryptic for a typical dev and certainly too cryptic for ***new-to-Blazor/new-to-loc/new-to-.NET devs***. This section makes it 💀 ***dead simple*** 💀 to set up with the existing examples in the topic.

@AlessandroMartinelli ... WRT ...

> * Localization keys (the terms to be translated) taken from a constants file. This would help guarantee uniqueness of keys but would introduce a little overhead since all terms have to be inserted in the constants file first.
> * Localization keys sparsed among the .razor files. This would allow to avoid the constants file overhead, but it would be harder to keep uniqueness of keys (important to avoid duplicated works during keys translation by the hand of the human translator)

That's beyond the scope for the Blazor node, as we just want to call out the general implementation approach here. What you're asking about applies to the whole subject of shared resources. When you say, 'sparsed among the .razor files,' that could just as easily be WRT pages of RP apps or views of MVC apps. It's a general concern. If you feel the current coverage in the main doc set is lacking guidance on it, please open a separate issue from the bottom of the [main doc set's localization article](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/localization) to be considered separately from this.

⚠️ ***NOTE TO SELF*** ⚠️: ~This is currently placed for 7.0 just for the feedback round on the PR. After any/all feedback is addressed, duplicate this section back to the 6.0, 5.0, and 3.1 zones of the article ***before merging this***.~ ***Done!*** :+1: