### PR TITLE
Patch a no-loc blockquote

### DIFF
--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -578,8 +578,7 @@ SignalR defines a message size limit that applies to every message Blazor receiv
 
 The logged error is similar to the following:
 
-> :::no-loc text="Error: Connection disconnected with error 'Error: Server returned an error on close: Connection closed with an error.'.
-e.log @ blazor.server.js:1":::
+> :::no-loc text="Error: Connection disconnected with error 'Error: Server returned an error on close: Connection closed with an error.'. e.log @ blazor.server.js:1":::
 
 When uploading files, reaching the message size limit on the first message is rare. If the limit is reached, the app can configure <xref:Microsoft.AspNetCore.SignalR.HubOptions.MaximumReceiveMessageSize?displayProperty=nameWithType> with a larger value.
 


### PR DESCRIPTION
Looks like a pesky CR/LF 😈 got in there and fouled up the `no-loc` markdown.

![image](https://user-images.githubusercontent.com/1622880/202788451-7205eb93-e5b5-4390-bc9f-5a44d2ef60b1.png)
