### PR TITLE
Update default host configuration sources list

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -58,10 +58,16 @@ var builder = WebApplication.CreateBuilder(args);
 
 ### Default host configuration sources
 
-The following list contains the default host configuration sources from highest to lowest priority:
+The following list contains the default host configuration sources from highest to lowest priority for <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder>:
 
 1. Command-line arguments using the [Command-line configuration provider](#command-line)
+1. `DOTNET_`-prefixed environment variables using the [Environment variables configuration provider](xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider).
 1. `ASPNETCORE_`-prefixed environment variables using the [Environment variables configuration provider](xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider).
+
+For the [.NET Generic Host](xref:fundamentals/host/generic-host) and [Web Host](xref:fundamentals/host/web-host), the the default host configuration sources from highest to lowest priority is:
+
+1. `ASPNETCORE_`-prefixed environment variables using the [Environment variables configuration provider](xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider).
+1.  Command-line arguments using the [Command-line configuration provider](#command-line)
 1. `DOTNET_`-prefixed environment variables using the [Environment variables configuration provider](xref:Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationProvider).
 
 When a configuration value is set in host and application configuration, the application configuration is used.


### PR DESCRIPTION
- The order between `WebApplicationBuilder` and the other hosts are different
- `ASPNETCORE_`-prefixed environment variables have the lowest precedence with `WebApplicationBuilder`

I reponed https://github.com/dotnet/aspnetcore/issues/17963 to track aligning this behavior in .NET 8.

I also made a breaking change announcement about this at https://github.com/aspnet/Announcements/issues/498. At first, I thought https://github.com/dotnet/runtime/issues/78583 was an issue related to this intentional breaking change, but it appears to have been caused by an unintended behavioral change specific to the content root. So, I'm still not sure if anyone has really been broken by this change, but I still think it's probably worth putting in the list of breaking changes between .NET 6 and 7.

