### PR TITLE
Add namepace for datacontext as workaround for CLI scaffolding

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -1,16 +1,14 @@
 ---
 title: Part 2, add a model
-author: rick-anderson
+author: wadepickett
 description: Part 2 of tutorial series on Razor Pages. In this section, model classes are added.
-ms.author: riande
+ms.author: wpickett
 ms.date: 11/04/2022
 monikerRange: '>= aspnetcore-3.1'
 ms.custom: contperf-fy21q2
 uid: tutorials/razor-pages/model
 ---
 # Part 2, add a model to a Razor Pages app in ASP.NET Core
-
-By [Rick Anderson](https://twitter.com/RickAndMSFT)
 
 :::moniker range=">= aspnetcore-7.0"
 
@@ -130,7 +128,7 @@ The `appsettings.json` file is updated with the connection string used to connec
 * Open a command shell to the project directory, which contains the `Program.cs` and `.csproj` files. On Windows, run the following command:
 
   ```dotnetcli
-  dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages\Movies --referenceScriptLibraries -sqlite
+  dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovie.Data.RazorPagesMovieContext -udl -outDir Pages\Movies --referenceScriptLibraries -sqlite
   ```
 
   On non-Windows machines, run the following command:
@@ -145,7 +143,7 @@ The following table details the ASP.NET Core code generator options.
 | Option               | Description|
 | ----------------- | ------------ |
 | `-m`  | The name of the model. |
-| `-dc`  | The `DbContext` class to use. |
+| `-dc`  | The `DbContext` class to use including namespace. |
 | `-udl` | Use the default layout. |
 | `-outDir` | The relative output folder path to create the views. |
 | `--referenceScriptLibraries` | Adds `_ValidationScriptsPartial` to Edit and Create pages |

--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -134,7 +134,7 @@ The `appsettings.json` file is updated with the connection string used to connec
   On non-Windows machines, run the following command:
 
   ```dotnetcli
-  dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries -sqlite
+  dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovie.Data.RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries -sqlite
   ```
 
 <a name="codegenerator"></a>


### PR DESCRIPTION
[Internal review - Add Scaffold section - for VSC](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-7.0&branch=pr-en-us-27700&tabs=visual-studio-code)
Fixes #27614 

- Added namespace for -dc class for windows/Linux on VSC tab.
- Noted that class with namespace is used for -dc for VSC tab.

Per workaround suggested by dev team until scaffold tool is updated.