### PR TITLE
Remove NOTE

### DIFF
--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -363,9 +363,6 @@ If the `Robot` component from the RCL is requested at `/robot`, the `GrantImahar
 * If unexpected rendering occurs, such as rendering a component from a previous navigation, confirm that the code throws if the cancellation token is set.
 * If assemblies configured for lazy loading unexpectedly load at app start, check that the assembly is marked for lazy loading in the project file.
 
-> [!NOTE]
-> A known issue exists for loading types from a lazily-loaded assembly. For more information, see [Blazor WebAssembly lazy loading assemblies not working when using @ref attribute in the component (dotnet/aspnetcore #29342)](https://github.com/dotnet/aspnetcore/issues/29342).
-
 ## Additional resources
 
 * [Handle asynchronous navigation events with `OnNavigateAsync`](xref:blazor/fundamentals/routing#handle-asynchronous-navigation-events-with-onnavigateasync)


### PR DESCRIPTION
Addresses #24615

Per https://github.com/dotnet/aspnetcore/issues/29342#issuecomment-1317311677, this looks like it was fixed. It isn't repro-ing in .NET 7. I'm going to remove the NOTE from the 7.0 or later coverage and leave it for earlier versions ***just in case*** 😈.