### PR TITLE
Example on how to automatically refresh the browser when Blazor Server reconnection fails

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -344,7 +344,7 @@ The default reconnection behavior requires the user to take manual action to ref
 
 `wwwroot/boot.js`:
 
-```js
+```javascript
 (() => {
   const maximumRetryCount = 3;
   const retryIntervalMilliseconds = 5000;

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -326,7 +326,7 @@ To modify the connection events, register callbacks for the following connection
 </body>
 ```
 
-### Advanced scenario: Automatically refresh the page when reconnection fails
+### Automatically refresh the page when reconnection fails (Blazor Server)
 
 The default reconnection behavior requires the user to take manual action to refresh the page after reconnection fails. However, a custom reconnection handler can be used to automatically refresh the page:
 


### PR DESCRIPTION
## Example on how to automatically refresh the browser when Blazor Server reconnection fails

This PR adds an example showing how to configure a Blazor Server app to automatically refresh the browser if reconnection to the server fails.

### Description

Customers have been asking for a way to keep the existing Blazor Server reconnection logic and UI, but modified slightly so that refreshing the browser happens automatically rather than requiring direct user action. We don't have an extensibility point in our current JavaScript API that allows this do be done without reimplementing the full reconnection logic and UI. That said, it's not _that_ much code, so it could be sufficient to provide an example in the docs showing how to achieve this.

I'm opening this initially as a draft PR because there are a few open questions:
1. How complete should the example code be?
    * Should we make the example more complete by including some example CSS for the `reconnect-modal`?
    * Or, should we take the opposite approach and reduce the example by simplifying the reconnect functionality?
      * I'm personally not in favor of this, because the customer ask is to retain existing reconnect functionality but with automatic browser refreshing.
2. Is pasting the code inline the best approach?
    * While the code is straightforward, it's a bit on the longer end. Should we put this code elsewhere and link to it from the docs?
3. Rather than having a docs example for this at all, should we address https://github.com/dotnet/aspnetcore/issues/32113 and add new APIs to enable this scenario without requiring reconnection logic to be reimplemented?

Fixes https://github.com/dotnet/aspnetcore/issues/44715