### PR TITLE
Update container reference to supported tag

### DIFF
--- a/aspnetcore/security/docker-compose-https.md
+++ b/aspnetcore/security/docker-compose-https.md
@@ -63,7 +63,7 @@ version: '3.4'
 
 services:
   webapp:
-    image: mcr.microsoft.com/dotnet/core/samples:aspnetapp
+    image: mcr.microsoft.com/dotnet/samples:aspnetapp
     ports:
       - 80
       - 443


### PR DESCRIPTION
The file had references to the `mcr.microsoft.com/dotnet/core/samples` tag which is [no longer a supported tag](https://github.com/dotnet/dotnet-docker/blob/9eb203c4890d3d0122d3939614ff25d68fc46d6e/README.samples.md?plain=1#L93), and no longer exists.

This updates it to the supported tag: `mcr.microsoft.com/dotnet/samples:aspnetapp`

Related:
- https://github.com/dotnet/AspNetCore.Docs/pull/27202
- https://github.com/dotnet/dotnet-docker/discussions/3674
- https://github.com/dotnet/AspNetCore.Docs/issues/27194