### PR TITLE
Clarify root component disposal

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1432,7 +1432,7 @@ The following `GenericTypeExample5` component with inferred cascaded types provi
 
 ## Render static root Razor components
 
-A *root Razor component* is the first component loaded of any component hierarachy loaded into the app.
+A *root Razor component* is the first component loaded of any component hierarachy created by the app.
 
 In an app created from a Blazor project template, the `App` component (`Pages/App.razor`) is created as the default root component in `Pages/_Host.cshtml` using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper):
 
@@ -3015,7 +3015,7 @@ The following `GenericTypeExample5` component with inferred cascaded types provi
 
 ## Render static root Razor components
 
-A *root Razor component* is the first component loaded of any component hierarachy loaded into the app.
+A *root Razor component* is the first component loaded of any component hierarachy created by the app.
 
 In an app created from a Blazor project template, the `App` component (`Pages/App.razor`) is created as the default root component in `Pages/_Host.cshtml` using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper):
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1434,13 +1434,25 @@ The following `GenericTypeExample5` component with inferred cascaded types provi
 
 A *root Razor component* is the first component loaded of any component hierarachy created by the app.
 
-In an app created from a Blazor project template, the `App` component (`Pages/App.razor`) is created as the default root component in `Pages/_Host.cshtml` using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper):
+In an app created from the Blazor Server project template, the `App` component (`App.razor`) is created as the default root component in `Pages/_Host.cshtml` using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper):
 
 ```cshtml
 <component type="typeof(App)" render-mode="ServerPrerendered" />
 ```
 
-Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) can only be added to the app. They can't be removed or updated afterwards.
+In an app created from the Blazor WebAssembly project template, the `App` component (`App.razor`) is created as the default root component in `Program.cs`:
+
+```csharp
+builder.RootComponents.Add<App>("#app");
+```
+
+In the preceding code, the CSS selector, `#app`, indicates that the `App` component is created for the `<div>` in `wwwroot/index.html` with an `id` of `app`:
+
+```html
+<div id="app">...</app>
+```
+
+Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) (Blazor Server) or registered by the app in `Program.cs` (Blazor WebAssembly) can only be added to the app. They can't be removed or updated afterwards.
 
 For more information, see the following resources:
 
@@ -3017,13 +3029,25 @@ The following `GenericTypeExample5` component with inferred cascaded types provi
 
 A *root Razor component* is the first component loaded of any component hierarachy created by the app.
 
-In an app created from a Blazor project template, the `App` component (`Pages/App.razor`) is created as the default root component in `Pages/_Host.cshtml` using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper):
+In an app created from the Blazor Server project template, the `App` component (`App.razor`) is created as the default root component in `Pages/_Host.cshtml` using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper):
 
 ```cshtml
 <component type="typeof(App)" render-mode="ServerPrerendered" />
 ```
 
-Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) can only be added to the app. They can't be removed or updated afterwards.
+In an app created from the Blazor WebAssembly project template, the `App` component (`App.razor`) is created as the default root component in `Program.cs`:
+
+```csharp
+builder.RootComponents.Add<App>("#app");
+```
+
+In the preceding code, the CSS selector, `#app`, indicates that the `App` component is created for the `<div>` in `wwwroot/index.html` with an `id` of `app`:
+
+```html
+<div id="app">...</app>
+```
+
+Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) (Blazor Server) or registered by the app in `Program.cs` (Blazor WebAssembly) can only be added to the app. They can't be removed or updated afterwards.
 
 For more information, see the following resources:
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1461,7 +1461,17 @@ Load Blazor into the JS app (`blazor.server.js` or `blazor.webassembly.js`). Ren
 
 ```javascript
 let containerElement = document.getElementById('my-counter');
-await Blazor.rootComponents.add(containerElement, 'counter', { incrementAmount: 10 });
+await window.Blazor.rootComponents.add(containerElement, 'counter', { incrementAmount: 10 });
+```
+
+`rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
+
+```javascript
+const rootComponent = await window.Blazor.rootComponents.add(...);
+
+...
+
+rootComponent.dispose();
 ```
 
 ## Blazor custom elements

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1452,6 +1452,12 @@ In the preceding code, the CSS selector, `#app`, indicates that the `App` compon
 <div id="app">...</app>
 ```
 
+MVC and Razor Pages apps can also use the [Component Tag Helper](xref:Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper) to register statically-rendered Blazor WebAssembly root components:
+
+```cshtml
+<component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
+```
+
 Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) (Blazor Server) or registered by the app in `Program.cs` (Blazor WebAssembly) can only be added to the app. They can't be removed or updated afterwards.
 
 For more information, see the following resources:
@@ -3045,6 +3051,12 @@ In the preceding code, the CSS selector, `#app`, indicates that the `App` compon
 
 ```html
 <div id="app">...</app>
+```
+
+MVC and Razor Pages apps can also use the [Component Tag Helper](xref:Microsoft.AspNetCore.Mvc.TagHelpers.ComponentTagHelper) to register statically-rendered Blazor WebAssembly root components:
+
+```cshtml
+<component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
 ```
 
 Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) (Blazor Server) or registered by the app in `Program.cs` (Blazor WebAssembly) can only be added to the app. They can't be removed or updated afterwards.

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1430,6 +1430,23 @@ The following `GenericTypeExample5` component with inferred cascaded types provi
 }
 ```
 
+## Render static root Razor components
+
+A *root Razor component* is the first component loaded of any component hierarachy loaded into the app.
+
+In an app created from a Blazor project template, the `App` component (`Pages/App.razor`) is created as the default root component in `Pages/_Host.cshtml` using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper):
+
+```cshtml
+<component type="typeof(App)" render-mode="ServerPrerendered" />
+```
+
+Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) can only be added to the app. They can't be removed or updated afterwards.
+
+For more information, see the following resources:
+
+* <xref:mvc/views/tag-helpers/builtin-th/component-tag-helper>
+* <xref:blazor/components/prerendering-and-integration>
+
 ## Render Razor components from JavaScript
 
 Razor components can be dynamically-rendered from JavaScript (JS) for existing JS apps.
@@ -2996,6 +3013,23 @@ The following `GenericTypeExample5` component with inferred cascaded types provi
 }
 ```
 
+## Render static root Razor components
+
+A *root Razor component* is the first component loaded of any component hierarachy loaded into the app.
+
+In an app created from a Blazor project template, the `App` component (`Pages/App.razor`) is created as the default root component in `Pages/_Host.cshtml` using the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper):
+
+```cshtml
+<component type="typeof(App)" render-mode="ServerPrerendered" />
+```
+
+Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) can only be added to the app. They can't be removed or updated afterwards.
+
+For more information, see the following resources:
+
+* <xref:mvc/views/tag-helpers/builtin-th/component-tag-helper>
+* <xref:blazor/components/prerendering-and-integration>
+
 ## Render Razor components from JavaScript
 
 Razor components can be dynamically-rendered from JavaScript (JS) for existing JS apps.
@@ -3027,7 +3061,17 @@ Load Blazor into the JS app (`blazor.server.js` or `blazor.webassembly.js`). Ren
 
 ```javascript
 let containerElement = document.getElementById('my-counter');
-await Blazor.rootComponents.add(containerElement, 'counter', { incrementAmount: 10 });
+await window.Blazor.rootComponents.add(containerElement, 'counter', { incrementAmount: 10 });
+```
+
+`rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
+
+```javascript
+const rootComponent = await window.Blazor.rootComponents.add(...);
+
+...
+
+rootComponent.dispose();
 ```
 
 ## Blazor custom elements

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1458,7 +1458,7 @@ MVC and Razor Pages apps can also use the [Component Tag Helper](xref:Microsoft.
 <component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
 ```
 
-Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) (Blazor Server) or registered by the app in `Program.cs` (Blazor WebAssembly) can only be added to the app. They can't be removed or updated afterwards.
+Statically-rendered components can only be added to the app. They can't be removed or updated afterwards.
 
 For more information, see the following resources:
 
@@ -3059,7 +3059,7 @@ MVC and Razor Pages apps can also use the [Component Tag Helper](xref:Microsoft.
 <component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
 ```
 
-Statically-rendered components with the [Component Tag Helper](xref:mvc/views/tag-helpers/builtin-th/component-tag-helper) (Blazor Server) or registered by the app in `Program.cs` (Blazor WebAssembly) can only be added to the app. They can't be removed or updated afterwards.
+Statically-rendered components can only be added to the app. They can't be removed or updated afterwards.
 
 For more information, see the following resources:
 

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -79,7 +79,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
 
      Add:
 
-     ```razor
+     ```cshtml
      <link href="css/app.css" rel="stylesheet" />
      <link href="BlazorHosted.Client.styles.css" rel="stylesheet" />
      <component type="typeof(HeadOutlet)" render-mode="WebAssemblyPrerendered" />
@@ -112,7 +112,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
 
      Add:
 
-     ```razor
+     ```cshtml
      <component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
      ```
 
@@ -193,7 +193,7 @@ Include the **:::no-loc text="Client":::** project's styles in the layout file. 
 
 Place the following lines in the `<head>` content of the layout file:
 
-```html
+```cshtml
 <title>@ViewData["Title"] - BlazorHosted</title>
 <link href="css/app.css" rel="stylesheet" />
 <link rel="stylesheet" href="BlazorHosted.Client.styles.css" asp-append-version="true" />
@@ -982,7 +982,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
 
      Add:
 
-     ```razor
+     ```cshtml
      <link href="css/app.css" rel="stylesheet" />
      <link href="BlazorHosted.Client.styles.css" rel="stylesheet" />
      <component type="typeof(HeadOutlet)" render-mode="WebAssemblyPrerendered" />
@@ -1031,7 +1031,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
 
      Add:
 
-     ```razor
+     ```cshtml
      <component type="typeof(App)" render-mode="WebAssemblyPrerendered" />
      ```
 
@@ -1115,7 +1115,7 @@ Include the **:::no-loc text="Client":::** project's styles in the layout file. 
 
 Place the following lines in the `<head>` content of the layout file:
 
-```html
+```cshtml
 <title>@ViewData["Title"] - BlazorHosted</title>
 <link href="css/app.css" rel="stylesheet" />
 <link rel="stylesheet" href="BlazorHosted.Client.styles.css" asp-append-version="true" />
@@ -1337,7 +1337,7 @@ Use the following guidance to integrate Razor components into pages and views of
 
    * Add the following `<base>` tag and <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component Tag Helper to the `<head>` element in `Pages/Shared/_Layout.cshtml` (Razor Pages) or `Views/Shared/_Layout.cshtml` (MVC):
 
-     ```html
+     ```cshtml
      <base href="~/" />
      <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
      ```


### PR DESCRIPTION
Fixes #27556

Mackinnion ...

* Today, there's a chasm between mentioning the purpose of the `App` component in the *Project Structure* topic and all of the juicy details in the *Prerendering and Integration* topic. I think we need a short section in the *Components Overview* topic to address static root components ... nothing too detailed or long ... just the basic idea with the cross-links to the *Component Tag Helper* doc and the *Prerendering and Integration* doc. Also, it makes sense to have such a section just above the new section for dynamically-rendered components from JS that was added back at 6.0. Now, we can cover both scenarios back-to-back/SxS ... static via C#/CSHTML root component registration/Tag Helper and dynamic via JS. 
* Javier asked me to flesh out dynamic root component disposal at https://github.com/dotnet/aspnetcore/issues/44928#issuecomment-1309118999.
* There's also a passing *NIT* update here on a code language change.

❓ ...

* Is the added static root component section ***sane*** 😵?
* Have I placed a ***sane*** 😵 remark and example on root component disposal? I placed something simple ... ***too simple???***

If ***insane*** ... no worries. I'll make updates per your feedback ~and get some treatment ... ***with*** 🍺 ***over the*** 🦃 ***weekend!***~ 🍻🤣

**UPDATE**: Yes, I've received "treatment" over the 🦃 break. ***All good!*** 🍻😆 