### PR TITLE
Simplified the code so it renders correct HTML when embedded

### DIFF
--- a/aspnetcore/fundamentals/environments/samples/6.x/EnvironmentsSample/Pages/About.cshtml
+++ b/aspnetcore/fundamentals/environments/samples/6.x/EnvironmentsSample/Pages/About.cshtml
@@ -19,15 +19,12 @@
 
 <!-- <snippet_Environment> -->
 <environment include="Development">
-    <div>The effective tag is: &lt;environment include="Development"&gt;</div>
+    <div>Environment is Development</div>
 </environment>
 <environment exclude="Development">
-    <div>The effective tag is: &lt;environment exclude="Development"&gt;</div>
+    <div>Environment is NOT Development</div>
 </environment>
 <environment include="Staging,Development,Staging_2">
-    <div>
-        The effective tag is:
-        &lt;environment include="Staging,Development,Staging_2"&gt;
-    </div>
+    <div>Environment is: Staging, Development or Staging_2</div>
 </environment>
 <!-- </snippet_Environment> -->


### PR DESCRIPTION
Fixed broken code render when embedded in documation on:

https://learn.microsoft.com/en-us/aspnet/core/fundamentals/environments?view=aspnetcore-7.0#environments

(ASP.NET Core 3.1 to 7.0 variations uses the same code sample)

The environment tag helper code  &lt; was rendered as actual HTML tags in the embedded code example, creating invalid  code.
