### PR TITLE
Fix typos in event-handling.md

### DIFF
--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -102,7 +102,7 @@ Custom events with custom event arguments are generally enabled with the followi
    ```html
    <script>
      Blazor.registerCustomEventType('customevent', {
-       createEventArgs: eventArgsCreator;
+       createEventArgs: eventArgsCreator
      });
    </script>
    ```
@@ -124,7 +124,7 @@ Custom events with custom event arguments are generally enabled with the followi
 
    ```csharp
    [EventHandler("oncustomevent", typeof(CustomEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
-   static class EventHandlers
+   public static class EventHandlers
    {
    }
    ```

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -427,7 +427,7 @@ Custom events with custom event arguments are generally enabled with the followi
    ```html
    <script>
      Blazor.registerCustomEventType('customevent', {
-       createEventArgs: eventArgsCreator;
+       createEventArgs: eventArgsCreator
      });
    </script>
    ```
@@ -449,7 +449,7 @@ Custom events with custom event arguments are generally enabled with the followi
 
    ```csharp
    [EventHandler("oncustomevent", typeof(CustomEventArgs), enableStopPropagation: true, enablePreventDefault: true)]
-   static class EventHandlers
+   public static class EventHandlers
    {
    }
    ```
@@ -461,7 +461,7 @@ Custom events with custom event arguments are generally enabled with the followi
 
    @code
    {
-       void HandleCustomEvent(CustomEventArgs eventArgs)
+       private void HandleCustomEvent(CustomEventArgs eventArgs)
        {
            // eventArgs.CustomProperty1
            // eventArgs.CustomProperty2

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -136,7 +136,7 @@ Custom events with custom event arguments are generally enabled with the followi
 
    @code
    {
-       void HandleCustomEvent(CustomEventArgs eventArgs)
+       private void HandleCustomEvent(CustomEventArgs eventArgs)
        {
            // eventArgs.CustomProperty1
            // eventArgs.CustomProperty2


### PR DESCRIPTION
- Fix typo in JS code
- Mark `EventHandlers` class as public, otherwise Razor compiler will not find it



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->