### PR TITLE
Access services from a different DI scope

### DIFF
--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -970,20 +970,38 @@ There may be times when a Razor component invokes asynchronous methods that exec
 
 For example, <xref:System.Net.Http.HttpClient> instances created using <xref:System.Net.Http.IHttpClientFactory> have their own DI service scope. As a result, <xref:System.Net.Http.HttpMessageHandler> instances configured on the <xref:System.Net.Http.HttpClient> aren't able to directly inject Blazor services.
 
-Create a static class `BlazorServiceAccessor` that defines an [`AsyncLocal<IServiceProvider>`](xref:System.Threading.AsyncLocal`1), which stores the Blazor <xref:System.IServiceProvider> for the current asynchronous context. Asynchronous code invoked from a Razor component can use `BlazorServiceAccessor.Services` to access Blazor services. *This is only necessary if the <xref:System.IServiceProvider> available to the invoked code was created in a different DI service scope.*
+Create a class `BlazorServiceAccessor` that defines an [`AsyncLocal`](xref:System.Threading.AsyncLocal`1), which stores the Blazor <xref:System.IServiceProvider> for the current asynchronous context. A `BlazorServiceAcccessor` instance can be acquired from within a different DI service scope to access Blazor services.
 
 `BlazorServiceAccessor.cs`:
 
 ```csharp
-internal static class BlazorServiceAccessor
+internal sealed class BlazorServiceAccessor
 {
-    private static readonly AsyncLocal<IServiceProvider> s_blazorServices = new();
+    private static readonly AsyncLocal<BlazorServiceHolder> s_currentServiceHolder = new();
 
-    public static IServiceProvider Services
+    public IServiceProvider? Services
     {
-        get => s_blazorServices.Value ?? throw new InvalidOperationException(
-            "Blazor services are not available in the current context.");
-        set => s_blazorServices.Value = value;
+        get => s_currentServiceHolder.Value?.Services;
+        set
+        {
+            if (s_currentServiceHolder.Value is { } holder)
+            {
+                // Clear the current IServiceProvider trapped in the AsyncLocal.
+                holder.Services = null;
+            }
+
+            if (value is not null)
+            {
+                // Use object indirection to hold the IServiceProvider in an AsyncLocal
+                // so it can be cleared in all ExecutionContexts when it's cleared.
+                s_currentServiceHolder.Value = new() { Services = value };
+            }
+        }
+    }
+
+    private sealed class BlazorServiceHolder
+    {
+        public IServiceProvider? Services { get; set; }
     }
 }
 ```
@@ -1008,10 +1026,13 @@ public class CustomComponentBase : ComponentBase, IHandleEvent, IHandleAfterRend
     [Inject]
     private IServiceProvider Services { get; set; } = default!;
 
+    [Inject]
+    private BlazorServiceAccessor BlazorServiceAccessor { get; set; } = default!;
+
     public override Task SetParametersAsync(ParameterView parameters)
         => InvokeWithBlazorServiceContext(() => base.SetParametersAsync(parameters));
 
-    private Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg)
+    Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg)
         => InvokeWithBlazorServiceContext(() =>
         {
             var task = callback.InvokeAsync(arg);
@@ -1025,7 +1046,7 @@ public class CustomComponentBase : ComponentBase, IHandleEvent, IHandleAfterRend
                 Task.CompletedTask;
         });
 
-    private Task IHandleAfterRender.OnAfterRenderAsync()
+    Task IHandleAfterRender.OnAfterRenderAsync()
         => InvokeWithBlazorServiceContext(() =>
         {
             var firstRender = !hasCalledOnAfterRender;
@@ -1057,13 +1078,29 @@ public class CustomComponentBase : ComponentBase, IHandleEvent, IHandleAfterRend
 
     private async Task InvokeWithBlazorServiceContext(Func<Task> func)
     {
-        BlazorServiceAccessor.Services = Services;
-        await func();
+        try
+        {
+            BlazorServiceAccessor.Services = Services;
+            await func();
+        }
+        finally
+        {
+            BlazorServiceAccessor.Services = null;
+        }
     }
 }
 ```
 
 Any components extending `CustomComponentBase` automatically have `BlazorServiceAccessor.Services` set to the <xref:System.IServiceProvider> in the current Blazor DI scope.
+
+Finally, in `Program.cs`, add the `BlazorServiceAccessor` as a scoped service:
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+// ...
+builder.Services.AddScoped<BlazorServiceAccessor>();
+// ...
+```
 
 ## Additional resources
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -970,8 +970,6 @@ There may be times when a Razor component invokes asynchronous methods that exec
 
 For example, <xref:System.Net.Http.HttpClient> instances created using <xref:System.Net.Http.IHttpClientFactory> have their own DI service scope. As a result, <xref:System.Net.Http.HttpMessageHandler> instances configured on the <xref:System.Net.Http.HttpClient> aren't able to directly inject Blazor services.
 
-Until this scenario is addressed as a product feature in a future Blazor release, the following workaround is available to configure accessible Blazor services from code in other DI scopes when invoked from a Razor component.
-
 Create a static class `BlazorServiceAccessor` that defines an [`AsyncLocal<IServiceProvider>`](xref:System.Threading.AsyncLocal`1), which stores the Blazor <xref:System.IServiceProvider> for the current asynchronous context. Asynchronous code invoked from a Razor component can use `BlazorServiceAccessor.Services` to access Blazor services. *This is only necessary if the <xref:System.IServiceProvider> available to the invoked code was created in a different DI service scope.*
 
 `BlazorServiceAccessor.cs`:

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -962,7 +962,7 @@ Navigate to the `TransientExample` component at `/transient-example` and an <xre
 
 > System.InvalidOperationException: Trying to resolve transient disposable service TransientDependency in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
   
-## Access Blazor services from another DI scope
+## Access Blazor services from a different DI scope
   
 *This section only applies to Blazor Server apps.**
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -961,6 +961,111 @@ The app can register transient disposables without throwing an exception. Howeve
 Navigate to the `TransientExample` component at `/transient-example` and an <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDependency`:
 
 > System.InvalidOperationException: Trying to resolve transient disposable service TransientDependency in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
+  
+## Access Blazor services from another DI scope
+  
+*This section only applies to Blazor Server apps.**
+
+There may be times when a Razor component invokes asynchronous methods that execute code in a different DI scope. Without the correct approach, these DI scopes don't have access to Blazor's services, such as `IJSInterop` and <xref:Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage>.
+
+For example, <xref:System.Net.Http.HttpClient> instances created using <xref:System.Net.Http.IHttpClientFactory> have their own DI service scope. As a result, <xref:System.Net.Http.HttpMessageHandler> instances configured on the <xref:System.Net.Http.HttpClient> aren't able to directly inject Blazor services.
+
+Until this scenario is addressed as a product feature in a future Blazor release, the following workaround is available to configure accessible Blazor services from code in other DI scopes when invoked from a Razor component.
+
+Create a static class `BlazorServiceAccessor` that defines an [`AsyncLocal<IServiceProvider>`](xref:System.Threading.AsyncLocal`1), which stores the Blazor <xref:System.IServiceProvider> for the current asynchronous context. Asynchronous code invoked from a Razor component can use `BlazorServiceAccessor.Services` to access Blazor services. *This is only necessary if the <xref:System.IServiceProvider> available to the invoked code was created in a different DI service scope.*
+
+`BlazorServiceAccessor.cs`:
+
+```csharp
+internal static class BlazorServiceAccessor
+{
+    private static readonly AsyncLocal<IServiceProvider> s_blazorServices = new();
+
+    public static IServiceProvider Services
+    {
+        get => s_blazorServices.Value ?? throw new InvalidOperationException(
+            "Blazor services are not available in the current context.");
+        set => s_blazorServices.Value = value;
+    }
+}
+```
+
+To set the value of `BlazorServiceAccessor.Services` automatically when an `async` component method is invoked, create a custom base component that re-implements the three primary asynchronous entry points into Razor component code:
+
+* <xref:Microsoft.AspNetCore.Components.IComponent.SetParametersAsync%2A?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Components.IHandleEvent.HandleEventAsync%2A?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Components.IHandleAfterRender.OnAfterRenderAsync%2A?displayProperty=nameWithType>
+
+The following class demonstrates the implementation for the base component.
+  
+`CustomComponentBase.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Components;
+
+public class CustomComponentBase : ComponentBase, IHandleEvent, IHandleAfterRender
+{
+    private bool hasCalledOnAfterRender;
+
+    [Inject]
+    private IServiceProvider Services { get; set; } = default!;
+
+    public override Task SetParametersAsync(ParameterView parameters)
+        => InvokeWithBlazorServiceContext(() => base.SetParametersAsync(parameters));
+
+    Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg)
+        => InvokeWithBlazorServiceContext(() =>
+        {
+            var task = callback.InvokeAsync(arg);
+            var shouldAwaitTask = task.Status != TaskStatus.RanToCompletion &&
+                task.Status != TaskStatus.Canceled;
+
+            StateHasChanged();
+
+            return shouldAwaitTask ?
+                CallStateHasChangedOnAsyncCompletion(task) :
+                Task.CompletedTask;
+        });
+
+    Task IHandleAfterRender.OnAfterRenderAsync()
+        => InvokeWithBlazorServiceContext(() =>
+        {
+            var firstRender = !hasCalledOnAfterRender;
+            hasCalledOnAfterRender |= true;
+
+            OnAfterRender(firstRender);
+
+            return OnAfterRenderAsync(firstRender);
+        });
+
+    private async Task CallStateHasChangedOnAsyncCompletion(Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch
+        {
+            if (task.IsCanceled)
+            {
+                return;
+            }
+
+            throw;
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task InvokeWithBlazorServiceContext(Func<Task> func)
+    {
+        BlazorServiceAccessor.Services = Services;
+        await func();
+    }
+}
+```
+
+Any components extending `CustomComponentBase` automatically have `BlazorServiceAccessor.Services` set to the <xref:System.IServiceProvider> in the current Blazor DI scope.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -966,7 +966,7 @@ Navigate to the `TransientExample` component at `/transient-example` and an <xre
   
 *This section only applies to Blazor Server apps.**
 
-There may be times when a Razor component invokes asynchronous methods that execute code in a different DI scope. Without the correct approach, these DI scopes don't have access to Blazor's services, such as `IJSInterop` and <xref:Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage>.
+There may be times when a Razor component invokes asynchronous methods that execute code in a different DI scope. Without the correct approach, these DI scopes don't have access to Blazor's services, such as <xref:Microsoft.JSInterop.IJSRuntime> and <xref:Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage>.
 
 For example, <xref:System.Net.Http.HttpClient> instances created using <xref:System.Net.Http.IHttpClientFactory> have their own DI service scope. As a result, <xref:System.Net.Http.HttpMessageHandler> instances configured on the <xref:System.Net.Http.HttpClient> aren't able to directly inject Blazor services.
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -1013,7 +1013,7 @@ public class CustomComponentBase : ComponentBase, IHandleEvent, IHandleAfterRend
     public override Task SetParametersAsync(ParameterView parameters)
         => InvokeWithBlazorServiceContext(() => base.SetParametersAsync(parameters));
 
-    Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg)
+    private Task IHandleEvent.HandleEventAsync(EventCallbackWorkItem callback, object? arg)
         => InvokeWithBlazorServiceContext(() =>
         {
             var task = callback.InvokeAsync(arg);
@@ -1027,7 +1027,7 @@ public class CustomComponentBase : ComponentBase, IHandleEvent, IHandleAfterRend
                 Task.CompletedTask;
         });
 
-    Task IHandleAfterRender.OnAfterRenderAsync()
+    private Task IHandleAfterRender.OnAfterRenderAsync()
         => InvokeWithBlazorServiceContext(() =>
         {
             var firstRender = !hasCalledOnAfterRender;


### PR DESCRIPTION
Fixes #27908

[Internal Review Topic (links to section)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/dependency-injection?view=aspnetcore-8.0&branch=pr-en-us-27909#access-blazor-services-from-a-different-di-scope)

Mackinnon:

The Blazor DI topic is probably the best spot for this.

Questions ❓ ...

1. Is `IJSInterop` a thing? I can't find that API. Did you mean `IJSRuntime`?
1. Is the "Blazor `IServiceProvider`" a `System.IServiceProvider`? I ask to make sure that I have the API cross-links correct.
1. I removed the `_` from `hasCalledOnAfterRender`. I was told that for developer code not to sweat it ... that it was more for framework purposes. I might be a bit off on that tho because the discussion surrounding using the underscore on fields was focused on how we would ***display Razor components to readers***, not so much for classes that we display to readers. Do you want me to add it back?
1. What versions can I display this for? ... Can this go all the way back to the 3.1 version of the topic?