### PR TITLE
Update custom Identity component guidance

### DIFF
--- a/aspnetcore/security/authentication/scaffold-identity.md
+++ b/aspnetcore/security/authentication/scaffold-identity.md
@@ -258,7 +258,7 @@ ASP.NET Core Identity is designed to work in the context of HTTP request and res
 
 Because <xref:Microsoft.AspNetCore.Identity.SignInManager%601> and <xref:Microsoft.AspNetCore.Identity.UserManager%601> aren't supported in Razor components, we recommend using web API to manage Identity actions from Razor components via a server-side Identity-enabled ASP.NET Core app. For guidance on creating web APIs for Blazor apps, see <xref:blazor/call-web-api>.
 
-An approach to using Razor components for Identity instead of Razor pages is to build your own custom Identity Razor components, but Microsoft doesn't recommend or support the approach. For additional context, explore the following discussions. Code examples provided by community members in the following discussions aren't supported by Microsoft but might be helpful to some developers:
+An approach to using Razor components for Identity instead of Razor pages is to build your own custom Identity Razor components, but Microsoft doesn't recommend or support the approach. For additional context, explore the following discussions. In the following discussions, code examples in issue comments and code examples cross-linked in non-Microsoft GitHub repositories aren't supported by Microsoft but might be helpful to some developers:
 
 * [Support Custom Login Component when using Identity (dotnet/aspnetcore #13601)](https://github.com/dotnet/aspnetcore/issues/13601)
 * [Reiteration on the `SigninManager<T>` not being supported in Razor Components (dotnet/aspnetcore #34095)](https://github.com/dotnet/aspnetcore/issues/34095)

--- a/aspnetcore/security/authentication/scaffold-identity.md
+++ b/aspnetcore/security/authentication/scaffold-identity.md
@@ -256,13 +256,16 @@ Because Blazor Server uses Razor Pages Identity pages, the styling of the UI cha
 
 ASP.NET Core Identity is designed to work in the context of HTTP request and response communication, which isn't the primary client-server communication model in Blazor apps. ASP.NET Core apps that use ASP.NET Core Identity for user management should use Razor Pages instead of Razor components for Identity-related UI, such as user registration, login, logout, and other user management tasks.
 
-An approach to using components for Identity instead of pages is to build custom Identity components. Because <xref:Microsoft.AspNetCore.Identity.SignInManager%601> and <xref:Microsoft.AspNetCore.Identity.UserManager%601> aren't supported in Razor components, use API endpoints to manage Identity actions. For guidance on creating web APIs for Blazor apps, see <xref:blazor/call-web-api>. <!-- For an example that uses <xref:Microsoft.AspNetCore.Identity.UserManager%601> in a hosted Blazor WebAssembly app, see <xref:blazor/security/webassembly/hosted-with-azure-active-directory#usermanager-and-signinmanager>. -->
+Because <xref:Microsoft.AspNetCore.Identity.SignInManager%601> and <xref:Microsoft.AspNetCore.Identity.UserManager%601> aren't supported in Razor components, we recommend using web API to manage Identity actions from Razor components via a server-side Identity-enabled ASP.NET Core app. For guidance on creating web APIs for Blazor apps, see <xref:blazor/call-web-api>.
 
-For additional context and further assistance, explore the following discussions and resources:
+An approach to using Razor components for Identity instead of Razor pages is to build your own custom Identity Razor components, but Microsoft doesn't recommend or support the approach. For additional context, explore the following discussions. Code examples provided by community members in the following discussions aren't supported by Microsoft but might be helpful to some developers:
 
 * [Support Custom Login Component when using Identity (dotnet/aspnetcore #13601)](https://github.com/dotnet/aspnetcore/issues/13601)
 * [Reiteration on the `SigninManager<T>` not being supported in Razor Components (dotnet/aspnetcore #34095)](https://github.com/dotnet/aspnetcore/issues/34095)
 * [There is no info on how to actually implement custom login form for server-side blazor (dotnet/AspNetCore.Docs #16813)](https://github.com/dotnet/AspNetCore.Docs/issues/16813)
+
+For additional assistance when seeking to build custom Identity Razor components or searching for third-party Razor components, we recommend the following resources:
+
 * [Stack Overflow (tag: `blazor`)](https://stackoverflow.com/questions/tagged/blazor) (Public support forum)
 * [ASP.NET Core Slack Team](https://join.slack.com/t/aspnetcore/shared_invite/zt-1b60h73p0-PZPq3YCCaPbB21RcujMSVA) (Public support chat)
 * [Blazor Gitter](https://gitter.im/aspnet/Blazor) (Public support chat)


### PR DESCRIPTION
Fixes #27921

cc: @fgalarraga

Thanks for the issue, @mattbeasley96. I've reviewed the cross-links, and I want to leave them in this section for a few reasons:

* Javier explains in full detail ***why*** they don't want to build such components into the framework, and we try not to get into design decisions in the docs. We prefer to link to the product unit discussions that explain the reasoning behind framework design decisions.
* Although MS doesn't support the approach, there are helpful tidbits in the discussions, including community sample code that might be helpful to some devs. Also, there are links to sample code in non-MS repos for custom Identity components that are worth taking a look at. 
* If we don't have the links to these discussions, devs are left trying to find these discussions on their own. Searching over there can be a bit hairy. A few simple search terms can return several dozen unrelated issues. By providing the links, we save readers a lot of time trying to find these discussions.

Although I think the original text of this section did say that these were just discussions ...

> For additional context and further assistance, explore the following discussions and resources:

... and this section did say what MS recommends ...

> Because `SignInManager<TUser>` and `UserManager<TUser>` aren't supported in Razor components, use API endpoints to manage Identity actions. For guidance on creating web APIs for Blazor apps, see *Call a web API from an ASP.NET Core Blazor app*.

... I think the text can be improved. What I do on this PR is make it clear what those links represent, along the lines of what @Rick-Anderson suggested. Product unit issue discussions are ***just discussions***, and this will now say that community code in issue comments over there isn't supported by MS.