### PR TITLE
Correct target framework

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -5,7 +5,7 @@ description: Learn how to host an ASP.NET Core app in a Windows Service.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 9/3/2022
+ms.date: 12/19/2022
 uid: host-and-deploy/windows-service
 ---
 # Host ASP.NET Core in a Windows Service
@@ -82,7 +82,7 @@ If using the [Web SDK](#sdk), a *web.config* file, which is normally produced wh
 
 ```xml
 <PropertyGroup>
-  <TargetFramework>netcoreapp3.0</TargetFramework>
+  <TargetFramework>net7.0</TargetFramework>
   <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
 </PropertyGroup>
 ```
@@ -406,7 +406,7 @@ If using the [Web SDK](#sdk), a *web.config* file, which is normally produced wh
 
 ```xml
 <PropertyGroup>
-  <TargetFramework>netcoreapp3.0</TargetFramework>
+  <TargetFramework>net6.0</TargetFramework>
   <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
 </PropertyGroup>
 ```


### PR DESCRIPTION
Fixes #23847 

This article was updated to 6.0 in https://github.com/dotnet/AspNetCore.Docs/pull/26844, and to 7.0 in https://github.com/dotnet/AspNetCore.Docs/pull/26913
In both cases a reference to .NET Core 3.1 remained in a project file example; that is what this PR corrects.