### PR TITLE
Move and rename "ASP.NET Core Performance Best Practices" doc

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -292,7 +292,12 @@
         },
         {
             "source_path": "aspnetcore/performance/measuring.md",
-            "redirect_url": "/aspnet/core/performance/",
+            "redirect_url": "/aspnet/core/performance/overview",
+            "redirect_document_id": false
+        },
+        {
+            "source_path": "aspnetcore/performance/performance-best-practices.md",
+            "redirect_url": "/aspnet/core/fundamentals/best-practices",
             "redirect_document_id": false
         },
         {

--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -298,7 +298,7 @@
         {
             "source_path": "aspnetcore/performance/performance-best-practices.md",
             "redirect_url": "/aspnet/core/fundamentals/best-practices",
-            "redirect_document_id": false
+            "redirect_document_id": true
         },
         {
             "source_path": "aspnetcore/security/authentication/oauth2.md",

--- a/aspnetcore/blazor/security/server/threat-mitigation.md
+++ b/aspnetcore/blazor/security/server/threat-mitigation.md
@@ -39,7 +39,7 @@ Resource exhaustion can occur when a client interacts with the server and causes
 
 Denial of service (DoS) attacks usually seek to exhaust an app or server's resources. However, resource exhaustion isn't necessarily the result of an attack on the system. For example, finite resources can be exhausted due to high user demand. DoS is covered further in the [Denial of service (DoS) attacks](#denial-of-service-dos-attacks) section.
 
-Resources external to the Blazor framework, such as databases and file handles (used to read and write files), may also experience resource exhaustion. For more information, see <xref:performance/performance-best-practices>.
+Resources external to the Blazor framework, such as databases and file handles (used to read and write files), may also experience resource exhaustion. For more information, see <xref:fundamentals/best-practices>.
 
 ### CPU
 
@@ -430,7 +430,7 @@ Resource exhaustion can occur when a client interacts with the server and causes
 
 Denial of service (DoS) attacks usually seek to exhaust an app or server's resources. However, resource exhaustion isn't necessarily the result of an attack on the system. For example, finite resources can be exhausted due to high user demand. DoS is covered further in the [Denial of service (DoS) attacks](#denial-of-service-dos-attacks) section.
 
-Resources external to the Blazor framework, such as databases and file handles (used to read and write files), may also experience resource exhaustion. For more information, see <xref:performance/performance-best-practices>.
+Resources external to the Blazor framework, such as databases and file handles (used to read and write files), may also experience resource exhaustion. For more information, see <xref:fundamentals/best-practices>.
 
 ### CPU
 
@@ -821,7 +821,7 @@ Resource exhaustion can occur when a client interacts with the server and causes
 
 Denial of service (DoS) attacks usually seek to exhaust an app or server's resources. However, resource exhaustion isn't necessarily the result of an attack on the system. For example, finite resources can be exhausted due to high user demand. DoS is covered further in the [Denial of service (DoS) attacks](#denial-of-service-dos-attacks) section.
 
-Resources external to the Blazor framework, such as databases and file handles (used to read and write files), may also experience resource exhaustion. For more information, see <xref:performance/performance-best-practices>.
+Resources external to the Blazor framework, such as databases and file handles (used to read and write files), may also experience resource exhaustion. For more information, see <xref:fundamentals/best-practices>.
 
 ### CPU
 

--- a/aspnetcore/fundamentals/best-practices.md
+++ b/aspnetcore/fundamentals/best-practices.md
@@ -15,7 +15,7 @@ This article provides guidelines for maximizing performance and reliability of A
 
 ## Cache aggressively
 
-Caching is discussed in several parts of this document. For more information, see <xref:performance/caching/overview>.
+Caching is discussed in several parts of this article. For more information, see <xref:performance/caching/overview>.
 
 ## Understand hot code paths
 
@@ -165,10 +165,6 @@ Recommendations:
 
 App diagnostic tools, such as Application Insights, can help to identify common exceptions in an app that may affect performance.
 
-## Performance and reliability
-
-The following sections provide performance tips and describe known reliability problems and solutions.
-
 ## Avoid synchronous read or write on HttpRequest/HttpResponse body
 
 All I/O in ASP.NET Core is asynchronous. Servers implement the `Stream` interface, which has both synchronous and asynchronous overloads. The asynchronous ones should be preferred to avoid blocking thread pool threads. Blocking threads can lead to thread pool starvation.
@@ -236,7 +232,7 @@ When using a serializer/de-serializer that only supports synchronous reads and w
 * Buffer the data into memory asynchronously before passing it into the serializer/de-serializer.
 
 > [!WARNING]
-> If the request is large, it could lead to an out of memory (OOM) condition. OOM can result in a Denial Of Service.  For more information, see [Avoid reading large request bodies or response bodies into memory](#arlb) in this document.
+> If the request is large, it could lead to an out of memory (OOM) condition. OOM can result in a Denial Of Service.  For more information, see [Avoid reading large request bodies or response bodies into memory](#arlb) in this article.
 
 ASP.NET Core 3.0 uses <xref:System.Text.Json> by default for JSON serialization. <xref:System.Text.Json>:
 

--- a/aspnetcore/fundamentals/best-practices.md
+++ b/aspnetcore/fundamentals/best-practices.md
@@ -1,43 +1,40 @@
 ---
-title: ASP.NET Core Performance Best Practices
+title: ASP.NET Core Best Practices
 author: mjrousos
-description: Tips for increasing performance in ASP.NET Core apps and avoiding common performance problems.
+description: Tips for maximizing performance and reliability in ASP.NET Core apps.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
-ms.date: 04/06/2020
-uid: performance/performance-best-practices
+ms.date: 12/20/2022
+uid: fundamentals/best-practices
 ---
-# ASP.NET Core Performance Best Practices
+# ASP.NET Core Best Practices
 
 By [Mike Rousos](https://github.com/mjrousos)
 
-This article provides guidelines for performance best practices with ASP.NET Core.
+This article provides guidelines for maximizing performance and reliability of ASP.NET Core apps.
 
 ## Cache aggressively
 
-Caching is discussed in several parts of this document. For more information, see <xref:performance/caching/response>.
+Caching is discussed in several parts of this document. For more information, see <xref:performance/caching>.
 
 ## Understand hot code paths
 
-In this document, a *hot code path* is defined as a code path that is frequently called and where much of the execution time occurs. Hot code paths typically limit app scale-out and performance and are discussed in several parts of this document.
+In this article, a *hot code path* is defined as a code path that is frequently called and where much of the execution time occurs. Hot code paths typically limit app scale-out and performance and are discussed in several parts of this article.
 
 ## Avoid blocking calls
 
 ASP.NET Core apps should be designed to process many requests simultaneously. Asynchronous APIs allow a small pool of threads to handle thousands of concurrent requests by not waiting on blocking calls. Rather than waiting on a long-running synchronous task to complete, the thread can work on another request.
 
-A common performance problem in ASP.NET Core apps is blocking calls that could be asynchronous. Many synchronous blocking calls lead to [Thread Pool starvation](/archive/blogs/vancem/diagnosing-net-core-threadpool-starvation-with-perfview-why-my-service-is-not-saturating-all-cores-or-seems-to-stall) and degraded response times.
+A common performance problem in ASP.NET Core apps is blocking calls that could be asynchronous. Many synchronous blocking calls lead to [Thread Pool starvation](xref:debug-threadpool-starvation) and degraded response times.
 
-**Do not**:
+**Do not** block asynchronous execution by calling <xref:System.Threading.Tasks.Task.Wait%2A?displayProperty=nameWithType> or <xref:System.Threading.Tasks.Task%601.Result%2A?displayProperty=nameWithType>.
+**Do not** acquire locks in common code paths. ASP.NET Core apps perform best when architected to run code in parallel.
+**Do not** call <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType> and immediately await it. ASP.NET Core already runs app code on normal Thread Pool threads, so calling `Task.Run` only results in extra unnecessary Thread Pool scheduling. Even if the scheduled code would block a thread, `Task.Run` does not prevent that.
 
-* Block asynchronous execution by calling <xref:System.Threading.Tasks.Task.Wait%2A?displayProperty=nameWithType> or <xref:System.Threading.Tasks.Task%601.Result%2A?displayProperty=nameWithType>.
-* Acquire locks in common code paths. ASP.NET Core apps are most performant when architected to run code in parallel.
-* Call <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType> and immediately await it. ASP.NET Core already runs app code on normal Thread Pool threads, so calling Task.Run only results in extra unnecessary Thread Pool scheduling. Even if the scheduled code would block a thread, Task.Run does not prevent that.
-
-**Do**:
-
-* Make [hot code paths](#understand-hot-code-paths) asynchronous.
-* Call data access, I/O, and long-running operations APIs asynchronously if an asynchronous API is available. Do **not** use <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType> to make a synchronous API asynchronous.
-* Make controller/Razor Page actions asynchronous. The entire call stack is asynchronous in order to benefit from [async/await](/dotnet/csharp/programming-guide/concepts/async/) patterns.
+* **Do** make [hot code paths](#understand-hot-code-paths) asynchronous.
+* **Do** call data access, I/O, and long-running operations APIs asynchronously if an asynchronous API is available.
+* **Do not** use <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType> to make a synchronous API asynchronous.
+* **Do** make controller/Razor Page actions asynchronous. The entire call stack is asynchronous in order to benefit from [async/await](/dotnet/csharp/programming-guide/concepts/async/) patterns.
 
 A profiler, such as [PerfView](https://github.com/Microsoft/perfview), can be used to find threads frequently added to the [Thread Pool](/windows/desktop/procthread/thread-pools). The `Microsoft-Windows-DotNETRuntime/ThreadPoolWorkerThread/Start` event indicates a thread added to the thread pool. <!--  For more information, see [async guidance docs](TBD-Link_To_Davifowl_Doc)  -->
 
@@ -96,7 +93,7 @@ Recommendations:
 * **Do** consider that EF Core resolves some query operators on the client, which may lead to inefficient query execution. For more information, see [Client evaluation performance issues](/ef/core/querying/client-eval#client-evaluation-performance-issues).
 * **Do not** use projection queries on collections, which can result in executing "N + 1" SQL queries. For more information, see [Optimization of correlated subqueries](/ef/core/what-is-new/ef-core-2.1#optimization-of-correlated-subqueries).
 
-See [EF High Performance](/ef/core/what-is-new/ef-core-2.0#explicitly-compiled-queries) for approaches that may improve performance in high-scale apps:
+The following approaches may improve performance in high-scale apps:
 
 * [DbContext pooling](/ef/core/what-is-new/ef-core-2.0#dbcontext-pooling)
 * [Explicitly compiled queries](/ef/core/what-is-new/ef-core-2.0#explicitly-compiled-queries)
@@ -107,7 +104,7 @@ Query issues can be detected by reviewing the time spent accessing data with [Ap
 
 ## Pool HTTP connections with HttpClientFactory
 
-Although <xref:System.Net.Http.HttpClient> implements the `IDisposable` interface, it's designed for reuse. Closed `HttpClient` instances leave sockets open in the `TIME_WAIT` state for a short period of time. If a code path that creates and disposes of `HttpClient` objects is frequently used, the app may exhaust available sockets. [HttpClientFactory](/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests) was introduced in ASP.NET Core 2.1 as a solution to this problem. It handles pooling HTTP connections to optimize performance and reliability.
+Although <xref:System.Net.Http.HttpClient> implements the `IDisposable` interface, it's designed for reuse. Closed `HttpClient` instances leave sockets open in the `TIME_WAIT` state for a short period of time. If a code path that creates and disposes of `HttpClient` objects is frequently used, the app may exhaust available sockets. `HttpClientFactory` was introduced in ASP.NET Core 2.1 as a solution to this problem. It handles pooling HTTP connections to optimize performance and reliability. For more information, see [Use `HttpClientFactory` to implement resilient HTTP requests](/dotnet/standard/microservices-architecture/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests).
 
 Recommendations:
 
@@ -145,7 +142,7 @@ ASP.NET Core apps with complex front-ends frequently serve many JavaScript, CSS,
 
 Recommendations:
 
-* **Do** use the [bundling and minification guidelines](xref:client-side/bundling-and-minification), which mentions compatible tools and shows how to use ASP.NET Core's `environment` tag to handle both `Development` and `Production` environments.
+* **Do** use the [bundling and minification guidelines](xref:client-side/bundling-and-minification), which mention compatible tools and show how to use ASP.NET Core's `environment` tag to handle both `Development` and `Production` environments.
 * **Do** consider other third-party tools, such as [Webpack](https://webpack.js.org/), for complex client asset management.
 
 ## Compress responses
@@ -154,7 +151,7 @@ Recommendations:
 
 ## Use the latest ASP.NET Core release
 
-Each new release of ASP.NET Core includes performance improvements. Optimizations in .NET Core and ASP.NET Core mean that newer versions generally outperform older versions. For example, .NET Core 2.1 added support for compiled regular expressions and benefitted from [Span\<T>](/archive/msdn-magazine/2018/january/csharp-all-about-span-exploring-a-new-net-mainstay). ASP.NET Core 2.2 added support for HTTP/2. [ASP.NET Core 3.0 adds many improvements](xref:aspnetcore-3.0) that reduce memory usage and improve throughput. If performance is a priority, consider upgrading to the current version of ASP.NET Core.
+Each new release of ASP.NET Core includes performance improvements. Optimizations in .NET Core and ASP.NET Core mean that newer versions generally outperform older versions. For example, .NET Core 2.1 added support for compiled regular expressions and benefitted from [Span\<T>](dotnet/standard/memory-and-spans/memory-t-usage-guidelines). ASP.NET Core 2.2 added support for HTTP/2. [ASP.NET Core 3.0 adds many improvements](xref:aspnetcore-3.0) that reduce memory usage and improve throughput. If performance is a priority, consider upgrading to the current version of ASP.NET Core.
 
 ## Minimize exceptions
 
@@ -170,7 +167,7 @@ App diagnostic tools, such as Application Insights, can help to identify common 
 
 ## Performance and reliability
 
-The following sections provide performance tips and known reliability problems and solutions.
+The following sections provide performance tips and describe known reliability problems and solutions.
 
 ## Avoid synchronous read or write on HttpRequest/HttpResponse body
 
@@ -190,9 +187,9 @@ In the preceding code, `Get` synchronously reads the entire HTTP request body in
 The preceding code asynchronously reads the entire HTTP request body into memory.
 
 > [!WARNING]
-> If the request is large, reading the entire HTTP request body into memory could lead to an out of memory (OOM) condition. OOM can result in a Denial Of Service.  For more information, see [Avoid reading large request bodies or response bodies into memory](#arlb) in this document.
+> If the request is large, reading the entire HTTP request body into memory could lead to an out of memory (OOM) condition. OOM can result in a Denial Of Service.  For more information, see [Avoid reading large request bodies or response bodies into memory](#arlb) in this article.
 
-**Do this:** The following example is fully asynchronous using a non buffered request body:
+**Do this:** The following example is fully asynchronous using a non-buffered request body:
 
 [!code-csharp[](performance-best-practices/samples/3.0/Controllers/MyFirstController.cs?name=snippet3)]
 
@@ -206,8 +203,7 @@ Use `HttpContext.Request.ReadFormAsync` instead of `HttpContext.Request.Form`.
 * The form has been read by a call to `ReadFormAsync`, and
 * The cached form value is being read using `HttpContext.Request.Form`
 
-**Do not do this:** The following example uses `HttpContext.Request.Form`.  `HttpContext.Request.Form` uses [sync over async](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#warning-sync-over-async
-) and can lead to thread pool starvation.
+**Do not do this:** The following example uses `HttpContext.Request.Form`.  `HttpContext.Request.Form` uses [sync over async](https://devblogs.microsoft.com/pfxteam/should-i-expose-synchronous-wrappers-for-asynchronous-methods/) and can lead to thread pool starvation.
 
 [!code-csharp[](performance-best-practices/samples/3.0/Controllers/MySecondController.cs?name=snippet1)]
 
@@ -226,9 +222,9 @@ In .NET, every object allocation greater than 85 KB ends up in the large object 
 
 This [blog post](https://adamsitnik.com/Array-Pool/#the-problem) describes the problem succinctly:
 
-> When a large object is allocated, it's marked as Gen 2 object. Not Gen 0 as for small objects. The consequences are that if you run out of memory in LOH, GC cleans up the whole managed heap, not only LOH. So it cleans up Gen 0, Gen 1 and Gen 2 including LOH. This is called full garbage collection and is the most time-consuming garbage collection. For many applications, it can be acceptable. But definitely not for high-performance web servers, where few big memory buffers are needed to handle an average web request (read from a socket, decompress, decode JSON & more).
+> When a large object is allocated, it's marked as Gen 2 object. Not Gen 0 as for small objects. The consequences are that if you run out of memory in LOH, GC cleans up the whole managed heap, not only LOH. So it cleans up Gen 0, Gen 1 and Gen 2 including LOH. This is called full garbage collection and is the most time-consuming garbage collection. For many applications, it can be acceptable. But definitely not for high-performance web servers, where few big memory buffers are needed to handle an average web request (read from a socket, decompress, decode JSON, and more).
 
-Naively storing a large request or response body into a single `byte[]` or `string`:
+Storing a large request or response body into a single `byte[]` or `string`:
 
 * May result in quickly running out of space in the LOH.
 * May cause performance issues for the app because of full GCs running.
@@ -246,7 +242,7 @@ ASP.NET Core 3.0 uses <xref:System.Text.Json> by default for JSON serialization.
 
 * Reads and writes JSON asynchronously.
 * Is optimized for UTF-8 text.
-* Typically higher performance than `Newtonsoft.Json`.
+* Typically is higher performance than `Newtonsoft.Json`.
 
 ## Do not store IHttpContextAccessor.HttpContext in a field
 
@@ -267,7 +263,7 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 
 ## Do not access HttpContext from multiple threads
 
-`HttpContext` is *NOT* thread-safe. Accessing `HttpContext` from multiple threads in parallel can result in undefined behavior such as hangs, crashes, and data corruption.
+`HttpContext` is **not** thread-safe. Accessing `HttpContext` from multiple threads in parallel can result in unexpected behavior such as hangs, crashes, and data corruption.
 
 **Do not do this:** The following example makes three parallel requests and logs the incoming request path before and after the outgoing HTTP request. The request path is accessed from multiple threads, potentially in parallel.
 
@@ -283,9 +279,9 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 
 **Do not do this:** The following example uses `async void` which makes the HTTP request complete when the first `await` is reached:
 
-* Which is **ALWAYS** a bad practice in ASP.NET Core apps.
-* Accesses the `HttpResponse` after the HTTP request is complete.
-* Crashes the process.
+* Using `async void` is **ALWAYS** a bad practice in ASP.NET Core apps.
+* The example code accesses the `HttpResponse` after the HTTP request is complete.
+* The late access crashes the process.
 
 [!code-csharp[](performance-best-practices/samples/3.0/Controllers/AsyncBadVoidController.cs?name=snippet1)]
 
@@ -313,7 +309,7 @@ Background tasks should be implemented as hosted services. For more information,
 
 ## Do not capture services injected into the controllers on background threads
 
-**Do not do this:** The following example shows a closure is capturing the `DbContext` from the `Controller` action parameter. This is a bad practice.  The work item could run outside of the request scope. The `ContosoDbContext` is scoped to the request, resulting in an `ObjectDisposedException`.
+**Do not do this:** The following example shows a closure that is capturing the `DbContext` from the `Controller` action parameter. This is a bad practice.  The work item could run outside of the request scope. The `ContosoDbContext` is scoped to the request, resulting in an `ObjectDisposedException`.
 
 [!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet1)]
 
@@ -357,7 +353,7 @@ Checking if the response has not started allows registering a callback that will
 * Provides the ability to append or override headers just in time.
 * Doesn't require knowledge of the next middleware in the pipeline.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Startup22.cs?name=snippet3)]
+[!code-csharp[](../performance/performance-best-practices/samples/3.0/Startup22.cs?name=snippet3)]
 
 ## Do not call next() if you have already started writing to the response body
 
@@ -370,3 +366,9 @@ Using in-process hosting, an ASP.NET Core app runs in the same process as its II
 Projects default to the in-process hosting model in ASP.NET Core 3.0 and later.
 
 For more information, see [Host ASP.NET Core on Windows with IIS](xref:host-and-deploy/iis/index)
+
+## Don't assume that HttpRequest.ContentLength is not null
+
+`HttpRequest.ContentLength` is null if the `Content-Length` header is not received. Null in that case means the length of the request body is not known; it doesn't mean the length is zero. Because all comparisons with null (except `==`) return false, the comparison `Request.ContentLength > 1024`  might return `false` when the request body size is more than 1024. Not knowing this can lead to security holes in apps. You might think you're guarding against too-large requests when you aren't.
+
+For more information, see [this StackOverflow answer](https://stackoverflow.com/a/73201538/652224).

--- a/aspnetcore/fundamentals/best-practices.md
+++ b/aspnetcore/fundamentals/best-practices.md
@@ -15,7 +15,7 @@ This article provides guidelines for maximizing performance and reliability of A
 
 ## Cache aggressively
 
-Caching is discussed in several parts of this document. For more information, see <xref:performance/caching>.
+Caching is discussed in several parts of this document. For more information, see <xref:performance/caching/overview>.
 
 ## Understand hot code paths
 
@@ -25,7 +25,7 @@ In this article, a *hot code path* is defined as a code path that is frequently 
 
 ASP.NET Core apps should be designed to process many requests simultaneously. Asynchronous APIs allow a small pool of threads to handle thousands of concurrent requests by not waiting on blocking calls. Rather than waiting on a long-running synchronous task to complete, the thread can work on another request.
 
-A common performance problem in ASP.NET Core apps is blocking calls that could be asynchronous. Many synchronous blocking calls lead to [Thread Pool starvation](xref:debug-threadpool-starvation) and degraded response times.
+A common performance problem in ASP.NET Core apps is blocking calls that could be asynchronous. Many synchronous blocking calls lead to [Thread Pool starvation](/dotnet/core/diagnostics/debug-threadpool-starvation) and degraded response times.
 
 **Do not** block asynchronous execution by calling <xref:System.Threading.Tasks.Task.Wait%2A?displayProperty=nameWithType> or <xref:System.Threading.Tasks.Task%601.Result%2A?displayProperty=nameWithType>.
 **Do not** acquire locks in common code paths. ASP.NET Core apps perform best when architected to run code in parallel.
@@ -151,7 +151,7 @@ Recommendations:
 
 ## Use the latest ASP.NET Core release
 
-Each new release of ASP.NET Core includes performance improvements. Optimizations in .NET Core and ASP.NET Core mean that newer versions generally outperform older versions. For example, .NET Core 2.1 added support for compiled regular expressions and benefitted from [Span\<T>](dotnet/standard/memory-and-spans/memory-t-usage-guidelines). ASP.NET Core 2.2 added support for HTTP/2. [ASP.NET Core 3.0 adds many improvements](xref:aspnetcore-3.0) that reduce memory usage and improve throughput. If performance is a priority, consider upgrading to the current version of ASP.NET Core.
+Each new release of ASP.NET Core includes performance improvements. Optimizations in .NET Core and ASP.NET Core mean that newer versions generally outperform older versions. For example, .NET Core 2.1 added support for compiled regular expressions and benefitted from [Span\<T>](/dotnet/standard/memory-and-spans/memory-t-usage-guidelines). ASP.NET Core 2.2 added support for HTTP/2. [ASP.NET Core 3.0 adds many improvements](xref:aspnetcore-3.0) that reduce memory usage and improve throughput. If performance is a priority, consider upgrading to the current version of ASP.NET Core.
 
 ## Minimize exceptions
 
@@ -176,13 +176,13 @@ All I/O in ASP.NET Core is asynchronous. Servers implement the `Stream` interfac
 **Do not do this:** The following example uses the <xref:System.IO.StreamReader.ReadToEnd%2A>. It blocks the current thread to wait for the result. This is an example of [sync over async](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md#warning-sync-over-async
 ).
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/MyFirstController.cs?name=snippet1)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/MyFirstController.cs?name=snippet1)]
 
 In the preceding code, `Get` synchronously reads the entire HTTP request body into memory. If the client is slowly uploading, the app is doing sync over async. The app does sync over async because Kestrel does **NOT** support synchronous reads.
 
 **Do this:** The following example uses <xref:System.IO.StreamReader.ReadToEndAsync%2A> and does not block the thread while reading.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/MyFirstController.cs?name=snippet2)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/MyFirstController.cs?name=snippet2)]
 
 The preceding code asynchronously reads the entire HTTP request body into memory.
 
@@ -191,7 +191,7 @@ The preceding code asynchronously reads the entire HTTP request body into memory
 
 **Do this:** The following example is fully asynchronous using a non-buffered request body:
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/MyFirstController.cs?name=snippet3)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/MyFirstController.cs?name=snippet3)]
 
 The preceding code asynchronously de-serializes the request body into a C# object.
 
@@ -205,11 +205,11 @@ Use `HttpContext.Request.ReadFormAsync` instead of `HttpContext.Request.Form`.
 
 **Do not do this:** The following example uses `HttpContext.Request.Form`.  `HttpContext.Request.Form` uses [sync over async](https://devblogs.microsoft.com/pfxteam/should-i-expose-synchronous-wrappers-for-asynchronous-methods/) and can lead to thread pool starvation.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/MySecondController.cs?name=snippet1)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/MySecondController.cs?name=snippet1)]
 
 **Do this:** The following example uses `HttpContext.Request.ReadFormAsync` to read the form body asynchronously.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/MySecondController.cs?name=snippet2)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/MySecondController.cs?name=snippet2)]
 
 <a name="arlb"></a>
 
@@ -250,7 +250,7 @@ The [IHttpContextAccessor.HttpContext](xref:Microsoft.AspNetCore.Http.IHttpConte
 
 **Do not do this:** The following example stores the `HttpContext` in a field and then attempts to use it later.
 
-[!code-csharp[](performance-best-practices/samples/3.0/MyType.cs?name=snippet1)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/MyType.cs?name=snippet1)]
 
 The preceding code frequently captures a null or incorrect `HttpContext` in the constructor.
 
@@ -259,7 +259,7 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 * Stores the <xref:Microsoft.AspNetCore.Http.IHttpContextAccessor> in a field.
 * Uses the `HttpContext` field at the correct time and checks for `null`.
 
-[!code-csharp[](performance-best-practices/samples/3.0/MyType.cs?name=snippet2)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/MyType.cs?name=snippet2)]
 
 ## Do not access HttpContext from multiple threads
 
@@ -267,11 +267,11 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 
 **Do not do this:** The following example makes three parallel requests and logs the incoming request path before and after the outgoing HTTP request. The request path is accessed from multiple threads, potentially in parallel.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/AsyncFirstController.cs?name=snippet1&highlight=25,28)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/AsyncFirstController.cs?name=snippet1&highlight=25,28)]
 
 **Do this:** The following example copies all data from the incoming request before making the three parallel requests.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/AsyncFirstController.cs?name=snippet2&highlight=6,8,22,28)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/AsyncFirstController.cs?name=snippet2&highlight=6,8,22,28)]
 
 ## Do not use the HttpContext after the request is complete
 
@@ -283,11 +283,11 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 * The example code accesses the `HttpResponse` after the HTTP request is complete.
 * The late access crashes the process.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/AsyncBadVoidController.cs?name=snippet1)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/AsyncBadVoidController.cs?name=snippet1)]
 
 **Do this:** The following example returns a `Task` to the framework, so the HTTP request doesn't complete until the action completes.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/AsyncSecondController.cs?name=snippet1)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/AsyncSecondController.cs?name=snippet1)]
 
 ## Do not capture the HttpContext in background threads
 
@@ -296,14 +296,14 @@ The preceding code frequently captures a null or incorrect `HttpContext` in the 
 * Run outside of the request scope.
 * Attempt to read the wrong `HttpContext`.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetFirstController.cs?name=snippet1)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetFirstController.cs?name=snippet1)]
 
 **Do this:** The following example:
 
 * Copies the data required in the background task during the request.
 * Doesn't reference anything from the controller.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetFirstController.cs?name=snippet2)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetFirstController.cs?name=snippet2)]
 
 Background tasks should be implemented as hosted services. For more information, see [Background tasks with hosted services](xref:fundamentals/host/hosted-services).
 
@@ -311,7 +311,7 @@ Background tasks should be implemented as hosted services. For more information,
 
 **Do not do this:** The following example shows a closure that is capturing the `DbContext` from the `Controller` action parameter. This is a bad practice.  The work item could run outside of the request scope. The `ContosoDbContext` is scoped to the request, resulting in an `ObjectDisposedException`.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet1)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet1)]
 
 **Do this:** The following example:
 
@@ -320,14 +320,14 @@ Background tasks should be implemented as hosted services. For more information,
 * Doesn't reference anything from the controller.
 * Doesn't capture the `ContosoDbContext` from the incoming request.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet2)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet2)]
 
 The following highlighted code:
 
 * Creates a scope for the lifetime of the background operation and resolves services from it.
 * Uses `ContosoDbContext` from the correct scope.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet2&highlight=9-16)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs?name=snippet2&highlight=9-16)]
 
 ## Do not modify the status code or headers after the response body has started
 
@@ -338,13 +338,13 @@ ASP.NET Core does not buffer the HTTP response body. The first time the response
 
 **Do not do this:** The following code tries to add response headers after the response has already started:
 
-[!code-csharp[](performance-best-practices/samples/3.0/Startup22.cs?name=snippet1)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Startup22.cs?name=snippet1)]
 
 In the preceding code, `context.Response.Headers["test"] = "test value";` will throw an exception if `next()` has written to the response.
 
 **Do this:** The following example checks if the HTTP response has started before modifying the headers.
 
-[!code-csharp[](performance-best-practices/samples/3.0/Startup22.cs?name=snippet2)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Startup22.cs?name=snippet2)]
 
 **Do this:** The following example uses `HttpResponse.OnStarting` to set the headers before the response headers are flushed to the client.
 
@@ -353,7 +353,7 @@ Checking if the response has not started allows registering a callback that will
 * Provides the ability to append or override headers just in time.
 * Doesn't require knowledge of the next middleware in the pipeline.
 
-[!code-csharp[](../performance/performance-best-practices/samples/3.0/Startup22.cs?name=snippet3)]
+[!code-csharp[](~/performance/performance-best-practices/samples/3.0/Startup22.cs?name=snippet3)]
 
 ## Do not call next() if you have already started writing to the response body
 

--- a/aspnetcore/fundamentals/best-practices.md
+++ b/aspnetcore/fundamentals/best-practices.md
@@ -369,6 +369,6 @@ For more information, see [Host ASP.NET Core on Windows with IIS](xref:host-and-
 
 ## Don't assume that HttpRequest.ContentLength is not null
 
-`HttpRequest.ContentLength` is null if the `Content-Length` header is not received. Null in that case means the length of the request body is not known; it doesn't mean the length is zero. Because all comparisons with null (except `==`) return false, the comparison `Request.ContentLength > 1024`  might return `false` when the request body size is more than 1024. Not knowing this can lead to security holes in apps. You might think you're guarding against too-large requests when you aren't.
+`HttpRequest.ContentLength` is null if the `Content-Length` header is not received. Null in that case means the length of the request body is not known; it doesn't mean the length is zero. Because all comparisons with null (except `==`) return false, the comparison `Request.ContentLength > 1024`, for example, might return `false` when the request body size is more than 1024. Not knowing this can lead to security holes in apps. You might think you're guarding against too-large requests when you aren't.
 
 For more information, see [this StackOverflow answer](https://stackoverflow.com/a/73201538/652224).

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -136,7 +136,7 @@ The `.vscode/launch.json` file is used only by Visual Studio Code.
 
 ### Production
 
-The production environment should be configured to maximize security, [performance](xref:performance/performance-best-practices), and application robustness. Some common settings that differ from development include:
+The production environment should be configured to maximize security, [performance](xref:performance/overview), and application robustness. Some common settings that differ from development include:
 
 * [Caching](xref:performance/caching/memory).
 * Client-side resources are bundled, minified, and potentially served from a CDN.
@@ -407,7 +407,7 @@ The `.vscode/launch.json` file is only used by Visual Studio Code.
 
 ### Production
 
-The production environment should be configured to maximize security, [performance](xref:performance/performance-best-practices), and application robustness. Some common settings that differ from development include:
+The production environment should be configured to maximize security, [performance](xref:performance/overview), and application robustness. Some common settings that differ from development include:
 
 * [Caching](xref:performance/caching/memory).
 * Client-side resources are bundled, minified, and potentially served from a CDN.

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -48,7 +48,7 @@ Chain multiple request delegates together with <xref:Microsoft.AspNetCore.Builde
 When a delegate doesn't pass a request to the next delegate, it's called *short-circuiting the request pipeline*. Short-circuiting is often desirable because it avoids unnecessary work. For example, [Static File Middleware](xref:fundamentals/static-files) can act as a *terminal middleware* by processing a request for a static file and short-circuiting the rest of the pipeline. Middleware added to the pipeline before the middleware that terminates further processing still processes code after their `next.Invoke` statements. However, see the following warning about attempting to write to a response that has already been sent.
 
 > [!WARNING]
-> Don't call `next.Invoke` after the response has been sent to the client. Changes to <xref:Microsoft.AspNetCore.Http.HttpResponse> after the response has started throw an exception. For example, [setting headers and a status code throw an exception](xref:performance/performance-best-practices#do-not-modify-the-status-code-or-headers-after-the-response-body-has-started). Writing to the response body after calling `next`:
+> Don't call `next.Invoke` after the response has been sent to the client. Changes to <xref:Microsoft.AspNetCore.Http.HttpResponse> after the response has started throw an exception. For example, [setting headers and a status code throw an exception](xref:fundamentals/best-practices#do-not-modify-the-status-code-or-headers-after-the-response-body-has-started). Writing to the response body after calling `next`:
 >
 > * May cause a protocol violation. For example, writing more than the stated `Content-Length`.
 > * May corrupt the body format. For example, writing an HTML footer to a CSS file.
@@ -321,7 +321,7 @@ Chain multiple request delegates together with <xref:Microsoft.AspNetCore.Builde
 When a delegate doesn't pass a request to the next delegate, it's called *short-circuiting the request pipeline*. Short-circuiting is often desirable because it avoids unnecessary work. For example, [Static File Middleware](xref:fundamentals/static-files) can act as a *terminal middleware* by processing a request for a static file and short-circuiting the rest of the pipeline. Middleware added to the pipeline before the middleware that terminates further processing still processes code after their `next.Invoke` statements. However, see the following warning about attempting to write to a response that has already been sent.
 
 > [!WARNING]
-> Don't call `next.Invoke` after the response has been sent to the client. Changes to <xref:Microsoft.AspNetCore.Http.HttpResponse> after the response has started throw an exception. For example, [setting headers and a status code throw an exception](xref:performance/performance-best-practices#do-not-modify-the-status-code-or-headers-after-the-response-body-has-started). Writing to the response body after calling `next`:
+> Don't call `next.Invoke` after the response has been sent to the client. Changes to <xref:Microsoft.AspNetCore.Http.HttpResponse> after the response has started throw an exception. For example, [setting headers and a status code throw an exception](xref:fundamentals/best-practices#do-not-modify-the-status-code-or-headers-after-the-response-body-has-started). Writing to the response body after calling `next`:
 >
 > * May cause a protocol violation. For example, writing more than the stated `Content-Length`.
 > * May corrupt the body format. For example, writing an HTML footer to a CSS file.

--- a/aspnetcore/fundamentals/use-http-context.md
+++ b/aspnetcore/fundamentals/use-http-context.md
@@ -26,7 +26,7 @@ Commonly used members on `HttpRequest` include:
 |<xref:Microsoft.AspNetCore.Http.HttpRequest.Headers?displayProperty=nameWithType>|A collection of request headers.|`user-agent=Edge`<br />`x-custom-header=MyValue`|
 |<xref:Microsoft.AspNetCore.Http.HttpRequest.RouteValues?displayProperty=nameWithType>|A collection of route values. The collection is set when the request is matched to a route.|`language=en`<br />`article=getstarted`|
 |<xref:Microsoft.AspNetCore.Http.HttpRequest.Query?displayProperty=nameWithType>|A collection of query values parsed from <xref:Microsoft.AspNetCore.Http.HttpRequest.QueryString>.|`filter=hello`<br />`page=1`|
-|[HttpRequest.ReadFormAsync()](xref:Microsoft.AspNetCore.Http.HttpRequest.ReadFormAsync(System.Threading.CancellationToken))|A method that reads the request body as a form and returns a form values collection. For information about why `ReadFormAsync` should be used to access form data, see [Prefer ReadFormAsync over Request.Form](xref:performance/performance-best-practices#prefer-readformasync-over-requestform).|`email=user@contoso.com`<br />`password=TNkt4taM`|
+|[HttpRequest.ReadFormAsync()](xref:Microsoft.AspNetCore.Http.HttpRequest.ReadFormAsync(System.Threading.CancellationToken))|A method that reads the request body as a form and returns a form values collection. For information about why `ReadFormAsync` should be used to access form data, see [Prefer ReadFormAsync over Request.Form](xref:fundamentals/best-practices#prefer-readformasync-over-requestform).|`email=user@contoso.com`<br />`password=TNkt4taM`|
 |<xref:Microsoft.AspNetCore.Http.HttpRequest.Body?displayProperty=nameWithType>|A <xref:System.IO.Stream> for reading the request body.|UTF-8 JSON payload|
 
 ### Get request headers

--- a/aspnetcore/performance/overview.md
+++ b/aspnetcore/performance/overview.md
@@ -11,12 +11,12 @@ uid: performance/overview
 
 The following articles provide information about how to maximize the performance of ASP.NET Core apps:
 
+* <xref:fundamentals/best-practices>
+* <xref:performance/caching/overview>
 * <xref:performance/rate-limit>
 * <xref:performance/memory>
 * <xref:host-and-deploy/scaling-aspnet-apps/scaling-aspnet-apps>
-* <xref:performance/caching/overview>
 * <xref:performance/ObjectPool>
 * <xref:performance/response-compression>
 * <xref:performance/diagnostic-tools>
 * <xref:test/loadtests>
-* <xref:fundamentals/best-practices>

--- a/aspnetcore/performance/overview.md
+++ b/aspnetcore/performance/overview.md
@@ -1,0 +1,22 @@
+---
+title: ASP.NET Core performance
+author: tdykstra
+description: Links to articles about performance in ASP.NET Core apps.
+monikerRange: '>= aspnetcore-6.0'
+ms.author: riande
+ms.date: 12/20/2022
+<xref:performance/overview
+---
+# ASP.NET Core performance
+
+The following articles provide information about how to maximize the performance of ASP.NET Core apps:
+
+* <xref:performance/rate-limit>
+* <xref:performance/memory>
+* <xref:host-and-deploy/scaling-aspnet-apps/scaling-aspnet-apps>
+* <xref:performance/caching/overview>
+* <xref:performance/ObjectPool>
+* <xref:performance/response-compression>
+* <xref:performance/diagnostic-tools>
+* <xref:test/loadtests>
+* <xref:fundamentals/best-practices>

--- a/aspnetcore/performance/overview.md
+++ b/aspnetcore/performance/overview.md
@@ -5,7 +5,7 @@ description: Links to articles about performance in ASP.NET Core apps.
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
 ms.date: 12/20/2022
-<xref:performance/overview
+uid: performance/overview
 ---
 # ASP.NET Core performance
 

--- a/aspnetcore/performance/overview.md
+++ b/aspnetcore/performance/overview.md
@@ -9,7 +9,7 @@ uid: performance/overview
 ---
 # ASP.NET Core performance
 
-The following articles provide information about how to maximize the performance of ASP.NET Core apps:
+The following articles provide information about how to optimize the performance of ASP.NET Core apps:
 
 * <xref:fundamentals/best-practices>
 * <xref:performance/caching/overview>

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -268,6 +268,7 @@ items:
       - name: Static files
         uid: fundamentals/static-files
       - name: Best practices
+        displayName: performance
         uid: fundamentals/best-practices
   - name: Web apps
     items:

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -267,6 +267,8 @@ items:
         uid: fundamentals/http-requests
       - name: Static files
         uid: fundamentals/static-files
+      - name: Best practices
+        uid: fundamentals/best-practices
   - name: Web apps
     items:
       - name: Choose an ASP.NET Core UI
@@ -1513,10 +1515,9 @@ items:
       - name: Application security - OWASP
         href: https://cheatsheetseries.owasp.org/cheatsheets/DotNet_Security_Cheat_Sheet.html
   - name: Performance
-    displayName: Performance Best Practices
     items:
       - name: Overview
-        uid: performance/performance-best-practices
+        uid: performance/overview
       - name: Rate limiting middleware
         uid: performance/rate-limit
       - name: Memory and GC

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -267,9 +267,6 @@ items:
         uid: fundamentals/http-requests
       - name: Static files
         uid: fundamentals/static-files
-      - name: Best practices
-        displayName: performance
-        uid: fundamentals/best-practices
   - name: Web apps
     items:
       - name: Choose an ASP.NET Core UI
@@ -918,6 +915,9 @@ items:
         href: https://github.com/grpc/grpc-dotnet/tree/master/examples
       - name: Troubleshoot
         uid: grpc/troubleshoot
+  - name: Best practices
+    displayName: performance
+    uid: fundamentals/best-practices
   - name: Test
     items:
       - name: .NET Hot Reload

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -1519,13 +1519,6 @@ items:
     items:
       - name: Overview
         uid: performance/overview
-      - name: Rate limiting middleware
-        uid: performance/rate-limit
-      - name: Memory and GC
-        uid: performance/memory
-      - name: Scaling apps on Azure
-        displayName: azure, deploy, publish, scale
-        uid: host-and-deploy/scaling-aspnet-apps/scaling-aspnet-apps
       - name: Caching
         items:
           - name: Overview
@@ -1546,6 +1539,13 @@ items:
           - name: Response caching middleware
             displayName: cache
             uid: performance/caching/middleware
+      - name: Rate limiting middleware
+        uid: performance/rate-limit
+      - name: Memory and GC
+        uid: performance/memory
+      - name: Scaling apps on Azure
+        displayName: azure, deploy, publish, scale
+        uid: host-and-deploy/scaling-aspnet-apps/scaling-aspnet-apps
       - name: Object reuse with ObjectPool
         uid: performance/ObjectPool
       - name: Response compression


### PR DESCRIPTION
Fixes #26643 

Moving this doc to Fundamentals left us with no overview article for the Performance TOC section, so this PR creates a simple one with a list of links.

[Internal review URL](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/best-practices?view=aspnetcore-8.0&branch=pr-en-us-27940)


