### PR TITLE
Restructure container div in example

### DIFF
--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
@@ -1,6 +1,5 @@
 @page
     <div class="container">
-        <div class="row">&nbsp;</div>
         <div class="row">
             <div class="col-2">User</div>
             <div class="col-4"><input type="text" id="userInput" /></div>
@@ -9,7 +8,6 @@
             <div class="col-2">Message</div>
             <div class="col-4"><input type="text" id="messageInput" /></div>
         </div>
-        <div class="row">&nbsp;</div>
         <div class="row">
             <div class="col-6">
                 <input type="button" id="sendButton" value="Send Message" />

--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
     <div class="container">
         <div class="row">&nbsp;</div>
         <div class="row">
@@ -16,7 +16,7 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-12">
+            <div class="col-6">
                 <hr />
             </div>
         </div>

--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
@@ -6,10 +6,10 @@
         </div>
         <div class="row">
             <div class="col-2">Message</div>
-            <div class="col-4"><input type="text" id="messageInput" /></div>
+            <div class="col-4"><input type="text" class="w-100" id="messageInput" /></div>
         </div>
         <div class="row">
-            <div class="col-6">
+            <div class="col-6 text-end">
                 <input type="button" id="sendButton" value="Send Message" />
             </div>
         </div>

--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
@@ -15,15 +15,15 @@
                 <input type="button" id="sendButton" value="Send Message" />
             </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <hr />
+        <div class="row">
+            <div class="col-12">
+                <hr />
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-6">
-            <ul id="messagesList"></ul>
+        <div class="row">
+            <div class="col-6">
+                <ul id="messagesList"></ul>
+            </div>
         </div>
     </div>
 <script src="~/js/signalr/dist/browser/signalr.js"></script>

--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
@@ -1,24 +1,24 @@
 @page
     <div class="container">
-        <div class="row">
+        <div class="row p-1">
             <div class="col-1">User</div>
             <div class="col-5"><input type="text" id="userInput" /></div>
         </div>
-        <div class="row">
+        <div class="row p-1">
             <div class="col-1">Message</div>
             <div class="col-5"><input type="text" class="w-100" id="messageInput" /></div>
         </div>
-        <div class="row">
+        <div class="row p-1">
             <div class="col-6 text-end">
                 <input type="button" id="sendButton" value="Send Message" />
             </div>
         </div>
-        <div class="row">
+        <div class="row p-1">
             <div class="col-6">
                 <hr />
             </div>
         </div>
-        <div class="row">
+        <div class="row p-1">
             <div class="col-6">
                 <ul id="messagesList"></ul>
             </div>

--- a/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/sample-snapshot/3.x/Index.cshtml
@@ -1,12 +1,12 @@
 @page
     <div class="container">
         <div class="row">
-            <div class="col-2">User</div>
-            <div class="col-4"><input type="text" id="userInput" /></div>
+            <div class="col-1">User</div>
+            <div class="col-5"><input type="text" id="userInput" /></div>
         </div>
         <div class="row">
-            <div class="col-2">Message</div>
-            <div class="col-4"><input type="text" class="w-100" id="messageInput" /></div>
+            <div class="col-1">Message</div>
+            <div class="col-5"><input type="text" class="w-100" id="messageInput" /></div>
         </div>
         <div class="row">
             <div class="col-6 text-end">

--- a/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+@page
     <div class="container">
         <div class="row">&nbsp;</div>
         <div class="row">
@@ -15,15 +15,15 @@
                 <input type="button" id="sendButton" value="Send Message" />
             </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-12">
-            <hr />
+        <div class="row">
+            <div class="col-6">
+                <hr />
+            </div>
         </div>
-    </div>
-    <div class="row">
-        <div class="col-6">
-            <ul id="messagesList"></ul>
+        <div class="row">
+            <div class="col-6">
+                <ul id="messagesList"></ul>
+            </div>
         </div>
     </div>
 <script src="~/js/signalr/dist/browser/signalr.js"></script>

--- a/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
@@ -1,6 +1,5 @@
 @page
     <div class="container">
-        <div class="row">&nbsp;</div>
         <div class="row">
             <div class="col-2">User</div>
             <div class="col-4"><input type="text" id="userInput" /></div>
@@ -9,7 +8,6 @@
             <div class="col-2">Message</div>
             <div class="col-4"><input type="text" id="messageInput" /></div>
         </div>
-        <div class="row">&nbsp;</div>
         <div class="row">
             <div class="col-6">
                 <input type="button" id="sendButton" value="Send Message" />

--- a/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
@@ -6,10 +6,10 @@
         </div>
         <div class="row">
             <div class="col-2">Message</div>
-            <div class="col-4"><input type="text" id="messageInput" /></div>
+            <div class="col-4"><input type="text" class="w-100" id="messageInput" /></div>
         </div>
         <div class="row">
-            <div class="col-6">
+            <div class="col-6 text-end">
                 <input type="button" id="sendButton" value="Send Message" />
             </div>
         </div>

--- a/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
@@ -1,24 +1,24 @@
 @page
     <div class="container">
-        <div class="row">
+        <div class="row p-1">
             <div class="col-1">User</div>
             <div class="col-5"><input type="text" id="userInput" /></div>
         </div>
-        <div class="row">
+        <div class="row p-1">
             <div class="col-1">Message</div>
             <div class="col-5"><input type="text" class="w-100" id="messageInput" /></div>
         </div>
-        <div class="row">
+        <div class="row p-1">
             <div class="col-6 text-end">
                 <input type="button" id="sendButton" value="Send Message" />
             </div>
         </div>
-        <div class="row">
+        <div class="row p-1">
             <div class="col-6">
                 <hr />
             </div>
         </div>
-        <div class="row">
+        <div class="row p-1">
             <div class="col-6">
                 <ul id="messagesList"></ul>
             </div>

--- a/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
+++ b/aspnetcore/tutorials/signalr/samples/SignalRChat/Pages/Index.cshtml
@@ -1,12 +1,12 @@
 @page
     <div class="container">
         <div class="row">
-            <div class="col-2">User</div>
-            <div class="col-4"><input type="text" id="userInput" /></div>
+            <div class="col-1">User</div>
+            <div class="col-5"><input type="text" id="userInput" /></div>
         </div>
         <div class="row">
-            <div class="col-2">Message</div>
-            <div class="col-4"><input type="text" class="w-100" id="messageInput" /></div>
+            <div class="col-1">Message</div>
+            <div class="col-5"><input type="text" class="w-100" id="messageInput" /></div>
         </div>
         <div class="row">
             <div class="col-6 text-end">


### PR DESCRIPTION
Fixes #27952

Thanks @smiller7812! 🚀 

🦖 did the following here ...

* Span these rows to 6 columns.
* Use one container.
* Drop the blank (`&nbsp;`) rows.
* Pad a pixel.
* Fill the message box to the cell size.
* Adjust the columns.
* Move the button.
* Have a 🍺😆.

I just tested it locally, and it renders like this ...

![image](https://user-images.githubusercontent.com/1622880/208953440-5864b0d5-695b-49f6-ad14-51418e0d0db2.png)