### PR TITLE
Remove note about increasing MaximumParallelInvocationsPerClient

### DIFF
--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -634,11 +634,6 @@ public class ChatHub : Hub
 }
 ```
 
-> [!NOTE]
-> Using `InvokeAsync` from a Hub method requires setting the [`MaximumParallelInvocationsPerClient`](xref:signalr/configuration#configure-server-options) option to a value greater than 1.
->
-> This will be addressed in a future release. For more information, see [Support returning values from client invocations](https://github.com/dotnet/aspnetcore/issues/5280).
-
 The second way is to call `Client(...)` on an instance of [`IHubContext<T>`](xref:signalr/hubcontext):
 
 ```csharp


### PR DESCRIPTION
As of 7.0-rc1, this is no longer necessary due to https://github.com/dotnet/aspnetcore/pull/42796.

Should we add a caveat for this "con" mentioned int the PR description?

> * `IHubContext` injected and used in Hubs for `InvokeAsync` can still block

I think injecting an `IHubContext` into a hub might be too contrived of a scenario to be worth mentioning. Lengthening the docs to cover every edge case can make things overwhelming. On the other hand, it'd probably be pretty difficult to diagnose if you did happen to run into it.
