### PR TITLE
Updated the data type

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -448,7 +448,7 @@ In the following example:
 
 ```csharp
 Navigation.GetUriWithQueryParameters(
-    new Dictionary<string, object>
+    new Dictionary<string, object?>
     {
         ["name"] = null,
         ["age"] = (int?)25,
@@ -474,7 +474,7 @@ In the following example:
 
 ```csharp
 Navigation.GetUriWithQueryParameters(
-    new Dictionary<string, object>
+    new Dictionary<string, object?>
     {
         ["full name"] = "Morena Baccarin",
         ["ping"] = new int?[] { 35, 16, null, 87, 240 }
@@ -1220,7 +1220,7 @@ In the following example:
 
 ```csharp
 Navigation.GetUriWithQueryParameters(
-    new Dictionary<string, object>
+    new Dictionary<string, object?>
     {
         ["name"] = null,
         ["age"] = (int?)25,
@@ -1246,7 +1246,7 @@ In the following example:
 
 ```csharp
 Navigation.GetUriWithQueryParameters(
-    new Dictionary<string, object>
+    new Dictionary<string, object?>
     {
         ["full name"] = "Morena Baccarin",
         ["ping"] = new int?[] { 35, 16, null, 87, 240 }


### PR DESCRIPTION
If we use the existing code, then we will get a warning in Visual Studio as shown below:

`
Warning (active)	CS8620	Argument of type 'Dictionary<string, object>' cannot be used for parameter 'parameters' of type 'IReadOnlyDictionary<string, object?>' in 'string NavigationManagerExtensions.GetUriWithQueryParameters(NavigationManager navigationManager, IReadOnlyDictionary<string, object?> parameters)' due to differences in the nullability of reference types.
`

This PR has updated the code sample to remove the warning.

Please let me know if you need any further information on reproducing this issue. 

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->