### PR TITLE
Update broken link

### DIFF
--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -505,7 +505,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that your selected signatures are valid.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that the selected signatures are valid.
 
 ### File name security
 
@@ -1229,7 +1229,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that your selected signatures are valid.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that the selected signatures are valid.
 
 ### File name security
 
@@ -1964,7 +1964,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that your selected signatures are valid.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that the selected signatures are valid.
 
 ### File name security
 

--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -505,7 +505,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that your selected signatures are valid.
 
 ### File name security
 
@@ -1229,7 +1229,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that your selected signatures are valid.
 
 ### File name security
 
@@ -1964,7 +1964,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications. Consulting official file specifications may ensure that your selected signatures are valid.
 
 ### File name security
 

--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -505,7 +505,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, see the [File Signatures Database](https://www.filesignatures.net/) and official file specifications.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications.
 
 ### File name security
 
@@ -1229,7 +1229,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, see the [File Signatures Database](https://www.filesignatures.net/) and official file specifications.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications.
 
 ### File name security
 
@@ -1964,7 +1964,7 @@ using (var reader = new BinaryReader(uploadedFileData))
 }
 ```
 
-To obtain additional file signatures, see the [File Signatures Database](https://www.filesignatures.net/) and official file specifications.
+To obtain additional file signatures, use a [file signatures database (Google search result)](https://www.google.com/search?q=file+signatures+databases) and official file specifications.
 
 ### File name security
 


### PR DESCRIPTION
Fixes #28042

Thanks @Taylor365! 🚀 

Rick, I think we can harden this and still help readers by just giving them the search result because there are dozens of file signature databases out there. I don't think we need to pick a winner.

I left the word "and" in there for 'use a dB' ***AND*** 'consult official file specs.' I add a sentence to this to clarify the "and" recommendation. I only say that official file specs ***may*** confirm a valid selection. I checked on a few official specs to support this remark, and it's true. Some number of official specs *do mention* the "magic number" file sig for their file type in their official guidance. I think we can go with this remark.

I don't have further changes. Please merge when you've reviewed or made additional mods to this.