### PR TITLE
JS interop script location

### DIFF
--- a/aspnetcore/blazor/fundamentals/logging.md
+++ b/aspnetcore/blazor/fundamentals/logging.md
@@ -569,7 +569,7 @@ Example 2: Set the <xref:Microsoft.Extensions.Logging.LogLevel.Information> log 
 </script>
 ```
 
-For more information on Blazor startup (`Blazor.start`), see <xref:blazor/fundamentals/startup>.
+For more information on Blazor startup (`Blazor.start()`), see <xref:blazor/fundamentals/startup>.
 
 ## SignalR client logging (Blazor WebAssembly)
 
@@ -1253,7 +1253,7 @@ Example 2: Set the <xref:Microsoft.Extensions.Logging.LogLevel.Information> log 
 </script>
 ```
 
-For more information on Blazor startup (`Blazor.start`), see <xref:blazor/fundamentals/startup>.
+For more information on Blazor startup (`Blazor.start()`), see <xref:blazor/fundamentals/startup>.
 
 ## SignalR client logging (Blazor WebAssembly)
 
@@ -1686,7 +1686,7 @@ Example 2: Set the <xref:Microsoft.Extensions.Logging.LogLevel.Information> log 
 </script>
 ```
 
-For more information on Blazor startup (`Blazor.start`), see <xref:blazor/fundamentals/startup>.
+For more information on Blazor startup (`Blazor.start()`), see <xref:blazor/fundamentals/startup>.
 
 ## SignalR client logging (Blazor WebAssembly)
 
@@ -2116,7 +2116,7 @@ Example 2: Set the <xref:Microsoft.Extensions.Logging.LogLevel.Information> log 
 </script>
 ```
 
-For more information on Blazor startup (`Blazor.start`), see <xref:blazor/fundamentals/startup>.
+For more information on Blazor startup (`Blazor.start()`), see <xref:blazor/fundamentals/startup>.
 
 ## SignalR client logging (Blazor WebAssembly)
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -250,12 +250,12 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
+Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (hosted Blazor WebAssembly with SignalR implemented):
 
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` or `blazor.webassembly.js` script.
-* Place a script that calls `Blazor.start` after the Blazor script is loaded and inside the closing `</body>` tag.
+* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.{server|webassembly}.js` script.
+* Place a script that calls `Blazor.start()` after the Blazor script is loaded and inside the closing `</body>` tag.
 
-When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
+When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start()` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
 
@@ -744,12 +744,12 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Layout.cshtml` file (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
+Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Layout.cshtml` file (Blazor Server) or `wwwroot/index.html` (hosted Blazor WebAssembly with SignalR implemented):
 
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` or `blazor.webassembly.js` script.
-* Place a script that calls `Blazor.start` after the Blazor script is loaded and inside the closing `</body>` tag.
+* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.{server|webassembly}.js` script.
+* Place a script that calls `Blazor.start()` after the Blazor script is loaded and inside the closing `</body>` tag.
 
-When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
+When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start()` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
 
@@ -1133,12 +1133,12 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
+Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (hosted Blazor WebAssembly with SignalR implemented):
 
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` or `blazor.webassembly.js` script.
-* Place a script that calls `Blazor.start` after the Blazor script is loaded and inside the closing `</body>` tag.
+* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.{server|webassembly}.js` script.
+* Place a script that calls `Blazor.start()` after the Blazor script is loaded and inside the closing `</body>` tag.
 
-When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
+When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start()` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
 
@@ -1489,12 +1489,12 @@ By default, Blazor Server apps prerender the UI on the server before the client 
 
 ## Blazor startup
 
-Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (Blazor WebAssembly):
+Configure the manual start of a Blazor app's SignalR circuit in the `Pages/_Host.cshtml` file (Blazor Server) or `wwwroot/index.html` (hosted Blazor WebAssembly with SignalR implemented):
 
-* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.server.js` or `blazor.webassembly.js` script.
-* Place a script that calls `Blazor.start` after the Blazor script is loaded and inside the closing `</body>` tag.
+* Add an `autostart="false"` attribute to the `<script>` tag for the `blazor.{server|webassembly}.js` script.
+* Place a script that calls `Blazor.start()` after the Blazor script is loaded and inside the closing `</body>` tag.
 
-When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
+When `autostart` is disabled, any aspect of the app that doesn't depend on the circuit works normally. For example, client-side routing is operational. However, any aspect that depends on the circuit isn't operational until `Blazor.start()` is called. App behavior is unpredictable without an established circuit. For example, component methods fail to execute while the circuit is disconnected.
 
 For more information, including how to initialize Blazor when the document is ready and how to chain to a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise), see <xref:blazor/fundamentals/startup>.
 

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -14,7 +14,7 @@ This article explains how to configure Blazor startup.
 
 :::moniker range=">= aspnetcore-7.0"
 
-The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
 To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
@@ -279,7 +279,7 @@ In `wwwroot/index.html`, remove the default SVG round indicator in `<div id="app
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
 
-The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
 To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server):
 
@@ -465,7 +465,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
 To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
@@ -647,7 +647,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 :::moniker range="< aspnetcore-5.0"
 
-The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
 To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -19,7 +19,7 @@ The Blazor startup process via the Blazor script (`blazor.{webassembly|server}.j
 To manually start Blazor:
 
 * Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
-* Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
+* Place a script that calls `Blazor.start()` after the Blazor `<script>` tag and inside the closing `</body>` tag.
 
 ## JavaScript initializers
 
@@ -271,7 +271,7 @@ In `wwwroot/index.html`, remove the default SVG round indicator in `<div id="app
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
   * [Disconnect the Blazor circuit from the client](xref:blazor/fundamentals/signalr#disconnect-the-blazor-circuit-from-the-client-blazor-server)
-* [Globalization and localization: Statically set the culture with `Blazor.start` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
+* [Globalization and localization: Statically set the culture with `Blazor.start()` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
 
@@ -284,7 +284,7 @@ The Blazor startup process via the Blazor script (`blazor.{webassembly|server}.j
 To manually start Blazor:
 
 * Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
-* Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
+* Place a script that calls `Blazor.start()` after the Blazor `<script>` tag and inside the closing `</body>` tag.
 
 ## JavaScript initializers
 
@@ -457,7 +457,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
   * [Disconnect the Blazor circuit from the client](xref:blazor/fundamentals/signalr#disconnect-the-blazor-circuit-from-the-client-blazor-server)
-* [Globalization and localization: Statically set the culture with `Blazor.start` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
+* [Globalization and localization: Statically set the culture with `Blazor.start()` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
 
@@ -470,7 +470,7 @@ The Blazor startup process via the Blazor script (`blazor.{webassembly|server}.j
 To manually start Blazor:
 
 * Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
-* Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
+* Place a script that calls `Blazor.start()` after the Blazor `<script>` tag and inside the closing `</body>` tag.
 
 ## Initialize Blazor when the document is ready
 
@@ -639,7 +639,7 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
   * [Modify the reconnection handler](xref:blazor/fundamentals/signalr#modify-the-reconnection-handler-blazor-server)
   * [Adjust the reconnection retry count and interval](xref:blazor/fundamentals/signalr#adjust-the-reconnection-retry-count-and-interval-blazor-server)
   * [Disconnect the Blazor circuit from the client](xref:blazor/fundamentals/signalr#disconnect-the-blazor-circuit-from-the-client-blazor-server)
-* [Globalization and localization: Statically set the culture with `Blazor.start` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
+* [Globalization and localization: Statically set the culture with `Blazor.start()` (*Blazor WebAssembly only*)](xref:blazor/globalization-localization?pivots=webassembly#statically-set-the-culture)
 * [JS interop: Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 * [Host and deploy: Blazor WebAssembly: Compression](xref:blazor/host-and-deploy/webassembly#compression)
 
@@ -652,7 +652,7 @@ The Blazor startup process via the Blazor script (`blazor.{webassembly|server}.j
 To manually start Blazor:
 
 * Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
-* Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
+* Place a script that calls `Blazor.start()` after the Blazor `<script>` tag and inside the closing `</body>` tag.
 
 ## Initialize Blazor when the document is ready
 

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -14,11 +14,11 @@ This article explains how to configure Blazor startup.
 
 :::moniker range=">= aspnetcore-7.0"
 
-The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process via the Blazor script (`blazor.{webassembly|server}.js`) is automatic and asynchronous. The Blazor `<script>` tag is found in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server). Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
-To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+To manually start Blazor:
 
-* Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
+* Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
 
 ## JavaScript initializers
@@ -279,11 +279,11 @@ In `wwwroot/index.html`, remove the default SVG round indicator in `<div id="app
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
 
-The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process via the Blazor script (`blazor.{webassembly|server}.js`) is automatic and asynchronous. The Blazor `<script>` tag is found in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server). Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
-To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server):
+To manually start Blazor:
 
-* Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
+* Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
 
 ## JavaScript initializers
@@ -465,11 +465,11 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process via the Blazor script (`blazor.{webassembly|server}.js`) is automatic and asynchronous. The Blazor `<script>` tag is found in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server). Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
-To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+To manually start Blazor:
 
-* Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
+* Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
 
 ## Initialize Blazor when the document is ready
@@ -647,11 +647,11 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 :::moniker range="< aspnetcore-5.0"
 
-The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process via the Blazor script (`blazor.{webassembly|server}.js`) is automatic and asynchronous. The Blazor `<script>` tag is found in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server). Scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
-To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+To manually start Blazor:
 
-* Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
+* Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
 
 ## Initialize Blazor when the document is ready

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -14,7 +14,9 @@ This article explains how to configure Blazor startup.
 
 :::moniker range=">= aspnetcore-7.0"
 
-Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+
+To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
 * Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
@@ -277,7 +279,9 @@ In `wwwroot/index.html`, remove the default SVG round indicator in `<div id="app
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
 
-Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server):
+The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+
+To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Layout.cshtml` file (Blazor Server):
 
 * Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
@@ -461,7 +465,9 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+
+To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
 * Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.
@@ -641,7 +647,9 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 :::moniker range="< aspnetcore-5.0"
 
-Configure a manual start in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
+The Blazor startup process is automatic and asynchronous. Scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+
+To manually start Blazor in the `wwwroot/index.html` file (Blazor WebAssembly) or `Pages/_Host.cshtml` file (Blazor Server):
 
 * Add an `autostart="false"` attribute and value to the `<script>` tag for the Blazor script.
 * Place a script that calls `Blazor.start` after the Blazor `<script>` tag and inside the closing `</body>` tag.

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -691,7 +691,7 @@ Load JavaScript (JS) code using any of approaches described by the [JS interop o
 
 * [Load a script in `<head>` markup](xref:blazor/js-interop/index#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](xref:blazor/js-interop/index#load-a-script-in-body-markup)
-* [Load a script from an external JS file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 
 For information on isolating scripts in [JS modules](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules), see the [JavaScript isolation in JavaScript modules](#javascript-isolation-in-javascript-modules) section.
@@ -1517,7 +1517,7 @@ Load JavaScript (JS) code using any of approaches described by the [JS interop o
 
 * [Load a script in `<head>` markup](xref:blazor/js-interop/index#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](xref:blazor/js-interop/index#load-a-script-in-body-markup)
-* [Load a script from an external JS file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 
 For information on isolating scripts in [JS modules](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules), see the [JavaScript isolation in JavaScript modules](#javascript-isolation-in-javascript-modules) section.
@@ -2035,7 +2035,7 @@ Load JavaScript (JS) code using any of approaches described by the [JS interop o
 * [Load a script in `<head>` markup](xref:blazor/js-interop/index#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](xref:blazor/js-interop/index#load-a-script-in-body-markup)
 * [Load a script from an external JavaScript file (`.js`) collocated with a component](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js-collocated-with-a-component)
-* [Load a script from an external JS file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 
 For information on isolating scripts in [JS modules](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules), see the [JavaScript isolation in JavaScript modules](#javascript-isolation-in-javascript-modules) section.
@@ -2460,7 +2460,7 @@ Load JavaScript (JS) code using any of approaches described by the [JS interop o
 
 * [Load a script in `<head>` markup](xref:blazor/js-interop/index#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](xref:blazor/js-interop/index#load-a-script-in-body-markup)
-* [Load a script from an external JS file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 
 > [!WARNING]

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -168,7 +168,7 @@ Load JavaScript (JS) code using any of approaches described by the [JavaScript (
 * [Load a script in `<head>` markup](xref:blazor/js-interop/index#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](xref:blazor/js-interop/index#load-a-script-in-body-markup)
 * [Load a script from an external JavaScript file (`.js`) collocated with a component](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js-collocated-with-a-component)
-* [Load a script from an external JS file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 
 For information on isolating scripts in [JS modules](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules), see the [JavaScript isolation in JavaScript modules](#javascript-isolation-in-javascript-modules) section.
@@ -931,7 +931,7 @@ Load JavaScript (JS) code using any of approaches described by the [JavaScript (
 * [Load a script in `<head>` markup](xref:blazor/js-interop/index#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](xref:blazor/js-interop/index#load-a-script-in-body-markup)
 * [Load a script from an external JavaScript file (`.js`) collocated with a component](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js-collocated-with-a-component)
-* [Load a script from an external JS file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 
 For information on isolating scripts in [JS modules](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules), see the [JavaScript isolation in JavaScript modules](#javascript-isolation-in-javascript-modules) section.
@@ -1750,7 +1750,7 @@ Load JavaScript (JS) code using any of approaches described by the [JavaScript (
 
 * [Load a script in `<head>` markup](xref:blazor/js-interop/index#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](xref:blazor/js-interop/index#load-a-script-in-body-markup)
-* [Load a script from an external JS file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 
 For information on isolating scripts in [JS modules](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Modules), see the [JavaScript isolation in JavaScript modules](#javascript-isolation-in-javascript-modules) section.
@@ -2383,7 +2383,7 @@ Load JavaScript (JS) code using any of approaches described by the [JavaScript (
 
 * [Load a script in `<head>` markup](xref:blazor/js-interop/index#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](xref:blazor/js-interop/index#load-a-script-in-body-markup)
-* [Load a script from an external JS file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](xref:blazor/js-interop/index#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](xref:blazor/js-interop/index#inject-a-script-after-blazor-starts)
 
 > [!WARNING]

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -136,7 +136,7 @@ For more information on RCLs, see <xref:blazor/components/class-libraries>.
 
 Place the JavaScript (JS) tags (`<script>...</script>`) with a script source (`src`) path inside the closing `</body>` tag after the Blazor script reference.
 
-The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
 
@@ -365,7 +365,7 @@ For more information on RCLs, see <xref:blazor/components/class-libraries>.
 
 Place the JavaScript (JS) tags (`<script>...</script>`) with a script source (`src`) path inside the closing `</body>` tag after the Blazor script reference.
 
-The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
@@ -581,7 +581,7 @@ The `{webassembly|server}` placeholder in the preceding markup is either `webass
 
 Place the script (`<script>...</script>`) with a script `src` path inside the closing `</body>` tag after the Blazor script reference.
 
-The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
 
@@ -792,7 +792,7 @@ The `{webassembly|server}` placeholder in the preceding markup is either `webass
 
 Place the script (`<script>...</script>`) with a script `src` path inside the closing `</body>` tag after the Blazor script reference.
 
-The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag block the Blazor JavaScript engine until they've finished loading.
 
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
 

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -136,6 +136,8 @@ For more information on RCLs, see <xref:blazor/components/class-libraries>.
 
 Place the JavaScript (JS) tags (`<script>...</script>`) with a script source (`src`) path inside the closing `</body>` tag after the Blazor script reference.
 
+The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
 
 ```html
@@ -363,6 +365,8 @@ For more information on RCLs, see <xref:blazor/components/class-libraries>.
 
 Place the JavaScript (JS) tags (`<script>...</script>`) with a script source (`src`) path inside the closing `</body>` tag after the Blazor script reference.
 
+The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
+
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Layout.cshtml` (Blazor Server):
 
 ```html
@@ -522,7 +526,7 @@ Load JavaScript (JS) code using any of the following approaches:
 
 * [Load a script in `<head>` markup](#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](#load-a-script-in-body-markup)
-* [Load a script from an external JS file (`.js`)](#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](#inject-a-script-after-blazor-starts)
 
 > [!WARNING]
@@ -573,9 +577,11 @@ Place the script (`<script>...</script>`) inside the closing `</body>` element m
 
 The `{webassembly|server}` placeholder in the preceding markup is either `webassembly` for a Blazor WebAssembly app (`blazor.webassembly.js`) or :::no-loc text="Server"::: for a Blazor Server app (`blazor.server.js`).
 
-### Load a script from an external JS file (`.js`)
+### Load a script from an external JavaScript file (`.js`)
 
 Place the script (`<script>...</script>`) with a script `src` path inside the closing `</body>` tag after the Blazor script reference.
+
+The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
 
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
 
@@ -731,7 +737,7 @@ Load JavaScript (JS) code using any of the following approaches:
 
 * [Load a script in `<head>` markup](#load-a-script-in-head-markup) (*Not generally recommended*)
 * [Load a script in `<body>` markup](#load-a-script-in-body-markup)
-* [Load a script from an external JS file (`.js`)](#load-a-script-from-an-external-js-file-js)
+* [Load a script from an external JavaScript file (`.js`)](#load-a-script-from-an-external-javascript-file-js)
 * [Inject a script after Blazor starts](#inject-a-script-after-blazor-starts)
 
 > [!WARNING]
@@ -782,9 +788,11 @@ Place the script (`<script>...</script>`) inside the closing `</body>` element m
 
 The `{webassembly|server}` placeholder in the preceding markup is either `webassembly` for a Blazor WebAssembly app (`blazor.webassembly.js`) or :::no-loc text="Server"::: for a Blazor Server app (`blazor.server.js`).
 
-### Load a script from an external JS file (`.js`)
+### Load a script from an external JavaScript file (`.js`)
 
 Place the script (`<script>...</script>`) with a script `src` path inside the closing `</body>` tag after the Blazor script reference.
+
+The Blazor startup process is asynchronous, so scripts added after the Blazor `<script>` tag are loaded and block the Blazor JavaScript engine until they've finished loading.
 
 In `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
 


### PR DESCRIPTION
Fixes #28044

Thanks @plastovicka! :rocket:

I'm adding a bit to explain how the Blazor JS engine ***should be blocked*** until the scripts are loaded.

If you take Steve's advice and open an issue for the product unit on [their GH repo](https://github.com/dotnet/aspnetcore/issues) with steps to reproduce and a sample app hosted in GH, please add the following to your opening comment there so that I can follow along ...

```
cc: @guardrex https://github.com/dotnet/AspNetCore.Docs/issues/28044
```

If something comes out of that investigation/discussion that we can add to the documentation, I'll take care of re-opening your original issue and working on it further. Thanks for your issue. This was an important bit to add.

WRT my mention about manually starting the Blazor JS engine, I'm adding some coverage to the Blazor *Startup* article.

I fleshed out the idea further based on Steve's remark to something like this ...

```html
<script src="_framework/blazor.{webassembly|server}.js" autostart="false"></script>
<script async src="./_content/{PACKAGE ID}/{SCRIPT PATH AND FILENAME (.js)}"></script>
<script>if (CHECK SCRIPT LOADED HERE) { Blazor.start(); }</script>
```

... so you can check to confirm a script is loaded and make darn sure that Blazor doesn't get going until your bits are there and ready to rock 🎸🎵. However, I'm not going add that to the *Startup* or *JS interop* docs at this time, given that Steve said it would be rare that a dev would need to go that far. I'll keep an 👂 open for more feedback on this point and possibly add that later if it becomes more relevant/important.

***... and sorry for the update churn!*** I see a few NITs along the way here that I'd like to knock out.