### PR TITLE
Fix/add missing use windows service dotnet7

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service/samples/7.x/WebAppServiceSample/Program.cs
+++ b/aspnetcore/host-and-deploy/windows-service/samples/7.x/WebAppServiceSample/Program.cs
@@ -4,6 +4,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
 builder.Services.AddHostedService<ServiceA>();
 
+builder.Host.UseWindowsService();
+
 var app = builder.Build();
 
 app.UseStaticFiles();

--- a/aspnetcore/host-and-deploy/windows-service/samples/7.x/WebAppServiceSample/SampleApp.csproj
+++ b/aspnetcore/host-and-deploy/windows-service/samples/7.x/WebAppServiceSample/SampleApp.csproj
@@ -7,4 +7,8 @@
 	<IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
[EDIT by guardrex to change the issue reference.]

Fixes #28055

* Compiling \aspnetcore\host-and-deploy\windows-service\samples\7.x\WebAppServiceSample and trying to add a Windows service for the executable was failing.
* Adding builder.Host.UseWindowsService() to the program.cs fixed it for me.