### PR TITLE
Update windows-service.md

### DIFF
--- a/aspnetcore/host-and-deploy/windows-service.md
+++ b/aspnetcore/host-and-deploy/windows-service.md
@@ -30,8 +30,7 @@ The ASP.NET Core Worker Service template provides a starting point for writing l
 
 ## App configuration
 
-[WebApplication.CreateBuilder](/dotnet/api/microsoft.aspnetcore.builder.webapplication.createbuilder) calls [AddWindowsService](https://source.dot.net/#Microsoft.Extensions.Hosting.WindowsServices/WindowsServiceLifetimeHostBuilderExtensions.cs,f8bfb38e255ef3b6,references)
-If the app is running as a Windows Service, `AddWindowsService`:
+Update Program.cs to call [AddWindowsService](https://source.dot.net/#Microsoft.Extensions.Hosting.WindowsServices/WindowsServiceLifetimeHostBuilderExtensions.cs,f8bfb38e255ef3b6,references). When the app is running as a Windows Service, `AddWindowsService`:
 
 * Sets the host lifetime to `WindowsServiceLifetime`.
 * Sets the [content root](xref:fundamentals/index#content-root) to [AppContext.BaseDirectory](xref:System.AppContext.BaseDirectory). For more information, see the [Current directory and content root](#current-directory-and-content-root) section.

--- a/aspnetcore/host-and-deploy/windows-service/samples/7.x/WebAppServiceSample/Program.cs
+++ b/aspnetcore/host-and-deploy/windows-service/samples/7.x/WebAppServiceSample/Program.cs
@@ -1,14 +1,14 @@
 using SampleApp.Services;
 
 var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddRazorPages();
-builder.Services.AddHostedService<ServiceA>();
 
-builder.Host.UseWindowsService();
+builder.Services.AddRazorPages();
+
+builder.Services.AddWindowsService();
+builder.Services.AddHostedService<ServiceA>();
 
 var app = builder.Build();
 
-app.UseStaticFiles();
-app.UseRouting();
 app.MapRazorPages();
-await app.RunAsync();
+
+app.Run();


### PR DESCRIPTION
I looked at this since I got pinged on #25572. `WebApplication.CreateBuilder` doesn't call `AddWindowsService`. You still need to call that manually. The worker template still uses `Host.CreateDefaultBuilder(args)`, so mentioning `WebApplication` could be confusing. Fortunately, `AddWindowsService` works both on `builder.Services` and in a `ConfigureServices` callback.

