### PR TITLE
fix ASP0013 violation in snippet_json

### DIFF
--- a/aspnetcore/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs
@@ -188,12 +188,9 @@ using Microsoft.Extensions.DependencyInjection.ConfigSample.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.AddJsonFile("MyConfig.json",
-                       optional: true,
-                       reloadOnChange: true);
-});
+builder.Configuration.AddJsonFile("MyConfig.json",
+        optional: true,
+        reloadOnChange: true);
 
 builder.Services.AddRazorPages();
 


### PR DESCRIPTION
As described in the diagnostic [ASP0013](https://learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0013?view=aspnetcore-7.0#rule-description):

> To fix a violation of this rule, use the `Configuration` property on the `WebApplicationBuilder` to modify application configuration directly without the need for an additional `ConfigureAppConfiguration` call.