### PR TITLE
Add hosted WASM content

### DIFF
--- a/aspnetcore/blazor/components/css-isolation.md
+++ b/aspnetcore/blazor/components/css-isolation.md
@@ -57,7 +57,7 @@ CSS isolation occurs at build time. Blazor rewrites CSS selectors to match marku
 <link href="{ASSEMBLY NAME}.styles.css" rel="stylesheet">
 ```
 
-The following example is from a hosted Blazor WebAssembly **:::no-loc text="Client":::** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor WebAssembly project template when the project is created with the Hosted option (`-ho|--hosted` option using the .NET CLI or **ASP.NET Core hosted** checkbox using Visual Studio):
+The following example is from a hosted Blazor WebAssembly **:::no-loc text="Client":::** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor WebAssembly project template when the project is created with the Hosted option (`-ho|--hosted` option using the .NET CLI or **ASP.NET Core Hosted** checkbox using Visual Studio):
 
 ```html
 <link href="BlazorSample.Client.styles.css" rel="stylesheet">
@@ -280,7 +280,7 @@ CSS isolation occurs at build time. Blazor rewrites CSS selectors to match marku
 <link href="{ASSEMBLY NAME}.styles.css" rel="stylesheet">
 ```
 
-The following example is from a hosted Blazor WebAssembly **:::no-loc text="Client":::** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor WebAssembly project template when the project is created with the Hosted option (`-ho|--hosted` option using the .NET CLI or **ASP.NET Core hosted** checkbox using Visual Studio):
+The following example is from a hosted Blazor WebAssembly **:::no-loc text="Client":::** app. The app's assembly name is `BlazorSample.Client`, and the `<link>` is added by the Blazor WebAssembly project template when the project is created with the Hosted option (`-ho|--hosted` option using the .NET CLI or **ASP.NET Core Hosted** checkbox using Visual Studio):
 
 ```html
 <link href="BlazorSample.Client.styles.css" rel="stylesheet">

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -929,7 +929,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
 
 1. Host the Blazor WebAssembly app in an ASP.NET Core app. A standalone Blazor WebAssembly app can be added to an ASP.NET Core solution, or you can use a hosted Blazor WebAssembly app created from the [Blazor WebAssembly project template](xref:blazor/tooling) with the hosted option:
 
-   * Visual Studio: In the **Additional information** dialog, select the **ASP.NET Core hosted** checkbox when creating the Blazor WebAssembly app. In this article's examples, the solution is named `BlazorHosted`.
+   * Visual Studio: In the **Additional information** dialog, select the **ASP.NET Core Hosted** checkbox when creating the Blazor WebAssembly app. In this article's examples, the solution is named `BlazorHosted`.
    * Visual Studio Code/.NET CLI command shell: `dotnet new blazorwasm -ho` (use the `-ho|--hosted` option). Use the `-o|--output {LOCATION}` option to create a folder for the solution and set the solution's project namespaces. In this article's examples, the solution is named `BlazorHosted` (`dotnet new blazorwasm -ho -o BlazorHosted`).
 
    For the examples in this article, the client project's namespace is `BlazorHosted.Client`, and the server project's namespace is `BlazorHosted.Server`.
@@ -1872,7 +1872,7 @@ To set up prerendering for a hosted Blazor WebAssembly app:
 
 1. Host the Blazor WebAssembly app in an ASP.NET Core app. A standalone Blazor WebAssembly app can be added to an ASP.NET Core solution, or you can use a hosted Blazor WebAssembly app created from the [Blazor WebAssembly project template](xref:blazor/tooling) with the hosted option:
 
-   * Visual Studio: In the **Additional information** dialog, select the **ASP.NET Core hosted** checkbox when creating the Blazor WebAssembly app. In this article's examples, the solution is named `BlazorHosted`.
+   * Visual Studio: In the **Additional information** dialog, select the **ASP.NET Core Hosted** checkbox when creating the Blazor WebAssembly app. In this article's examples, the solution is named `BlazorHosted`.
    * Visual Studio Code/.NET CLI command shell: `dotnet new blazorwasm -ho` (use the `-ho|--hosted` option). Use the `-o|--output {LOCATION}` option to create a folder for the solution and set the solution's project namespaces. In this article's examples, the solution is named `BlazorHosted` (`dotnet new blazorwasm -ho -o BlazorHosted`).
 
    For the examples in this article, the client project's namespace is `BlazorHosted.Client`, and the server project's namespace is `BlazorHosted.Server`.

--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -38,7 +38,7 @@ The preceding configurations are beyond the scope of this demonstration. For mor
 * <xref:security/enforcing-ssl>
 * <xref:blazor/components/prerendering-and-integration?pivots=webassembly>
 
-Use an existing hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln) or create a [new hosted Blazor WebAssembly solution](xref:blazor/tooling) from the Blazor WebAssembly project template by passing the `-ho|--hosted` option if using the .NET CLI or selecting the **ASP.NET Core hosted** checkbox in Visual Studio or Visual Studio for Mac when the project is created in the IDE.
+Use an existing hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln) or create a [new hosted Blazor WebAssembly solution](xref:blazor/tooling) from the Blazor WebAssembly project template by passing the `-ho|--hosted` option if using the .NET CLI or selecting the **ASP.NET Core Hosted** checkbox in Visual Studio or Visual Studio for Mac when the project is created in the IDE.
 
 Use a folder for the solution named `MultipleBlazorApps` and name the project `MultipleBlazorApps`.
 
@@ -57,7 +57,7 @@ In the client app's project file (`MultipleBlazorApps.Client.csproj`), add a [`<
 > [!NOTE]
 > The demonstration in this section uses web asset path names of `FirstApp` and `SecondApp`, but these specific names are merely for demonstration purposes. Any base path segments that distinguish the client apps are acceptable, such as `App1`/`App2`, `Client1`/`Client2`, `1`/`2`, or any similar naming scheme. These base path segments are used internally to route requests and serve responses and are ***not*** seen in a browser's address bar.
 
-Add a second client app to the solution. Add the project as a standalone Blazor WebAssembly app. To create a standalone Blazor WebAssembly app, don't pass the `-ho|--hosted` option if using the .NET CLI or don't use the **ASP.NET Core hosted** checkbox if using Visual Studio:
+Add a second client app to the solution. Add the project as a standalone Blazor WebAssembly app. To create a standalone Blazor WebAssembly app, don't pass the `-ho|--hosted` option if using the .NET CLI or don't use the **ASP.NET Core Hosted** checkbox if using Visual Studio:
 
 * Name the project `MultipleBlazorApps.SecondClient` and place the app into a folder named `SecondClient`.
 * The solution folder created from the project template contains the following solution file and folders after the `SecondClient` folder is added:

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -80,7 +80,7 @@ When a Blazor WebAssembly app is published, the output is statically compressed 
 * [Brotli](https://tools.ietf.org/html/rfc7932) (highest level)
 * [Gzip](https://tools.ietf.org/html/rfc1952)
 
-Blazor relies on the host to the serve the appropriate compressed files. When using an ASP.NET Core hosted project, the host project is capable of performing content negotiation and serving the statically-compressed files. When hosting a Blazor WebAssembly standalone app, additional work might be required to ensure that statically-compressed files are served:
+Blazor relies on the host to the serve the appropriate compressed files. When using an ASP.NET Core Hosted project, the host project is capable of performing content negotiation and serving the statically-compressed files. When hosting a Blazor WebAssembly standalone app, additional work might be required to ensure that statically-compressed files are served:
 
 * For IIS `web.config` compression configuration, see the [IIS: Brotli and Gzip compression](#brotli-and-gzip-compression) section. 
 * When hosting on static hosting solutions that don't support statically-compressed file content negotiation, such as GitHub Pages, consider configuring the app to fetch and decode Brotli compressed files:
@@ -1149,7 +1149,7 @@ When a Blazor WebAssembly app is published, the output is statically compressed 
 * [Brotli](https://tools.ietf.org/html/rfc7932) (highest level)
 * [Gzip](https://tools.ietf.org/html/rfc1952)
 
-Blazor relies on the host to the serve the appropriate compressed files. When using an ASP.NET Core hosted project, the host project is capable of performing content negotiation and serving the statically-compressed files. When hosting a Blazor WebAssembly standalone app, additional work might be required to ensure that statically-compressed files are served:
+Blazor relies on the host to the serve the appropriate compressed files. When using an ASP.NET Core Hosted project, the host project is capable of performing content negotiation and serving the statically-compressed files. When hosting a Blazor WebAssembly standalone app, additional work might be required to ensure that statically-compressed files are served:
 
 * For IIS `web.config` compression configuration, see the [IIS: Brotli and Gzip compression](#brotli-and-gzip-compression) section. 
 * When hosting on static hosting solutions that don't support statically-compressed file content negotiation, such as GitHub Pages, consider configuring the app to fetch and decode Brotli compressed files:
@@ -2174,7 +2174,7 @@ When a Blazor WebAssembly app is published, the output is statically compressed 
 * [Brotli](https://tools.ietf.org/html/rfc7932) (highest level)
 * [Gzip](https://tools.ietf.org/html/rfc1952)
 
-Blazor relies on the host to the serve the appropriate compressed files. When using an ASP.NET Core hosted project, the host project is capable of performing content negotiation and serving the statically-compressed files. When hosting a Blazor WebAssembly standalone app, additional work might be required to ensure that statically-compressed files are served:
+Blazor relies on the host to the serve the appropriate compressed files. When using an ASP.NET Core Hosted project, the host project is capable of performing content negotiation and serving the statically-compressed files. When hosting a Blazor WebAssembly standalone app, additional work might be required to ensure that statically-compressed files are served:
 
 * For IIS `web.config` compression configuration, see the [IIS: Brotli and Gzip compression](#brotli-and-gzip-compression) section. 
 * When hosting on static hosting solutions that don't support statically-compressed file content negotiation, such as GitHub Pages, consider configuring the app to fetch and decode Brotli compressed files:
@@ -2989,7 +2989,7 @@ When a Blazor WebAssembly app is published, the output is statically compressed 
 * [Brotli](https://tools.ietf.org/html/rfc7932) (highest level)
 * [Gzip](https://tools.ietf.org/html/rfc1952)
 
-Blazor relies on the host to the serve the appropriate compressed files. When using an ASP.NET Core hosted project, the host project is capable of performing content negotiation and serving the statically-compressed files. When hosting a Blazor WebAssembly standalone app, additional work might be required to ensure that statically-compressed files are served:
+Blazor relies on the host to the serve the appropriate compressed files. When using an ASP.NET Core Hosted project, the host project is capable of performing content negotiation and serving the statically-compressed files. When hosting a Blazor WebAssembly standalone app, additional work might be required to ensure that statically-compressed files are served:
 
 * For IIS `web.config` compression configuration, see the [IIS: Brotli and Gzip compression](#brotli-and-gzip-compression) section. 
 * When hosting on static hosting solutions that don't support statically-compressed file content negotiation, such as GitHub Pages, consider configuring the app to fetch and decode Brotli compressed files:

--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -106,6 +106,19 @@ Project structure:
 
 Additional files and folders may appear in an app produced from a Blazor WebAssembly project template when additional options are configured. For example, generating an app with ASP.NET Core Identity includes additional assets for authentication and authorization features.
 
+A *hosted Blazor WebAssembly solution* includes the following ASP.NET Core projects:
+
+* ":::no-loc text="Client":::": The Blazor WebAssembly app.
+* ":::no-loc text="Server":::": An app that serves the Blazor WebAssembly app and weather data to clients.
+* ":::no-loc text="Shared":::": A project that maintains common classes, methods, and resources.
+
+The solution is generated from the Blazor WebAssembly project template in Visual Studio with the **ASP.NET Core Hosted** checkbox selected or with the `-ho|--hosted` option using the .NET CLI's `dotnet new blazorwasm` command. For more information, see <xref:blazor/tooling>.
+
+The project structure of the client-side app in a hosted Blazor Webassembly solution (":::no-loc text="Client":::" project) is the same as the project structure for a standalone Blazor WebAssembly app. Additional files in a hosted Blazor WebAssembly solution:
+
+* The ":::no-loc text="Server":::" project includes a weather forecast controller at `Controllers/WeatherForecastController.cs` that returns weather data to the ":::no-loc text="Client":::" project's `FetchData` component.
+* The ":::no-loc text="Shared":::" project includes a weather forecast class at `WeatherForecast.cs` that represents weather data for the ":::no-loc text="Client":::" and ":::no-loc text="Server":::" projects.
+
 ## Location of `<head>` content
 
 In Blazor Server apps, `<head>` content is located in the `Pages/_Host.cshtml` file.
@@ -205,6 +218,19 @@ The Blazor WebAssembly template creates the initial files and directory structur
   * [Services](xref:blazor/fundamentals/dependency-injection) are added and configured (for example, `builder.Services.AddSingleton<IMyDependency, MyDependency>()`).
 
 Additional files and folders may appear in an app produced from a Blazor WebAssembly project template when additional options are configured. For example, generating an app with ASP.NET Core Identity includes additional assets for authentication and authorization features.
+
+A *hosted Blazor WebAssembly solution* includes the following ASP.NET Core projects:
+
+* ":::no-loc text="Client":::": The Blazor WebAssembly app.
+* ":::no-loc text="Server":::": An app that serves the Blazor WebAssembly app and weather data to clients.
+* ":::no-loc text="Shared":::": A project that maintains common classes, methods, and resources.
+
+The solution is generated from the Blazor WebAssembly project template in Visual Studio with the **ASP.NET Core Hosted** checkbox selected or with the `-ho|--hosted` option using the .NET CLI's `dotnet new blazorwasm` command. For more information, see <xref:blazor/tooling>.
+
+The project structure of the client-side app in a hosted Blazor Webassembly solution (":::no-loc text="Client":::" project) is the same as the project structure for a standalone Blazor WebAssembly app. Additional files in a hosted Blazor WebAssembly solution:
+
+* The ":::no-loc text="Server":::" project includes a weather forecast controller at `Controllers/WeatherForecastController.cs` that returns weather data to the ":::no-loc text="Client":::" project's `FetchData` component.
+* The ":::no-loc text="Shared":::" project includes a weather forecast class at `WeatherForecast.cs` that represents weather data for the ":::no-loc text="Client":::" and ":::no-loc text="Server":::" projects.
 
 ## Location of `<head>` content
 
@@ -307,6 +333,19 @@ The Blazor WebAssembly template creates the initial files and directory structur
 
 Additional files and folders may appear in an app produced from a Blazor WebAssembly project template when additional options are configured. For example, generating an app with ASP.NET Core Identity includes additional assets for authentication and authorization features.
 
+A *hosted Blazor WebAssembly solution* includes the following ASP.NET Core projects:
+
+* ":::no-loc text="Client":::": The Blazor WebAssembly app.
+* ":::no-loc text="Server":::": An app that serves the Blazor WebAssembly app and weather data to clients.
+* ":::no-loc text="Shared":::": A project that maintains common classes, methods, and resources.
+
+The solution is generated from the Blazor WebAssembly project template in Visual Studio with the **ASP.NET Core Hosted** checkbox selected or with the `-ho|--hosted` option using the .NET CLI's `dotnet new blazorwasm` command. For more information, see <xref:blazor/tooling>.
+
+The project structure of the client-side app in a hosted Blazor Webassembly solution (":::no-loc text="Client":::" project) is the same as the project structure for a standalone Blazor WebAssembly app. Additional files in a hosted Blazor WebAssembly solution:
+
+* The ":::no-loc text="Server":::" project includes a weather forecast controller at `Controllers/WeatherForecastController.cs` that returns weather data to the ":::no-loc text="Client":::" project's `FetchData` component.
+* The ":::no-loc text="Shared":::" project includes a weather forecast class at `WeatherForecast.cs` that represents weather data for the ":::no-loc text="Client":::" and ":::no-loc text="Server":::" projects.
+
 ## Location of `<head>` content
 
 In Blazor Server apps, `<head>` content is located in the `Pages/_Host.cshtml` file.
@@ -402,6 +441,19 @@ The Blazor WebAssembly template creates the initial files and directory structur
   * [Services](xref:blazor/fundamentals/dependency-injection) are added and configured (for example, `builder.Services.AddSingleton<IMyDependency, MyDependency>()`).
 
 Additional files and folders may appear in an app produced from a Blazor WebAssembly project template when additional options are configured. For example, generating an app with ASP.NET Core Identity includes additional assets for authentication and authorization features.
+
+A *hosted Blazor WebAssembly solution* includes the following ASP.NET Core projects:
+
+* ":::no-loc text="Client":::": The Blazor WebAssembly app.
+* ":::no-loc text="Server":::": An app that serves the Blazor WebAssembly app and weather data to clients.
+* ":::no-loc text="Shared":::": A project that maintains common classes, methods, and resources.
+
+The solution is generated from the Blazor WebAssembly project template in Visual Studio with the **ASP.NET Core Hosted** checkbox selected or with the `-ho|--hosted` option using the .NET CLI's `dotnet new blazorwasm` command. For more information, see <xref:blazor/tooling>.
+
+The project structure of the client-side app in a hosted Blazor Webassembly solution (":::no-loc text="Client":::" project) is the same as the project structure for a standalone Blazor WebAssembly app. Additional files in a hosted Blazor WebAssembly solution:
+
+* The ":::no-loc text="Server":::" project includes a weather forecast controller at `Controllers/WeatherForecastController.cs` that returns weather data to the ":::no-loc text="Client":::" project's `FetchData` component.
+* The ":::no-loc text="Shared":::" project includes a weather forecast class at `WeatherForecast.cs` that represents weather data for the ":::no-loc text="Client":::" and ":::no-loc text="Server":::" projects.
 
 ## Location of `<head>` content
 

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -37,7 +37,7 @@ To create a new Blazor WebAssembly project with an authentication mechanism:
 
 1. In the **Additional information** dialog, select **Individual Accounts** as the **Authentication Type** to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
 
-1. Select the **ASP.NET Core hosted** checkbox.
+1. Select the **ASP.NET Core Hosted** checkbox.
 
 # [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
 
@@ -59,7 +59,7 @@ For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) comm
 
 To create a new hosted Blazor WebAssembly solution with an authentication mechanism:
 
-1. Select **Individual Authentication (in-app)** from the **Authentication** dropdown list when creating the app with the **ASP.NET Core hosted** checkbox. For guidance on creating a hosted Blazor WebAssembly solution, see <xref:blazor/tooling>.
+1. Select **Individual Authentication (in-app)** from the **Authentication** dropdown list when creating the app with the **ASP.NET Core Hosted** checkbox. For guidance on creating a hosted Blazor WebAssembly solution, see <xref:blazor/tooling>.
 
 1. The app is created for individual users stored in the app with ASP.NET Core [Identity](xref:security/authentication/identity).
 
@@ -582,7 +582,7 @@ To create a new Blazor WebAssembly project with an authentication mechanism:
 
 1. In the **Additional information** dialog, select **Individual Accounts** as the **Authentication Type** to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
 
-1. Select the **ASP.NET Core hosted** checkbox.
+1. Select the **ASP.NET Core Hosted** checkbox.
 
 # [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
 
@@ -604,7 +604,7 @@ For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) comm
 
 To create a new hosted Blazor WebAssembly solution with an authentication mechanism:
 
-1. Select **Individual Authentication (in-app)** from the **Authentication** dropdown list when creating the app with the **ASP.NET Core hosted** checkbox. For guidance on creating a hosted Blazor WebAssembly solution, see <xref:blazor/tooling>.
+1. Select **Individual Authentication (in-app)** from the **Authentication** dropdown list when creating the app with the **ASP.NET Core Hosted** checkbox. For guidance on creating a hosted Blazor WebAssembly solution, see <xref:blazor/tooling>.
 
 1. The app is created for individual users stored in the app with ASP.NET Core [Identity](xref:security/authentication/identity).
 
@@ -1122,7 +1122,7 @@ To create a new Blazor WebAssembly project with an authentication mechanism:
 
 1. In the **Additional information** dialog, select **Individual Accounts** as the **Authentication Type** to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
 
-1. Select the **ASP.NET Core hosted** checkbox.
+1. Select the **ASP.NET Core Hosted** checkbox.
 
 # [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
 
@@ -1144,7 +1144,7 @@ For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) comm
 
 To create a new hosted Blazor WebAssembly solution with an authentication mechanism:
 
-1. Select **Individual Authentication (in-app)** from the **Authentication** dropdown list when creating the app with the **ASP.NET Core hosted** checkbox. For guidance on creating a hosted Blazor WebAssembly solution, see <xref:blazor/tooling>.
+1. Select **Individual Authentication (in-app)** from the **Authentication** dropdown list when creating the app with the **ASP.NET Core Hosted** checkbox. For guidance on creating a hosted Blazor WebAssembly solution, see <xref:blazor/tooling>.
 
 1. The app is created for individual users stored in the app with ASP.NET Core [Identity](xref:security/authentication/identity).
 
@@ -1832,7 +1832,7 @@ To create a new Blazor WebAssembly project with an authentication mechanism:
 
 1. In the **Additional information** dialog, select **Individual Accounts** as the **Authentication Type** to store users within the app using ASP.NET Core's [Identity](xref:security/authentication/identity) system.
 
-1. Select the **ASP.NET Core hosted** checkbox.
+1. Select the **ASP.NET Core Hosted** checkbox.
 
 # [Visual Studio Code / .NET Core CLI](#tab/visual-studio-code+netcore-cli)
 
@@ -1854,7 +1854,7 @@ For more information, see the [`dotnet new`](/dotnet/core/tools/dotnet-new) comm
 
 To create a new Blazor WebAssembly solution with an authentication mechanism:
 
-1. Select **Individual Authentication (in-app)** from the **Authentication** dropdown list when creating the app with the **ASP.NET Core hosted** checkbox. For guidance on creating a hosted Blazor WebAssembly solution, see <xref:blazor/tooling>.
+1. Select **Individual Authentication (in-app)** from the **Authentication** dropdown list when creating the app with the **ASP.NET Core Hosted** checkbox. For guidance on creating a hosted Blazor WebAssembly solution, see <xref:blazor/tooling>.
 
 1. The app is created for individual users stored in the app with ASP.NET Core [Identity](xref:security/authentication/identity).
 

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -27,7 +27,7 @@ This article describes tools for building Blazor apps on various platforms.
 
 1. Provide a **Project name** and confirm that the **Location** is correct. Select **Next**.
 
-1. In the **Additional information** dialog, select the **ASP.NET Core hosted** checkbox for a hosted Blazor WebAssembly app. Select **Create**.
+1. In the **Additional information** dialog, select the **ASP.NET Core Hosted** checkbox for a hosted Blazor WebAssembly app. Select **Create**.
 
    For information on the two Blazor hosting models, *Blazor WebAssembly* (standalone and hosted) and *Blazor Server*, see <xref:blazor/hosting-models>.
 
@@ -270,7 +270,7 @@ For more information, see <xref:security/enforcing-ssl#trust-https-certificate-o
 
 1. Confirm that **Authentication** is set to **No Authentication**. Select **Continue**.
 
-1. For a hosted Blazor WebAssembly experience, select the **ASP.NET Core hosted** checkbox.
+1. For a hosted Blazor WebAssembly experience, select the **ASP.NET Core Hosted** checkbox.
 
 1. In the **Project name** field, name the app `WebApplication1`. Select **Create**.
 
@@ -292,7 +292,7 @@ Tooling outside of Visual Studio and Visual Studio for Mac can interact with sol
 * The [.NET CLI](/dotnet/core/tools/) can create solution files and list/modify the projects in solution files via the [`dotnet sln` command](/dotnet/core/tools/dotnet-sln). Other .NET CLI commands use the path of the solution file for various publishing, testing, and packaging commands.
 * [Visual Studio Code](https://code.visualstudio.com) can execute the `dotnet sln` command and other .NET CLI commands through its integrated terminal but doesn't use the settings in a solution file directly.
 
-Throughout the Blazor documentation, *solution* is used to describe apps created from the Blazor WebAssembly project template with the *ASP.NET Core hosted* option enabled or from a Blazor Hybrid project template. Apps produced from these project templates include a solution file (`.sln`) by default. For hosted Blazor WebAssembly apps where the developer isn't using Visual Studio or Visual Studio for Mac, the solution file can be ignored or deleted if it isn't used with .NET CLI commands.
+Throughout the Blazor documentation, *solution* is used to describe apps created from the Blazor WebAssembly project template with the *ASP.NET Core Hosted* option enabled or from a Blazor Hybrid project template. Apps produced from these project templates include a solution file (`.sln`) by default. For hosted Blazor WebAssembly apps where the developer isn't using Visual Studio or Visual Studio for Mac, the solution file can be ignored or deleted if it isn't used with .NET CLI commands.
 
 For more information, see the following resources in the Visual Studio documentation:
 
@@ -396,7 +396,7 @@ For more information, see the following resources:
 
 1. Provide a **Project name** and confirm that the **Location** is correct. Select **Next**.
 
-1. In the **Additional information** dialog, select the **ASP.NET Core hosted** checkbox for a hosted Blazor WebAssembly app. Select **Create**.
+1. In the **Additional information** dialog, select the **ASP.NET Core Hosted** checkbox for a hosted Blazor WebAssembly app. Select **Create**.
 
    For information on the two Blazor hosting models, *Blazor WebAssembly* (standalone and hosted) and *Blazor Server*, see <xref:blazor/hosting-models>.
 
@@ -619,7 +619,7 @@ For more information, see <xref:security/enforcing-ssl#trust-https-certificate-o
 
 1. Confirm that **Authentication** is set to **No Authentication**. Select **Continue**.
 
-1. For a hosted Blazor WebAssembly experience, select the **ASP.NET Core hosted** checkbox.
+1. For a hosted Blazor WebAssembly experience, select the **ASP.NET Core Hosted** checkbox.
 
 1. In the **Project name** field, name the app `WebApplication1`. Select **Create**.
 
@@ -641,7 +641,7 @@ Tooling outside of Visual Studio and Visual Studio for Mac can interact with sol
 * The [.NET CLI](/dotnet/core/tools/) can create solution files and list/modify the projects in solution files via the [`dotnet sln` command](/dotnet/core/tools/dotnet-sln). Other .NET CLI commands use the path of the solution file for various publishing, testing, and packaging commands.
 * [Visual Studio Code](https://code.visualstudio.com) can execute the `dotnet sln` command and other .NET CLI commands through its integrated terminal but doesn't use the settings in a solution file directly.
 
-Throughout the Blazor documentation, *solution* is used to describe apps created from the Blazor WebAssembly project template with the *ASP.NET Core hosted* option enabled or from a Blazor Hybrid project template. Apps produced from these project templates include a solution file (`.sln`) by default. For hosted Blazor WebAssembly apps where the developer isn't using Visual Studio or Visual Studio for Mac, the solution file can be ignored or deleted if it isn't used with .NET CLI commands.
+Throughout the Blazor documentation, *solution* is used to describe apps created from the Blazor WebAssembly project template with the *ASP.NET Core Hosted* option enabled or from a Blazor Hybrid project template. Apps produced from these project templates include a solution file (`.sln`) by default. For hosted Blazor WebAssembly apps where the developer isn't using Visual Studio or Visual Studio for Mac, the solution file can be ignored or deleted if it isn't used with .NET CLI commands.
 
 For more information, see the following resources in the Visual Studio documentation:
 
@@ -717,7 +717,7 @@ For more information, see the following resources:
 
 1. Provide a **Project name** and confirm that the **Location** is correct. Select **Next**.
 
-1. In the **Additional information** dialog, select the **ASP.NET Core hosted** checkbox for a hosted Blazor WebAssembly app. Select **Create**.
+1. In the **Additional information** dialog, select the **ASP.NET Core Hosted** checkbox for a hosted Blazor WebAssembly app. Select **Create**.
 
    For information on the two Blazor hosting models, *Blazor WebAssembly* (standalone and hosted) and *Blazor Server*, see <xref:blazor/hosting-models>.
 
@@ -894,7 +894,7 @@ For more information, see <xref:security/enforcing-ssl#trust-https-certificate-o
 
 1. Confirm that **Authentication** is set to **No Authentication**. Select **Continue**.
 
-1. For a hosted Blazor WebAssembly experience, select the **ASP.NET Core hosted** checkbox.
+1. For a hosted Blazor WebAssembly experience, select the **ASP.NET Core Hosted** checkbox.
 
 1. In the **Project name** field, name the app `WebApplication1`. Select **Create**.
 
@@ -916,7 +916,7 @@ Tooling outside of Visual Studio and Visual Studio for Mac can interact with sol
 * The [.NET CLI](/dotnet/core/tools/) can create solution files and list/modify the projects in solution files via the [`dotnet sln` command](/dotnet/core/tools/dotnet-sln). Other .NET CLI commands use the path of the solution file for various publishing, testing, and packaging commands.
 * [Visual Studio Code](https://code.visualstudio.com) can execute the `dotnet sln` command and other .NET CLI commands through its integrated terminal but doesn't use the settings in a solution file directly.
 
-Throughout the Blazor documentation, *solution* is used to describe apps created from the Blazor WebAssembly project template with the *ASP.NET Core hosted* option enabled or from a Blazor Hybrid project template. Apps produced from these project templates include a solution file (`.sln`) by default. For hosted Blazor WebAssembly apps where the developer isn't using Visual Studio or Visual Studio for Mac, the solution file can be ignored or deleted if it isn't used with .NET CLI commands.
+Throughout the Blazor documentation, *solution* is used to describe apps created from the Blazor WebAssembly project template with the *ASP.NET Core Hosted* option enabled or from a Blazor Hybrid project template. Apps produced from these project templates include a solution file (`.sln`) by default. For hosted Blazor WebAssembly apps where the developer isn't using Visual Studio or Visual Studio for Mac, the solution file can be ignored or deleted if it isn't used with .NET CLI commands.
 
 For more information, see the following resources in the Visual Studio documentation:
 
@@ -974,7 +974,7 @@ dotnet new blazorserver -h
 
 1. Provide a **Project name** and confirm that the **Location** is correct. Select **Next**.
 
-1. In the **Additional information** dialog, select the **ASP.NET Core hosted** checkbox for a hosted Blazor WebAssembly app. Select **Create**.
+1. In the **Additional information** dialog, select the **ASP.NET Core Hosted** checkbox for a hosted Blazor WebAssembly app. Select **Create**.
 
    For information on the two Blazor hosting models, *Blazor WebAssembly* (standalone and hosted) and *Blazor Server*, see <xref:blazor/hosting-models>.
 
@@ -1147,7 +1147,7 @@ For more information, see <xref:security/enforcing-ssl#trust-https-certificate-o
 
 1. Confirm that **Authentication** is set to **No Authentication**. Select **Continue**.
 
-1. For a hosted Blazor WebAssembly experience, select the **ASP.NET Core hosted** checkbox.
+1. For a hosted Blazor WebAssembly experience, select the **ASP.NET Core Hosted** checkbox.
 
 1. In the **Project name** field, name the app `WebApplication1`. Select **Create**.
 
@@ -1169,7 +1169,7 @@ Tooling outside of Visual Studio and Visual Studio for Mac can interact with sol
 * The [.NET CLI](/dotnet/core/tools/) can create solution files and list/modify the projects in solution files via the [`dotnet sln` command](/dotnet/core/tools/dotnet-sln). Other .NET CLI commands use the path of the solution file for various publishing, testing, and packaging commands.
 * [Visual Studio Code](https://code.visualstudio.com) can execute the `dotnet sln` command and other .NET CLI commands through its integrated terminal but doesn't use the settings in a solution file directly.
 
-Throughout the Blazor documentation, *solution* is used to describe apps created from the Blazor WebAssembly project template with the *ASP.NET Core hosted* option enabled or from a Blazor Hybrid project template. Apps produced from these project templates include a solution file (`.sln`) by default. For hosted Blazor WebAssembly apps where the developer isn't using Visual Studio or Visual Studio for Mac, the solution file can be ignored or deleted if it isn't used with .NET CLI commands.
+Throughout the Blazor documentation, *solution* is used to describe apps created from the Blazor WebAssembly project template with the *ASP.NET Core Hosted* option enabled or from a Blazor Hybrid project template. Apps produced from these project templates include a solution file (`.sln`) by default. For hosted Blazor WebAssembly apps where the developer isn't using Visual Studio or Visual Studio for Mac, the solution file can be ignored or deleted if it isn't used with .NET CLI commands.
 
 For more information, see the following resources in the Visual Studio documentation:
 

--- a/aspnetcore/blazor/tutorials/signalr-blazor.md
+++ b/aspnetcore/blazor/tutorials/signalr-blazor.md
@@ -108,7 +108,7 @@ To configure Visual Studio Code assets in the `.vscode` folder for debugging, se
 
 1. Choose the **Blazor WebAssembly App** template. Select **Continue**.
 
-1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core hosted** checkbox. Select **Continue**.
+1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core Hosted** checkbox. Select **Continue**.
 
 1. In the **Project name** field, name the app `BlazorWebAssemblySignalRApp`. Select **Create**.
 
@@ -116,7 +116,7 @@ To configure Visual Studio Code assets in the `.vscode` folder for debugging, se
 
 1. Open the project by navigating to the project folder and opening the project's [solution](xref:blazor/tooling#visual-studio-solution-file-sln) file (`.sln`).
 
-1. Confirm that a hosted Blazor WebAssembly app was created: In **Solution Explorer**, confirm the presence of a **:::no-loc text="Client":::** project and a **:::no-loc text="Server":::** project. If the two projects aren't present, start over and confirm selection of the **ASP.NET Core hosted** checkbox before selecting **Create**.
+1. Confirm that a hosted Blazor WebAssembly app was created: In **Solution Explorer**, confirm the presence of a **:::no-loc text="Client":::** project and a **:::no-loc text="Server":::** project. If the two projects aren't present, start over and confirm selection of the **ASP.NET Core Hosted** checkbox before selecting **Create**.
 
 # [.NET Core CLI](#tab/netcore-cli/)
 
@@ -669,7 +669,7 @@ To configure Visual Studio Code assets in the `.vscode` folder for debugging, se
 
 1. Choose the **Blazor WebAssembly App** template. Select **Continue**.
 
-1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core hosted** checkbox. Select **Continue**.
+1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core Hosted** checkbox. Select **Continue**.
 
 1. In the **Project name** field, name the app `BlazorWebAssemblySignalRApp`. Select **Create**.
 
@@ -677,7 +677,7 @@ To configure Visual Studio Code assets in the `.vscode` folder for debugging, se
 
 1. Open the project by navigating to the project folder and opening the project's [solution](xref:blazor/tooling#visual-studio-solution-file-sln) file (`.sln`).
 
-1. Confirm that a hosted Blazor WebAssembly app was created: In **Solution Explorer**, confirm the presence of a **:::no-loc text="Client":::** project and a **:::no-loc text="Server":::** project. If the two projects aren't present, start over and confirm selection of the **ASP.NET Core hosted** checkbox before selecting **Create**.
+1. Confirm that a hosted Blazor WebAssembly app was created: In **Solution Explorer**, confirm the presence of a **:::no-loc text="Client":::** project and a **:::no-loc text="Server":::** project. If the two projects aren't present, start over and confirm selection of the **ASP.NET Core Hosted** checkbox before selecting **Create**.
 
 # [.NET Core CLI](#tab/netcore-cli/)
 
@@ -1226,7 +1226,7 @@ To configure Visual Studio Code assets in the `.vscode` folder for debugging, se
 
 1. Choose the **Blazor WebAssembly App** template. Select **Continue**.
 
-1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core hosted** checkbox. Select **Continue**.
+1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core Hosted** checkbox. Select **Continue**.
 
 1. In the **Project name** field, name the app `BlazorWebAssemblySignalRApp`. Select **Create**.
 
@@ -1772,7 +1772,7 @@ To configure Visual Studio Code assets in the `.vscode` folder for debugging, se
 
 1. Choose the **Blazor WebAssembly App** template. Select **Continue**.
 
-1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core hosted** checkbox. Select **Continue**.
+1. Confirm that **Authentication** is set to **No Authentication**. Select the **ASP.NET Core Hosted** checkbox. Select **Continue**.
 
 1. In the **Project name** field, name the app `BlazorWebAssemblySignalRApp`. Select **Create**.
 


### PR DESCRIPTION
Fixes  #27832

... and the latest VS release now capitalizes the word "hosted" in the UI option for a hosted WASM solution (**ASP.NET Core hosted** 👉 **ASP.NET Core Hosted**), so I update that across the Blazor docs on this PR, too.