### PR TITLE
JS interop disposal guidance updates

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -238,6 +238,18 @@ Components shouldn't need to implement <xref:System.IDisposable> and <xref:Syste
 
 Developer code must ensure that <xref:System.IAsyncDisposable> implementations don't take a long time to complete.
 
+### Disposal of JavaScript interop object references
+
+Examples throughout the [JavaScript (JS) interop articles](xref:blazor/js-interop/index) demonstrate typical object disposal patterns:
+
+* When calling JS from .NET, as described in <xref:blazor/js-interop/call-javascript-from-dotnet>, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference> either from .NET or from JS to avoid leaking JS memory.
+
+* When calling .NET from JS, as described in <xref:blazor/js-interop/call-dotnet-from-javascript>, dispose of a created <xref:Microsoft.JSInterop.DotNetObjectReference> either from .NET or from JS to avoid leaking .NET memory.
+
+JS interop object references are implemented as a map keyed by an identifier on the side of the JS interop call that creates the reference. When object disposal is initiated from either the .NET or JS side, Blazor removes the entry from the map, and the object can be garbage collected as long as no other strong reference to the object is present.
+
+At a minimum, always dispose objects created on the .NET side to avoid leaking .NET managed memory.
+
 ### Document Object Model (DOM) cleanup tasks during component disposal
 
 Don't execute JS interop code for DOM cleanup tasks during component disposal. Instead, use the [`MutationObserver`](https://developer.mozilla.org/docs/Web/API/MutationObserver) pattern in JavaScript on the client for the following reasons:

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -242,7 +242,7 @@ Developer code must ensure that <xref:System.IAsyncDisposable> implementations d
 
 Examples throughout the [JavaScript (JS) interop articles](xref:blazor/js-interop/index) demonstrate typical object disposal patterns:
 
-* When calling JS from .NET, as described in <xref:blazor/js-interop/call-javascript-from-dotnet>, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference> either from .NET or from JS to avoid leaking JS memory.
+* When calling JS from .NET, as described in <xref:blazor/js-interop/call-javascript-from-dotnet>, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference>/`JSObjectReference` either from .NET or from JS to avoid leaking JS memory.
 
 * When calling .NET from JS, as described in <xref:blazor/js-interop/call-dotnet-from-javascript>, dispose of a created <xref:Microsoft.JSInterop.DotNetObjectReference> either from .NET or from JS to avoid leaking .NET memory.
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -622,6 +622,9 @@ Handlers are only executed for internal navigation within the app. If the user s
 
 Implement <xref:System.IDisposable> and dispose registered handlers to unregister them. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
 
+> [!IMPORTANT]
+> Don't attempt to execute Document Object Model (DOM) cleanup tasks via JavaScript (JS) interop when handling location changes. Use the [`MutationObserver`](https://developer.mozilla.org/docs/Web/API/MutationObserver) pattern in JS on the client. For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#document-object-model-dom-cleanup-tasks-during-component-disposal>.
+
 In the following example, a location changing handler is registered for navigation events.
 
 `Pages/NavHandler.razor`:

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -126,7 +126,7 @@ In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAs
 Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the [JS `Object`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
 ```javascript
-DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', 
+DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject', 
   DotNet.createJSObjectReference(window));
 ```
 
@@ -138,7 +138,7 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 }
 ```
 
-In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 > [!NOTE]
 > The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
@@ -148,12 +148,12 @@ Maintaining a reference to a `JSObjectReference` requires disposing of it to avo
 ```javascript
 var jsObjectReference = DotNet.createJSObjectReference(window);
 
-DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', jsObjectReference);
+DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject', jsObjectReference);
 
 DotNet.disposeJSObjectReference(jsObjectReference);
 ```
 
-In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream reference so that it can be passed to .NET, where `streamReference` is an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob), or any [typed array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), such as [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) or [`Float32Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array), used to create the JS stream reference.
 
@@ -979,7 +979,7 @@ In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAs
 Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the [JS `Object`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
 ```javascript
-DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', 
+DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject', 
   DotNet.createJSObjectReference(window));
 ```
 
@@ -991,7 +991,7 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 }
 ```
 
-In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 > [!NOTE]
 > The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
@@ -1001,12 +1001,12 @@ Maintaining a reference to a `JSObjectReference` requires disposing of it to avo
 ```javascript
 var jsObjectReference = DotNet.createJSObjectReference(window);
 
-DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', jsObjectReference);
+DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject', jsObjectReference);
 
 DotNet.disposeJSObjectReference(jsObjectReference);
 ```
 
-In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream reference so that it can be passed to .NET, where `streamReference` is an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob), or any [typed array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), such as [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) or [`Float32Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array), used to create the JS stream reference.
 
@@ -1810,7 +1810,7 @@ In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAs
 Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the [JS `Object`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
 ```javascript
-DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', 
+DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject', 
   DotNet.createJSObjectReference(window));
 ```
 
@@ -1822,7 +1822,7 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 }
 ```
 
-In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 > [!NOTE]
 > The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
@@ -1832,12 +1832,12 @@ Maintaining a reference to a `JSObjectReference` requires disposing of it to avo
 ```javascript
 var jsObjectReference = DotNet.createJSObjectReference(window);
 
-DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', jsObjectReference);
+DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject', jsObjectReference);
 
 DotNet.disposeJSObjectReference(jsObjectReference);
 ```
 
-In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream reference so that it can be passed to .NET, where `streamReference` is an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob), or any [typed array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), such as [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) or [`Float32Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array), used to create the JS stream reference.
 
@@ -2251,7 +2251,7 @@ In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAs
 Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the [JS `Object`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
 ```javascript
-DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', 
+DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject', 
   DotNet.createJSObjectReference(window));
 ```
 
@@ -2263,7 +2263,7 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 }
 ```
 
-In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 > [!NOTE]
 > The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
@@ -2273,12 +2273,12 @@ Maintaining a reference to a `JSObjectReference` requires disposing of it to avo
 ```javascript
 var jsObjectReference = DotNet.createJSObjectReference(window);
 
-DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', jsObjectReference);
+DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject', jsObjectReference);
 
 DotNet.disposeJSObjectReference(jsObjectReference);
 ```
 
-In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream reference so that it can be passed to .NET, where `streamReference` is an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob), or any [typed array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), such as [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) or [`Float32Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array), used to create the JS stream reference.
 

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -141,9 +141,9 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 > [!NOTE]
-> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
+> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't held in JS.
 
-Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference` with a call to `DotNet.disposeJSObjectReference()` for disposal of the `window` object:
+Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference`, followed by a call to `DotNet.disposeJSObjectReference()` to dispose of the reference:
 
 ```javascript
 var jsObjectReference = DotNet.createJSObjectReference(window);
@@ -994,9 +994,9 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 > [!NOTE]
-> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
+> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't held in JS.
 
-Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference` with a call to `DotNet.disposeJSObjectReference()` for disposal of the `window` object:
+Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference`, followed by a call to `DotNet.disposeJSObjectReference()` to dispose of the reference:
 
 ```javascript
 var jsObjectReference = DotNet.createJSObjectReference(window);
@@ -1825,9 +1825,9 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 > [!NOTE]
-> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
+> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't held in JS.
 
-Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference` with a call to `DotNet.disposeJSObjectReference()` for disposal of the `window` object:
+Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference`, followed by a call to `DotNet.disposeJSObjectReference()` to dispose of the reference:
 
 ```javascript
 var jsObjectReference = DotNet.createJSObjectReference(window);
@@ -2266,9 +2266,9 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 In the preceding example, the `{ASSEMBLY NAME}` placeholder is the app's namespace.
 
 > [!NOTE]
-> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
+> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't held in JS.
 
-Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference` with a call to `DotNet.disposeJSObjectReference()` for disposal of the `window` object:
+Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference`, followed by a call to `DotNet.disposeJSObjectReference()` to dispose of the reference:
 
 ```javascript
 var jsObjectReference = DotNet.createJSObjectReference(window);

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -123,10 +123,10 @@ In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAs
 
 ## Create JavaScript object and data references to pass to .NET
 
-Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the JS object used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
+Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the [JS `Object`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
 ```javascript
-DotNet.invokeMethodAsync('{APP NAMESPACE}', 'ReceiveWindowObject', 
+DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', 
   DotNet.createJSObjectReference(window));
 ```
 
@@ -138,7 +138,22 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 }
 ```
 
-In the preceding example, the `{APP NAMESPACE}` placeholder is the app's namespace.
+In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+
+> [!NOTE]
+> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
+
+Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference` with a call to `DotNet.disposeJSObjectReference()` for disposal of the `window` object:
+
+```javascript
+var jsObjectReference = DotNet.createJSObjectReference(window);
+
+DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', jsObjectReference);
+
+DotNet.disposeJSObjectReference(jsObjectReference);
+```
+
+In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
 
 Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream reference so that it can be passed to .NET, where `streamReference` is an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob), or any [typed array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), such as [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) or [`Float32Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array), used to create the JS stream reference.
 
@@ -961,10 +976,10 @@ In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAs
 
 ## Create JavaScript object and data references to pass to .NET
 
-Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the JS object used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
+Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the [JS `Object`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
 ```javascript
-DotNet.invokeMethodAsync('{APP NAMESPACE}', 'ReceiveWindowObject', 
+DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', 
   DotNet.createJSObjectReference(window));
 ```
 
@@ -976,7 +991,22 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 }
 ```
 
-In the preceding example, the `{APP NAMESPACE}` placeholder is the app's namespace.
+In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+
+> [!NOTE]
+> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
+
+Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference` with a call to `DotNet.disposeJSObjectReference()` for disposal of the `window` object:
+
+```javascript
+var jsObjectReference = DotNet.createJSObjectReference(window);
+
+DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', jsObjectReference);
+
+DotNet.disposeJSObjectReference(jsObjectReference);
+```
+
+In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
 
 Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream reference so that it can be passed to .NET, where `streamReference` is an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob), or any [typed array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), such as [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) or [`Float32Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array), used to create the JS stream reference.
 
@@ -1777,10 +1807,10 @@ In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAs
 
 ## Create JavaScript object and data references to pass to .NET
 
-Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the JS object used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
+Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the [JS `Object`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
 ```javascript
-DotNet.invokeMethodAsync('{APP NAMESPACE}', 'ReceiveWindowObject', 
+DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', 
   DotNet.createJSObjectReference(window));
 ```
 
@@ -1792,7 +1822,22 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 }
 ```
 
-In the preceding example, the `{APP NAMESPACE}` placeholder is the app's namespace.
+In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+
+> [!NOTE]
+> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
+
+Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference` with a call to `DotNet.disposeJSObjectReference()` for disposal of the `window` object:
+
+```javascript
+var jsObjectReference = DotNet.createJSObjectReference(window);
+
+DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', jsObjectReference);
+
+DotNet.disposeJSObjectReference(jsObjectReference);
+```
+
+In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
 
 Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream reference so that it can be passed to .NET, where `streamReference` is an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob), or any [typed array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), such as [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) or [`Float32Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array), used to create the JS stream reference.
 
@@ -2203,10 +2248,10 @@ In the call to `DotNet.invokeMethodAsync` or `DotNet.invokeMethod` (Blazor WebAs
 
 ## Create JavaScript object and data references to pass to .NET
 
-Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the JS object used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
+Call `DotNet.createJSObjectReference(jsObject)` to construct a JS object reference so that it can be passed to .NET, where `jsObject` is the [JS `Object`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object) used to create the JS object reference. The following example passes a reference to the non-serializable `window` object to .NET, which receives it in the `ReceiveWindowObject` C# method as an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
 ```javascript
-DotNet.invokeMethodAsync('{APP NAMESPACE}', 'ReceiveWindowObject', 
+DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', 
   DotNet.createJSObjectReference(window));
 ```
 
@@ -2218,7 +2263,22 @@ public void ReceiveWindowObject(IJSObjectReference objRef)
 }
 ```
 
-In the preceding example, the `{APP NAMESPACE}` placeholder is the app's namespace.
+In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
+
+> [!NOTE]
+> The preceding example doesn't require disposal of the `JSObjectReference`, as a reference to the `window` object isn't assigned and maintained in JS.
+
+Maintaining a reference to a `JSObjectReference` requires disposing of it to avoid leaking JS memory on the client. The following example refactors the preceding code to capture a reference to the `JSObjectReference` with a call to `DotNet.disposeJSObjectReference()` for disposal of the `window` object:
+
+```javascript
+var jsObjectReference = DotNet.createJSObjectReference(window);
+
+DotNet.invokeMethodAsync('{APP ASSEMBLY}', 'ReceiveWindowObject', jsObjectReference);
+
+DotNet.disposeJSObjectReference(jsObjectReference);
+```
+
+In the preceding example, the `{APP ASSEMBLY}` placeholder is the app's namespace.
 
 Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream reference so that it can be passed to .NET, where `streamReference` is an [`ArrayBuffer`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer), [`Blob`](https://developer.mozilla.org/docs/Web/API/Blob), or any [typed array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray), such as [`Uint8Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) or [`Float32Array`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Float32Array), used to create the JS stream reference.
 

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -842,7 +842,7 @@ Examples throughout the JavaScript (JS) interop articles demonstrate typical obj
 
 * When calling .NET from JS, as described in this article, dispose of a created <xref:Microsoft.JSInterop.DotNetObjectReference> either from .NET or from JS to avoid leaking .NET memory.
 
-* When calling JS from .NET, as described in <xref:blazor/js-interop/call-javascript-from-dotnet>, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference> either from .NET or from JS to avoid leaking JS memory.
+* When calling JS from .NET, as described in <xref:blazor/js-interop/call-javascript-from-dotnet>, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference>/`JSObjectReference` either from .NET or from JS to avoid leaking JS memory.
 
 JS interop object references are implemented as a map keyed by an identifier on the side of the JS interop call that creates the reference. When object disposal is initiated from either the .NET or JS side, Blazor removes the entry from the map, and the object can be garbage collected as long as no other strong reference to the object is present.
 

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -819,7 +819,19 @@ In the preceding example:
 
 As an alternative to interacting with JavaScript (JS) in Blazor WebAssembly apps using Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface, a JS `[JSImport]`/`[JSExport]` interop API is available to apps targeting .NET 7 or later.
 
-For more information, see <xref:blazor/js-interop/import-export-interop>. 
+For more information, see <xref:blazor/js-interop/import-export-interop>.
+
+## Disposal of JavaScript interop object references
+
+Examples throughout the JavaScript (JS) interop articles demonstrate typical object disposal patterns:
+
+* When calling .NET from JS, as described in this article, dispose of a created <xref:Microsoft.JSInterop.DotNetObjectReference> either from .NET or from JS to avoid leaking .NET memory.
+
+* When calling JS from .NET, as described in <xref:blazor/js-interop/call-javascript-from-dotnet>, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference> either from .NET or from JS to avoid leaking JS memory.
+
+JS interop object references are implemented as a map keyed by an identifier on the side of the JS interop call that creates the reference. When object disposal is initiated from either the .NET or JS side, Blazor removes the entry from the map, and the object can be garbage collected as long as no other strong reference to the object is present.
+
+At a minimum, always dispose objects created on the .NET side to avoid leaking .NET managed memory.
 
 ## Document Object Model (DOM) cleanup tasks during component disposal
 

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -757,7 +757,7 @@ For more information, see <xref:blazor/js-interop/import-export-interop>.
 
 Examples throughout the JavaScript (JS) interop articles demonstrate typical object disposal patterns:
 
-* When calling JS from .NET, as described in this article, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference> either from .NET or from JS to avoid leaking JS memory.
+* When calling JS from .NET, as described in this article, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference>/`JSObjectReference` either from .NET or from JS to avoid leaking JS memory.
 
 * When calling .NET from JS, as described in <xref:blazor/js-interop/call-dotnet-from-javascript>, dispose of a created <xref:Microsoft.JSInterop.DotNetObjectReference> either from .NET or from JS to avoid leaking .NET memory.
 

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -751,7 +751,19 @@ For more information, see <xref:blazor/js-interop/import-export-interop>.
 
 Unmarshalled interop using the <xref:Microsoft.JSInterop.IJSUnmarshalledRuntime> interface is obsolete and should be replaced with JavaScript `[JSImport]`/`[JSExport]` interop.
 
-For more information, see <xref:blazor/js-interop/import-export-interop>. 
+For more information, see <xref:blazor/js-interop/import-export-interop>.
+
+## Disposal of JavaScript interop object references
+
+Examples throughout the JavaScript (JS) interop articles demonstrate typical object disposal patterns:
+
+* When calling JS from .NET, as described in this article, dispose any created <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference> either from .NET or from JS to avoid leaking JS memory.
+
+* When calling .NET from JS, as described in <xref:blazor/js-interop/call-dotnet-from-javascript>, dispose of a created <xref:Microsoft.JSInterop.DotNetObjectReference> either from .NET or from JS to avoid leaking .NET memory.
+
+JS interop object references are implemented as a map keyed by an identifier on the side of the JS interop call that creates the reference. When object disposal is initiated from either the .NET or JS side, Blazor removes the entry from the map, and the object can be garbage collected as long as no other strong reference to the object is present.
+
+At a minimum, always dispose objects created on the .NET side to avoid leaking .NET managed memory.
 
 ## Document Object Model (DOM) cleanup tasks during component disposal
 


### PR DESCRIPTION
Fixes #27536

Thanks @lonix1! 🎸 

There are two side updates that I think must be accomplished and are on this PR:

* As part of the work for this PR, I found an example that doesn't show the proper disposal pattern.
* I think it's a good idea to call out that trying to perform any kind of DOM cleanup on location changes is a BAD idea. I add an IMPORTANT note to the *Routing* article.

This PR adds new section to the *Lifecycle* topic and the two JS interop topics that ***reiterates to reinforce*** all of the existing demonstrations and written content on disposal of JS interop objects.

We exclusively show `IJSObjectReference`/`IJSInProcessObjectReference` created and disposed ***on the .NET side***. If there was something to say about disposal of that on the JS side, I'm not sure what to say and show in code. Currently, this new section states ...

> \* When calling JS from .NET, as described in \<xref:blazor/js-interop/call-javascript-from-dotnet>, dispose any created \<xref:Microsoft.JSInterop.IJSObjectReference>/\<xref:Microsoft.JSInterop.IJSInProcessObjectReference> either from .NET or from JS to avoid leaking JS memory.

... which mirrors your (Javier's) remarks at https://github.com/dotnet/aspnetcore/issues/44960#issuecomment-1308481061.

However, we're not explaining in any text or code example the disposal in JS of objects that triggers automatic .NET-side disposal (if I'm understanding this correctly).

Outside of that, I'm 👂 for anything you'd like to add and any changes to the language.