### PR TITLE
SignalR-based (Blazor Server) stage mgmt

### DIFF
--- a/aspnetcore/fundamentals/app-state.md
+++ b/aspnetcore/fundamentals/app-state.md
@@ -29,6 +29,12 @@ State can be stored using several approaches. Each approach is described later i
 | [HttpContext.Items](#httpcontextitems) | Server-side app code |
 | [Cache](#cache) | Server-side app code |
 
+## SignalR/Blazor Server and HTTP context-based state management
+
+[SignalR](xref:signalr/introduction) apps shouldn't use session state and other state management approaches that rely upon a stable HTTP context to store information. SignalR apps can store per-connection state in [`Context.Items` in the hub](xref:signalr/hubs). <!-- https://github.com/aspnet/SignalR/issues/2139 https://github.com/dotnet/AspNetCore.Docs/issues/27956 https://github.com/dotnet/AspNetCore.Docs/issues/14974 -->
+
+For more information and alternative state management approaches for Blazor Server apps, see <xref:blazor/state-management?pivots=server>.
+
 ## Cookies
 
 Cookies store data across requests. Because cookies are sent with every request, their size should be kept to a minimum. Ideally, only an identifier should be stored in a cookie with the data stored by the app. Most browsers restrict cookie size to 4096 bytes. Only a limited number of cookies are available for each domain.
@@ -270,10 +276,6 @@ If the session middleware fails to persist a session:
 The session middleware can fail to persist a session if the backing store isn't available. For example, a user stores a shopping cart in session. The user adds an item to the cart but the commit fails. The app doesn't know about the failure so it reports to the user that the item was added to their cart, which isn't true.
 
 The recommended approach to check for errors is to call `await feature.Session.CommitAsync` when the app is done writing to the session. <xref:Microsoft.AspNetCore.Http.ISession.CommitAsync*> throws an exception if the backing store is unavailable. If `CommitAsync` fails, the app can process the exception. <xref:Microsoft.AspNetCore.Http.ISession.LoadAsync*> throws under the same conditions when the data store is unavailable.
-  
-## SignalR and session state
-
-SignalR apps should not use session state to store information. SignalR apps can store per connection state in `Context.Items` in the hub. <!-- https://github.com/aspnet/SignalR/issues/2139 -->
 
 ## Additional resources
 
@@ -304,6 +306,12 @@ State can be stored using several approaches. Each approach is described later i
 | [Hidden fields](#hidden-fields) | HTTP form fields |
 | [HttpContext.Items](#httpcontextitems) | Server-side app code |
 | [Cache](#cache) | Server-side app code |
+
+## SignalR/Blazor Server and HTTP context-based state management
+
+[SignalR](xref:signalr/introduction) apps shouldn't use session state and other state management approaches that rely upon a stable HTTP context to store information. SignalR apps can store per-connection state in [`Context.Items` in the hub](xref:signalr/hubs). <!-- https://github.com/aspnet/SignalR/issues/2139 https://github.com/dotnet/AspNetCore.Docs/issues/27956 https://github.com/dotnet/AspNetCore.Docs/issues/14974 -->
+
+For more information and alternative state management approaches for Blazor Server apps, see <xref:blazor/state-management?pivots=server>.
 
 ## Cookies
 
@@ -543,10 +551,6 @@ If the session middleware fails to persist a session:
 The session middleware can fail to persist a session if the backing store isn't available. For example, a user stores a shopping cart in session. The user adds an item to the cart but the commit fails. The app doesn't know about the failure so it reports to the user that the item was added to their cart, which isn't true.
 
 The recommended approach to check for errors is to call `await feature.Session.CommitAsync` when the app is done writing to the session. <xref:Microsoft.AspNetCore.Http.ISession.CommitAsync*> throws an exception if the backing store is unavailable. If `CommitAsync` fails, the app can process the exception. <xref:Microsoft.AspNetCore.Http.ISession.LoadAsync*> throws under the same conditions when the data store is unavailable.
-  
-## SignalR and session state
-
-SignalR apps should not use session state to store information. SignalR apps can store per connection state in `Context.Items` in the hub. <!-- https://github.com/aspnet/SignalR/issues/2139 -->
 
 ## Additional resources
 

--- a/aspnetcore/fundamentals/app-state.md
+++ b/aspnetcore/fundamentals/app-state.md
@@ -31,9 +31,7 @@ State can be stored using several approaches. Each approach is described later i
 
 ## SignalR/Blazor Server and HTTP context-based state management
 
-[SignalR](xref:signalr/introduction) apps shouldn't use session state and other state management approaches that rely upon a stable HTTP context to store information. SignalR apps can store per-connection state in [`Context.Items` in the hub](xref:signalr/hubs). <!-- https://github.com/aspnet/SignalR/issues/2139 https://github.com/dotnet/AspNetCore.Docs/issues/27956 https://github.com/dotnet/AspNetCore.Docs/issues/14974 -->
-
-For more information and alternative state management approaches for Blazor Server apps, see <xref:blazor/state-management?pivots=server>.
+[SignalR](xref:signalr/introduction) apps shouldn't use session state and other state management approaches that rely upon a stable HTTP context to store information. SignalR apps can store per-connection state in [`Context.Items` in the hub](xref:signalr/hubs). For more information and alternative state management approaches for Blazor Server apps, see <xref:blazor/state-management?pivots=server>. <!-- https://github.com/aspnet/SignalR/issues/2139 https://github.com/dotnet/AspNetCore.Docs/issues/27956 https://github.com/dotnet/AspNetCore.Docs/issues/14974 -->
 
 ## Cookies
 
@@ -309,9 +307,7 @@ State can be stored using several approaches. Each approach is described later i
 
 ## SignalR/Blazor Server and HTTP context-based state management
 
-[SignalR](xref:signalr/introduction) apps shouldn't use session state and other state management approaches that rely upon a stable HTTP context to store information. SignalR apps can store per-connection state in [`Context.Items` in the hub](xref:signalr/hubs). <!-- https://github.com/aspnet/SignalR/issues/2139 https://github.com/dotnet/AspNetCore.Docs/issues/27956 https://github.com/dotnet/AspNetCore.Docs/issues/14974 -->
-
-For more information and alternative state management approaches for Blazor Server apps, see <xref:blazor/state-management?pivots=server>.
+[SignalR](xref:signalr/introduction) apps shouldn't use session state and other state management approaches that rely upon a stable HTTP context to store information. SignalR apps can store per-connection state in [`Context.Items` in the hub](xref:signalr/hubs). For more information and alternative state management approaches for Blazor Server apps, see <xref:blazor/state-management?pivots=server>. <!-- https://github.com/aspnet/SignalR/issues/2139 https://github.com/dotnet/AspNetCore.Docs/issues/27956 https://github.com/dotnet/AspNetCore.Docs/issues/14974 -->
 
 ## Cookies
 


### PR DESCRIPTION
Fixes #28093

Thanks @baktay! 🚀 

Rick ... I'm playing with some ideas here that I hope will help surface additional concepts surrounding HTTP context-based state management and SignalR apps, including Blazor Server ...

* The section title probably should include "Blazor Server" somehow. The PR uses a slash, but parentheses or a conjunction probably work, too. A conjunction is a bit trickier, since "and" is already there.
* It's not merely "session state" but any HTTP context-based strategy, so I make wording changes along those lines. I don't get into an explicit list tho. For example, use of QS in Blazor Server apps works and is covered in the Blazor docs. I just say here that the "HTTP context-based approaches" aren't going to work.
* The prior heading isn't cross-linked anywhere (bookmarked), so this change won't 💥 the repo and send 🌍 flying out of its orbit! 😄
* I move the whole section because this is fundamental for these types of apps. It feels like it should appear closer to the top, just under the *State management* section, but that's your call ... the PR is just a suggestion/idea for surfacing this better.
* I add some cross-links. The one that I add for the `Context.Items` could go to the bookmark at *The context object* section of the SignalR *Hubs* doc; however, we've had so much trouble with broken bookmarks and no solution in sight that I'm starting to work away from them by mentioning sections in text, merely linking to the doc (as I do here), or recasting docs away from *Whole-topic Versioning* back to normal use of monikers ***within sections only*** (no dup sections). If you do want to do it tho, I think the section is `#the-context-object-3` for https://learn.microsoft.com/en-us/aspnet/core/signalr/hubs?view=aspnetcore-7.0#the-context-object-3, yielding `(xref:signalr/hubs#the-context-object-3)` for the article if you wish.
* I add two more hidden cross-links for future work/cross-linking here. Perhaps, the most important one will be https://github.com/dotnet/AspNetCore.Docs/issues/14974. I noticed there's a bit of state mgmt code at https://github.com/dotnet/AspNetCore.Docs/issues/27956, too. Not sure if that's still right, but I don't see anything like that in the docs based on a quick search. I'm going to chat with Dan and Artak about that Javier issue in a bit. I'm waiting on that so that I can cross-link to it from Blazor docs. I might end up taking the lead on sorting it out.
* The important thing for Blazor Server is to cross-link to the Blazor state management article, so that's here now on the PR.