### PR TITLE
Document javaScriptInitializer

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1530,12 +1530,28 @@ rootComponent.dispose();
 
 Blazor Server (`Program.cs`):
 
+Add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`.
+
+```csharp
+using BlazorSample.Shared;
+```
+
+Register the `Quote` component:
+
 ```csharp
 options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
     javaScriptInitializer: "initializeComponent");
 ```
 
 Blazor WebAssembly (`Program.cs`):
+
+Add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`.
+
+```csharp
+using BlazorSample.Shared;
+```
+
+Register the `Quote` component:
 
 ```csharp
 builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
@@ -3257,12 +3273,28 @@ rootComponent.dispose();
 
 Blazor Server (`Program.cs`):
 
+Add the namespace for the location of the component. The following example places the `Quote` component in the app's `Shared` folder, and the app's namespace is `BlazorSample`.
+
+```csharp
+using BlazorSample.Shared;
+```
+
+Register the `Quote` component:
+
 ```csharp
 options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
     javaScriptInitializer: "initializeComponent");
 ```
 
 Blazor WebAssembly (`Program.cs`):
+
+Add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`.
+
+```csharp
+using BlazorSample.Shared;
+```
+
+Register the `Quote` component:
 
 ```csharp
 builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1528,30 +1528,22 @@ rootComponent.dispose();
 }
 ```
 
-Blazor Server (`Program.cs`):
-
-Add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`.
+In `Program.cs`, add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`:
 
 ```csharp
 using BlazorSample.Shared;
 ```
 
-Register the `Quote` component:
+In `Program.cs`, register the `Quote` component.
+
+Blazor Server:
 
 ```csharp
 options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
     javaScriptInitializer: "initializeComponent");
 ```
 
-Blazor WebAssembly (`Program.cs`):
-
-Add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`.
-
-```csharp
-using BlazorSample.Shared;
-```
-
-Register the `Quote` component:
+Blazor WebAssembly:
 
 ```csharp
 builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
@@ -3271,30 +3263,22 @@ rootComponent.dispose();
 }
 ```
 
-Blazor Server (`Program.cs`):
-
-Add the namespace for the location of the component. The following example places the `Quote` component in the app's `Shared` folder, and the app's namespace is `BlazorSample`.
+In `Program.cs`, add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`:
 
 ```csharp
 using BlazorSample.Shared;
 ```
 
-Register the `Quote` component:
+In `Program.cs`, register the `Quote` component.
+
+Blazor Server:
 
 ```csharp
 options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
     javaScriptInitializer: "initializeComponent");
 ```
 
-Blazor WebAssembly (`Program.cs`):
-
-Add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`.
-
-```csharp
-using BlazorSample.Shared;
-```
-
-Register the `Quote` component:
+Blazor WebAssembly:
 
 ```csharp
 builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -3230,55 +3230,12 @@ For more information, see the following resources:
 
 Razor components can be dynamically-rendered from JavaScript (JS) for existing JS apps.
 
-To render a Razor component from JS, register the component as a root component for JS rendering and assign the component an identifier:
-
-* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
-
-  ```csharp
-  builder.Services.AddServerSideBlazor(options =>
-  {
-      options.RootComponents.RegisterForJavaScript<Counter>(identifier: "counter");
-  });
-  ```
-  
-  > [!NOTE]
-  > The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
-
-* In a Blazor WebAssembly app, call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
-
-  ```csharp
-  builder.RootComponents.RegisterForJavaScript<Counter>(identifier: "counter");
-  ```
-  
-  > [!NOTE]
-  > The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
-
-Load Blazor into the JS app (`blazor.server.js` or `blazor.webassembly.js`). Render the component from JS into a container element using the registered identifier, passing component parameters as needed:
-
-```javascript
-let containerElement = document.getElementById('my-counter');
-await window.Blazor.rootComponents.add(containerElement, 'counter', { incrementAmount: 10 });
-```
-
-`rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
-
-```javascript
-const rootComponent = await window.Blazor.rootComponents.add(...);
-
-...
-
-rootComponent.dispose();
-```
-
-<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts a JS function to register the custom element (`javaScriptInitializer`). The following example demonstrates the dynamic registration of a component that renders a quote.
-
-> [!IMPORTANT]
-> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
+The example in this section renders the following Razor component into a page via JS.
 
 `Shared/Quote.razor`:
 
 ```razor
-<div id="quoteDiv" class="m-5 p-5">
+<div class="m-5 p-5">
     <h2>Quote</h2>
     <p>@Text</p>
 </div>
@@ -3295,46 +3252,115 @@ In `Program.cs`, add the namespace for the location of the component. The follow
 using BlazorSample.Shared;
 ```
 
-In `Program.cs`, register the `Quote` component.
+Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the `Quote` component as a root component for JS rendering. Assign the component an identifier, `quote` in the following example. 
 
-Blazor Server:
+<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that performs initialization logic after the component gets registered (`javaScriptInitializer`). The JS function is called immediately after the Blazor app starts, before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework. The following example demonstrates the dynamic registration of the preceding `Quote` component.
 
-```csharp
-options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-    javaScriptInitializer: "initializeComponent");
+* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
+
+  ```csharp
+  builder.Services.AddServerSideBlazor(options =>
+  {
+      options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+          javaScriptInitializer: "jsComponentInitializers.initializeComponent");
+  });
+  ```
+
+* In a Blazor WebAssembly app, call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
+
+  ```csharp
+  builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+      javaScriptInitializer: "jsComponentInitializers.initializeComponent");
+  ```
+  
+> [!IMPORTANT]
+> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
+
+Attach the initializer function with `name` and `parameters` function parameters to the `window` object. For demonstration purposes, the following `initializeComponent` function logs the name and parameters of the registered component.
+
+`wwwroot/js/jsComponentInitializers.js`:
+
+```javascript
+(function () {
+  window.jsComponentInitializers = {
+    initializeComponent: function (name, parameters) {
+      console.log({ name: name, parameters: parameters });
+    }
+  };
+})();
 ```
 
-Blazor WebAssembly:
+Render the component from JS into a container element using the registered identifier, passing component parameters as needed. 
 
-```csharp
-builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-    javaScriptInitializer: "initializeComponent");
+In the following example:
+
+* The `Quote` component (`quote` identifier) is rendered into the `quoteContainer` element when the `showQuote` function is called.
+* A quote string is passed to the component's `Text` parameter.
+
+`wwwroot/js/scripts.js`:
+
+```javascript
+async function showQuote() {
+  let targetElement = document.getElementById('quoteContainer');
+  await Blazor.rootComponents.add(targetElement, 'quote', 
+  {
+    text: "Crow: I have my doubts that this movie is actually 'starring' " +
+      "anybody. More like, 'camera is generally pointed at.'"
+  });
+}
 ```
 
-In HTML:
+Load Blazor (`blazor.server.js` or `blazor.webassembly.js`) with the preceding scripts into the JS app:
+
+```html
+<script src="_framework/blazor.{server|webassembly}.js"></script>
+<script src="js/jsComponentInitializers.js"></script>
+<script src="js/scripts.js"></script>
+```
+
+In HTML, place the target container element (`quoteContainer`). For the demonstration in this section, a button triggers rendering the `Quote` component by calling the `showQuote` JS function:
 
 ```html
 <button onclick="showQuote()">Show Quote</button>
 
 <div id="quoteContainer"></div>
-
-<script>
-  async function showQuote() {
-    let targetElement = document.getElementById('quoteContainer');
-    await Blazor.rootComponents.add(targetElement, 'quote', 
-    {
-        text: "Crow: I have my doubts that this movie is actually 'starring' " +
-        "anybody. More like, 'camera is generally pointed at.'"
-    });
-  }
-
-  async function initializeComponent() {
-    console.log("initializeComponent called!");
-  }
-</script>
 ```
 
+On initialization before any components are rendered, the browser's developer tools console logs the `Quote` component's identifier (`name`) and parameters (`parameters`) when `initializeComponent` is called:
+
+```console
+Object { name: "quote", parameters: (1) […] }
+​  name: "quote"
+​  parameters: Array [ {…} ]
+​​    0: Object { name: "Text", type: "string" }
+​​    length: 1
+```
+
+The `Quote` component is rendered with the quote stored in `Text` displayed:
+
+<h3>:::no-loc text="Quote":::</h3>
+<p>:::no-loc text="Crow: I have my doubts that this movie is actually 'starring' anybody. More like, 'camera is generally pointed at.'":::</p>
+
 Quote &copy;1988-1999 Satellite of Love LLC: [*Mystery Science Theater 3000*](https://mst3k.com/) ([Trace Beaulieu (Crow)](https://www.imdb.com/name/nm0064546/))
+
+> [!NOTE]
+> `rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
+>
+> ```javascript
+> const rootComponent = await window.Blazor.rootComponents.add(...);
+>
+> ...
+>
+> rootComponent.dispose();
+> ```
+
+For an advanced example with additional features, see the example in the `BasicTestApp` of the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository):
+
+* [`JavaScriptRootComponents.razor`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/JavaScriptRootComponents.razor)
+* [`wwwroot/js/jsRootComponentInitializers.js`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsRootComponentInitializers.js)
+* [`wwwroot/index.html`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/index.html)
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 ## Blazor custom elements
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1495,7 +1495,10 @@ Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtension
 
 <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that executes initialization logic (`javaScriptInitializer`). The JS function is called once per component registration immediately after the Blazor app starts and before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework.
 
-One or more initializer functions can be created and called by different component registrations, but the typical use case is to reuse the same initializer function for multiple components. One function is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
+One or more initializer functions can be created and called by different component registrations. The typical use case is to reuse the same initializer function for multiple components, which is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
+
+> [!IMPORTANT]
+> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
 
 The following example demonstrates the dynamic registration of the preceding `Quote` component with "`quote`" as the identifier.
 
@@ -1515,9 +1518,6 @@ The following example demonstrates the dynamic registration of the preceding `Qu
   builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
       javaScriptInitializer: "initializeComponent");
   ```
-  
-> [!IMPORTANT]
-> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
 
 Attach the initializer function with `name` and `parameters` function parameters to the `window` object. For demonstration purposes, the following `initializeComponent` function logs the name and parameters of the registered component.
 
@@ -1575,7 +1575,7 @@ Object { name: "quote", parameters: (1) […] }
 ​​    length: 1
 ```
 
-The `Quote` component is rendered with the quote stored in `Text` displayed:
+When the **:::no-loc text="Show Quote":::** button is selected, the `Quote` component is rendered with the quote stored in `Text` displayed:
 
 <h3>:::no-loc text="Quote":::</h3>
 <p>:::no-loc text="Crow: I have my doubts that this movie is actually 'starring' anybody. More like, 'camera is generally pointed at.'":::</p>
@@ -3256,7 +3256,10 @@ Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtension
 
 <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that executes initialization logic (`javaScriptInitializer`). The JS function is called once per component registration immediately after the Blazor app starts and before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework.
 
-One or more initializer functions can be created and called by different component registrations, but the typical use case is to reuse the same initializer function for multiple components. One function is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
+One or more initializer functions can be created and called by different component registrations. The typical use case is to reuse the same initializer function for multiple components, which is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
+
+> [!IMPORTANT]
+> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
 
 The following example demonstrates the dynamic registration of the preceding `Quote` component with "`quote`" as the identifier.
 
@@ -3276,9 +3279,6 @@ The following example demonstrates the dynamic registration of the preceding `Qu
   builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
       javaScriptInitializer: "initializeComponent");
   ```
-  
-> [!IMPORTANT]
-> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
 
 Attach the initializer function with `name` and `parameters` function parameters to the `window` object. For demonstration purposes, the following `initializeComponent` function logs the name and parameters of the registered component.
 
@@ -3336,7 +3336,7 @@ Object { name: "quote", parameters: (1) […] }
 ​​    length: 1
 ```
 
-The `Quote` component is rendered with the quote stored in `Text` displayed:
+When the **:::no-loc text="Show Quote":::** button is selected, the `Quote` component is rendered with the quote stored in `Text` displayed:
 
 <h3>:::no-loc text="Quote":::</h3>
 <p>:::no-loc text="Crow: I have my doubts that this movie is actually 'starring' anybody. More like, 'camera is generally pointed at.'":::</p>

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1469,55 +1469,12 @@ For more information, see the following resources:
 
 Razor components can be dynamically-rendered from JavaScript (JS) for existing JS apps.
 
-To render a Razor component from JS, register the component as a root component for JS rendering and assign the component an identifier:
-
-* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
-
-  ```csharp
-  builder.Services.AddServerSideBlazor(options =>
-  {
-      options.RootComponents.RegisterForJavaScript<Counter>(identifier: "counter");
-  });
-  ```
-  
-  > [!NOTE]
-  > The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
-
-* In a Blazor WebAssembly app, call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
-
-  ```csharp
-  builder.RootComponents.RegisterForJavaScript<Counter>(identifier: "counter");
-  ```
-  
-  > [!NOTE]
-  > The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
-
-Load Blazor into the JS app (`blazor.server.js` or `blazor.webassembly.js`). Render the component from JS into a container element using the registered identifier, passing component parameters as needed:
-
-```javascript
-let containerElement = document.getElementById('my-counter');
-await window.Blazor.rootComponents.add(containerElement, 'counter', { incrementAmount: 10 });
-```
-
-`rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
-
-```javascript
-const rootComponent = await window.Blazor.rootComponents.add(...);
-
-...
-
-rootComponent.dispose();
-```
-
-<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts a JS function to register the custom element (`javaScriptInitializer`). The following example demonstrates the dynamic registration of a component that renders a quote.
-
-> [!IMPORTANT]
-> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
+The example in this section renders the following Razor component into a page via JS.
 
 `Shared/Quote.razor`:
 
 ```razor
-<div id="quoteDiv" class="m-5 p-5">
+<div class="m-5 p-5">
     <h2>Quote</h2>
     <p>@Text</p>
 </div>
@@ -1534,46 +1491,115 @@ In `Program.cs`, add the namespace for the location of the component. The follow
 using BlazorSample.Shared;
 ```
 
-In `Program.cs`, register the `Quote` component.
+Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the `Quote` component as a root component for JS rendering. Assign the component an identifier, `quote` in the following example. 
 
-Blazor Server:
+<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that performs initialization logic after the component gets registered (`javaScriptInitializer`). The JS function is called immediately after the Blazor app starts, before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework. The following example demonstrates the dynamic registration of the preceding `Quote` component.
 
-```csharp
-options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-    javaScriptInitializer: "initializeComponent");
+* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
+
+  ```csharp
+  builder.Services.AddServerSideBlazor(options =>
+  {
+      options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+          javaScriptInitializer: "jsComponentInitializers.initializeComponent");
+  });
+  ```
+
+* In a Blazor WebAssembly app, call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
+
+  ```csharp
+  builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+      javaScriptInitializer: "jsComponentInitializers.initializeComponent");
+  ```
+  
+> [!IMPORTANT]
+> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
+
+Attach the initializer function with `name` and `parameters` function parameters to the `window` object. For demonstration purposes, the following `initializeComponent` function logs the name and parameters of the registered component.
+
+`wwwroot/js/jsComponentInitializers.js`:
+
+```javascript
+(function () {
+  window.jsComponentInitializers = {
+    initializeComponent: function (name, parameters) {
+      console.log({ name: name, parameters: parameters });
+    }
+  };
+})();
 ```
 
-Blazor WebAssembly:
+Render the component from JS into a container element using the registered identifier, passing component parameters as needed. 
 
-```csharp
-builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-    javaScriptInitializer: "initializeComponent");
+In the following example:
+
+* The `Quote` component (`quote` identifier) is rendered into the `quoteContainer` element when the `showQuote` function is called.
+* A quote string is passed to the component's `Text` parameter.
+
+`wwwroot/js/scripts.js`:
+
+```javascript
+async function showQuote() {
+  let targetElement = document.getElementById('quoteContainer');
+  await Blazor.rootComponents.add(targetElement, 'quote', 
+  {
+    text: "Crow: I have my doubts that this movie is actually 'starring' " +
+      "anybody. More like, 'camera is generally pointed at.'"
+  });
+}
 ```
 
-In HTML:
+Load Blazor (`blazor.server.js` or `blazor.webassembly.js`) with the preceding scripts into the JS app:
+
+```html
+<script src="_framework/blazor.{server|webassembly}.js"></script>
+<script src="js/jsComponentInitializers.js"></script>
+<script src="js/scripts.js"></script>
+```
+
+In HTML, place the target container element (`quoteContainer`). For the demonstration in this section, a button triggers rendering the `Quote` component by calling the `showQuote` JS function:
 
 ```html
 <button onclick="showQuote()">Show Quote</button>
 
 <div id="quoteContainer"></div>
-
-<script>
-  async function showQuote() {
-    let targetElement = document.getElementById('quoteContainer');
-    await Blazor.rootComponents.add(targetElement, 'quote', 
-    {
-        text: "Crow: I have my doubts that this movie is actually 'starring' " +
-        "anybody. More like, 'camera is generally pointed at.'"
-    });
-  }
-
-  async function initializeComponent() {
-    console.log("initializeComponent called!");
-  }
-</script>
 ```
 
+On initialization before any components are rendered, the browser's developer tools console logs the `Quote` component's identifier (`name`) and parameters (`parameters`) when `initializeComponent` is called:
+
+```console
+Object { name: "quote", parameters: (1) […] }
+​  name: "quote"
+​  parameters: Array [ {…} ]
+​​    0: Object { name: "Text", type: "string" }
+​​    length: 1
+```
+
+The `Quote` component is rendered with the quote stored in `Text` displayed:
+
+<h3>:::no-loc text="Quote":::</h3>
+<p>:::no-loc text="Crow: I have my doubts that this movie is actually 'starring' anybody. More like, 'camera is generally pointed at.'":::</p>
+
 Quote &copy;1988-1999 Satellite of Love LLC: [*Mystery Science Theater 3000*](https://mst3k.com/) ([Trace Beaulieu (Crow)](https://www.imdb.com/name/nm0064546/))
+
+> [!NOTE]
+> `rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
+>
+> ```javascript
+> const rootComponent = await window.Blazor.rootComponents.add(...);
+>
+> ...
+>
+> rootComponent.dispose();
+> ```
+
+For an advanced example with additional features, see the example in the `BasicTestApp` of the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository):
+
+* [`JavaScriptRootComponents.razor`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/JavaScriptRootComponents.razor)
+* [`wwwroot/js/jsRootComponentInitializers.js`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsRootComponentInitializers.js)
+* [`wwwroot/index.html`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/index.html)
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 ## Blazor custom elements
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1509,6 +1509,64 @@ const rootComponent = await window.Blazor.rootComponents.add(...);
 rootComponent.dispose();
 ```
 
+<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts a JS function to register the custom element (`javaScriptInitializer`). The following example demonstrates the dynamic registration of a component that renders a quote.
+
+> [!IMPORTANT]
+> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
+
+`Shared/Quote.razor`:
+
+```razor
+<div id="quoteDiv" class="m-5 p-5">
+    <h2>Quote</h2>
+    <p>@Text</p>
+</div>
+
+@code {
+    [Parameter]
+    public string? Text { get; set; }
+}
+```
+
+Blazor Server (`Program.cs`):
+
+```csharp
+options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+    javaScriptInitializer: "initializeComponent");
+```
+
+Blazor WebAssembly (`Program.cs`):
+
+```csharp
+builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+    javaScriptInitializer: "initializeComponent");
+```
+
+In HTML:
+
+```html
+<button onclick="showQuote()">Show Quote</button>
+
+<div id="quoteContainer"></div>
+
+<script>
+  async function showQuote() {
+    let targetElement = document.getElementById('quoteContainer');
+    await Blazor.rootComponents.add(targetElement, 'quote', 
+    {
+        text: "Crow: I have my doubts that this movie is actually 'starring' " +
+        "anybody. More like, 'camera is generally pointed at.'"
+    });
+  }
+
+  async function initializeComponent() {
+    console.log("initializeComponent called!");
+  }
+</script>
+```
+
+Quote &copy;1988-1999 Satellite of Love LLC: [*Mystery Science Theater 3000*](https://mst3k.com/) ([Trace Beaulieu (Crow)](https://www.imdb.com/name/nm0064546/))
+
 ## Blazor custom elements
 
 Use Blazor custom elements to dynamically render Razor components from other SPA frameworks, such as Angular or React.
@@ -3177,6 +3235,64 @@ const rootComponent = await window.Blazor.rootComponents.add(...);
 
 rootComponent.dispose();
 ```
+
+<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts a JS function to register the custom element (`javaScriptInitializer`). The following example demonstrates the dynamic registration of a component that renders a quote.
+
+> [!IMPORTANT]
+> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
+
+`Shared/Quote.razor`:
+
+```razor
+<div id="quoteDiv" class="m-5 p-5">
+    <h2>Quote</h2>
+    <p>@Text</p>
+</div>
+
+@code {
+    [Parameter]
+    public string? Text { get; set; }
+}
+```
+
+Blazor Server (`Program.cs`):
+
+```csharp
+options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+    javaScriptInitializer: "initializeComponent");
+```
+
+Blazor WebAssembly (`Program.cs`):
+
+```csharp
+builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+    javaScriptInitializer: "initializeComponent");
+```
+
+In HTML:
+
+```html
+<button onclick="showQuote()">Show Quote</button>
+
+<div id="quoteContainer"></div>
+
+<script>
+  async function showQuote() {
+    let targetElement = document.getElementById('quoteContainer');
+    await Blazor.rootComponents.add(targetElement, 'quote', 
+    {
+        text: "Crow: I have my doubts that this movie is actually 'starring' " +
+        "anybody. More like, 'camera is generally pointed at.'"
+    });
+  }
+
+  async function initializeComponent() {
+    console.log("initializeComponent called!");
+  }
+</script>
+```
+
+Quote &copy;1988-1999 Satellite of Love LLC: [*Mystery Science Theater 3000*](https://mst3k.com/) ([Trace Beaulieu (Crow)](https://www.imdb.com/name/nm0064546/))
 
 ## Blazor custom elements
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1491,9 +1491,13 @@ In `Program.cs`, add the namespace for the location of the component. The follow
 using BlazorSample.Shared;
 ```
 
-Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the `Quote` component as a root component for JS rendering. Assign the component an identifier, `quote` in the following example. 
+Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the a Razor component as a root component for JS rendering.
 
-<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that performs initialization logic after the component gets registered (`javaScriptInitializer`). The JS function is called immediately after the Blazor app starts, before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework. The following example demonstrates the dynamic registration of the preceding `Quote` component.
+<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that executes initialization logic (`javaScriptInitializer`). The JS function is called once per component registration immediately after the Blazor app starts and before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework.
+
+One or more initializer functions can be created and called by different component registrations, but the typical use case is to reuse the same initializer function for multiple components. One function is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
+
+The following example demonstrates the dynamic registration of the preceding `Quote` component with "`quote`" as the identifier.
 
 * In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
 
@@ -1501,7 +1505,7 @@ Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtension
   builder.Services.AddServerSideBlazor(options =>
   {
       options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-          javaScriptInitializer: "jsComponentInitializers.initializeComponent");
+          javaScriptInitializer: "initializeComponent");
   });
   ```
 
@@ -1509,7 +1513,7 @@ Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtension
 
   ```csharp
   builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-      javaScriptInitializer: "jsComponentInitializers.initializeComponent");
+      javaScriptInitializer: "initializeComponent");
   ```
   
 > [!IMPORTANT]
@@ -1520,13 +1524,9 @@ Attach the initializer function with `name` and `parameters` function parameters
 `wwwroot/js/jsComponentInitializers.js`:
 
 ```javascript
-(function () {
-  window.jsComponentInitializers = {
-    initializeComponent: function (name, parameters) {
-      console.log({ name: name, parameters: parameters });
-    }
-  };
-})();
+window.initializeComponent = (name, parameters) => {
+  console.log({ name: name, parameters: parameters });
+}
 ```
 
 Render the component from JS into a container element using the registered identifier, passing component parameters as needed. 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -3252,9 +3252,13 @@ In `Program.cs`, add the namespace for the location of the component. The follow
 using BlazorSample.Shared;
 ```
 
-Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the `Quote` component as a root component for JS rendering. Assign the component an identifier, `quote` in the following example. 
+Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the a Razor component as a root component for JS rendering.
 
-<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that performs initialization logic after the component gets registered (`javaScriptInitializer`). The JS function is called immediately after the Blazor app starts, before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework. The following example demonstrates the dynamic registration of the preceding `Quote` component.
+<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that executes initialization logic (`javaScriptInitializer`). The JS function is called once per component registration immediately after the Blazor app starts and before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework.
+
+One or more initializer functions can be created and called by different component registrations, but the typical use case is to reuse the same initializer function for multiple components. One function is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
+
+The following example demonstrates the dynamic registration of the preceding `Quote` component with "`quote`" as the identifier.
 
 * In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
 
@@ -3262,7 +3266,7 @@ Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtension
   builder.Services.AddServerSideBlazor(options =>
   {
       options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-          javaScriptInitializer: "jsComponentInitializers.initializeComponent");
+          javaScriptInitializer: "initializeComponent");
   });
   ```
 
@@ -3270,7 +3274,7 @@ Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtension
 
   ```csharp
   builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-      javaScriptInitializer: "jsComponentInitializers.initializeComponent");
+      javaScriptInitializer: "initializeComponent");
   ```
   
 > [!IMPORTANT]
@@ -3281,13 +3285,9 @@ Attach the initializer function with `name` and `parameters` function parameters
 `wwwroot/js/jsComponentInitializers.js`:
 
 ```javascript
-(function () {
-  window.jsComponentInitializers = {
-    initializeComponent: function (name, parameters) {
-      console.log({ name: name, parameters: parameters });
-    }
-  };
-})();
+window.initializeComponent = (name, parameters) => {
+  console.log({ name: name, parameters: parameters });
+}
 ```
 
 Render the component from JS into a container element using the registered identifier, passing component parameters as needed. 


### PR DESCRIPTION
Fixes #28135

[Internal Review Topic (links to section)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/index?view=aspnetcore-8.0&branch=pr-en-us-28140#render-razor-components-from-javascript)

Mackinnon: @SQL-MisterMagoo [asked in 2021 about coverage for javaScriptInitializer in a PU issue](https://github.com/dotnet/aspnetcore/issues/37181#issuecomment-940567797) that I didn't see until yesterday. I'm going to work on that here ***and*** use the opportunity to knock up a quick example of the whole feature, along the lines of my usual ***fully-working, cut-'n-paste demos*** 👍 that makes it easy for devs to see how features compose.

In addition to just checking the basic technical aspects, I've hit a knowledge gap (not surprising for the 🦖🙈) on part of the coverage. The API states the following:

> **javaScriptInitializer**: Specifies an optional identifier for a JavaScript function that will be called to register the custom element.

Cross-ref: https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.web.jscomponentconfigurationextensions.registerforjavascript?view=aspnetcore-7.0

In *my goofy MST quote demo* 😄, I can see my `initializeComponent` FN being called, but I'm not sure what I can do there given that I'm not a JS jockey for non-MS SPA frameworks ...

* Can that do *something* better than just `console.log(...)` that would be germane to the demo?
* What is meant by "to register the custom element" in the param definition? Whatever that means, I think we want to steer clear of "custom elements" language (i.e., "Blazor custom elements") right? ... which is in the very next section of the doc here. I thought it was more like a JS FN that's ***called for initialization/configuration purposes*** ... *guessing* 🤔 of course.
* WRT timing of the JS FN call: It seems to be called before the component is rendered. Is that correct? It seems like the text should say that if that's the case. I'd like to add some kind of remark on the timing of the call.