### PR TITLE
Timeouts disabled when debugger is attached

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -47,9 +47,9 @@ The following timeouts and rate limits aren't enforced when a debugger is attach
 * <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.RequestHeadersTimeout?displayProperty=nameWithType>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinRequestBodyDataRate?displayProperty=nameWithType>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinResponseDataRate?displayProperty=nameWithType>
-* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IConnectionTimeoutFeature?displayProperty=nameWithType>
-* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinRequestBodyDataRateFeature?displayProperty=nameWithType>
-* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseDataRateFeature?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IConnectionTimeoutFeature>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinRequestBodyDataRateFeature>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseDataRateFeature>
 
 ## Additional resources
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -49,7 +49,7 @@ The following timeouts and rate limits aren't enforced when a debugger is attach
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinResponseDataRate?displayProperty=nameWithType>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IConnectionTimeoutFeature?displayProperty=nameWithType>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinRequestBodyDataRateFeature?displayProperty=nameWithType>
-* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseBodyDataRateFeature?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseDataRateFeature?displayProperty=nameWithType>
 
 ## Additional resources
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -45,9 +45,9 @@ The following timeouts and rate limits aren't enforced when a debugger is attach
 
 * <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.KeepAliveTimeout?displayProperty=nameWithType>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.RequestHeadersTimeout?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinRequestBodyDataRate?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinResponseDataRate?displayProperty=nameWithType>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IConnectionTimeoutFeature?displayProperty=nameWithType>
-* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.MinRequestBodyDataRate?displayProperty=nameWithType>
-* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.MinResponseDataRate?displayProperty=nameWithType>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinRequestBodyDataRateFeature?displayProperty=nameWithType>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseBodyDataRateFeature?displayProperty=nameWithType>
 

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -5,7 +5,7 @@ description: Learn about Kestrel, the cross-platform web server for ASP.NET Core
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/01/2022
+ms.date: 01/26/2023
 uid: fundamentals/servers/kestrel
 ---
 # Kestrel web server implementation in ASP.NET Core
@@ -38,6 +38,18 @@ For more information on configuring `WebApplication` and `WebApplicationBuilder`
 ## Optional client certificates
 
 For information on apps that must protect a subset of the app with a certificate, see [Optional client certificates](xref:security/authentication/certauth#optional-client-certificates).
+
+## Behavior with debugger attached
+
+The following timeouts and rate limits aren't enforced when a debugger is attached to a Kestrel process:
+
+* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.KeepAliveTimeout?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.RequestHeadersTimeout?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IConnectionTimeoutFeature?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.MinRequestBodyDataRate?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.MinResponseDataRate?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinRequestBodyDataRateFeature?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseBodyDataRateFeature?displayProperty=nameWithType>
 
 ## Additional resources
 

--- a/aspnetcore/fundamentals/servers/kestrel/diagnostics.md
+++ b/aspnetcore/fundamentals/servers/kestrel/diagnostics.md
@@ -116,4 +116,4 @@ app.Run();
 
 ## Behavior with debugger attached
 
-Certain timeouts and rate limits aren't enforced when a debugger is attached to a Kestrel process. For more information, see [Behavior with debugger attached](../kestrel.md#behavior-with-debugger-attached).
+Certain timeouts and rate limits aren't enforced when a debugger is attached to a Kestrel process. For more information, see [Behavior with debugger attached](xref:fundamentals/servers/kestrel#behavior-with-debugger-attached).

--- a/aspnetcore/fundamentals/servers/kestrel/diagnostics.md
+++ b/aspnetcore/fundamentals/servers/kestrel/diagnostics.md
@@ -4,7 +4,7 @@ author: shirhatti
 description: Learn how to gather diagnostics from Kestrel.
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
-ms.date: 07/01/2021
+ms.date: 01/26/2023
 uid: fundamentals/servers/kestrel/diagnostics
 ---
 
@@ -113,3 +113,7 @@ using var badRequestListener = new BadRequestEventListener(diagnosticSource, (ba
 app.MapGet("/", () => "Hello world");
 app.Run();
 ```
+
+## Behavior with debugger attached
+
+Certain timeouts and rate limits aren't enforced when a debugger is attached to a Kestrel process. For more information, see [Behavior with debugger attached](../kestrel.md#behavior-with-debugger-attached).

--- a/aspnetcore/fundamentals/servers/kestrel/options.md
+++ b/aspnetcore/fundamentals/servers/kestrel/options.md
@@ -186,7 +186,7 @@ For information about other Kestrel options and limits, see:
     
 ## Behavior with debugger attached
 
-Certain timeouts and rate limits aren't enforced when a debugger is attached to a Kestrel process. For more information, see [Behavior with debugger attached](../kestrel.md#behavior-with-debugger-attached).
+Certain timeouts and rate limits aren't enforced when a debugger is attached to a Kestrel process. For more information, see [Behavior with debugger attached](xref:fundamentals/servers/kestrel#behavior-with-debugger-attached).
 
 :::moniker-end
 

--- a/aspnetcore/fundamentals/servers/kestrel/options.md
+++ b/aspnetcore/fundamentals/servers/kestrel/options.md
@@ -5,7 +5,7 @@ description: Learn about configuring options for Kestrel, the cross-platform web
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/20/2022
+ms.date: 01/26/2023
 uid: fundamentals/servers/kestrel/options
 ---
 # Configure options for the ASP.NET Core Kestrel web server
@@ -44,6 +44,8 @@ By default, Kestrel configuration is loaded from the `Kestrel` section using a p
 <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.KeepAliveTimeout> gets or sets the [keep-alive timeout](https://www.rfc-editor.org/rfc/rfc9112.html#name-keep-alive-connections):
 
 :::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsKeepAliveTimeout" highlight="3":::
+
+This timeout is not enforced when a debugger is attached to the Kestrel process.
 
 ### Maximum client connections
 
@@ -100,6 +102,8 @@ Server-wide rate limits configured via <xref:Microsoft.AspNetCore.Server.Kestrel
 <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.RequestHeadersTimeout> gets or sets the maximum amount of time the server spends receiving request headers:
 
 :::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelLimitsRequestHeadersTimeout" highlight="3":::
+
+This timeout is not enforced when a debugger is attached to the Kestrel process.
 
 ## HTTP/2 limits
 
@@ -180,6 +184,10 @@ For information about other Kestrel options and limits, see:
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions>
     
+## Behavior with debugger attached
+
+Certain timeouts and rate limits aren't enforced when a debugger is attached to a Kestrel process. For more information, see [Behavior with debugger attached](../kestrel.md#behavior-with-debugger-attached).
+
 :::moniker-end
 
 :::moniker range="< aspnetcore-6.0"


### PR DESCRIPTION
Fixes #23945

* [Internal review URL - Kestrel](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?branch=pr-en-us-28212)
* [Internal review URL - Kestrel options](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options?branch=pr-en-us-28212)
* [Internal review URL - Kestrel diagnostics](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/diagnostics?branch=pr-en-us-28212)