### PR TITLE
Reflecting ASPNETCORE_ and DOTNET_ breaking change in .NET 7

### DIFF
--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -21,11 +21,17 @@ ASP.NET Core configures app behavior based on the runtime environment using an e
 To determine the runtime environment, ASP.NET Core reads from the following environment variables:
 
 1. [DOTNET_ENVIRONMENT](xref:fundamentals/configuration/index#default-host-configuration)
+
 :::moniker range="< aspnetcore-7.0"
+
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `ASPNETCORE_ENVIRONMENT` value overrides `DOTNET_ENVIRONMENT`.
+
 :::moniker-end
+
 :::moniker range=">= aspnetcore-7.0"
+
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `DOTNET_ENVIRONMENT` value overrides `ASPNETCORE_ENVIRONMENT` when `WebApplicationBuilder` is used. For other hosts, such as `ConfigureWebHostDefaults` and `WebHost.CreateDefaultBuilder`, `ASPNETCORE_ENVIRONMENT` has higher precedence.
+
 :::moniker-end
 
 `IHostEnvironment.EnvironmentName` can be set to any value, but the following values are provided by the framework:

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -21,7 +21,12 @@ ASP.NET Core configures app behavior based on the runtime environment using an e
 To determine the runtime environment, ASP.NET Core reads from the following environment variables:
 
 1. [DOTNET_ENVIRONMENT](xref:fundamentals/configuration/index#default-host-configuration)
+:::moniker range="< aspnetcore-7.0"
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `ASPNETCORE_ENVIRONMENT` value overrides `DOTNET_ENVIRONMENT`.
+:::moniker-end
+:::moniker range=">= aspnetcore-7.0"
+1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `DOTNET_ENVIRONMENT` value overrides `ASPNETCORE_ENVIRONMENT` when `WebApplicationBuilder` is used. For other hosts, such as `ConfigureWebHostDefaults` and `WebHost.CreateDefaultBuilder`, `ASPNETCORE_ENVIRONMENT` has higher precedence.
+:::moniker-end
 
 `IHostEnvironment.EnvironmentName` can be set to any value, but the following values are provided by the framework:
 

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -26,13 +26,13 @@ To determine the runtime environment, ASP.NET Core reads from the following envi
 
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `ASPNETCORE_ENVIRONMENT` value overrides `DOTNET_ENVIRONMENT`.
 
-:::moniker-end range=">= aspnetcore-6.0 < aspnetcore-7.0"
+:::moniker-end
 
 :::moniker range=">= aspnetcore-7.0"
 
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `DOTNET_ENVIRONMENT` value overrides `ASPNETCORE_ENVIRONMENT` when `WebApplicationBuilder` is used. For other hosts, such as `ConfigureWebHostDefaults` and `WebHost.CreateDefaultBuilder`, `ASPNETCORE_ENVIRONMENT` has higher precedence.
 
-:::moniker-end range=">= aspnetcore-7.0"
+:::moniker-end
 
 `IHostEnvironment.EnvironmentName` can be set to any value, but the following values are provided by the framework:
 

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -26,13 +26,13 @@ To determine the runtime environment, ASP.NET Core reads from the following envi
 
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `ASPNETCORE_ENVIRONMENT` value overrides `DOTNET_ENVIRONMENT`.
 
-:::moniker-end
+:::moniker-end range=">= aspnetcore-6.0 < aspnetcore-7.0"
 
 :::moniker range=">= aspnetcore-7.0"
 
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `DOTNET_ENVIRONMENT` value overrides `ASPNETCORE_ENVIRONMENT` when `WebApplicationBuilder` is used. For other hosts, such as `ConfigureWebHostDefaults` and `WebHost.CreateDefaultBuilder`, `ASPNETCORE_ENVIRONMENT` has higher precedence.
 
-:::moniker-end
+:::moniker-end range=">= aspnetcore-7.0"
 
 `IHostEnvironment.EnvironmentName` can be set to any value, but the following values are provided by the framework:
 

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -22,7 +22,7 @@ To determine the runtime environment, ASP.NET Core reads from the following envi
 
 1. [DOTNET_ENVIRONMENT](xref:fundamentals/configuration/index#default-host-configuration)
 
-:::moniker range="< aspnetcore-7.0"
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
 
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `ASPNETCORE_ENVIRONMENT` value overrides `DOTNET_ENVIRONMENT`.
 

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -21,18 +21,7 @@ ASP.NET Core configures app behavior based on the runtime environment using an e
 To determine the runtime environment, ASP.NET Core reads from the following environment variables:
 
 1. [DOTNET_ENVIRONMENT](xref:fundamentals/configuration/index#default-host-configuration)
-
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `ASPNETCORE_ENVIRONMENT` value overrides `DOTNET_ENVIRONMENT`.
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-7.0"
-
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `DOTNET_ENVIRONMENT` value overrides `ASPNETCORE_ENVIRONMENT` when `WebApplicationBuilder` is used. For other hosts, such as `ConfigureWebHostDefaults` and `WebHost.CreateDefaultBuilder`, `ASPNETCORE_ENVIRONMENT` has higher precedence.
-
-:::moniker-end
 
 `IHostEnvironment.EnvironmentName` can be set to any value, but the following values are provided by the framework:
 

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -35,6 +35,8 @@ To determine the runtime environment, ASP.NET Core reads from the following envi
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-6.0"
+
 `IHostEnvironment.EnvironmentName` can be set to any value, but the following values are provided by the framework:
 
 * <xref:Microsoft.Extensions.Hosting.Environments.Development>: The [launchSettings.json](#lsj) file sets `ASPNETCORE_ENVIRONMENT` to `Development` on the local machine.

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -18,10 +18,22 @@ ASP.NET Core configures app behavior based on the runtime environment using an e
 
 ## Environments
 
+:::moniker-end
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
+To determine the runtime environment, ASP.NET Core reads from the following environment variables:
+
+1. [DOTNET_ENVIRONMENT](xref:fundamentals/configuration/index#default-host-configuration)
+1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `ASPNETCORE_ENVIRONMENT` value overrides `DOTNET_ENVIRONMENT`.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0"
 To determine the runtime environment, ASP.NET Core reads from the following environment variables:
 
 1. [DOTNET_ENVIRONMENT](xref:fundamentals/configuration/index#default-host-configuration)
 1. `ASPNETCORE_ENVIRONMENT` when the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method is called. The default ASP.NET Core web app templates call `WebApplication.CreateBuilder`. The `DOTNET_ENVIRONMENT` value overrides `ASPNETCORE_ENVIRONMENT` when `WebApplicationBuilder` is used. For other hosts, such as `ConfigureWebHostDefaults` and `WebHost.CreateDefaultBuilder`, `ASPNETCORE_ENVIRONMENT` has higher precedence.
+
+:::moniker-end
 
 `IHostEnvironment.EnvironmentName` can be set to any value, but the following values are provided by the framework:
 


### PR DESCRIPTION
Now `DOTNET_` variables have higher precedence then  `ASPNETCORE_` ones which affects the `ASPNETCORE_ENVIRONMENT` too. See [this breaking change arrticle](https://learn.microsoft.com/en-us/dotnet/core/compatibility/aspnet-core/7.0/environment-variable-precedence)

***EDIT by @Rick-Anderson***

FIxes #28242
