### PR TITLE
Fix comment in minimal APIs AuthN sample

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs
@@ -3,7 +3,6 @@
 #elif FIRST
 // <snippet_1>
 var builder = WebApplication.CreateBuilder(args);
-// Requires Microsoft.AspNetCore.Authentication.JwtBearer
 builder.Services.AddAuthentication();
 var app = builder.Build();
 
@@ -13,6 +12,7 @@ app.Run();
 #elif JWT1
 // <snippet_jwt1>
 var builder = WebApplication.CreateBuilder(args);
+// Requires Microsoft.AspNetCore.Authentication.JwtBearer
 builder.Services.AddAuthentication().AddJwtBearer();
 var app = builder.Build();
 


### PR DESCRIPTION
Move the comment about requiring the JwtBearer package to the sample that actually uses JwtBearer.