### PR TITLE
Update docs for macOS + TLS on .NET 8

### DIFF
--- a/aspnetcore/fundamentals/servers/index.md
+++ b/aspnetcore/fundamentals/servers/index.md
@@ -178,7 +178,30 @@ A `launchSettings.json` file provides configuration when launching an app with `
 
 [HTTP/2](https://httpwg.org/specs/rfc7540.html) is supported with ASP.NET Core in the following deployment scenarios:
 
-:::moniker range=">= aspnetcore-5.0"
+:::moniker range=">= aspnetcore-8.0"
+
+* [Kestrel](xref:fundamentals/servers/kestrel/http2)
+  * Operating system
+    * Windows Server 2016/Windows 10 or later&dagger;
+    * Linux with OpenSSL 1.0.2 or later (for example, Ubuntu 16.04 or later)
+    * macOS 10.15 or later
+  * Target framework: .NET Core 2.2 or later
+* [HTTP.sys](xref:fundamentals/servers/httpsys#http2-support)
+  * Windows Server 2016/Windows 10 or later
+  * Target framework: Not applicable to HTTP.sys deployments.
+* [IIS (in-process)](xref:host-and-deploy/iis/index#http2-support)
+  * Windows Server 2016/Windows 10 or later; IIS 10 or later
+  * Target framework: .NET Core 2.2 or later
+* [IIS (out-of-process)](xref:host-and-deploy/iis/index#http2-support)
+  * Windows Server 2016/Windows 10 or later; IIS 10 or later
+  * Public-facing edge server connections use HTTP/2, but the reverse proxy connection to Kestrel uses HTTP/1.1.
+  * Target framework: Not applicable to IIS out-of-process deployments.
+
+&dagger;Kestrel has limited support for HTTP/2 on Windows Server 2012 R2 and Windows 8.1. Support is limited because the list of supported TLS cipher suites available on these operating systems is limited. A certificate generated using an Elliptic Curve Digital Signature Algorithm (ECDSA) may be required to secure TLS connections.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-8.0"
 
 * [Kestrel](xref:fundamentals/servers/kestrel/http2)
   * Operating system

--- a/aspnetcore/fundamentals/servers/kestrel.md
+++ b/aspnetcore/fundamentals/servers/kestrel.md
@@ -12,7 +12,68 @@ uid: fundamentals/servers/kestrel
 
 By [Tom Dykstra](https://github.com/tdykstra), [Chris Ross](https://github.com/Tratcher), and [Stephen Halter](https://twitter.com/halter73)
 
-:::moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-8.0"
+
+Kestrel is a cross-platform [web server for ASP.NET Core](xref:fundamentals/servers/index). Kestrel is the web server that's included and enabled by default in ASP.NET Core project templates.
+
+Kestrel supports the following scenarios:
+
+* HTTPS
+* [HTTP/2](xref:fundamentals/servers/kestrel/http2)
+* Opaque upgrade used to enable [WebSockets](xref:fundamentals/websockets)
+* Unix sockets for high performance behind Nginx
+
+Kestrel is supported on all platforms and versions that .NET Core supports.
+
+## Get started
+
+ASP.NET Core project templates use Kestrel by default when not hosted with IIS. In the following template-generated `Program.cs`, the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateBuilder%2A?displayProperty=nameWithType> method calls <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderKestrelExtensions.UseKestrel%2A> internally:
+
+:::code language="csharp" source="kestrel/samples/6.x/KestrelSample/Program.cs" id="snippet_CreateBuilder" highlight="1":::
+
+For more information on configuring `WebApplication` and `WebApplicationBuilder`, see <xref:fundamentals/minimal-apis>.
+
+## Optional client certificates
+
+For information on apps that must protect a subset of the app with a certificate, see [Optional client certificates](xref:security/authentication/certauth#optional-client-certificates).
+
+## Behavior with debugger attached
+
+The following timeouts and rate limits aren't enforced when a debugger is attached to a Kestrel process:
+
+* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.KeepAliveTimeout?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelServerLimits.RequestHeadersTimeout?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinRequestBodyDataRate?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits.MinResponseDataRate?displayProperty=nameWithType>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IConnectionTimeoutFeature>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinRequestBodyDataRateFeature>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Features.IHttpMinResponseDataRateFeature>
+
+## Additional resources
+
+<a name="endpoint-configuration"></a>
+* <xref:fundamentals/servers/kestrel/endpoints>
+* Source for [`WebApplication.CreateBuilder` method call to `UseKestrel`](https://github.com/dotnet/aspnetcore/blob/v6.0.2/src/DefaultBuilder/src/WebHost.cs#L224)
+<a name="kestrel-options"></a>
+* <xref:fundamentals/servers/kestrel/options>
+<a name="http2-support"></a>
+* <xref:fundamentals/servers/kestrel/http2>
+<a name="when-to-use-kestrel-with-a-reverse-proxy"></a>
+* <xref:fundamentals/servers/kestrel/when-to-use-a-reverse-proxy>
+<a name="host-filtering"></a>
+* <xref:fundamentals/servers/kestrel/host-filtering>
+* <xref:test/troubleshoot>
+* <xref:security/enforcing-ssl>
+* <xref:host-and-deploy/proxy-load-balancer>
+* [RFC 9110: HTTP Semantics (Section 7.2: Host and :authority)](https://www.rfc-editor.org/rfc/rfc9110#field.host)
+* When using UNIX sockets on Linux, the socket isn't automatically deleted on app shutdown. For more information, see [this GitHub issue](https://github.com/dotnet/aspnetcore/issues/14134).
+
+> [!NOTE]
+> As of ASP.NET Core 5.0, Kestrel's libuv transport is obsolete. The libuv transport doesn't receive updates to support new OS platforms, such as Windows ARM64, and will be removed in a future release. Remove any calls to the obsolete <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderLibuvExtensions.UseLibuv%2A> method and use Kestrel's default Socket transport instead.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
 Kestrel is a cross-platform [web server for ASP.NET Core](xref:fundamentals/servers/index). Kestrel is the web server that's included and enabled by default in ASP.NET Core project templates.
 

--- a/aspnetcore/fundamentals/servers/kestrel/http2.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http2.md
@@ -75,7 +75,7 @@ Additional HTTP/2 features in Kestrel support gRPC, including support for respon
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-7.0"
+:::moniker range="< aspnetcore-7.0"
 
 [HTTP/2](https://httpwg.org/specs/rfc7540.html) is available for ASP.NET Core apps if the following base requirements are met:
 

--- a/aspnetcore/fundamentals/servers/kestrel/http2.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http2.md
@@ -43,7 +43,7 @@ Additional HTTP/2 features in Kestrel support gRPC, including support for respon
 
 :::moniker-end
 
-:::moniker range="< aspnetcore-7.0 < aspnetcore-8.0"
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
 
 [HTTP/2](https://httpwg.org/specs/rfc7540.html) is available for ASP.NET Core apps if the following base requirements are met:
 

--- a/aspnetcore/fundamentals/servers/kestrel/http2.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http2.md
@@ -11,7 +11,7 @@ uid: fundamentals/servers/kestrel/http2
 
 # Use HTTP/2 with the ASP.NET Core Kestrel web server
 
-:::moniker range="< aspnetcore-8.0"
+:::moniker range=">= aspnetcore-8.0"
 
 [HTTP/2](https://httpwg.org/specs/rfc7540.html) is available for ASP.NET Core apps if the following base requirements are met:
 

--- a/aspnetcore/fundamentals/servers/kestrel/http2.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http2.md
@@ -11,7 +11,39 @@ uid: fundamentals/servers/kestrel/http2
 
 # Use HTTP/2 with the ASP.NET Core Kestrel web server
 
-:::moniker range="< aspnetcore-7.0"
+:::moniker range="< aspnetcore-8.0"
+
+[HTTP/2](https://httpwg.org/specs/rfc7540.html) is available for ASP.NET Core apps if the following base requirements are met:
+
+* Operating system
+  * Windows Server 2016/Windows 10 or later&Dagger;
+  * Linux with OpenSSL 1.0.2 or later (for example, Ubuntu 16.04 or later)
+  * macOS 10.15 or later
+* Target framework: .NET Core 2.2 or later
+* [Application-Layer Protocol Negotiation (ALPN)](https://tools.ietf.org/html/rfc7301#section-3) connection
+* TLS 1.2 or later connection
+
+&Dagger;Kestrel has limited support for HTTP/2 on Windows Server 2012 R2 and Windows 8.1. Support is limited because the list of supported TLS cipher suites available on these operating systems is limited. A certificate generated using an Elliptic Curve Digital Signature Algorithm (ECDSA) may be required to secure TLS connections.
+
+If an HTTP/2 connection is established, [HttpRequest.Protocol](xref:Microsoft.AspNetCore.Http.HttpRequest.Protocol%2A) reports `HTTP/2`.
+
+Starting with .NET Core 3.0, HTTP/2 is enabled by default. For more information on configuration, see the [Kestrel HTTP/2 limits](xref:fundamentals/servers/kestrel/options#http2-limits) and [ListenOptions.Protocols](xref:fundamentals/servers/kestrel/endpoints#listenoptionsprotocols) sections.
+
+## Advanced HTTP/2 features
+
+Additional HTTP/2 features in Kestrel support gRPC, including support for response trailers and sending reset frames.
+
+### Trailers
+
+[!INCLUDE[](~/includes/trailers.md)]
+
+### Reset
+
+[!INCLUDE[](~/includes/reset.md)]
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-7.0 < aspnetcore-8.0"
 
 [HTTP/2](https://httpwg.org/specs/rfc7540.html) is available for ASP.NET Core apps if the following base requirements are met:
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -133,7 +133,7 @@ If an HTTP/2 endpoint is configured without TLS, the endpoint's [ListenOptions.P
 For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpoint configuration](xref:fundamentals/servers/kestrel/endpoints).
 
 > [!NOTE]
-> macOS doesn't support ASP.NET Core gRPC with TLS up to .NET 7. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
+> macOS doesn't support ASP.NET Core gRPC with TLS before .NET 8. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
 
 ## IIS
 
@@ -189,7 +189,7 @@ If an HTTP/2 endpoint is configured without TLS, the endpoint's [ListenOptions.P
 For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpoint configuration](xref:fundamentals/servers/kestrel/endpoints).
 
 > [!NOTE]
-> macOS doesn't support ASP.NET Core gRPC with TLS up to .NET 7. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
+> macOS doesn't support ASP.NET Core gRPC with TLS before .NET 8. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
 
 ## IIS
 
@@ -245,7 +245,7 @@ If an HTTP/2 endpoint is configured without TLS, the endpoint's [ListenOptions.P
 For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration).
 
 > [!NOTE]
-> macOS doesn't support ASP.NET Core gRPC with TLS up to .NET 7. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
+> macOS doesn't support ASP.NET Core gRPC with TLS before .NET 8. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
 
 :::moniker-end
 

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -133,7 +133,7 @@ If an HTTP/2 endpoint is configured without TLS, the endpoint's [ListenOptions.P
 For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpoint configuration](xref:fundamentals/servers/kestrel/endpoints).
 
 > [!NOTE]
-> macOS doesn't support ASP.NET Core gRPC with TLS. Additional configuration is required to successfully run gRPC services on macOS. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
+> macOS doesn't support ASP.NET Core gRPC with TLS up to .NET 7. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
 
 ## IIS
 
@@ -189,7 +189,7 @@ If an HTTP/2 endpoint is configured without TLS, the endpoint's [ListenOptions.P
 For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpoint configuration](xref:fundamentals/servers/kestrel/endpoints).
 
 > [!NOTE]
-> macOS doesn't support ASP.NET Core gRPC with TLS. Additional configuration is required to successfully run gRPC services on macOS. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
+> macOS doesn't support ASP.NET Core gRPC with TLS up to .NET 7. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
 
 ## IIS
 
@@ -245,7 +245,7 @@ If an HTTP/2 endpoint is configured without TLS, the endpoint's [ListenOptions.P
 For more information on enabling HTTP/2 and TLS with Kestrel, see [Kestrel endpoint configuration](xref:fundamentals/servers/kestrel#endpoint-configuration).
 
 > [!NOTE]
-> macOS doesn't support ASP.NET Core gRPC with TLS. Additional configuration is required to successfully run gRPC services on macOS. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
+> macOS doesn't support ASP.NET Core gRPC with TLS up to .NET 7. Additional configuration is required to successfully run gRPC services on macOS when using .NET 7 or earlier. For more information, see [Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
 
 :::moniker-end
 

--- a/aspnetcore/grpc/supported-platforms.md
+++ b/aspnetcore/grpc/supported-platforms.md
@@ -36,6 +36,18 @@ Hosting gRPC services with ASP.NET Core requires .NET Core 3.x or later.
 
 ASP.NET Core gRPC services can be hosted on all operating system that .NET Core supports.
 
+:::moniker range=">= aspnetcore-8.0"
+
+> [!div class="checklist"]
+>
+> * Windows
+> * Linux
+> * macOS
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
 > [!div class="checklist"]
 >
 > * Windows
@@ -43,6 +55,8 @@ ASP.NET Core gRPC services can be hosted on all operating system that .NET Core 
 > * macOS&dagger;
 
 &dagger;[macOS doesn't support hosting ASP.NET Core apps with HTTPS](xref:grpc/troubleshoot#unable-to-start-aspnet-core-grpc-app-on-macos).
+
+:::moniker-end
 
 ### Supported ASP.NET Core servers
 

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -96,11 +96,11 @@ The `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch is only 
 
 ## Unable to start ASP.NET Core gRPC app on macOS
 
-Kestrel doesn't support HTTP/2 with TLS on macOS and older Windows versions such as Windows 7. The ASP.NET Core gRPC template and samples use TLS by default. You'll see the following error message when you attempt to start the gRPC server:
+Kestrel doesn't support HTTP/2 with TLS on macOS before .NET 8. The ASP.NET Core gRPC template and samples use TLS by default. You'll see the following error message when you attempt to start the gRPC server:
 
 > Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on macOS due to missing ALPN support.'.
 
-To work around this issue, configure Kestrel and the gRPC client to use HTTP/2 *without* TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
+To work around this issue in .NET 7 and earlier, configure Kestrel and the gRPC client to use HTTP/2 *without* TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 
 Kestrel must configure an HTTP/2 endpoint without TLS in `Program.cs`:
 
@@ -359,11 +359,11 @@ The `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch is only 
 
 ## Unable to start ASP.NET Core gRPC app on macOS
 
-Kestrel doesn't support HTTP/2 with TLS on macOS and older Windows versions such as Windows 7. The ASP.NET Core gRPC template and samples use TLS by default. You'll see the following error message when you attempt to start the gRPC server:
+Kestrel doesn't support HTTP/2 with TLS on macOS before .NET 8. The ASP.NET Core gRPC template and samples use TLS by default. You'll see the following error message when you attempt to start the gRPC server:
 
 > Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on macOS due to missing ALPN support.'.
 
-To work around this issue, configure Kestrel and the gRPC client to use HTTP/2 *without* TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
+To work around this issue in .NET 7 and earlier, configure Kestrel and the gRPC client to use HTTP/2 *without* TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 
 Kestrel must configure an HTTP/2 endpoint without TLS in `Program.cs`:
 
@@ -575,11 +575,11 @@ The `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch is only 
 
 ## Unable to start ASP.NET Core gRPC app on macOS
 
-Kestrel doesn't support HTTP/2 with TLS on macOS and older Windows versions such as Windows 7. The ASP.NET Core gRPC template and samples use TLS by default. You'll see the following error message when you attempt to start the gRPC server:
+Kestrel doesn't support HTTP/2 with TLS on macOS before .NET 8. The ASP.NET Core gRPC template and samples use TLS by default. You'll see the following error message when you attempt to start the gRPC server:
 
 > Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on macOS due to missing ALPN support.'.
 
-To work around this issue, configure Kestrel and the gRPC client to use HTTP/2 *without* TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
+To work around this issue in .NET 7 and earlier, configure Kestrel and the gRPC client to use HTTP/2 *without* TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
 
 Kestrel must configure an HTTP/2 endpoint without TLS in `Program.cs`:
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -8,7 +8,310 @@ uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core
 
-:::moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-8.0"
+This tutorial shows how to create a .NET Core [gRPC](xref:grpc/index) client and an ASP.NET Core gRPC Server. At the end, you'll have a gRPC client that communicates with the gRPC Greeter service.
+
+In this tutorial, you:
+
+> [!div class="checklist"]
+> * Create a gRPC Server.
+> * Create a gRPC client.
+> * Test the gRPC client with the gRPC Greeter service.
+
+## Prerequisites
+
+# [Visual Studio](#tab/visual-studio)
+
+[!INCLUDE[](~/includes/net-prereqs-vs-6.0.md)]
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+[!INCLUDE[](~/includes/net-prereqs-vsc-6.0.md)]
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+[!INCLUDE[](~/includes/net-prereqs-mac-6.0.md)]
+
+---
+
+## Create a gRPC service
+
+# [Visual Studio](#tab/visual-studio)
+
+* Start Visual Studio 2022 and select **Create a new project**.
+* In the **Create a new project** dialog, search for `gRPC`. Select **ASP.NET Core gRPC Service** and select **Next**.
+* In the **Configure your new project** dialog, enter `GrpcGreeter` for **Project name**. It's important to name the project *GrpcGreeter* so the namespaces match when you copy and paste code.
+* Select **Next**.
+* In the **Additional information** dialog, select **.NET 6.0 (Long-term support)** and then select **Create**.
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+The tutorial assumes familiarity with VS Code. For more information, see [Getting started with VS Code](https://code.visualstudio.com/docs)
+
+* Open the [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal).
+* Change to the directory (`cd`) that will contain the project.
+* Run the following commands:
+
+  ```dotnetcli
+  dotnet new grpc -o GrpcGreeter
+  code -r GrpcGreeter
+  ```
+
+  * The `dotnet new` command creates a new gRPC service in the *GrpcGreeter* folder.
+  * The `code` command opens the *GrpcGreeter* folder in a new instance of Visual Studio Code.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+* Start Visual Studio for Mac and select **File** > **New Project**.
+* In the **Choose a template for your new project** dialog, select **Web and Console** > **App** > **gRPC Service** and select **Continue**.
+* Select **.NET 6.0** for the target framework and select **Continue**.
+* Name the project **GrpcGreeter**. It's important to name the project *GrpcGreeter* so the namespaces match when you copy and paste code.
+* Select **Continue**.
+
+---
+
+### Run the service
+ 
+[!INCLUDE[](~/includes/run-the-app6.0.md)]
+
+The logs show the service listening on `https://localhost:<port>`, where `<port>` is the localhost port number randomly assigned when the project is created and set in `Properties/launchSettings.json`.
+
+```console
+info: Microsoft.Hosting.Lifetime[0]
+      Now listening on: https://localhost:<port>
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.
+info: Microsoft.Hosting.Lifetime[0]
+      Hosting environment: Development
+```
+
+> [!NOTE]
+> The gRPC template is configured to use [Transport Layer Security (TLS)](https://tools.ietf.org/html/rfc5246). gRPC clients need to use HTTPS to call the server.  The gRPC service localhost port number is randomly assigned when the project is created and set in the *Properties\launchSettings.json* file of the gRPC service project.
+
+### Examine the project files
+
+*GrpcGreeter* project files:
+
+* `Protos/greet.proto`: defines the `Greeter` gRPC and is used to generate the gRPC server assets. For more information, see [Introduction to gRPC](xref:grpc/index).
+* `Services` folder: Contains the implementation of the `Greeter` service.
+* `appSettings.json`: Contains configuration data such as the protocol used by Kestrel. For more information, see <xref:fundamentals/configuration/index>.
+* `Program.cs`, which contains:
+  * The entry point for the gRPC service. For more information, see <xref:fundamentals/host/generic-host>.
+  * Code that configures app behavior. For more information, see [App startup](xref:fundamentals/startup).
+
+## Create the gRPC client in a .NET console app
+
+# [Visual Studio](#tab/visual-studio)
+
+* Open a second instance of Visual Studio and select **Create a new project**.
+* In the **Create a new project** dialog, select **Console Application**, and select **Next**.
+* In the **Project name** text box, enter **GrpcGreeterClient** and select **Next**.
+* In the **Additional information** dialog, select **.NET 6.0 (Long-term support)** and then select **Create**.
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+* Open the [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal).
+* Change directories (`cd`) to a folder for the project.
+* Run the following commands:
+
+  ```dotnetcli
+  dotnet new console -o GrpcGreeterClient
+  code -r GrpcGreeterClient
+  ```
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+Follow the instructions in [Building a complete .NET Core solution on macOS using Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution) to create a console app with the name *GrpcGreeterClient*.
+
+---
+
+### Add required NuGet packages
+
+The gRPC client project requires the following NuGet packages:
+
+* [Grpc.Net.Client](https://www.nuget.org/packages/Grpc.Net.Client), which contains the .NET Core client.
+* [Google.Protobuf](https://www.nuget.org/packages/Google.Protobuf/), which contains protobuf message APIs for C#.
+* [Grpc.Tools](https://www.nuget.org/packages/Grpc.Tools/), which contain C# tooling support for protobuf files. The tooling package isn't required at runtime, so the dependency is marked with `PrivateAssets="All"`.
+
+# [Visual Studio](#tab/visual-studio)
+
+Install the packages using either the Package Manager Console (PMC) or Manage NuGet Packages.
+
+#### PMC option to install packages
+
+* From Visual Studio, select **Tools** > **NuGet Package Manager** > **Package Manager Console**
+* From the **Package Manager Console** window, run `cd GrpcGreeterClient` to change directories to the folder containing the `GrpcGreeterClient.csproj` files.
+* Run the following commands:
+
+  ```powershell
+  Install-Package Grpc.Net.Client
+  Install-Package Google.Protobuf
+  Install-Package Grpc.Tools
+  ```
+
+#### Manage NuGet Packages option to install packages
+
+* Right-click the project in **Solution Explorer** > **Manage NuGet Packages**.
+* Select the **Browse** tab.
+* Enter **Grpc.Net.Client** in the search box.
+* Select the **Grpc.Net.Client** package from the **Browse** tab and select **Install**.
+* Repeat for `Google.Protobuf` and `Grpc.Tools`.
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+Run the following commands from the **Integrated Terminal**:
+
+```dotnetcli
+dotnet add GrpcGreeterClient.csproj package Grpc.Net.Client
+dotnet add GrpcGreeterClient.csproj package Google.Protobuf
+dotnet add GrpcGreeterClient.csproj package Grpc.Tools
+```
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+* Right-click **GrpcGreeterClient** project in the **Solution Pad** and select **Manage NuGet Packages**.
+* Enter **Grpc.Net.Client** in the search box.
+* Select the **Grpc.Net.Client** package from the results pane and select **Add Package**.
+* In **Select Projects** select **OK**.
+* If the **License Acceptance** dialog appears, select **Accept** if you agree to the license terms.
+* Repeat for `Google.Protobuf` and `Grpc.Tools`.
+
+---
+
+### Add greet.proto
+
+* Create a *Protos* folder in the gRPC client project.
+* Copy the *Protos\greet.proto* file from the gRPC Greeter service to the *Protos* folder in the gRPC client project.
+* Update the namespace inside the `greet.proto` file to the project's namespace:
+
+  ```
+  option csharp_namespace = "GrpcGreeterClient";
+  ```
+
+* Edit the `GrpcGreeterClient.csproj` project file:
+
+# [Visual Studio](#tab/visual-studio)
+
+  Right-click the project and select **Edit Project File**.
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+  Select the `GrpcGreeterClient.csproj` file.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+  Right-click the project and select **Edit Project File**.
+
+  ---
+
+* Add an item group with a `<Protobuf>` element that refers to the *greet.proto* file:
+
+  ```xml
+  <ItemGroup>
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Client" />
+  </ItemGroup>
+  ```
+
+### Create the Greeter client
+
+* Build the client project to create the types in the `GrpcGreeterClient` namespace.
+
+> [!NOTE]
+> The `GrpcGreeterClient` types are generated automatically by the build process. The tooling package [Grpc.Tools](https://www.nuget.org/packages/Grpc.Tools/) generates the following files based on the *greet.proto* file:
+>
+> * `GrpcGreeterClient\obj\Debug\[TARGET_FRAMEWORK]\Protos\Greet.cs`: The protocol buffer code which populates, serializes and retrieves the request and response message types.
+> * `GrpcGreeterClient\obj\Debug\[TARGET_FRAMEWORK]\Protos\GreetGrpc.cs`: Contains the generated client classes.
+>
+> For more information on the C# assets automatically generated by [Grpc.Tools](https://www.nuget.org/packages/Grpc.Tools/), see [gRPC services with C#: Generated C# assets](xref:grpc/basics#generated-c-assets).
+
+* Update the gRPC client `Program.cs` file with the following code.
+
+  [!code-csharp[](~/tutorials/grpc/grpc-start/sample6/GrpcGreeterClient/Program.cs?name=snippet2&highlight=6)]
+
+* In the preceding highlighted code, replace the localhost port number `7042` with the `HTTPS` port number specified in `Properties/launchSettings.json` within the `GrpcGreeter` service project.
+
+`Program.cs` contains the entry point and logic for the gRPC client.
+
+The Greeter client is created by:
+
+* Instantiating a `GrpcChannel` containing the information for creating the connection to the gRPC service.
+* Using the `GrpcChannel` to construct the Greeter client:
+
+[!code-csharp[](~/tutorials/grpc/grpc-start/sample6/GrpcGreeterClient/Program.cs?name=snippet&highlight=1-3)]
+
+The Greeter client calls the asynchronous `SayHello` method. The result of the `SayHello` call is displayed:
+
+[!code-csharp[](~/tutorials/grpc/grpc-start/sample6/GrpcGreeterClient/Program.cs?name=snippet&highlight=4-7)]
+
+## Test the gRPC client with the gRPC Greeter service
+
+# [Visual Studio](#tab/visual-studio)
+
+* In the Greeter service, press `Ctrl+F5` to start the server without the debugger.
+* In the `GrpcGreeterClient` project, press `Ctrl+F5` to start the client without the debugger.
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+* Start the Greeter service.
+* Start the client.
+
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+* Start the Greeter service.
+* Start the client.
+
+---
+
+The client sends a greeting to the service with a message containing its name, *GreeterClient*. The service sends the message "Hello GreeterClient" as a response. The "Hello GreeterClient" response is displayed in the command prompt:
+
+```console
+Greeting: Hello GreeterClient
+Press any key to exit...
+```
+
+The gRPC service records the details of the successful call in the logs written to the command prompt:
+
+```console
+info: Microsoft.Hosting.Lifetime[0]
+      Now listening on: https://localhost:<port>
+info: Microsoft.Hosting.Lifetime[0]
+      Application started. Press Ctrl+C to shut down.
+info: Microsoft.Hosting.Lifetime[0]
+      Hosting environment: Development
+info: Microsoft.Hosting.Lifetime[0]
+      Content root path: C:\GH\aspnet\docs\4\Docs\aspnetcore\tutorials\grpc\grpc-start\sample\GrpcGreeter
+info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
+      Request starting HTTP/2 POST https://localhost:<port>/Greet.Greeter/SayHello application/grpc
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
+      Executing endpoint 'gRPC - /Greet.Greeter/SayHello'
+info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
+      Executed endpoint 'gRPC - /Greet.Greeter/SayHello'
+info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
+      Request finished in 78.32260000000001ms 200 application/grpc
+```
+
+Update the `appsettings.Development.json` file by adding the following lines:
+
+ ```
+ "Microsoft.AspNetCore.Hosting": "Information",
+ "Microsoft.AspNetCore.Routing.EndpointMiddleware": "Information"
+  ```
+
+
+
+> [!NOTE]
+> The code in this article requires the ASP.NET Core HTTPS development certificate to secure the gRPC service. If the .NET gRPC client fails with the message `The remote certificate is invalid according to the validation procedure.` or `The SSL connection could not be established.`, the development certificate isn't trusted. To fix this issue, see [Call a gRPC service with an untrusted/invalid certificate](xref:grpc/troubleshoot#call-a-grpc-service-with-an-untrustedinvalid-certificate).
+
+### Next steps
+
+* View or download [the completed sample code for this tutorial](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/grpc/grpc-start/sample6) ([how to download](xref:index#how-to-download-a-sample)).
+* <xref:grpc/index>
+* <xref:grpc/basics>
+* <xref:grpc/migration>
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 This tutorial shows how to create a .NET Core [gRPC](xref:grpc/index) client and an ASP.NET Core gRPC Server. At the end, you'll have a gRPC client that communicates with the gRPC Greeter service.
 
 In this tutorial, you:


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/45569

On some pages, I've left a note that macOS + TLS doesn't work before .NET 8, rather than removing mentioning it completely. I did that because I think there could be people using older versions of .NET who visit those pages to get troubleshooting advice.