### PR TITLE
Fix highlighted lines in authz policies example

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/security.md
+++ b/aspnetcore/fundamentals/minimal-apis/security.md
@@ -108,7 +108,7 @@ The code creates a new authorization policy, named `policy_greetings`, that enca
 
 The `admin_greetings` policy is provided as a required policy to the `/hello` endpoint.
 
-:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_greet" highlight="3,11-12":::
+:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_greet" highlight="5-9,12-13":::
 
 ## Use `dotnet user-jwts` for development testing
 

--- a/aspnetcore/fundamentals/minimal-apis/security.md
+++ b/aspnetcore/fundamentals/minimal-apis/security.md
@@ -108,7 +108,7 @@ The code creates a new authorization policy, named `policy_greetings`, that enca
 
 The `admin_greetings` policy is provided as a required policy to the `/hello` endpoint.
 
-:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_greet" highlight="5-9,12-13":::
+:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_greet" highlight="5-9,13-14":::
 
 ## Use `dotnet user-jwts` for development testing
 

--- a/aspnetcore/fundamentals/minimal-apis/security.md
+++ b/aspnetcore/fundamentals/minimal-apis/security.md
@@ -33,7 +33,7 @@ To enable authentication, call [`AddAuthentication`](/dotnet/api/microsoft.exten
 
 Typically, a specific authentication strategy is used. In the following sample, the app is configured with support for JWT bearer-based authentication.
 
-:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_jwt1" highlight="3":::
+:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_jwt1" highlight="2-3":::
 
 By default, the [`WebApplication`](/dotnet/api/microsoft.aspnetcore.builder.webapplication) automatically registers the authentication and authorization middlewares if certain authentication and authorization services are enabled. In the following sample, it's not necessary to invoke [`UseAuthentication`](/dotnet/api/microsoft.aspnetcore.builder.authappbuilderextensions.useauthentication) or [`UseAuthorization`](/dotnet/api/microsoft.aspnetcore.builder.authorizationappbuilderextensions.useauthorization) to register the middlewares because [`WebApplication`](/dotnet/api/microsoft.aspnetcore.builder.webapplication) does this automatically after `AddAuthentication` or `AddAuthorization` are called.
 

--- a/aspnetcore/fundamentals/minimal-apis/security.md
+++ b/aspnetcore/fundamentals/minimal-apis/security.md
@@ -29,11 +29,11 @@ In ASP.NET Core, both strategies are captured into an authorization requirement.
 
 To enable authentication, call [`AddAuthentication`](/dotnet/api/microsoft.extensions.dependencyinjection.authenticationservicecollectionextensions.addauthentication) to register the required authentication services on the app's service provider.
 
-:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_1" highlight="2-3":::
+:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_1" highlight="2":::
 
 Typically, a specific authentication strategy is used. In the following sample, the app is configured with support for JWT bearer-based authentication.
 
-:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_jwt1" highlight="2":::
+:::code language="csharp" source="~/fundamentals/minimal-apis/security/7.0-samples/MinApiAuth/MinApiAuth/Program.cs" id="snippet_jwt1" highlight="3":::
 
 By default, the [`WebApplication`](/dotnet/api/microsoft.aspnetcore.builder.webapplication) automatically registers the authentication and authorization middlewares if certain authentication and authorization services are enabled. In the following sample, it's not necessary to invoke [`UseAuthentication`](/dotnet/api/microsoft.aspnetcore.builder.authappbuilderextensions.useauthentication) or [`UseAuthorization`](/dotnet/api/microsoft.aspnetcore.builder.authorizationappbuilderextensions.useauthorization) to register the middlewares because [`WebApplication`](/dotnet/api/microsoft.aspnetcore.builder.webapplication) does this automatically after `AddAuthentication` or `AddAuthorization` are called.
 


### PR DESCRIPTION
Currently the lines highlighted aren't relevant to the section (see image below). This change should highlight the lines associated with creating and using the authorization policy.

<img width="361" alt="image" src="https://user-images.githubusercontent.com/249088/216131066-d2f77313-b1cd-4db4-90a7-c68d39015692.png">
