### PR TITLE
JS interop updates

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -174,7 +174,6 @@ To invoke an instance .NET method from JavaScript (JS):
   ```
 
   > [!NOTE]
-  >   > [!NOTE]
   > `invokeMethodAsync` and `invokeMethod` don't accept an assembly name parameter when invoking an instance method.
 
   `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
@@ -1045,7 +1044,6 @@ To invoke an instance .NET method from JavaScript (JS):
   ```
 
   > [!NOTE]
-  >   > [!NOTE]
   > `invokeMethodAsync` and `invokeMethod` don't accept an assembly name parameter when invoking an instance method.
 
   `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
@@ -1894,7 +1892,6 @@ To invoke an instance .NET method from JavaScript (JS):
   ```
 
   > [!NOTE]
-  >   > [!NOTE]
   > `invokeMethodAsync` and `invokeMethod` don't accept an assembly name parameter when invoking an instance method.
 
   `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
@@ -2353,7 +2350,6 @@ To invoke an instance .NET method from JavaScript (JS):
   ```
 
   > [!NOTE]
-  >   > [!NOTE]
   > `invokeMethodAsync` and `invokeMethod` don't accept an assembly name parameter when invoking an instance method.
 
   `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -162,7 +162,25 @@ Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream 
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethodAsync` or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethodAsync` (*Recommended*) or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. Pass the identifier of the instance .NET method and any arguments. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+
+  In the following example:
+
+  * The `{.NET METHOD ID}` placeholder is the .NET method identifier.
+  * The `{ARGUMENTS}` placeholder are optional, comma-separated arguments to pass to the method, each of which must be JSON-serializable.
+
+  ```javascript
+  DotNet.invokeMethodAsync('{.NET METHOD ID}', {ARGUMENTS});
+  ```
+
+  > [!NOTE]
+  > `invokeMethodAsync`/`invokeMethod` doesn't accept an assembly name parameter when invoking an instance method.
+
+  `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
+
+  > [!IMPORTANT]
+  > The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
+
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:
@@ -565,7 +583,7 @@ In the preceding `CallDotNetExample5` component, the .NET object reference is di
 
 ```javascript
 window.{JS FUNCTION NAME} = (dotNetHelper) => {
-  dotNetHelper.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}');
+  dotNetHelper.invokeMethodAsync('{.NET METHOD ID}');
   dotNetHelper.dispose();
 }
 ```
@@ -574,7 +592,6 @@ In the preceding example:
 
 * The `{JS FUNCTION NAME}` placeholder is the JS function's name.
 * The variable name `dotNetHelper` is arbitrary and can be changed to any preferred name.
-* The `{ASSEMBLY NAME}` placeholder is the app's assembly name.
 * The `{.NET METHOD ID}` placeholder is the .NET method identifier.
 
 ## Component instance .NET method helper class
@@ -590,18 +607,18 @@ In the following example:
 * Each `ListItem1` component is composed of a message and a button.
 * When a `ListItem1` component button is selected, that `ListItem1`'s `UpdateMessage` method changes the list item text and hides the button.
 
-The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET method, `UpdateMessageCaller`, to invoke the <xref:System.Action> specified when the class is instantiated. `BlazorSample` is the app's assembly name.
+The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET method, `UpdateMessageCaller`, to invoke the <xref:System.Action> specified when the class is instantiated.
 
 `MessageUpdateInvokeHelper.cs`:
 
 :::code language="csharp" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/MessageUpdateInvokeHelper.cs":::
 
-The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method. `BlazorSample` is the app's assembly name.
+The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method.
 
 ```html
 <script>
   window.updateMessageCaller = (dotNetHelper) => {
-    dotNetHelper.invokeMethodAsync('BlazorSample', 'UpdateMessageCaller');
+    dotNetHelper.invokeMethodAsync('UpdateMessageCaller');
     dotNetHelper.dispose();
   }
 </script>
@@ -736,14 +753,14 @@ Objects that contain circular references can't be serialized on the client for e
 
 Blazor supports optimized byte array JavaScript (JS) interop that avoids encoding/decoding byte arrays into Base64. The following example uses JS interop to pass a byte array to .NET.
 
-Provide a `sendByteArray` JS function. The function is called by a button in the component and doesn't return a value:
+Provide a `sendByteArray` JS function. The function is called statically, which includes the assembly name parameter in the `invokeMethodAsync` call, by a button in the component and doesn't return a value:
 
 ```html
 <script>
   window.sendByteArray = () => {
     const data = new Uint8Array([0x45,0x76,0x65,0x72,0x79,0x74,0x68,0x69,
       0x6e,0x67,0x27,0x73,0x20,0x73,0x68,0x69,0x6e,0x79,0x2c,
-      0x20,0x43,0x61,0x70,0x74,0x69,0x61,0x6e,0x2e,0x20,0x4e,
+      0x20,0x43,0x61,0x70,0x74,0x61,0x69,0x6e,0x2e,0x20,0x4e,
       0x6f,0x74,0x20,0x74,0x6f,0x20,0x66,0x72,0x65,0x74,0x2e]);
     DotNet.invokeMethodAsync('BlazorSample', 'ReceiveByteArray', data)
       .then(str => {
@@ -1015,7 +1032,25 @@ Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream 
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethodAsync` or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethodAsync` (*Recommended*) or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. Pass the identifier of the instance .NET method and any arguments. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+
+  In the following example:
+
+  * The `{.NET METHOD ID}` placeholder is the .NET method identifier.
+  * The `{ARGUMENTS}` placeholder are optional, comma-separated arguments to pass to the method, each of which must be JSON-serializable.
+
+  ```javascript
+  DotNet.invokeMethodAsync('{.NET METHOD ID}', {ARGUMENTS});
+  ```
+
+  > [!NOTE]
+  > `invokeMethodAsync`/`invokeMethod` doesn't accept an assembly name parameter when invoking an instance method.
+
+  `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
+
+  > [!IMPORTANT]
+  > The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
+
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:
@@ -1418,7 +1453,7 @@ In the preceding `CallDotNetExample5` component, the .NET object reference is di
 
 ```javascript
 window.{JS FUNCTION NAME} = (dotNetHelper) => {
-  dotNetHelper.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}');
+  dotNetHelper.invokeMethodAsync('{.NET METHOD ID}');
   dotNetHelper.dispose();
 }
 ```
@@ -1427,7 +1462,6 @@ In the preceding example:
 
 * The `{JS FUNCTION NAME}` placeholder is the JS function's name.
 * The variable name `dotNetHelper` is arbitrary and can be changed to any preferred name.
-* The `{ASSEMBLY NAME}` placeholder is the app's assembly name.
 * The `{.NET METHOD ID}` placeholder is the .NET method identifier.
 
 ## Component instance .NET method helper class
@@ -1443,18 +1477,18 @@ In the following example:
 * Each `ListItem1` component is composed of a message and a button.
 * When a `ListItem1` component button is selected, that `ListItem1`'s `UpdateMessage` method changes the list item text and hides the button.
 
-The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET method, `UpdateMessageCaller`, to invoke the <xref:System.Action> specified when the class is instantiated. `BlazorSample` is the app's assembly name.
+The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET method, `UpdateMessageCaller`, to invoke the <xref:System.Action> specified when the class is instantiated.
 
 `MessageUpdateInvokeHelper.cs`:
 
 :::code language="csharp" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/MessageUpdateInvokeHelper.cs":::
 
-The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method. `BlazorSample` is the app's assembly name.
+The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method.
 
 ```html
 <script>
   window.updateMessageCaller = (dotNetHelper) => {
-    dotNetHelper.invokeMethodAsync('BlazorSample', 'UpdateMessageCaller');
+    dotNetHelper.invokeMethodAsync('UpdateMessageCaller');
     dotNetHelper.dispose();
   }
 </script>
@@ -1589,14 +1623,14 @@ Objects that contain circular references can't be serialized on the client for e
 
 Blazor supports optimized byte array JavaScript (JS) interop that avoids encoding/decoding byte arrays into Base64. The following example uses JS interop to pass a byte array to .NET.
 
-Provide a `sendByteArray` JS function. The function is called by a button in the component and doesn't return a value:
+Provide a `sendByteArray` JS function. The function is called statically, which includes the assembly name parameter in the `invokeMethodAsync` call, by a button in the component and doesn't return a value:
 
 ```html
 <script>
   window.sendByteArray = () => {
     const data = new Uint8Array([0x45,0x76,0x65,0x72,0x79,0x74,0x68,0x69,
       0x6e,0x67,0x27,0x73,0x20,0x73,0x68,0x69,0x6e,0x79,0x2c,
-      0x20,0x43,0x61,0x70,0x74,0x69,0x61,0x6e,0x2e,0x20,0x4e,
+      0x20,0x43,0x61,0x70,0x74,0x61,0x69,0x6e,0x2e,0x20,0x4e,
       0x6f,0x74,0x20,0x74,0x6f,0x20,0x66,0x72,0x65,0x74,0x2e]);
     DotNet.invokeMethodAsync('BlazorSample', 'ReceiveByteArray', data)
       .then(str => {
@@ -1846,7 +1880,25 @@ Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream 
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethodAsync` or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethodAsync` (*Recommended*) or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. Pass the identifier of the instance .NET method and any arguments. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+
+  In the following example:
+
+  * The `{.NET METHOD ID}` placeholder is the .NET method identifier.
+  * The `{ARGUMENTS}` placeholder are optional, comma-separated arguments to pass to the method, each of which must be JSON-serializable.
+
+  ```javascript
+  DotNet.invokeMethodAsync('{.NET METHOD ID}', {ARGUMENTS});
+  ```
+
+  > [!NOTE]
+  > `invokeMethodAsync`/`invokeMethod` doesn't accept an assembly name parameter when invoking an instance method.
+
+  `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
+
+  > [!IMPORTANT]
+  > The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
+
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:
@@ -1956,7 +2008,7 @@ In the preceding `CallDotNetExample5` component, the .NET object reference is di
 
 ```javascript
 window.{JS FUNCTION NAME} = (dotNetHelper) => {
-  dotNetHelper.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}');
+  dotNetHelper.invokeMethodAsync('{.NET METHOD ID}');
   dotNetHelper.dispose();
 }
 ```
@@ -1965,7 +2017,6 @@ In the preceding example:
 
 * The `{JS FUNCTION NAME}` placeholder is the JS function's name.
 * The variable name `dotNetHelper` is arbitrary and can be changed to any preferred name.
-* The `{ASSEMBLY NAME}` placeholder is the app's assembly name.
 * The `{.NET METHOD ID}` placeholder is the .NET method identifier.
 
 ## Component instance .NET method helper class
@@ -1981,20 +2032,20 @@ In the following example:
 * Each `ListItem1` component is composed of a message and a button.
 * When a `ListItem1` component button is selected, that `ListItem1`'s `UpdateMessage` method changes the list item text and hides the button.
 
-The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET method, `UpdateMessageCaller`, to invoke the <xref:System.Action> specified when the class is instantiated. `BlazorSample` is the app's assembly name.
+The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET method, `UpdateMessageCaller`, to invoke the <xref:System.Action> specified when the class is instantiated.
 
 `MessageUpdateInvokeHelper.cs`:
 
 :::code language="csharp" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/MessageUpdateInvokeHelper.cs" highlight="8,13-17":::
 
-The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method. `BlazorSample` is the app's assembly name.
+The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method.
 
 Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
 
 ```html
 <script>
   window.updateMessageCaller = (dotNetHelper) => {
-    dotNetHelper.invokeMethodAsync('BlazorSample', 'UpdateMessageCaller');
+    dotNetHelper.invokeMethodAsync('UpdateMessageCaller');
     dotNetHelper.dispose();
   }
 </script>
@@ -2287,7 +2338,25 @@ Call `DotNet.createJSStreamReference(streamReference)` to construct a JS stream 
 To invoke an instance .NET method from JavaScript (JS):
 
 * Pass the .NET instance by reference to JS by wrapping the instance in a <xref:Microsoft.JSInterop.DotNetObjectReference> and calling <xref:Microsoft.JSInterop.DotNetObjectReference.Create%2A> on it.
-* Invoke a .NET instance method from JS using `invokeMethodAsync` or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+* Invoke a .NET instance method from JS using `invokeMethodAsync` (*Recommended*) or `invokeMethod` (Blazor WebAssembly only) from the passed <xref:Microsoft.JSInterop.DotNetObjectReference>. Pass the identifier of the instance .NET method and any arguments. The .NET instance can also be passed as an argument when invoking other .NET methods from JS.
+
+  In the following example:
+
+  * The `{.NET METHOD ID}` placeholder is the .NET method identifier.
+  * The `{ARGUMENTS}` placeholder are optional, comma-separated arguments to pass to the method, each of which must be JSON-serializable.
+
+  ```javascript
+  DotNet.invokeMethodAsync('{.NET METHOD ID}', {ARGUMENTS});
+  ```
+
+  > [!NOTE]
+  > `invokeMethodAsync`/`invokeMethod` doesn't accept an assembly name parameter when invoking an instance method.
+
+  `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
+
+  > [!IMPORTANT]
+  > The asynchronous function (`invokeMethodAsync`) is preferred over the synchronous version (`invokeMethod`) to support Blazor Server scenarios.
+
 * Dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference>.
 
 The following sections of this article demonstrate various approaches for invoking an instance .NET method:
@@ -2397,7 +2466,7 @@ In the preceding `CallDotNetExample5` component, the .NET object reference is di
 
 ```javascript
 window.{JS FUNCTION NAME} = (dotNetHelper) => {
-  dotNetHelper.invokeMethodAsync('{ASSEMBLY NAME}', '{.NET METHOD ID}');
+  dotNetHelper.invokeMethodAsync('{.NET METHOD ID}');
   dotNetHelper.dispose();
 }
 ```
@@ -2406,7 +2475,6 @@ In the preceding example:
 
 * The `{JS FUNCTION NAME}` placeholder is the JS function's name.
 * The variable name `dotNetHelper` is arbitrary and can be changed to any preferred name.
-* The `{ASSEMBLY NAME}` placeholder is the app's assembly name.
 * The `{.NET METHOD ID}` placeholder is the .NET method identifier.
 
 ## Component instance .NET method helper class
@@ -2422,20 +2490,20 @@ In the following example:
 * Each `ListItem1` component is composed of a message and a button.
 * When a `ListItem1` component button is selected, that `ListItem1`'s `UpdateMessage` method changes the list item text and hides the button.
 
-The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET method, `UpdateMessageCaller`, to invoke the <xref:System.Action> specified when the class is instantiated. `BlazorSample` is the app's assembly name.
+The following `MessageUpdateInvokeHelper` class maintains a JS-invokable .NET method, `UpdateMessageCaller`, to invoke the <xref:System.Action> specified when the class is instantiated.
 
 `MessageUpdateInvokeHelper.cs`:
 
 :::code language="csharp" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/MessageUpdateInvokeHelper.cs" highlight="8,13-17":::
 
-The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method. `BlazorSample` is the app's assembly name.
+The following `updateMessageCaller` JS function invokes the `UpdateMessageCaller` .NET method.
 
 Inside the closing `</body>` tag of `wwwroot/index.html` (Blazor WebAssembly) or `Pages/_Host.cshtml` (Blazor Server):
 
 ```html
 <script>
   window.updateMessageCaller = (dotNetHelper) => {
-    dotNetHelper.invokeMethodAsync('BlazorSample', 'UpdateMessageCaller');
+    dotNetHelper.invokeMethodAsync('UpdateMessageCaller');
     dotNetHelper.dispose();
   }
 </script>

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to invoke .NET methods from JavaScript functions in Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
-ms.custom: mvc 
+ms.custom: mvc
 ms.date: 11/08/2022
 uid: blazor/js-interop/call-dotnet-from-javascript
 ---
@@ -174,7 +174,8 @@ To invoke an instance .NET method from JavaScript (JS):
   ```
 
   > [!NOTE]
-  > `invokeMethodAsync`/`invokeMethod` doesn't accept an assembly name parameter when invoking an instance method.
+  >   > [!NOTE]
+  > `invokeMethodAsync` and `invokeMethod` don't accept an assembly name parameter when invoking an instance method.
 
   `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
 
@@ -1044,7 +1045,8 @@ To invoke an instance .NET method from JavaScript (JS):
   ```
 
   > [!NOTE]
-  > `invokeMethodAsync`/`invokeMethod` doesn't accept an assembly name parameter when invoking an instance method.
+  >   > [!NOTE]
+  > `invokeMethodAsync` and `invokeMethod` don't accept an assembly name parameter when invoking an instance method.
 
   `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
 
@@ -1892,7 +1894,8 @@ To invoke an instance .NET method from JavaScript (JS):
   ```
 
   > [!NOTE]
-  > `invokeMethodAsync`/`invokeMethod` doesn't accept an assembly name parameter when invoking an instance method.
+  >   > [!NOTE]
+  > `invokeMethodAsync` and `invokeMethod` don't accept an assembly name parameter when invoking an instance method.
 
   `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
 
@@ -2350,7 +2353,8 @@ To invoke an instance .NET method from JavaScript (JS):
   ```
 
   > [!NOTE]
-  > `invokeMethodAsync`/`invokeMethod` doesn't accept an assembly name parameter when invoking an instance method.
+  >   > [!NOTE]
+  > `invokeMethodAsync` and `invokeMethod` don't accept an assembly name parameter when invoking an instance method.
 
   `DotNet.invokeMethodAsync` returns a [JS `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise) representing the result of the operation. `DotNet.invokeMethod` (Blazor WebAssembly only) returns the result of the operation.
 


### PR DESCRIPTION
Fixes #26980

Thanks @contractcooker! 🚀 ...

* I finally reached your issue. Sorry for the delay. It was a busy .NET 7 release season late last year, and I'm just now wrapping up last year's backlog issues.
* Two things that I found out improving the JS interop coverage:
  * I found a bug in one of the examples that didn't prevent it from running ... the example just wasn't composed correctly. I found one line in the article's disposal example for instance methods that required an update. (I wish that I had known about this because I would've marked your issue as a 🪲 and worked it last year.)
  * Also, I found a blasted ***spelling error*** 😈 in one of the code examples 🙈 ... that HEX array byte array support example that writes out a Serenity movie quote via JS interop ... that code example misspelled one of the words in the quote. ***Arrrrrgh!*** 😠 Anyway, I spotted it, updated the HEX, and it will be fine going forward.
* Assembly names aren't optional in the static method call case. The call throws at runtime if the assembly name isn't the first parameter. In the instance cases, the assembly name isn't a parameter. I've improved the section on instance method calls. I'm curious about the circumstances where you found that the assembly name is optional and the call is invoked either way. You didn't state exactly which JS interop scenario that you were working with at the time. If you found one or more cases where it looks optional and instance method calls execute either way, please put up a GH repro project or paste your code examples without and with the assembly name parameter into an issue comment back on the original issue that you opened because I'd like to research it further and see what I'm failing to understand ... I'd reach out to Javier to ask for a clarification on it for another update to this article. Currently tho, all of the instance method examples are going to show ***no*** assembly name parameter. I've made a note to follow-up on this PR with a series of example tests to make sure that the sample apps that provide this code are all working well.