### PR TITLE
Removed UseEndpoints

### DIFF
--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -26,10 +26,7 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.UseEndpoints(endpoints =>
-{
-    endpoints.MapGrpcService<GreeterService>();
-});
+app.MapGrpcService<GreeterService>();
 ```
 
 > [!NOTE]


### PR DESCRIPTION
It's not necessary to have UseEndpoints for Authentication/Authorization. You can just use MapGrpcService instead.

There is no issue associated with this doc, so I didn't referenced any.