### PR TITLE
Change ASP.NET Core Code Generator command

### DIFF
--- a/aspnetcore/tutorials/razor-pages/model.md
+++ b/aspnetcore/tutorials/razor-pages/model.md
@@ -125,13 +125,7 @@ The `appsettings.json` file is updated with the connection string used to connec
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-* Open a command shell to the project directory, which contains the `Program.cs` and `.csproj` files. On Windows, run the following command:
-
-  ```dotnetcli
-  dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovie.Data.RazorPagesMovieContext -udl -outDir Pages\Movies --referenceScriptLibraries -sqlite
-  ```
-
-  On non-Windows machines, run the following command:
+* Open a command shell to the project directory, which contains the `Program.cs` and `.csproj` files. Run the following command:
 
   ```dotnetcli
   dotnet aspnet-codegenerator razorpage -m Movie -dc RazorPagesMovie.Data.RazorPagesMovieContext -udl -outDir Pages/Movies --referenceScriptLibraries -sqlite
@@ -274,7 +268,7 @@ In this section, the **Package Manager Console** (PMC) window is used to:
 
 The preceding commands:
 
-* Install the latest [the Entity Framework Core tools](/ef/core/get-started/overview/install#get-the-entity-framework-core-tools) after uninstalling any previous version, if it exists.
+* Install the latest [Entity Framework Core tools](/ef/core/get-started/overview/install#get-the-entity-framework-core-tools) after uninstalling any previous version, if it exists.
 * Run the `migrations` command to generate code that creates the initial database schema.
 
 The following warning is displayed, which is addressed in a later step:


### PR DESCRIPTION
[Internal review](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/model?view=aspnetcore-8.0&branch=pr-en-us-28290&tabs=visual-studio-code#scaffold-the-movie-model)

Fixes #28299 

The page currently instructs you to run an ASP.NET Code Generator command using the relative output folder "Pages\Movies" if you're using Windows and "Pages/Movies" otherwise. However, I was going through this tutorial on a Windows machine using VS Code and found that these instructions generate a PagesMovies folder, rather than a Pages/Movies folder. I resolved the issue by using the non-Windows command, which is why I suggest this change.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->