### PR TITLE
Improve SignalR Redis Cluster section

### DIFF
--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -221,7 +221,7 @@ There's a tradeoff between the number of nodes in the cluster and the throughput
 In the SignalR app, include all of the possible Redis nodes using either of the following approaches:
 
 * List the nodes in the connection string delimited with commas.
-* If using a custom behavior for connection failures, add the nodes to [`ConfigurationOptions.Endpoints`](https://stackexchange.github.io/StackExchange.Redis/Configuration#configuration-options).
+* If using custom behavior for connection failures, add the nodes to [`ConfigurationOptions.Endpoints`](https://stackexchange.github.io/StackExchange.Redis/Configuration#configuration-options).
 
 ## Next steps
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -214,7 +214,7 @@ services.AddSignalR()
 
 ## Redis Cluster
 
-[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, messages are delivered to all of the nodes of the cluster without code modifications to the app.
+[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers to achieve high availability. When Redis Cluster is used as the backplane for SignalR, messages are delivered to all of the nodes of the cluster without code modifications to the app.
 
 There's a tradeoff between the number of nodes in the cluster and the availability of the backplane, increasing one decreases the other. When additional nodes are added to the cluster, the backplane's availability to process messages is reduced.
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -212,15 +212,12 @@ services.AddSignalR()
 
 :::moniker-end
 
-## Redis high availability
+## Redis Cluster
 
-Redis offers two options for achieving high availability:
-
-1. [Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, all messages will get delivered to all the nodes of the Cluster without any code modifications to the app. However, there is a trade-off in that increasing the number of nodes in the Cluster decreases the message throughput of the backplane. This is because each message has to be sent N times where N is the number of active nodes in the Cluster.
-
-2. [Redis Sentinel](https://redis.io/docs/management/sentinel/) utilizes one or more Sentinel nodes to appoint a single active node out of multiple replicas. If the active node fails, another node will be promoted to be the active node. This achieves high availability without the message throughput trade-off.
+[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, all messages will get delivered to all the nodes of the Cluster without any code modifications to the app. However, there is a trade-off in that increasing the number of nodes in the Cluster decreases the message throughput of the backplane. This is because each message has to be sent N times where N is the number of active nodes in the Cluster.
 
 In the SignalR app, you should include all the possible Redis nodes either in the connection string using a comma as the delimiter, or by adding them as `EndPoints` in the `ConfigurationOptions` object if using a custom behavior for connection failures.
+
 
 ## Next steps
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -104,7 +104,7 @@ This article explains SignalR-specific aspects of setting up a [Redis](https://r
   
 * Configure options as needed:
  
-  Most options can be set in the connection string or in the [ConfigurationOptions](https://stackexchange.github.io/StackExchange.Redis/Configuration#configuration-options) object. Options specified in `ConfigurationOptions` override the ones set in the connection string.
+  Most options can be set in the connection string or in the [`ConfigurationOptions`](https://stackexchange.github.io/StackExchange.Redis/Configuration#configuration-options) object. Options specified in `ConfigurationOptions` override the ones set in the connection string.
 
   The following example shows how to set options in the `ConfigurationOptions` object. This example adds a channel prefix so that multiple apps can share the same Redis instance, as explained in the following step.
 
@@ -214,10 +214,12 @@ services.AddSignalR()
 
 ## Redis Cluster
 
-[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, all messages will get delivered to all the nodes of the Cluster without any code modifications to the app. However, there is a trade-off in that increasing the number of nodes in the Cluster decreases the message throughput of the backplane. This is because each message has to be sent N times where N is the number of active nodes in the Cluster.
+[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, all messages are delivered to all of the nodes of the cluster without code modifications to the app. However, there's a tradeoff in that increasing the number of nodes in the cluster decreases the message throughput of the backplane. This is because each message must be sent to every active node in the cluster.
 
-In the SignalR app, you should include all the possible Redis nodes either in the connection string using a comma as the delimiter, or by adding them as `EndPoints` in the `ConfigurationOptions` object if using a custom behavior for connection failures.
+In the SignalR app, include all of the possible Redis nodes using either of the following approaches:
 
+* List the nodes in the connection string delimited with commas.
+* If using a custom behavior for connection failures, add the nodes to [`ConfigurationOptions.Endpoints`](https://stackexchange.github.io/StackExchange.Redis/Configuration#configuration-options).
 
 ## Next steps
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -212,9 +212,15 @@ services.AddSignalR()
 
 :::moniker-end
 
-## Redis Clustering
+## Redis high availability
 
-[Redis Clustering](https://redis.io/topics/cluster-spec) is a method for achieving high availability by using multiple Redis servers. Clustering is supported without any code modifications to the app.
+Redis offers two options for achieving high availability:
+
+1. [Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, all messages will get delivered to all the nodes of the Cluster without any code modifications to the app. However, there is a trade-off in that increasing the number of nodes in the Cluster decreases the message throughput of the backplane. This is because each message has to be sent N times where N is the number of active nodes in the Cluster.
+
+2. [Redis Sentinel](https://redis.io/docs/management/sentinel/) utilizes one or more Sentinel nodes to appoint a single active node out of multiple replicas. If the active node fails, another node will be promoted to be the active node. This achieves high availability without the message throughput trade-off.
+
+In the SignalR app, you should include all the possible Redis nodes either in the connection string using a comma as the delimiter, or by adding them as `EndPoints` in the `ConfigurationOptions` object if using a custom behavior for connection failures.
 
 ## Next steps
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -214,7 +214,9 @@ services.AddSignalR()
 
 ## Redis Cluster
 
-[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, all messages are delivered to all of the nodes of the cluster without code modifications to the app. There's a tradeoff between the number of nodes in the cluster and the message throughput of the backplane, increasing one decreases the other.
+[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, messages are delivered to all of the nodes of the cluster without code modifications to the app.
+
+There's a tradeoff between the number of nodes in the cluster and the availability of the backplane, increasing one decreases the other. When additional nodes are added to the cluster, the backplane's availability to process messages is reduced.
 
 In the SignalR app, include all of the possible Redis nodes using either of the following approaches:
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -216,7 +216,7 @@ services.AddSignalR()
 
 [Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers to achieve high availability. When Redis Cluster is used as the backplane for SignalR, messages are delivered to all of the nodes of the cluster without code modifications to the app.
 
-There's a tradeoff between the number of nodes in the cluster and the availability of the backplane, increasing one decreases the other. When additional nodes are added to the cluster, the backplane's availability to process messages is reduced.
+There's a tradeoff between the number of nodes in the cluster and the throughput of the backplane. Increasing the number of nodes increases the availability of the cluster but decreases the throughput because messages must be transmitted to all of the nodes in the cluster.
 
 In the SignalR app, include all of the possible Redis nodes using either of the following approaches:
 

--- a/aspnetcore/signalr/redis-backplane.md
+++ b/aspnetcore/signalr/redis-backplane.md
@@ -214,7 +214,7 @@ services.AddSignalR()
 
 ## Redis Cluster
 
-[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, all messages are delivered to all of the nodes of the cluster without code modifications to the app. However, there's a tradeoff in that increasing the number of nodes in the cluster decreases the message throughput of the backplane. This is because each message must be sent to every active node in the cluster.
+[Redis Cluster](https://redis.io/topics/cluster-spec) utilizes multiple simultaneously active Redis servers. When Redis Cluster is used as the backplane for SignalR, all messages are delivered to all of the nodes of the cluster without code modifications to the app. There's a tradeoff between the number of nodes in the cluster and the message throughput of the backplane, increasing one decreases the other.
 
 In the SignalR app, include all of the possible Redis nodes using either of the following approaches:
 


### PR DESCRIPTION
SignalR Redis backplane documentation informs about the trade-off that increasing the number of nodes in a Redis Cluster decreases the message throughput of the backplane ([source video](https://www.youtube.com/watch?v=6G22a5Iooqk), and [source slides](https://www.slideshare.net/RedisLabs/redis-day-tlv-2018-scaling-redis-pubsub)).

Also mention that in the SignalR app, all the Redis nodes should be included in the Redis connection string or added as `EndPoints` in the `ConfigurationOptions` object.

Reference issue: https://github.com/dotnet/aspnetcore/issues/46408 