### PR TITLE
Switch VS Code launch.json URL to be http instead of https

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -194,7 +194,7 @@ For information on configuring VS Code assets in the `.vscode` folder, see the *
      "name": "Launch and Debug",
      "type": "blazorwasm",
      "request": "launch",
-     "url": "https://localhost:{PORT}"
+     "url": "http://localhost:{PORT}"
    }
    ```
 


### PR DESCRIPTION
Blazor WebAssembly apps used to launch by default with an HTTPS address, but users kept hitting issues with that so we switch back to HTTP by default. I copied the url property from the doc and it didn't work because the app was listening on an HTTP address, not HTTPS.
