### PR TITLE
Trust RHEL /6

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -425,6 +425,11 @@ certutil -d sql:$HOME/.pki/nssdb -D -n localhost
 certutil -d sql:$HOME/.mozilla/firefox/{userprofiles}/ -D -n localhost
 # Remove The Curl Alias
 ```
+
+# [SUSE Linux Enterprise Server](#tab/linux-sles)
+
+See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/28292)
+
 ---
 
 <a name="wsl"></a>

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -400,8 +400,8 @@ certutil -d sql:$HOME/.pki/nssdb -A -t "P,," -n localhost -i ~/web/localhost.crt
 certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n localhost -i ~/web/localhost.crt
 
 # Mozilla Firefox
-certutil -d sql:$HOME/.mozilla/firefox/{userprofile}/ -A -t "P,," -n localhost -i ~/web/ocalhost.crt
-certutil -d sql:$HOME/.mozilla/firefox/{userprofile}/ -A -t "C,," -n localhost -i ~/web/ocalhost.crt
+certutil -d sql:$HOME/.mozilla/firefox/{userprofile}/ -A -t "P,," -n localhost -i ~/web/localhost.crt
+certutil -d sql:$HOME/.mozilla/firefox/{userprofile}/ -A -t "C,," -n localhost -i ~/web/localhost.crt
 ```
 
 Create An Alias To Test With Curl:


### PR DESCRIPTION
Fixes [#28278](https://github.com/dotnet/AspNetCore.Docs/issues/28278)

[Internal review URL](https://review.learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?view=aspnetcore-8.0&branch=pr-en-us-28354&tabs=visual-studio%2Clinux-rhel#trust-https-certificate-on-linux-using-edge-or-chrome)

## Public review  of the doc build:
- download the [HTML files](https://www.dropbox.com/sh/yy994551cje0kap/AAB0tRnm7gze2kYrSYPSFHIda?dl=0)
- unzip
- view HTML file in a browser.
- For links outside the doc, remove the `review.` from URL.