### PR TITLE
Launch settings file for hosted WASM apps

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -1538,6 +1538,9 @@ The **:::no-loc text="Server":::** project's `Properties/launchSettings.json` fi
 }
 ```
 
+> [!NOTE]
+> When the app is launched from the :::no-loc text="Server"::: project, only the `Properties/launchSettings.json` file in the :::no-loc text="Server"::: project is used. The `Properties/launchSettings.json` file in the :::no-loc text="Client"::: project is ***not*** used.
+
 ## Attach to an existing debugging session
 
 To attach to a running Blazor app, create a `.vscode/launch.json` file with the following configuration. Replace the `{URL}` placeholder with the URL where the app is running:

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -47,6 +47,8 @@ For more information on trusting the ASP.NET Core HTTPS development certificate,
 
 > [!IMPORTANT]
 > When executing a hosted Blazor WebAssembly app, run the app from the solution's **:::no-loc text="Server":::** project.
+>
+> When the app is launched, only the `Properties/launchSettings.json` file in the :::no-loc text="Server"::: project is used.
 
 :::zone-end
 
@@ -250,6 +252,8 @@ Use the [.NET command-line interface (CLI)](/dotnet/core/tools/) to execute comm
 
    > [!IMPORTANT]
    > When executing a hosted Blazor WebAssembly app, run the app from the solution's **:::no-loc text="Server":::** project.
+   >
+   > When the app is launched, only the `Properties/launchSettings.json` file in the :::no-loc text="Server"::: project is used.
 
 :::moniker range=">= aspnetcore-6.0"
 
@@ -446,6 +450,8 @@ If a prompt appears to trust the development certificate, trust the certificate 
 
 > [!IMPORTANT]
 > When executing a hosted Blazor WebAssembly app, run the app from the solution's **:::no-loc text="Server":::** project.
+>
+> When the app is launched, only the `Properties/launchSettings.json` file in the :::no-loc text="Server"::: project is used.
 
 :::zone-end
 


### PR DESCRIPTION
Fixes #28382

Thanks @ScottPeabody! 🚀 ... This should help clear up the confusion about the `launchSettings.json` file in the **Client** project when the hosted app is run from the **Server** project. The remark(s) shouldn't appear in the *Host and deploy* node because this file is for local, debug/`dotnet run` runs of the app. Therefore, I only place it in the *Debug* and *Tooling* topic content where they speak to how to run a hosted WASM app (i.e., from the **Server** project).

WRT Kestrel settings at play with anything in Blazor, you'd need to call out the specifics that might be missing. The host app (the **Server** project) is just an ASP.NET Core app, so all of the main doc set guidance for configuring Kestrel applies. The only rub is that the app is serving the Blazor WASM app. I'm not aware of anything special to call out. You can open a new issue if you have something (or of list) of specific pain points or for general missing coverage.