### PR TITLE
Update integration-tests.md

### DIFF
--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -55,6 +55,39 @@ If the SUT's [environment](xref:fundamentals/environments) isn't set, the enviro
 
 ## Basic tests with the default WebApplicationFactory
 
+ASP.NET Core 6 introduced <xref:Microsoft.AspNetCore.Builder.WebApplication> which removed the need for a `Startup` class. To test with `WebApplicationFactory` without a `Startup` class, an ASP.NET Core 6 app needs to expose the implicitly defined `Program` class to the test project by doing one of the following:
+
+* Expose internal types from the web app to the test project. This can be done in the project file (`.csproj`):
+  ```xml
+  <ItemGroup>
+       <InternalsVisibleTo Include="MyTestProject" />
+  </ItemGroup>
+  ```
+* Make the `Program` class public using a partial class declaration:
+  ```diff
+  var builder = WebApplication.CreateBuilder(args);
+  // ... Configure services, routes, etc.
+  app.Run();
+  + public partial class Program { }
+  ```
+
+After making the changes in the web application, the test project now can use the `Program` class for the `WebApplicationFactory`.
+
+```csharp
+[Fact]
+public async Task HelloWorldTest()
+{
+    var application = new WebApplicationFactory<Program>()
+        .WithWebHostBuilder(builder =>
+        {
+            // ... Configure test services
+        });
+        
+    var client = application.CreateClient();
+    //...
+}
+```
+
 Expose the implicitly defined `Program` class to the test project by doing one of the following:
 
 * Expose internal types from the web app to the test project. This can be done in the SUT project's file (`.csproj`):
@@ -381,45 +414,6 @@ Entity Framework Core is also used in the tests. The app references:
 If the SUT's [environment](xref:fundamentals/environments) isn't set, the environment defaults to Development.
 
 ## Basic tests with the default WebApplicationFactory
-
-:::moniker-end
-:::moniker range="= aspnetcore-6.0"
-
-ASP.NET Core 6 introduced <xref:Microsoft.AspNetCore.Builder.WebApplication> which removed the need for a `Startup` class. To test with `WebApplicationFactory` without a `Startup` class, an ASP.NET Core 6 app needs to expose the implicitly defined `Program` class to the test project by doing one of the following:
-
-* Expose internal types from the web app to the test project. This can be done in the project file (`.csproj`):
-  ```xml
-  <ItemGroup>
-       <InternalsVisibleTo Include="MyTestProject" />
-  </ItemGroup>
-  ```
-* Make the `Program` class public using a partial class declaration:
-  ```diff
-  var builder = WebApplication.CreateBuilder(args);
-  // ... Configure services, routes, etc.
-  app.Run();
-  + public partial class Program { }
-  ```
-
-After making the changes in the web application, the test project now can use the `Program` class for the `WebApplicationFactory`.
-
-```csharp
-[Fact]
-public async Task HelloWorldTest()
-{
-    var application = new WebApplicationFactory<Program>()
-        .WithWebHostBuilder(builder =>
-        {
-            // ... Configure test services
-        });
-        
-    var client = application.CreateClient();
-    //...
-}
-```
-
-:::moniker-end
-:::moniker range="< aspnetcore-6.0"
 
 <xref:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory%601> is used to create a <xref:Microsoft.AspNetCore.TestHost.TestServer> for the integration tests. `TEntryPoint` is the entry point class of the SUT, usually the `Startup` class.
 

--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -419,7 +419,7 @@ public async Task HelloWorldTest()
 ```
 
 :::moniker-end
-:::moniker range="<= aspnetcore-6.0"
+:::moniker range="< aspnetcore-6.0"
 
 <xref:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory%601> is used to create a <xref:Microsoft.AspNetCore.TestHost.TestServer> for the integration tests. `TEntryPoint` is the entry point class of the SUT, usually the `Startup` class.
 

--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -55,38 +55,6 @@ If the SUT's [environment](xref:fundamentals/environments) isn't set, the enviro
 
 ## Basic tests with the default WebApplicationFactory
 
-ASP.NET Core 6 introduced <xref:Microsoft.AspNetCore.Builder.WebApplication> which removed the need for a `Startup` class. To test with `WebApplicationFactory` without a `Startup` class, an ASP.NET Core 6 app needs to expose the implicitly defined `Program` class to the test project by doing one of the following:
-
-* Expose internal types from the web app to the test project. This can be done in the project file (`.csproj`):
-  ```xml
-  <ItemGroup>
-       <InternalsVisibleTo Include="MyTestProject" />
-  </ItemGroup>
-  ```
-* Make the `Program` class public using a partial class declaration:
-  ```diff
-  var builder = WebApplication.CreateBuilder(args);
-  // ... Configure services, routes, etc.
-  app.Run();
-  + public partial class Program { }
-  ```
-
-After making the changes in the web application, the test project now can use the `Program` class for the `WebApplicationFactory`.
-
-```csharp
-[Fact]
-public async Task HelloWorldTest()
-{
-    var application = new WebApplicationFactory<Program>()
-        .WithWebHostBuilder(builder =>
-        {
-            // ... Configure test services
-        });
-        
-    var client = application.CreateClient();
-    //...
-}
-```
 
 Expose the implicitly defined `Program` class to the test project by doing one of the following:
 

--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -14,7 +14,7 @@ By [Jos van der Til](https://jvandertil.nl), [Martin Costello](https://martincos
 
 Integration tests ensure that an app's components function correctly at a level that includes the app's supporting infrastructure, such as the database, file system, and network. ASP.NET Core supports integration tests using a unit test framework with a test web host and an in-memory test server.
 
-:::moniker range=">= aspnetcore-7.0"
+:::moniker range=">= aspnetcore-6.0"
 
 This article assumes a basic understanding of unit tests. If unfamiliar with test concepts, see the [Unit Testing in .NET Core and .NET Standard](/dotnet/core/testing/) article and its linked content.
 
@@ -334,7 +334,7 @@ The SUT's database context is registered in `Program.cs`. The test app's `builde
 
 :::moniker-end
 
-:::moniker range="<= aspnetcore-6.0"
+:::moniker range="<= aspnetcore-5.0"
 
 This topic assumes a basic understanding of unit tests. If unfamiliar with test concepts, see the [Unit Testing in .NET Core and .NET Standard](/dotnet/core/testing/) topic and its linked content.
 


### PR DESCRIPTION
Fixes #23543

@jvandertil the .NET 7 version should work with .NET 6. The monikers for .NET 6 used the .NET 5 version.

[Internal review URL](https://review.learn.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-8.0&branch=pr-en-us-28389)

## Public review  of the doc build:
- download the [HTML files](https://www.dropbox.com/sh/yy994551cje0kap/AAB0tRnm7gze2kYrSYPSFHIda?dl=0)
- unzip
- view HTML file in a browser.
- For links outside the doc, remove the `review.` from URL.