### PR TITLE
gRPC json transcoding - Clarify proto path

### DIFF
--- a/aspnetcore/grpc/json-transcoding.md
+++ b/aspnetcore/grpc/json-transcoding.md
@@ -4,8 +4,9 @@ author: jamesnk
 description: Learn how to create JSON HTTP APIs for gRPC services using gRPC JSON transcoding.
 monikerRange: '>= aspnetcore-7.0'
 ms.author: jamesnk
-ms.date: 09/20/2022
+ms.date: 02/19/2023
 uid: grpc/json-transcoding
+ms.custom: engagement-fy23
 ---
 # gRPC JSON transcoding in ASP.NET Core gRPC apps
 
@@ -13,7 +14,7 @@ By [James Newton-King](https://twitter.com/jamesnk)
 
 [gRPC](https://grpc.io) is a high-performance Remote Procedure Call (RPC) framework. gRPC uses HTTP/2, streaming, Protobuf, and message contracts to create high-performance, real-time services.
 
-One limitation with gRPC is not every platform can use it. Browsers don't fully support HTTP/2, making [REST APIs](https://www.redhat.com/topics/api/what-is-a-rest-api) and JSON the primary way to get data into browser apps. Despite the benefits that gRPC brings, REST APIs and JSON have an important place in modern apps. Building gRPC ***and*** JSON Web APIs adds unwanted overhead to app development.
+One limitation with gRPC is that not every platform can use it. Browsers don't fully support HTTP/2, making [REST APIs](https://www.redhat.com/topics/api/what-is-a-rest-api) and JSON the primary way to get data into browser apps. Despite the benefits that gRPC brings, REST APIs and JSON have an important place in modern apps. Building gRPC ***and*** JSON Web APIs adds unwanted overhead to app development.
 
 This document discusses how to create JSON Web APIs using gRPC services.
 
@@ -34,7 +35,8 @@ gRPC can still be used to call services.
 
 1. Add a package reference to [`Microsoft.AspNetCore.Grpc.JsonTranscoding`](https://www.nuget.org/packages/Microsoft.AspNetCore.Grpc.JsonTranscoding).
 1. Register transcoding in server startup code by adding `AddJsonTranscoding`. For example, `services.AddGrpc().AddJsonTranscoding()`.
-1. Add [`google/api/http.proto`](https://github.com/dotnet/aspnetcore/blob/main/src/Grpc/JsonTranscoding/test/testassets/Sandbox/google/api/http.proto) and [`google/api/annotations.proto`](https://github.com/dotnet/aspnetcore/blob/main/src/Grpc/JsonTranscoding/test/testassets/Sandbox/google/api/annotations.proto) files to the project.
+1. Create the directory structure `/google/api` in the project directory that contains the `.csproj` file.
+1. Add [`google/api/http.proto`](https://github.com/dotnet/aspnetcore/blob/main/src/Grpc/JsonTranscoding/test/testassets/Sandbox/google/api/http.proto) and [`google/api/annotations.proto`](https://github.com/dotnet/aspnetcore/blob/main/src/Grpc/JsonTranscoding/test/testassets/Sandbox/google/api/annotations.proto) files to the `/google/api` directory.
 1. Annotate gRPC methods in your `.proto` files with HTTP bindings and routes:
 
 [!code-protobuf[](~/grpc/json-transcoding/greet.proto?highlight=3,9-11)]
@@ -46,7 +48,7 @@ The `SayHello` gRPC method can now be invoked as gRPC and as a JSON Web API:
 
 If the server is configured to write logs for each request, server logs show that a gRPC service executes the HTTP call. Transcoding maps the incoming HTTP request to a gRPC message and converts the response message to JSON.
 
-```
+```text
 info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
       Request starting HTTP/1.1 GET https://localhost:5001/v1/greeter/world
 info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]


### PR DESCRIPTION
[Internal review](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/json-transcoding?view=aspnetcore-8.0&branch=pr-en-us-28454#usage)
Fixes #27206

Clarifying where to add google/api/http.proto and google/api/annotations proto files in an ASP.NET Core gRPC project