### PR TITLE
Patch JS collocation content

### DIFF
--- a/aspnetcore/blazor/file-downloads.md
+++ b/aspnetcore/blazor/file-downloads.md
@@ -3,7 +3,7 @@ title: ASP.NET Core Blazor file downloads
 author: guardrex
 description: Learn how to download files using Blazor Server and Blazor WebAssembly.
 monikerRange: '>= aspnetcore-6.0'
-ms.author: taparik
+ms.author: riande
 ms.custom: mvc
 ms.date: 11/08/2022
 uid: blazor/file-downloads

--- a/aspnetcore/blazor/images.md
+++ b/aspnetcore/blazor/images.md
@@ -3,7 +3,7 @@ title: Work with images in ASP.NET Core Blazor
 author: guardrex
 description: Learn how to work with images in ASP.NET Core Blazor apps.
 monikerRange: '>= aspnetcore-6.0'
-ms.author: taparik
+ms.author: riande
 ms.custom: mvc
 ms.date: 11/08/2022
 uid: blazor/images

--- a/aspnetcore/includes/js-collocation.md
+++ b/aspnetcore/includes/js-collocation.md
@@ -31,7 +31,7 @@ Collocated JS files are publicly addressable using the ***path to the file in th
 
   Blazor example:
 
-  A JS file for the `Index` component is placed in the `Pages` folder (`Pages/Index.razor.js`) next to the `Index` component (`Pages/Index.razor`). In the `Index` component, the script is referenced at the path in the `Pages` folder. The following example is based on an example shown in the <xref:blazor/js-interop/call-javascript-from-dotnet#javascript-isolation-in-javascript-modules> article.
+  A JS file for the `Index` component is placed in the `Pages` folder (`Pages/Index.razor.js`) next to the `Index` component (`Pages/Index.razor`). In the `Index` component, the script is referenced at the path in the `Pages` folder.
 
   `Pages/Index.razor.js`:
 


### PR DESCRIPTION
Patch needed that I noticed in passing on https://github.com/dotnet/AspNetCore.Docs/issues/28456. The example in this file is no longer the exact example in the cross-linked content, so I'm just going to 🔪💀 that line. 

I'll also take Tanay off of the `ms.author` metadata, which I see flagged on the build report.