### PR TITLE
document conditional attribute rendering in razor

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -263,11 +263,11 @@ Razor will automatically omit attributes that are not needed. If the value passe
 For example, the following razor code:
 
 ```cshtml
-<div class="@false" >False</div>
-<div class="@null" >Null</div>
-<div class="@("")" >Empty</div>
-<div class="@("false")" >False String</div>
-<div class="@("active")" >String</div>
+<div class="@false">False</div>
+<div class="@null">Null</div>
+<div class="@("")">Empty</div>
+<div class="@("false")">False String</div>
+<div class="@("active")">String</div>
 <input type="checkbox" checked="@true" name="true" />
 <input type="checkbox" checked="@false" name="false" />
 <input type="checkbox" checked="@null" name="null" />
@@ -281,9 +281,9 @@ Will produce the following output:
 <div class="">Empty</div>
 <div class="False">False String</div>
 <div class="active">String</div>
-<input type="checkbox" checked="checked">
-<input type="checkbox">
-<input type="checkbox">
+<input type="checkbox" checked="checked" name="true">
+<input type="checkbox" name="false">
+<input type="checkbox" name="null">
 ```
 
 ## Control structures

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -256,6 +256,36 @@ Without the `@:` in the code, a Razor runtime error is generated.
 
 Extra `@` characters in a Razor file can cause compiler errors at statements later in the block. These compiler errors can be difficult to understand because the actual error occurs before the reported error. This error is common after combining multiple implicit/explicit expressions into a single code block.
 
+### Conditional attribute rendering
+
+Razor will automatically omit attributes that are not needed. If the value passed in is `null` or `false` the attribute won't be rendered.
+
+For example, the following razor code:
+
+```cshtml
+<div class="@false" >False</div>
+<div class="@null" >Null</div>
+<div class="@("")" >Empty</div>
+<div class="@("false")" >False String</div>
+<div class="@("active")" >String</div>
+<input type="checkbox" checked="@true" name="true" />
+<input type="checkbox" checked="@false" name="false" />
+<input type="checkbox" checked="@null" name="null" />
+```
+
+Will produce the following output:
+
+```html
+<div>False</div>
+<div>Null</div>
+<div class="">Empty</div>
+<div class="False">False String</div>
+<div class="active">String</div>
+<input type="checkbox" checked="checked">
+<input type="checkbox">
+<input type="checkbox">
+```
+
 ## Control structures
 
 Control structures are an extension of code blocks. All aspects of code blocks (transitioning to markup, inline C#) also apply to the following structures:

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -254,13 +254,16 @@ To render the rest of an entire line as HTML inside a code block, use `@:` synta
 
 Without the `@:` in the code, a Razor runtime error is generated.
 
-Extra `@` characters in a Razor file can cause compiler errors at statements later in the block. These compiler errors can be difficult to understand because the actual error occurs before the reported error. This error is common after combining multiple implicit/explicit expressions into a single code block.
+Extra `@` characters in a Razor file can cause compiler errors at statements later in the block. These extra `@` compiler errors:
+
+* Can be difficult to understand because the actual error occurs before the reported error.
+* Is common after combining multiple implicit and explicit expressions into a single code block.
 
 ### Conditional attribute rendering
 
-Razor will automatically omit attributes that are not needed. If the value passed in is `null` or `false` the attribute won't be rendered.
+Razor automatically omits attributes that aren't needed. If the value passed in is `null` or `false`, the attribute won't be rendered.
 
-For example, the following razor code:
+For example,  consider the following razor code:
 
 ```cshtml
 <div class="@false">False</div>
@@ -273,7 +276,7 @@ For example, the following razor code:
 <input type="checkbox" checked="@null" name="null" />
 ```
 
-Will produce the following output:
+The preceding Razor markup generates the following HTML:
 
 ```html
 <div>False</div>

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -261,7 +261,7 @@ Extra `@` characters in a Razor file can cause compiler errors at statements lat
 
 ### Conditional attribute rendering
 
-Razor automatically omits attributes that aren't needed. If the value passed in is `null` or `false`, the attribute won't be rendered.
+Razor automatically omits attributes that aren't needed. If the value passed in is `null` or `false`, the attribute isn't rendered.
 
 For example,  consider the following razor code:
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -263,7 +263,7 @@ Extra `@` characters in a Razor file can cause compiler errors at statements lat
 
 Razor automatically omits attributes that aren't needed. If the value passed in is `null` or `false`, the attribute isn't rendered.
 
-For example,  consider the following razor code:
+For example,  consider the following razor:
 
 ```cshtml
 <div class="@false">False</div>


### PR DESCRIPTION
The only two most prominent places I could find this docummented are:

* [Conditional Attributes in Razor View Engine and ASP.NET MVC 4](https://www.davidhayden.me/blog/conditional-attributes-in-razor-view-engine-and-asp.net-mvc-4)
* [Jon Galloway - ASP.NET MVC 4 Beta Released!](https://weblogs.asp.net/jongalloway/asp-net-4-beta-released)

As well as these two Stack Overflow posts:

* [Conditional HTML Attributes using Razor](https://stackoverflow.com/questions/8061647/1366033)
* [ASP.NET MVC razor - Conditional attribute in HTML](https://stackoverflow.com/questions/9399531/1366033)

But couldn't find anything about this behavior in the official docs.  


Since it's more likely that people will use these attributes with variables, instead of inlined hard coded values, the example might be more illustrative if the cshtml block looked like this:

```cshtml
@{
    var myClassFalse = false;
    string myClassNull = null;
    var myClassEmpty = "";
    var myClassFalseString = "false";
    var myClassString = "active";
    var isCheckedTrue = true;
    var isCheckedFalse = false;
    bool? isCheckedNull = null;
}

<div class="@myClassFalse" >False</div>
<div class="@myClassNull" >Null</div>
<div class="@myClassEmpty" >Empty</div>
<div class="@myClassFalseString" >False String</div>
<div class="@myClassString" >String</div>
<input type="checkbox" checked="@isCheckedTrue" name="true" />
<input type="checkbox" checked="@isCheckedFalse" name="false" />
<input type="checkbox" checked="@isCheckedNull" name="null" />
```

Which would produce the same output, but then also gets a little long to effectively illustrate the same concept.

***EDIT by @Rick-Anderson***
Fixes #28476