### PR TITLE
SignalR: libman: command not found

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -6,7 +6,7 @@ description: In this tutorial, you create a chat app that uses ASP.NET Core Sign
 ms.author: wpickett
 monikerRange: '>= aspnetcore-3.1'
 ms.custom: mvc
-ms.date: 11/21/2021
+ms.date: 02/22/2023
 uid: tutorials/signalr
 
 # Customer intent: As a developer, I want to get a quick proof-of-concept app running, so I can get a practical introduction to ASP.NET Core SignalR.
@@ -124,9 +124,10 @@ The SignalR server library is included in the ASP.NET Core shared framework. The
 
 # [Visual Studio Code](#tab/visual-studio-code/)
 
-  * In the integrated terminal, run the following command to install LibMan.
+  * In the integrated terminal, run the following command to install LibMan after uninstalling any previous version, if one exists.
 
   ```dotnetcli
+  dotnet tool uninstall -g Microsoft.Web.LibraryManager.Cli
   dotnet tool install -g Microsoft.Web.LibraryManager.Cli
   ```
 

--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -124,7 +124,7 @@ The SignalR server library is included in the ASP.NET Core shared framework. The
 
 # [Visual Studio Code](#tab/visual-studio-code/)
 
-  * In the integrated terminal, run the following command to install LibMan after uninstalling any previous version, if one exists.
+  * In the integrated terminal, run the following commands to install LibMan after uninstalling any previous version, if one exists.
 
   ```dotnetcli
   dotnet tool uninstall -g Microsoft.Web.LibraryManager.Cli
@@ -152,9 +152,10 @@ The SignalR server library is included in the ASP.NET Core shared framework. The
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
-  * In the **Terminal**, run the following command to install LibMan.
+  * In the **Terminal**, run the following commands to install LibMan after uninstalling any previous version, if one exists.
 
   ```dotnetcli
+  dotnet tool uninstall -g Microsoft.Web.LibraryManager.Cli
   dotnet tool install -g Microsoft.Web.LibraryManager.Cli
   ```
 


### PR DESCRIPTION
Fixes #26776 

[Review URL -  Both VSC and VS for Mac tabs](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/signalr?view=aspnetcore-8.0&branch=pr-en-us-28475&tabs=visual-studio-code#add-the-signalr-client-library)

