### PR TITLE
Breakout sections and updates

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -111,7 +111,7 @@ The following markup in the `HeadingExample` component renders the preceding `He
 
 :::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Pages/index/HeadingExample.razor":::
 
-If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespaces](#class-name-and-namespaces) section.
+If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespace](#class-name-and-namespace) section.
 
 The `Heading` component example shown in this section doesn't have an [`@page`][9] directive, so the `Heading` component isn't directly accessible to a user via a direct request in the browser. However, any component with an [`@page`][9] directive can be nested in another component. If the `Heading` component was directly accessible by including `@page "/heading"` at the top of its Razor file, then the component would be rendered for browser requests at both `/heading` and `/heading-example`.
 
@@ -1613,7 +1613,7 @@ The following markup in the `HeadingExample` component renders the preceding `He
 
 :::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/index/HeadingExample.razor":::
 
-If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespaces](#class-name-and-namespaces) section.
+If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespace](#class-name-and-namespace) section.
 
 The `Heading` component example shown in this section doesn't have an [`@page`][9] directive, so the `Heading` component isn't directly accessible to a user via a direct request in the browser. However, any component with an [`@page`][9] directive can be nested in another component. If the `Heading` component was directly accessible by including `@page "/heading"` at the top of its Razor file, then the component would be rendered for browser requests at both `/heading` and `/heading-example`.
 
@@ -3067,7 +3067,7 @@ The following markup in the `HeadingExample` component renders the preceding `He
 
 :::code language="razor" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/Pages/index/HeadingExample.razor":::
 
-If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespaces](#class-name-and-namespaces) section.
+If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespace](#class-name-and-namespace) section.
 
 The `Heading` component example shown in this section doesn't have an [`@page`][9] directive, so the `Heading` component isn't directly accessible to a user via a direct request in the browser. However, any component with an [`@page`][9] directive can be nested in another component. If the `Heading` component was directly accessible by including `@page "/heading"` at the top of its Razor file, then the component would be rendered for browser requests at both `/heading` and `/heading-example`.
 
@@ -4086,7 +4086,7 @@ The following markup in the `HeadingExample` component renders the preceding `He
 
 :::code language="razor" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/Pages/index/HeadingExample.razor":::
 
-If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespaces](#class-name-and-namespaces) section.
+If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespace](#class-name-and-namespace) section.
 
 The `Heading` component example shown in this section doesn't have an [`@page`][9] directive, so the `Heading` component isn't directly accessible to a user via a direct request in the browser. However, any component with an [`@page`][9] directive can be nested in another component. If the `Heading` component was directly accessible by including `@page "/heading"` at the top of its Razor file, then the component would be rendered for browser requests at both `/heading` and `/heading-example`.
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -89,8 +89,6 @@ Component members are used in rendering logic using C# expressions that start wi
 
 The Blazor framework processes a component internally as a [*render tree*](https://developer.mozilla.org/docs/Web/Performance/How_browsers_work#render), which is the combination of a component's [Document Object Model (DOM)](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction) and [Cascading Style Sheet Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model). After the component is initially rendered, the component's render tree is regenerated in response to events. Blazor compares the new render tree against the previous render tree and applies any modifications to the browser's DOM for display. For more information, see <xref:blazor/components/rendering>.
 
-Components are ordinary [C# classes](/dotnet/csharp/programming-guide/classes-and-structs/classes) and can be placed anywhere within a project. Components that produce webpages usually reside in the `Pages` folder. Non-page components are frequently placed in the `Shared` folder or a custom folder added to the project.
-
 Razor syntax for C# control structures, directives, and directive attributes are lowercase (examples: [`@if`](xref:mvc/views/razor#conditionals-if-else-if-else-and-switch), [`@code`](xref:mvc/views/razor#code), [`@bind`](xref:mvc/views/razor#bind)). Property names are uppercase (example: `@Body` for <xref:Microsoft.AspNetCore.Components.LayoutComponentBase.Body?displayProperty=nameWithType>).
 
 ### Asynchronous methods (`async`) don't support returning `void`
@@ -113,11 +111,13 @@ The following markup in the `HeadingExample` component renders the preceding `He
 
 :::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Pages/index/HeadingExample.razor":::
 
-If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Namespaces](#namespaces) section.
+If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespaces](#class-name-and-namespaces) section.
 
 The `Heading` component example shown in this section doesn't have an [`@page`][9] directive, so the `Heading` component isn't directly accessible to a user via a direct request in the browser. However, any component with an [`@page`][9] directive can be nested in another component. If the `Heading` component was directly accessible by including `@page "/heading"` at the top of its Razor file, then the component would be rendered for browser requests at both `/heading` and `/heading-example`.
 
-### Namespaces
+### Class name and namespace
+
+Components are ordinary [C# classes](/dotnet/csharp/programming-guide/classes-and-structs/classes) and can be placed anywhere within a project. Components that produce webpages usually reside in the `Pages` folder. Non-page components are frequently placed in the `Shared` folder or a custom folder added to the project.
 
 Typically, a component's namespace is derived from the app's root namespace and the component's location (folder) within the app. If the app's root namespace is `BlazorSample` and the `Counter` component resides in the `Pages` folder:
 
@@ -1464,263 +1464,6 @@ For more information, see the following resources:
 * <xref:mvc/views/tag-helpers/builtin-th/component-tag-helper>
 * <xref:blazor/components/prerendering-and-integration>
 
-## Render Razor components from JavaScript
-
-Razor components can be dynamically-rendered from JavaScript (JS) for existing JS apps.
-
-The example in this section renders the following Razor component into a page via JS.
-
-`Shared/Quote.razor`:
-
-```razor
-<div class="m-5 p-5">
-    <h2>Quote</h2>
-    <p>@Text</p>
-</div>
-
-@code {
-    [Parameter]
-    public string? Text { get; set; }
-}
-```
-
-In `Program.cs`, add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`:
-
-```csharp
-using BlazorSample.Shared;
-```
-
-Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the a Razor component as a root component for JS rendering.
-
-<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that executes initialization logic (`javaScriptInitializer`). The JS function is called once per component registration immediately after the Blazor app starts and before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework.
-
-One or more initializer functions can be created and called by different component registrations. The typical use case is to reuse the same initializer function for multiple components, which is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
-
-> [!IMPORTANT]
-> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
-
-The following example demonstrates the dynamic registration of the preceding `Quote` component with "`quote`" as the identifier.
-
-* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
-
-  ```csharp
-  builder.Services.AddServerSideBlazor(options =>
-  {
-      options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-          javaScriptInitializer: "initializeComponent");
-  });
-  ```
-
-* In a Blazor WebAssembly app, call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
-
-  ```csharp
-  builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-      javaScriptInitializer: "initializeComponent");
-  ```
-
-Attach the initializer function with `name` and `parameters` function parameters to the `window` object. For demonstration purposes, the following `initializeComponent` function logs the name and parameters of the registered component.
-
-`wwwroot/js/jsComponentInitializers.js`:
-
-```javascript
-window.initializeComponent = (name, parameters) => {
-  console.log({ name: name, parameters: parameters });
-}
-```
-
-Render the component from JS into a container element using the registered identifier, passing component parameters as needed. 
-
-In the following example:
-
-* The `Quote` component (`quote` identifier) is rendered into the `quoteContainer` element when the `showQuote` function is called.
-* A quote string is passed to the component's `Text` parameter.
-
-`wwwroot/js/scripts.js`:
-
-```javascript
-async function showQuote() {
-  let targetElement = document.getElementById('quoteContainer');
-  await Blazor.rootComponents.add(targetElement, 'quote', 
-  {
-    text: "Crow: I have my doubts that this movie is actually 'starring' " +
-      "anybody. More like, 'camera is generally pointed at.'"
-  });
-}
-```
-
-Load Blazor (`blazor.server.js` or `blazor.webassembly.js`) with the preceding scripts into the JS app:
-
-```html
-<script src="_framework/blazor.{server|webassembly}.js"></script>
-<script src="js/jsComponentInitializers.js"></script>
-<script src="js/scripts.js"></script>
-```
-
-In HTML, place the target container element (`quoteContainer`). For the demonstration in this section, a button triggers rendering the `Quote` component by calling the `showQuote` JS function:
-
-```html
-<button onclick="showQuote()">Show Quote</button>
-
-<div id="quoteContainer"></div>
-```
-
-On initialization before any components are rendered, the browser's developer tools console logs the `Quote` component's identifier (`name`) and parameters (`parameters`) when `initializeComponent` is called:
-
-```console
-Object { name: "quote", parameters: (1) […] }
-  name: "quote"
-  parameters: Array [ {…} ]
-    0: Object { name: "Text", type: "string" }
-    length: 1
-```
-
-When the **:::no-loc text="Show Quote":::** button is selected, the `Quote` component is rendered with the quote stored in `Text` displayed:
-
-![Quote rendered in the browser](~/blazor/components/index/_static/quote.png)
-
-Quote &copy;1988-1999 Satellite of Love LLC: [*Mystery Science Theater 3000*](https://mst3k.com/) ([Trace Beaulieu (Crow)](https://www.imdb.com/name/nm0064546/))
-
-> [!NOTE]
-> `rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
->
-> ```javascript
-> const rootComponent = await window.Blazor.rootComponents.add(...);
->
-> ...
->
-> rootComponent.dispose();
-> ```
-
-For an advanced example with additional features, see the example in the `BasicTestApp` of the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository):
-
-* [`JavaScriptRootComponents.razor`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/JavaScriptRootComponents.razor)
-* [`wwwroot/js/jsRootComponentInitializers.js`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsRootComponentInitializers.js)
-* [`wwwroot/index.html`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/index.html)
-
-[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
-
-## Blazor custom elements
-
-Use Blazor custom elements to dynamically render Razor components from other SPA frameworks, such as Angular or React.
-
-Blazor custom elements:
-
-* Use standard HTML interfaces to implement custom HTML elements.
-* Eliminate the need to manually manage the state and lifecycle of root Razor components using JavaScript APIs.
-* Are useful for gradually introducing Razor components into existing projects written in other SPA frameworks.
-
-Custom elements don't support [child content](#child-content-render-fragments) or [templated components](xref:blazor/components/templated-components).
-
-### Element name
-
-Per the [HTML specification](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts), custom element tag names must adopt kebab case:
-
-<span aria-hidden="true">❌</span><span class="visually-hidden">Invalid:</span> `mycounter`  
-<span aria-hidden="true">❌</span><span class="visually-hidden">Invalid:</span> `MY-COUNTER`  
-<span aria-hidden="true">❌</span><span class="visually-hidden">Invalid:</span> `MyCounter`  
-<span aria-hidden="true">✔️</span><span class="visually-hidden">Valid:</span> `my-counter`  
-<span aria-hidden="true">✔️</span><span class="visually-hidden">Valid:</span> `my-cool-counter`
-
-### Package
-
-Add a package reference for [`Microsoft.AspNetCore.Components.CustomElements`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.CustomElements) to the app's project file.
-
-[!INCLUDE[](~/includes/package-reference.md)]
-
-### Blazor Server registration
-
-To register a root component as a custom element in a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`. The following example registers the `Counter` component with the custom HTML element `my-counter`:
-
-```csharp
-builder.Services.AddServerSideBlazor(options =>
-{
-    options.RootComponents.RegisterCustomElement<Counter>("my-counter");
-});
-```
-
-> [!NOTE]
-> The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
-
-### Blazor WebAssembly registration
-
-To register a root component as a custom element in a Blazor WebAssembly app, call `RegisterCustomElement` on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`. The following example registers the `Counter` component with the custom HTML element `my-counter`:
-
-```csharp
-builder.RootComponents.RegisterCustomElement<Counter>("my-counter");
-```
-
-> [!NOTE]
-> The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
-
-### Use the registered custom element
-
-Use the custom element with any web framework. For example, the preceding `my-counter` custom HTML element that renders the app's `Counter` component is used in a React app with the following markup:
-
-```html
-<my-counter></my-counter>
-```
-
-For a complete example of how to create custom elements with Blazor, see the [`CustomElementsComponent` component](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/CustomElementsComponent.razor) in the reference source.
-
-[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
-
-### Pass parameters
-
-Pass parameters to your Blazor component either as HTML attributes or as JavaScript properties on the DOM element.
-
-The following `Counter` component uses an `IncrementAmount` parameter to set the increment amount of the **:::no-loc text="Click me":::** button.
-
-`Pages/Counter.razor`:
-
-```razor
-@page "/counter"
-
-<h1>Counter</h1>
-
-<p role="status">Current count: @currentCount</p>
-
-<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
-
-@code {
-    private int currentCount = 0;
-
-    [Parameter]
-    public int IncrementAmount { get; set; } = 1;
-
-    private void IncrementCount()
-    {
-        currentCount += IncrementAmount;
-    }
-}
-```
-
-Render the `Counter` component with the custom element and pass a value to the `IncrementAmount` parameter as an HTML attribute. The attribute name adopts kebab-case syntax (`increment-amount`, not `IncrementAmount`):
-
-```html
-<my-counter increment-amount="10"></my-counter>
-```
-
-Alternatively, you can set the parameter's value as a JavaScript property on the element object. The property name adopts camel case syntax (`incrementAmount`, not `IncrementAmount`):
-
-```javascript
-const elem = document.querySelector("my-counter");
-elem.incrementAmount = 10;
-```
-
-You can update parameter values at any time using either attribute or property syntax.
-
-Supported parameter types:
-
-* Using JavaScript property syntax, you can pass objects of any JSON-serializable type.
-* Using HTML attributes, you are limited to passing objects of string, boolean, or numerical types.
-
-## Generate Angular and React components
-
-Generate framework-specific JavaScript (JS) components from Razor components for web frameworks, such as Angular or React. This capability isn't included with .NET, but is enabled by the support for rendering Razor components from JS. The [JS component generation sample on GitHub](https://github.com/aspnet/samples/tree/main/samples/aspnetcore/blazor/JSComponentGeneration) demonstrates how to generate Angular and React components from Razor components. See the GitHub sample app's `README.md` file for additional information.
-
-> [!WARNING]
-> The Angular and React component features are currently **experimental, unsupported, and subject to change or be removed at any time**. We welcome your feedback on how well this particular approach meets your requirements.
-
 ## `QuickGrid` component
 
 The `QuickGrid` component is an experimental Razor component for quickly and efficiently displaying data in tabular form. `QuickGrid` provides a simple and convenient data grid component for common grid rendering scenarios and serves as a reference architecture and performance baseline for building data grid components. `QuickGrid` is highly optimized and uses advanced techniques to achieve optimal rendering performance.
@@ -1848,8 +1591,6 @@ Component members are used in rendering logic using C# expressions that start wi
 
 The Blazor framework processes a component internally as a [*render tree*](https://developer.mozilla.org/docs/Web/Performance/How_browsers_work#render), which is the combination of a component's [Document Object Model (DOM)](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction) and [Cascading Style Sheet Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model). After the component is initially rendered, the component's render tree is regenerated in response to events. Blazor compares the new render tree against the previous render tree and applies any modifications to the browser's DOM for display. For more information, see <xref:blazor/components/rendering>.
 
-Components are ordinary [C# classes](/dotnet/csharp/programming-guide/classes-and-structs/classes) and can be placed anywhere within a project. Components that produce webpages usually reside in the `Pages` folder. Non-page components are frequently placed in the `Shared` folder or a custom folder added to the project.
-
 Razor syntax for C# control structures, directives, and directive attributes are lowercase (examples: [`@if`](xref:mvc/views/razor#conditionals-if-else-if-else-and-switch), [`@code`](xref:mvc/views/razor#code), [`@bind`](xref:mvc/views/razor#bind)). Property names are uppercase (example: `@Body` for <xref:Microsoft.AspNetCore.Components.LayoutComponentBase.Body?displayProperty=nameWithType>).
 
 ### Asynchronous methods (`async`) don't support returning `void`
@@ -1872,11 +1613,13 @@ The following markup in the `HeadingExample` component renders the preceding `He
 
 :::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/index/HeadingExample.razor":::
 
-If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Namespaces](#namespaces) section.
+If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespaces](#class-name-and-namespaces) section.
 
 The `Heading` component example shown in this section doesn't have an [`@page`][9] directive, so the `Heading` component isn't directly accessible to a user via a direct request in the browser. However, any component with an [`@page`][9] directive can be nested in another component. If the `Heading` component was directly accessible by including `@page "/heading"` at the top of its Razor file, then the component would be rendered for browser requests at both `/heading` and `/heading-example`.
 
-### Namespaces
+### Class name and namespace
+
+Components are ordinary [C# classes](/dotnet/csharp/programming-guide/classes-and-structs/classes) and can be placed anywhere within a project. Components that produce webpages usually reside in the `Pages` folder. Non-page components are frequently placed in the `Shared` folder or a custom folder added to the project.
 
 Typically, a component's namespace is derived from the app's root namespace and the component's location (folder) within the app. If the app's root namespace is `BlazorSample` and the `Counter` component resides in the `Pages` folder:
 
@@ -3223,196 +2966,6 @@ For more information, see the following resources:
 * <xref:mvc/views/tag-helpers/builtin-th/component-tag-helper>
 * <xref:blazor/components/prerendering-and-integration>
 
-## Render Razor components from JavaScript
-
-Razor components can be dynamically-rendered from JavaScript (JS) for existing JS apps.
-
-The example in this section renders the following Razor component into a page via JS.
-
-`Shared/Quote.razor`:
-
-```razor
-<div class="m-5 p-5">
-    <h2>Quote</h2>
-    <p>@Text</p>
-</div>
-
-@code {
-    [Parameter]
-    public string? Text { get; set; }
-}
-```
-
-In `Program.cs`, add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`:
-
-```csharp
-using BlazorSample.Shared;
-```
-
-Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the a Razor component as a root component for JS rendering.
-
-<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that executes initialization logic (`javaScriptInitializer`). The JS function is called once per component registration immediately after the Blazor app starts and before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework.
-
-One or more initializer functions can be created and called by different component registrations. The typical use case is to reuse the same initializer function for multiple components, which is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
-
-> [!IMPORTANT]
-> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
-
-The following example demonstrates the dynamic registration of the preceding `Quote` component with "`quote`" as the identifier.
-
-* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
-
-  ```csharp
-  builder.Services.AddServerSideBlazor(options =>
-  {
-      options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-          javaScriptInitializer: "initializeComponent");
-  });
-  ```
-
-* In a Blazor WebAssembly app, call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
-
-  ```csharp
-  builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
-      javaScriptInitializer: "initializeComponent");
-  ```
-
-Attach the initializer function with `name` and `parameters` function parameters to the `window` object. For demonstration purposes, the following `initializeComponent` function logs the name and parameters of the registered component.
-
-`wwwroot/js/jsComponentInitializers.js`:
-
-```javascript
-window.initializeComponent = (name, parameters) => {
-  console.log({ name: name, parameters: parameters });
-}
-```
-
-Render the component from JS into a container element using the registered identifier, passing component parameters as needed. 
-
-In the following example:
-
-* The `Quote` component (`quote` identifier) is rendered into the `quoteContainer` element when the `showQuote` function is called.
-* A quote string is passed to the component's `Text` parameter.
-
-`wwwroot/js/scripts.js`:
-
-```javascript
-async function showQuote() {
-  let targetElement = document.getElementById('quoteContainer');
-  await Blazor.rootComponents.add(targetElement, 'quote', 
-  {
-    text: "Crow: I have my doubts that this movie is actually 'starring' " +
-      "anybody. More like, 'camera is generally pointed at.'"
-  });
-}
-```
-
-Load Blazor (`blazor.server.js` or `blazor.webassembly.js`) with the preceding scripts into the JS app:
-
-```html
-<script src="_framework/blazor.{server|webassembly}.js"></script>
-<script src="js/jsComponentInitializers.js"></script>
-<script src="js/scripts.js"></script>
-```
-
-In HTML, place the target container element (`quoteContainer`). For the demonstration in this section, a button triggers rendering the `Quote` component by calling the `showQuote` JS function:
-
-```html
-<button onclick="showQuote()">Show Quote</button>
-
-<div id="quoteContainer"></div>
-```
-
-On initialization before any components are rendered, the browser's developer tools console logs the `Quote` component's identifier (`name`) and parameters (`parameters`) when `initializeComponent` is called:
-
-```console
-Object { name: "quote", parameters: (1) […] }
-​  name: "quote"
-​  parameters: Array [ {…} ]
-​​    0: Object { name: "Text", type: "string" }
-​​    length: 1
-```
-
-When the **:::no-loc text="Show Quote":::** button is selected, the `Quote` component is rendered with the quote stored in `Text` displayed:
-
-<h3>:::no-loc text="Quote":::</h3>
-<p>:::no-loc text="Crow: I have my doubts that this movie is actually 'starring' anybody. More like, 'camera is generally pointed at.'":::</p>
-
-Quote &copy;1988-1999 Satellite of Love LLC: [*Mystery Science Theater 3000*](https://mst3k.com/) ([Trace Beaulieu (Crow)](https://www.imdb.com/name/nm0064546/))
-
-> [!NOTE]
-> `rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
->
-> ```javascript
-> const rootComponent = await window.Blazor.rootComponents.add(...);
->
-> ...
->
-> rootComponent.dispose();
-> ```
-
-For an advanced example with additional features, see the example in the `BasicTestApp` of the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository):
-
-* [`JavaScriptRootComponents.razor`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/JavaScriptRootComponents.razor)
-* [`wwwroot/js/jsRootComponentInitializers.js`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsRootComponentInitializers.js)
-* [`wwwroot/index.html`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/index.html)
-
-[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
-
-## Blazor custom elements
-
-*Experimental* support is available for building custom elements using the [`Microsoft.AspNetCore.Components.CustomElements` NuGet package](https://www.nuget.org/packages/microsoft.aspnetcore.components.customelements). Custom elements use standard HTML interfaces to implement custom HTML elements.
-
-> [!WARNING]
-> Experimental features are provided for the purpose of exploring feature viability and may not ship in a stable version.
-
-Register a root component as a custom element:
-
-* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
-
-  ```csharp
-  builder.Services.AddServerSideBlazor(options =>
-  {
-      options.RootComponents.RegisterAsCustomElement<Counter>("my-counter");
-  });
-  ```
-  
-  > [!NOTE]
-  > The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
-
-* In a Blazor WebAssembly app, call `RegisterAsCustomElement` on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
-
-  ```csharp
-  builder.RootComponents.RegisterAsCustomElement<Counter>("my-counter");
-  ```
-  
-  > [!NOTE]
-  > The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
-
-Include the following `<script>` tag in the app's HTML ***before*** the Blazor script tag:
-
-```html
-<script src="/_content/Microsoft.AspNetCore.Components.CustomElements/BlazorCustomElements.js"></script>
-```
-
-Use the custom element with any web framework. For example, the preceding counter custom element is used in a React app with the following markup:
-
-```html
-<my-counter increment-amount={incrementAmount}></my-counter>
-```
-
-For a complete example of how to create custom elements with Blazor, see the [Blazor Custom Elements sample project](https://github.com/aspnet/AspLabs/tree/main/src/BlazorCustomElements).
-
-> [!WARNING]
-> The custom elements feature is currently **experimental, unsupported, and subject to change or be removed at any time**. We welcome your feedback on how well this particular approach meets your requirements.
-
-## Generate Angular and React components
-
-Generate framework-specific JavaScript (JS) components from Razor components for web frameworks, such as Angular or React. This capability isn't included with .NET 6, but is enabled by the new support for rendering Razor components from JS. The [JS component generation sample on GitHub](https://github.com/aspnet/samples/tree/main/samples/aspnetcore/blazor/JSComponentGeneration) demonstrates how to generate Angular and React components from Razor components. See the GitHub sample app's `README.md` file for additional information.
-
-> [!WARNING]
-> The Angular and React component features are currently **experimental, unsupported, and subject to change or be removed at any time**. We welcome your feedback on how well this particular approach meets your requirements.
-
 :::moniker-end
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
@@ -3492,8 +3045,6 @@ Component members are used in rendering logic using C# expressions that start wi
 
 The Blazor framework processes a component internally as a [*render tree*](https://developer.mozilla.org/docs/Web/Performance/How_browsers_work#render), which is the combination of a component's [Document Object Model (DOM)](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction) and [Cascading Style Sheet Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model). After the component is initially rendered, the component's render tree is regenerated in response to events. Blazor compares the new render tree against the previous render tree and applies any modifications to the browser's DOM for display. For more information, see <xref:blazor/components/rendering>.
 
-Components are ordinary [C# classes](/dotnet/csharp/programming-guide/classes-and-structs/classes) and can be placed anywhere within a project. Components that produce webpages usually reside in the `Pages` folder. Non-page components are frequently placed in the `Shared` folder or a custom folder added to the project.
-
 Razor syntax for C# control structures, directives, and directive attributes are lowercase (examples: [`@if`](xref:mvc/views/razor#conditionals-if-else-if-else-and-switch), [`@code`](xref:mvc/views/razor#code), [`@bind`](xref:mvc/views/razor#bind)). Property names are uppercase (example: `@Body` for <xref:Microsoft.AspNetCore.Components.LayoutComponentBase.Body?displayProperty=nameWithType>).
 
 ### Asynchronous methods (`async`) don't support returning `void`
@@ -3516,11 +3067,13 @@ The following markup in the `HeadingExample` component renders the preceding `He
 
 :::code language="razor" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/Pages/index/HeadingExample.razor":::
 
-If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Namespaces](#namespaces) section.
+If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespaces](#class-name-and-namespaces) section.
 
 The `Heading` component example shown in this section doesn't have an [`@page`][9] directive, so the `Heading` component isn't directly accessible to a user via a direct request in the browser. However, any component with an [`@page`][9] directive can be nested in another component. If the `Heading` component was directly accessible by including `@page "/heading"` at the top of its Razor file, then the component would be rendered for browser requests at both `/heading` and `/heading-example`.
 
-### Namespaces
+### Class name and namespace
+
+Components are ordinary [C# classes](/dotnet/csharp/programming-guide/classes-and-structs/classes) and can be placed anywhere within a project. Components that produce webpages usually reside in the `Pages` folder. Non-page components are frequently placed in the `Shared` folder or a custom folder added to the project.
 
 Typically, a component's namespace is derived from the app's root namespace and the component's location (folder) within the app. If the app's root namespace is `BlazorSample` and the `Counter` component resides in the `Pages` folder:
 
@@ -4511,8 +4064,6 @@ Component members are used in rendering logic using C# expressions that start wi
 
 The Blazor framework processes a component internally as a [*render tree*](https://developer.mozilla.org/docs/Web/Performance/How_browsers_work#render), which is the combination of a component's [Document Object Model (DOM)](https://developer.mozilla.org/docs/Web/API/Document_Object_Model/Introduction) and [Cascading Style Sheet Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model). After the component is initially rendered, the component's render tree is regenerated in response to events. Blazor compares the new render tree against the previous render tree and applies any modifications to the browser's DOM for display. For more information, see <xref:blazor/components/rendering>.
 
-Components are ordinary [C# classes](/dotnet/csharp/programming-guide/classes-and-structs/classes) and can be placed anywhere within a project. Components that produce webpages usually reside in the `Pages` folder. Non-page components are frequently placed in the `Shared` folder or a custom folder added to the project.
-
 Razor syntax for C# control structures, directives, and directive attributes are lowercase (examples: [`@if`](xref:mvc/views/razor#conditionals-if-else-if-else-and-switch), [`@code`](xref:mvc/views/razor#code), [`@bind`](xref:mvc/views/razor#bind)). Property names are uppercase (example: `@Body` for <xref:Microsoft.AspNetCore.Components.LayoutComponentBase.Body?displayProperty=nameWithType>).
 
 ### Asynchronous methods (`async`) don't support returning `void`
@@ -4535,11 +4086,13 @@ The following markup in the `HeadingExample` component renders the preceding `He
 
 :::code language="razor" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/Pages/index/HeadingExample.razor":::
 
-If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Namespaces](#namespaces) section.
+If a component contains an HTML element with an uppercase first letter that doesn't match a component name within the same namespace, a warning is emitted indicating that the element has an unexpected name. Adding an [`@using`][2] directive for the component's namespace makes the component available, which resolves the warning. For more information, see the [Class name and namespaces](#class-name-and-namespaces) section.
 
 The `Heading` component example shown in this section doesn't have an [`@page`][9] directive, so the `Heading` component isn't directly accessible to a user via a direct request in the browser. However, any component with an [`@page`][9] directive can be nested in another component. If the `Heading` component was directly accessible by including `@page "/heading"` at the top of its Razor file, then the component would be rendered for browser requests at both `/heading` and `/heading-example`.
 
-### Namespaces
+### Class name and namespace
+
+Components are ordinary [C# classes](/dotnet/csharp/programming-guide/classes-and-structs/classes) and can be placed anywhere within a project. Components that produce webpages usually reside in the `Pages` folder. Non-page components are frequently placed in the `Shared` folder or a custom folder added to the project.
 
 Typically, a component's namespace is derived from the app's root namespace and the component's location (folder) within the app. If the app's root namespace is `BlazorSample` and the `Counter` component resides in the `Pages` folder:
 

--- a/aspnetcore/blazor/components/js-spa-frameworks.md
+++ b/aspnetcore/blazor/components/js-spa-frameworks.md
@@ -1,0 +1,323 @@
+---
+title: Use Razor components in JavaScript apps and SPA frameworks
+author: guardrex
+description: Learn how to create and use Razor components in JavaScript apps and SPA frameworks.
+monikerRange: '>= aspnetcore-6.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 02/25/2023
+uid: blazor/components/js-spa-frameworks
+---
+# Use Razor components in JavaScript apps and SPA frameworks
+
+This article covers how to render Razor components from JavaScript, use Blazor custom elements, and generate Angular and React components.
+
+## Render Razor components from JavaScript
+
+Razor components can be dynamically-rendered from JavaScript (JS) for existing JS apps.
+
+The example in this section renders the following Razor component into a page via JS.
+
+`Shared/Quote.razor`:
+
+```razor
+<div class="m-5 p-5">
+    <h2>Quote</h2>
+    <p>@Text</p>
+</div>
+
+@code {
+    [Parameter]
+    public string? Text { get; set; }
+}
+```
+
+In `Program.cs`, add the namespace for the location of the component. The following example assumes that the `Quote` component is in the app's `Shared` folder, and the app's namespace is `BlazorSample`:
+
+```csharp
+using BlazorSample.Shared;
+```
+
+Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the a Razor component as a root component for JS rendering.
+
+<xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that executes initialization logic (`javaScriptInitializer`). The JS function is called once per component registration immediately after the Blazor app starts and before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework.
+
+One or more initializer functions can be created and called by different component registrations. The typical use case is to reuse the same initializer function for multiple components, which is expected if the initializer function is configuring integration with custom elements or another JS-based SPA framework.
+
+> [!IMPORTANT]
+> Don't confuse the `javaScriptInitializer` parameter of <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> with [JavaScript initializers](xref:blazor/fundamentals/startup#javascript-initializers). The name of the parameter and the JS initializers feature is coincidental.
+
+The following example demonstrates the dynamic registration of the preceding `Quote` component with "`quote`" as the identifier.
+
+* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
+
+  ```csharp
+  builder.Services.AddServerSideBlazor(options =>
+  {
+      options.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+          javaScriptInitializer: "initializeComponent");
+  });
+  ```
+
+* In a Blazor WebAssembly app, call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
+
+  ```csharp
+  builder.RootComponents.RegisterForJavaScript<Quote>(identifier: "quote", 
+      javaScriptInitializer: "initializeComponent");
+  ```
+
+Attach the initializer function with `name` and `parameters` function parameters to the `window` object. For demonstration purposes, the following `initializeComponent` function logs the name and parameters of the registered component.
+
+`wwwroot/js/jsComponentInitializers.js`:
+
+```javascript
+window.initializeComponent = (name, parameters) => {
+  console.log({ name: name, parameters: parameters });
+}
+```
+
+Render the component from JS into a container element using the registered identifier, passing component parameters as needed. 
+
+In the following example:
+
+* The `Quote` component (`quote` identifier) is rendered into the `quoteContainer` element when the `showQuote` function is called.
+* A quote string is passed to the component's `Text` parameter.
+
+`wwwroot/js/scripts.js`:
+
+```javascript
+async function showQuote() {
+  let targetElement = document.getElementById('quoteContainer');
+  await Blazor.rootComponents.add(targetElement, 'quote', 
+  {
+    text: "Crow: I have my doubts that this movie is actually 'starring' " +
+      "anybody. More like, 'camera is generally pointed at.'"
+  });
+}
+```
+
+Load Blazor (`blazor.server.js` or `blazor.webassembly.js`) with the preceding scripts into the JS app:
+
+```html
+<script src="_framework/blazor.{server|webassembly}.js"></script>
+<script src="js/jsComponentInitializers.js"></script>
+<script src="js/scripts.js"></script>
+```
+
+In HTML, place the target container element (`quoteContainer`). For the demonstration in this section, a button triggers rendering the `Quote` component by calling the `showQuote` JS function:
+
+```html
+<button onclick="showQuote()">Show Quote</button>
+
+<div id="quoteContainer"></div>
+```
+
+On initialization before any components are rendered, the browser's developer tools console logs the `Quote` component's identifier (`name`) and parameters (`parameters`) when `initializeComponent` is called:
+
+```console
+Object { name: "quote", parameters: (1) […] }
+  name: "quote"
+  parameters: Array [ {…} ]
+    0: Object { name: "Text", type: "string" }
+    length: 1
+```
+
+When the **:::no-loc text="Show Quote":::** button is selected, the `Quote` component is rendered with the quote stored in `Text` displayed:
+
+![Quote rendered in the browser](~/blazor/components/index/_static/quote.png)
+
+Quote &copy;1988-1999 Satellite of Love LLC: [*Mystery Science Theater 3000*](https://mst3k.com/) ([Trace Beaulieu (Crow)](https://www.imdb.com/name/nm0064546/))
+
+> [!NOTE]
+> `rootComponents.add` returns an instance of the component. Call `dispose` on the instance to release it:
+>
+> ```javascript
+> const rootComponent = await window.Blazor.rootComponents.add(...);
+>
+> ...
+>
+> rootComponent.dispose();
+> ```
+
+For an advanced example with additional features, see the example in the `BasicTestApp` of the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository):
+
+* [`JavaScriptRootComponents.razor`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/JavaScriptRootComponents.razor)
+* [`wwwroot/js/jsRootComponentInitializers.js`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/js/jsRootComponentInitializers.js)
+* [`wwwroot/index.html`](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/wwwroot/index.html)
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+## Blazor custom elements
+
+:::moniker range=">= aspnetcore-6.0"
+
+Use Blazor custom elements to dynamically render Razor components from other SPA frameworks, such as Angular or React.
+
+Blazor custom elements:
+
+* Use standard HTML interfaces to implement custom HTML elements.
+* Eliminate the need to manually manage the state and lifecycle of root Razor components using JavaScript APIs.
+* Are useful for gradually introducing Razor components into existing projects written in other SPA frameworks.
+
+Custom elements don't support [child content](#child-content-render-fragments) or [templated components](xref:blazor/components/templated-components).
+
+### Element name
+
+Per the [HTML specification](https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts), custom element tag names must adopt kebab case:
+
+<span aria-hidden="true">❌</span><span class="visually-hidden">Invalid:</span> `mycounter`  
+<span aria-hidden="true">❌</span><span class="visually-hidden">Invalid:</span> `MY-COUNTER`  
+<span aria-hidden="true">❌</span><span class="visually-hidden">Invalid:</span> `MyCounter`  
+<span aria-hidden="true">✔️</span><span class="visually-hidden">Valid:</span> `my-counter`  
+<span aria-hidden="true">✔️</span><span class="visually-hidden">Valid:</span> `my-cool-counter`
+
+### Package
+
+Add a package reference for [`Microsoft.AspNetCore.Components.CustomElements`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.CustomElements) to the app's project file.
+
+[!INCLUDE[](~/includes/package-reference.md)]
+
+### Blazor Server registration
+
+To register a root component as a custom element in a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`. The following example registers the `Counter` component with the custom HTML element `my-counter`:
+
+```csharp
+builder.Services.AddServerSideBlazor(options =>
+{
+    options.RootComponents.RegisterCustomElement<Counter>("my-counter");
+});
+```
+
+> [!NOTE]
+> The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
+
+### Blazor WebAssembly registration
+
+To register a root component as a custom element in a Blazor WebAssembly app, call `RegisterCustomElement` on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`. The following example registers the `Counter` component with the custom HTML element `my-counter`:
+
+```csharp
+builder.RootComponents.RegisterCustomElement<Counter>("my-counter");
+```
+
+> [!NOTE]
+> The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
+
+### Use the registered custom element
+
+Use the custom element with any web framework. For example, the preceding `my-counter` custom HTML element that renders the app's `Counter` component is used in a React app with the following markup:
+
+```html
+<my-counter></my-counter>
+```
+
+For a complete example of how to create custom elements with Blazor, see the [`CustomElementsComponent` component](https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/BasicTestApp/CustomElementsComponent.razor) in the reference source.
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+### Pass parameters
+
+Pass parameters to your Blazor component either as HTML attributes or as JavaScript properties on the DOM element.
+
+The following `Counter` component uses an `IncrementAmount` parameter to set the increment amount of the **:::no-loc text="Click me":::** button.
+
+`Pages/Counter.razor`:
+
+```razor
+@page "/counter"
+
+<h1>Counter</h1>
+
+<p role="status">Current count: @currentCount</p>
+
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    [Parameter]
+    public int IncrementAmount { get; set; } = 1;
+
+    private void IncrementCount()
+    {
+        currentCount += IncrementAmount;
+    }
+}
+```
+
+Render the `Counter` component with the custom element and pass a value to the `IncrementAmount` parameter as an HTML attribute. The attribute name adopts kebab-case syntax (`increment-amount`, not `IncrementAmount`):
+
+```html
+<my-counter increment-amount="10"></my-counter>
+```
+
+Alternatively, you can set the parameter's value as a JavaScript property on the element object. The property name adopts camel case syntax (`incrementAmount`, not `IncrementAmount`):
+
+```javascript
+const elem = document.querySelector("my-counter");
+elem.incrementAmount = 10;
+```
+
+You can update parameter values at any time using either attribute or property syntax.
+
+Supported parameter types:
+
+* Using JavaScript property syntax, you can pass objects of any JSON-serializable type.
+* Using HTML attributes, you are limited to passing objects of string, boolean, or numerical types.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-6.0"
+
+*Experimental* support is available for building custom elements using the [`Microsoft.AspNetCore.Components.CustomElements` NuGet package](https://www.nuget.org/packages/microsoft.aspnetcore.components.customelements). Custom elements use standard HTML interfaces to implement custom HTML elements.
+
+> [!WARNING]
+> Experimental features are provided for the purpose of exploring feature viability and may not ship in a stable version.
+
+Register a root component as a custom element:
+
+* In a Blazor Server app, modify the call to <xref:Microsoft.Extensions.DependencyInjection.ComponentServiceCollectionExtensions.AddServerSideBlazor%2A> in `Program.cs`:
+
+  ```csharp
+  builder.Services.AddServerSideBlazor(options =>
+  {
+      options.RootComponents.RegisterAsCustomElement<Counter>("my-counter");
+  });
+  ```
+  
+  > [!NOTE]
+  > The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
+
+* In a Blazor WebAssembly app, call `RegisterAsCustomElement` on <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.RootComponents> in `Program.cs`:
+
+  ```csharp
+  builder.RootComponents.RegisterAsCustomElement<Counter>("my-counter");
+  ```
+  
+  > [!NOTE]
+  > The preceding code example requires a namespace for the app's components (for example, `using BlazorSample.Pages;`) in the `Program.cs` file.
+
+Include the following `<script>` tag in the app's HTML ***before*** the Blazor script tag:
+
+```html
+<script src="/_content/Microsoft.AspNetCore.Components.CustomElements/BlazorCustomElements.js"></script>
+```
+
+Use the custom element with any web framework. For example, the preceding counter custom element is used in a React app with the following markup:
+
+```html
+<my-counter increment-amount={incrementAmount}></my-counter>
+```
+
+For a complete example of how to create custom elements with Blazor, see the [Blazor Custom Elements sample project](https://github.com/aspnet/AspLabs/tree/main/src/BlazorCustomElements).
+
+> [!WARNING]
+> The custom elements feature is currently **experimental, unsupported, and subject to change or be removed at any time**. We welcome your feedback on how well this particular approach meets your requirements.
+
+:::moniker-end
+
+## Generate Angular and React components
+
+Generate framework-specific JavaScript (JS) components from Razor components for web frameworks, such as Angular or React. This capability isn't included with .NET, but is enabled by the support for rendering Razor components from JS. The [JS component generation sample on GitHub](https://github.com/aspnet/samples/tree/main/samples/aspnetcore/blazor/JSComponentGeneration) demonstrates how to generate Angular and React components from Razor components. See the GitHub sample app's `README.md` file for additional information.
+
+> [!WARNING]
+> The Angular and React component features are currently **experimental, unsupported, and subject to change or be removed at any time**. We welcome your feedback on how well this particular approach meets your requirements.

--- a/aspnetcore/blazor/components/js-spa-frameworks.md
+++ b/aspnetcore/blazor/components/js-spa-frameworks.md
@@ -149,7 +149,7 @@ For an advanced example with additional features, see the example in the `BasicT
 
 ## Blazor custom elements
 
-:::moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-7.0"
 
 Use Blazor custom elements to dynamically render Razor components from other SPA frameworks, such as Angular or React.
 
@@ -159,7 +159,7 @@ Blazor custom elements:
 * Eliminate the need to manually manage the state and lifecycle of root Razor components using JavaScript APIs.
 * Are useful for gradually introducing Razor components into existing projects written in other SPA frameworks.
 
-Custom elements don't support [child content](#child-content-render-fragments) or [templated components](xref:blazor/components/templated-components).
+Custom elements don't support [child content](xref:blazor/components/index#child-content-render-fragments) or [templated components](xref:blazor/components/templated-components).
 
 ### Element name
 
@@ -266,7 +266,7 @@ Supported parameter types:
 
 :::moniker-end
 
-:::moniker range="< aspnetcore-6.0"
+:::moniker range="< aspnetcore-7.0"
 
 *Experimental* support is available for building custom elements using the [`Microsoft.AspNetCore.Components.CustomElements` NuGet package](https://www.nuget.org/packages/microsoft.aspnetcore.components.customelements). Custom elements use standard HTML interfaces to implement custom HTML elements.
 

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -761,7 +761,7 @@ When using a custom folder to hold the project's Razor components, add the names
 
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
-For more information, see <xref:blazor/components/index#namespaces>.
+For more information, see <xref:blazor/components/index#class-name-and-namespaces>.
 
 :::zone-end
 
@@ -1704,7 +1704,7 @@ When using a custom folder to hold the project's Razor components, add the names
 
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
-For more information, see <xref:blazor/components/index#namespaces>.
+For more information, see <xref:blazor/components/index#class-name-and-namespaces>.
 
 :::zone-end
 
@@ -2512,7 +2512,7 @@ When using a custom folder to hold the project's Razor components, add the names
 
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
-For more information, see <xref:blazor/components/index#namespaces>.
+For more information, see <xref:blazor/components/index#class-name-and-namespaces>.
 
 :::zone-end
 
@@ -2975,7 +2975,7 @@ When using a custom folder to hold the project's Razor components, add the names
 
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
-For more information, see <xref:blazor/components/index#namespaces>.
+For more information, see <xref:blazor/components/index#class-name-and-namespaces>.
 
 ## Prerendered state size and SignalR message size limit
 

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -761,7 +761,7 @@ When using a custom folder to hold the project's Razor components, add the names
 
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
-For more information, see <xref:blazor/components/index#class-name-and-namespaces>.
+For more information, see <xref:blazor/components/index#class-name-and-namespace>.
 
 :::zone-end
 
@@ -1704,7 +1704,7 @@ When using a custom folder to hold the project's Razor components, add the names
 
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
-For more information, see <xref:blazor/components/index#class-name-and-namespaces>.
+For more information, see <xref:blazor/components/index#class-name-and-namespace>.
 
 :::zone-end
 
@@ -2512,7 +2512,7 @@ When using a custom folder to hold the project's Razor components, add the names
 
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
-For more information, see <xref:blazor/components/index#class-name-and-namespaces>.
+For more information, see <xref:blazor/components/index#class-name-and-namespace>.
 
 :::zone-end
 
@@ -2975,7 +2975,7 @@ When using a custom folder to hold the project's Razor components, add the names
 
 The `_ViewImports.cshtml` file is located in the `Pages` folder of a Razor Pages app or the `Views` folder of an MVC app.
 
-For more information, see <xref:blazor/components/index#class-name-and-namespaces>.
+For more information, see <xref:blazor/components/index#class-name-and-namespace>.
 
 ## Prerendered state size and SignalR message size limit
 

--- a/aspnetcore/blazor/hybrid/class-libraries.md
+++ b/aspnetcore/blazor/hybrid/class-libraries.md
@@ -66,7 +66,7 @@ The .NET Podcasts app showcases the following technologies:
 
 Components from an RCL can be simultaneously shared by web and native client apps built using Blazor. The guidance in <xref:blazor/components/class-libraries> explains how to share Razor components using a Razor class library (RCL). The same guidance applies to reusing Razor components from an RCL in a Blazor Hybrid app.
 
-Component namespaces are derived from the RCL's package ID or assembly name and the component's folder path within the RCL. For more information, see <xref:blazor/components/index#namespaces>. [`@using`](xref:mvc/views/razor#using) directives can be placed in `_Imports.razor` files for components and code, as the following example demonstrates for an RCL named `SharedLibrary` with a `Shared` folder of shared Razor components and a `Data` folder of shared data classes:
+Component namespaces are derived from the RCL's package ID or assembly name and the component's folder path within the RCL. For more information, see <xref:blazor/components/index#class-name-and-namespaces>. [`@using`](xref:mvc/views/razor#using) directives can be placed in `_Imports.razor` files for components and code, as the following example demonstrates for an RCL named `SharedLibrary` with a `Shared` folder of shared Razor components and a `Data` folder of shared data classes:
 
 ```razor
 @using SharedLibrary

--- a/aspnetcore/blazor/hybrid/class-libraries.md
+++ b/aspnetcore/blazor/hybrid/class-libraries.md
@@ -66,7 +66,7 @@ The .NET Podcasts app showcases the following technologies:
 
 Components from an RCL can be simultaneously shared by web and native client apps built using Blazor. The guidance in <xref:blazor/components/class-libraries> explains how to share Razor components using a Razor class library (RCL). The same guidance applies to reusing Razor components from an RCL in a Blazor Hybrid app.
 
-Component namespaces are derived from the RCL's package ID or assembly name and the component's folder path within the RCL. For more information, see <xref:blazor/components/index#class-name-and-namespaces>. [`@using`](xref:mvc/views/razor#using) directives can be placed in `_Imports.razor` files for components and code, as the following example demonstrates for an RCL named `SharedLibrary` with a `Shared` folder of shared Razor components and a `Data` folder of shared data classes:
+Component namespaces are derived from the RCL's package ID or assembly name and the component's folder path within the RCL. For more information, see <xref:blazor/components/index#class-name-and-namespace>. [`@using`](xref:mvc/views/razor#using) directives can be placed in `_Imports.razor` files for components and code, as the following example demonstrates for an RCL named `SharedLibrary` with a `Shared` folder of shared Razor components and a `Data` folder of shared data classes:
 
 ```razor
 @using SharedLibrary

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -455,6 +455,8 @@ items:
                 uid: blazor/components/prerendering-and-integration
               - name: Class libraries
                 uid: blazor/components/class-libraries
+              - name: JavaScript apps and SPA frameworks
+                uid: blazor/components/js-spa-frameworks
               - name: Built-in components
                 uid: blazor/components/built-in-components
           - name: Globalization and localization


### PR DESCRIPTION
Addresses #28001

* Break out the JS apps/SPA frameworks sections into a new topic.
* Move the component class remarks to the "namespaces" section and rename the section "Class name and namespaces."