### PR TITLE
Blazor hosted WASM security updates

### DIFF
--- a/aspnetcore/blazor/security/includes/3.1/troubleshoot.md
+++ b/aspnetcore/blazor/security/includes/3.1/troubleshoot.md
@@ -93,11 +93,17 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 
 ### Run the Server app
 
-When testing and troubleshooting a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln), make sure that you're running the app from the **`Server`** project. For example in Visual Studio, confirm that the Server project is highlighted in **Solution Explorer** before you start the app with any of the following approaches:
+When testing and troubleshooting a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln), make sure that you're running the app from the **`Server`** project.
 
-* Select the **Run** button.
-* Use **Debug** > **Start Debugging** from the menu.
-* Press <kbd>F5</kbd>.
+For example in Visual Studio, adopt ***one*** of the following approaches:
+
+* Select the dropdown arrow next to the **Run** button. Open **Configure Startup Projects** from the dropdown list. Select the **Single startup project** option. Confirm or change the project for the startup project to the **`Server`** project.
+
+* Confirm that the Server project is highlighted in **Solution Explorer** before you start the app with any of the following approaches:
+
+  * Select the **Run** button.
+  * Use **Debug** > **Start Debugging** from the menu.
+  * Press <kbd>F5</kbd>.
 
 ### Inspect the user
 

--- a/aspnetcore/blazor/security/includes/5.0/troubleshoot.md
+++ b/aspnetcore/blazor/security/includes/5.0/troubleshoot.md
@@ -93,11 +93,17 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 
 ### Run the Server app
 
-When testing and troubleshooting a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln), make sure that you're running the app from the **`Server`** project. For example in Visual Studio, confirm that the Server project is highlighted in **Solution Explorer** before you start the app with any of the following approaches:
+When testing and troubleshooting a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln), make sure that you're running the app from the **`Server`** project.
 
-* Select the **Run** button.
-* Use **Debug** > **Start Debugging** from the menu.
-* Press <kbd>F5</kbd>.
+For example in Visual Studio, adopt ***one*** of the following approaches:
+
+* Select the dropdown arrow next to the **Run** button. Open **Configure Startup Projects** from the dropdown list. Select the **Single startup project** option. Confirm or change the project for the startup project to the **`Server`** project.
+
+* Confirm that the Server project is highlighted in **Solution Explorer** before you start the app with any of the following approaches:
+
+  * Select the **Run** button.
+  * Use **Debug** > **Start Debugging** from the menu.
+  * Press <kbd>F5</kbd>.
 
 ### Inspect the user
 

--- a/aspnetcore/blazor/security/includes/6.0/troubleshoot.md
+++ b/aspnetcore/blazor/security/includes/6.0/troubleshoot.md
@@ -93,11 +93,17 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 
 ### Run the Server app
 
-When testing and troubleshooting a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln), make sure that you're running the app from the **`Server`** project. For example in Visual Studio, confirm that the Server project is highlighted in **Solution Explorer** before you start the app with any of the following approaches:
+When testing and troubleshooting a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln), make sure that you're running the app from the **`Server`** project.
 
-* Select the **Run** button.
-* Use **Debug** > **Start Debugging** from the menu.
-* Press <kbd>F5</kbd>.
+For example in Visual Studio, adopt ***one*** of the following approaches:
+
+* Select the dropdown arrow next to the **Run** button. Open **Configure Startup Projects** from the dropdown list. Select the **Single startup project** option. Confirm or change the project for the startup project to the **`Server`** project.
+
+* Confirm that the Server project is highlighted in **Solution Explorer** before you start the app with any of the following approaches:
+
+  * Select the **Run** button.
+  * Use **Debug** > **Start Debugging** from the menu.
+  * Press <kbd>F5</kbd>.
 
 ### Inspect the user
 

--- a/aspnetcore/blazor/security/includes/7.0/troubleshoot.md
+++ b/aspnetcore/blazor/security/includes/7.0/troubleshoot.md
@@ -97,11 +97,17 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 
 ### Run the Server app
 
-When testing and troubleshooting a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln), make sure that you're running the app from the **`Server`** project. For example in Visual Studio, confirm that the Server project is highlighted in **Solution Explorer** before you start the app with any of the following approaches:
+When testing and troubleshooting a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln), make sure that you're running the app from the **`Server`** project.
 
-* Select the **Run** button.
-* Use **Debug** > **Start Debugging** from the menu.
-* Press <kbd>F5</kbd>.
+For example in Visual Studio, adopt ***one*** of the following approaches:
+
+* Select the dropdown arrow next to the **Run** button. Open **Configure Startup Projects** from the dropdown list. Select the **Single startup project** option. Confirm or change the project for the startup project to the **`Server`** project.
+
+* Confirm that the Server project is highlighted in **Solution Explorer** before you start the app with any of the following approaches:
+
+  * Select the **Run** button.
+  * Use **Debug** > **Start Debugging** from the menu.
+  * Press <kbd>F5</kbd>.
 
 ### Inspect the user
 

--- a/aspnetcore/blazor/security/includes/azure-scope.md
+++ b/aspnetcore/blazor/security/includes/azure-scope.md
@@ -5,41 +5,27 @@ options.ProviderOptions.DefaultAccessTokenScopes
     .Add("https://{TENANT}.onmicrosoft.com/{SERVER API APP CLIENT ID OR CUSTOM VALUE}/{DEFAULT SCOPE}");
 ```
 
-To configure the server API app for a matching audience, set the `Audience` in the **`Server`** API app settings file (`appsettings.json`) to match the app's audience provided by the Azure portal:
+To configure the server API app for a matching audience, set the `Audience` in the server API app settings file (`appsettings.json`) to match the app's audience provided by the Azure portal:
 
 ```json
-{
-  "AzureAd": {
-    "Authority": "https://login.microsoftonline.com/{TENANT ID}",
-    "ClientId": "{SERVER API APP CLIENT ID}",
-    "ValidateAuthority": true,
-    "Audience": "https://{TENANT}.onmicrosoft.com/{SERVER API APP CLIENT ID OR CUSTOM VALUE}"
-  }
-}
+"Audience": "https://{TENANT}.onmicrosoft.com/{SERVER API APP CLIENT ID OR CUSTOM VALUE}"
 ```
 
 In the preceding configuration, the end of the `Audience` value does **not** include the default scope `/{DEFAULT SCOPE}`.
 
 Example:
 
-In `Program.cs` of the **`Client`** app:
+In `Program.cs` of the client app:
 
 ```csharp
 options.ProviderOptions.DefaultAccessTokenScopes
     .Add("https://contoso.onmicrosoft.com/41451fa7-82d9-4673-8fa5-69eff5a761fd/API.Access");
 ```
 
-Configure the **`Server`** API app settings file (`appsettings.json`) with a matching audience (`Audience`):
+Configure the server API app settings file (`appsettings.json`) with a matching audience (`Audience`):
 
 ```json
-{
-  "AzureAd": {
-    "Authority": "https://login.microsoftonline.com/e86c78e2-...-918e0565a45e",
-    "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd",
-    "ValidateAuthority": true,
-    "Audience": "https://contoso.onmicrosoft.com/41451fa7-82d9-4673-8fa5-69eff5a761fd"
-  }
-}
+"Audience": "https://contoso.onmicrosoft.com/41451fa7-82d9-4673-8fa5-69eff5a761fd"
 ```
 
 In the preceding example, the end of the `Audience` value does **not** include the default scope `/API.Access`.

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -998,7 +998,7 @@ The `appsettings.json` file contains the options to configure the JWT bearer han
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "Domain": "{DOMAIN}",
+    "Domain": "{TENANT DOMAIN}",
     "TenantId": "{TENANT ID}",
     "ClientId": "{SERVER API APP CLIENT ID}",
     "CallbackPath": "/signin-oidc"
@@ -1402,7 +1402,7 @@ The `appsettings.json` file contains the options to configure the JWT bearer han
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "Domain": "{DOMAIN}",
+    "Domain": "{TENANT DOMAIN}",
     "TenantId": "{TENANT ID}",
     "ClientId": "{SERVER API APP CLIENT ID}",
   }

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -117,7 +117,7 @@ dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}"
 The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name. **Avoid using dashes (`-`) in the app name that break the formation of the OIDC app identifier (see the earlier WARNING).**
 
 > [!NOTE]
-> A configuration change might be required when using an Azure tenant with an [unverified publisher domain](/azure/active-directory/develop/howto-configure-publisher-domain), which is described in the [App settings](#app-settings) section.
+> A configuration change might be required when using an Azure tenant with an [unverified publisher domain](/azure/active-directory/develop/howto-configure-publisher-domain), which is described in the [App settings](#app-settings-server-project) section.
 
 ## **:::no-loc text="Server":::** app configuration
 
@@ -527,7 +527,7 @@ dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}"
 The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name. **Avoid using dashes (`-`) in the app name that break the formation of the OIDC app identifier (see the earlier WARNING).**
 
 > [!NOTE]
-> A configuration change might be required when using an Azure tenant with an [unverified publisher domain](/azure/active-directory/develop/howto-configure-publisher-domain), which is described in the [App settings](#app-settings) section.
+> A configuration change might be required when using an Azure tenant with an [unverified publisher domain](/azure/active-directory/develop/howto-configure-publisher-domain), which is described in the [App settings](#app-settings-server-project) section.
 
 ## **:::no-loc text="Server":::** app configuration
 
@@ -935,7 +935,7 @@ dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}"
 The output location specified with the `-o|--output` option creates a project folder if it doesn't exist and becomes part of the app's name. **Avoid using dashes (`-`) in the app name that break the formation of the OIDC app identifier (see the earlier WARNING).**
 
 > [!NOTE]
-> A configuration change might be required when using an Azure tenant with an [unverified publisher domain](/azure/active-directory/develop/howto-configure-publisher-domain), which is described in the [App settings](#app-settings) section.
+> A configuration change might be required when using an Azure tenant with an [unverified publisher domain](/azure/active-directory/develop/howto-configure-publisher-domain), which is described in the [App settings](#app-settings-server-project) section.
 
 ## **:::no-loc text="Server":::** app configuration
 

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -5,7 +5,7 @@ description: Learn how to secure a hosted ASP.NET Core Blazor WebAssembly app wi
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: "devx-track-csharp, mvc"
-ms.date: 11/08/2022
+ms.date: 02/27/2023
 uid: blazor/security/webassembly/hosted-with-azure-active-directory
 ---
 # Secure a hosted ASP.NET Core Blazor WebAssembly app with Azure Active Directory
@@ -174,7 +174,7 @@ To configure the app to receive the value from the `name` claim type:
       });
   ```
 
-### App settings
+### App settings (**`Server`** project)
 
 The `appsettings.json` file contains the options to configure the JWT bearer handler used to validate access tokens:
 
@@ -182,10 +182,12 @@ The `appsettings.json` file contains the options to configure the JWT bearer han
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "Domain": "{DOMAIN}",
+    "Domain": "{TENANT DOMAIN}",
     "TenantId": "{TENANT ID}",
     "ClientId": "{SERVER API APP CLIENT ID}",
-    "CallbackPath": "/signin-oidc"
+    "CallbackPath": "/signin-oidc",
+    "Scopes": "{SCOPES}",
+    "Audience": "https://guardrexorg.onmicrosoft.com/{SERVER API APP CLIENT ID}"
   }
 }
 ```
@@ -199,12 +201,12 @@ Example:
     "Domain": "contoso.onmicrosoft.com",
     "TenantId": "e86c78e2-8bb4-4c41-aefd-918e0565a45e",
     "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd",
-    "CallbackPath": "/signin-oidc"
+    "CallbackPath": "/signin-oidc",
+    "Scopes": "API.Access",
+    "Audience": "https://guardrexorg.onmicrosoft.com/41451fa7-82d9-4673-8fa5-69eff5a761fd"
   }
 }
 ```
-
-[!INCLUDE[](~/blazor/security/includes/azure-scope.md)]
 
 ### WeatherForecast controller
 
@@ -271,6 +273,8 @@ builder.Services.AddMsalAuthentication(options =>
 ```
 
 The <xref:Microsoft.Extensions.DependencyInjection.MsalWebAssemblyServiceCollectionExtensions.AddMsalAuthentication%2A> method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Azure Portal AAD configuration when you register the app.
+
+### App settings (**`Client`** project)
 
 Configuration is supplied by the `wwwroot/appsettings.json` file:
 
@@ -577,7 +581,7 @@ To configure the app to receive the value from the `name` claim type:
       });
   ```
 
-### App settings
+### App settings (**`Server`** project)
 
 The `appsettings.json` file contains the options to configure the JWT bearer handler used to validate access tokens:
 
@@ -585,10 +589,12 @@ The `appsettings.json` file contains the options to configure the JWT bearer han
 {
   "AzureAd": {
     "Instance": "https://login.microsoftonline.com/",
-    "Domain": "{DOMAIN}",
+    "Domain": "{TENANT DOMAIN}",
     "TenantId": "{TENANT ID}",
     "ClientId": "{SERVER API APP CLIENT ID}",
-    "CallbackPath": "/signin-oidc"
+    "CallbackPath": "/signin-oidc",
+    "Scopes": "{SCOPES}",
+    "Audience": "https://guardrexorg.onmicrosoft.com/{SERVER API APP CLIENT ID}"
   }
 }
 ```
@@ -602,12 +608,12 @@ Example:
     "Domain": "contoso.onmicrosoft.com",
     "TenantId": "e86c78e2-8bb4-4c41-aefd-918e0565a45e",
     "ClientId": "41451fa7-82d9-4673-8fa5-69eff5a761fd",
-    "CallbackPath": "/signin-oidc"
+    "CallbackPath": "/signin-oidc",
+    "Scopes": "API.Access",
+    "Audience": "https://guardrexorg.onmicrosoft.com/41451fa7-82d9-4673-8fa5-69eff5a761fd"
   }
 }
 ```
-
-[!INCLUDE[](~/blazor/security/includes/azure-scope.md)]
 
 ### WeatherForecast controller
 
@@ -674,6 +680,8 @@ builder.Services.AddMsalAuthentication(options =>
 ```
 
 The <xref:Microsoft.Extensions.DependencyInjection.MsalWebAssemblyServiceCollectionExtensions.AddMsalAuthentication%2A> method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Azure Portal AAD configuration when you register the app.
+
+### App settings (**`Client`** project)
 
 Configuration is supplied by the `wwwroot/appsettings.json` file:
 
@@ -980,7 +988,7 @@ To configure the app to receive the value from the `name` claim type:
       });
   ```
 
-### App settings
+### App settings (**`Server`** project)
 
 The `appsettings.json` file contains the options to configure the JWT bearer handler used to validate access tokens:
 
@@ -1077,6 +1085,8 @@ builder.Services.AddMsalAuthentication(options =>
 ```
 
 The <xref:Microsoft.Extensions.DependencyInjection.MsalWebAssemblyServiceCollectionExtensions.AddMsalAuthentication%2A> method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Azure Portal AAD configuration when you register the app.
+
+### App settings (**`Client`** project)
 
 Configuration is supplied by the `wwwroot/appsettings.json` file:
 
@@ -1381,7 +1391,7 @@ To configure the app to receive the value from the `name` claim type:
       });
   ```
 
-### App settings
+### App settings (**`Server`** project)
 
 The `appsettings.json` file contains the options to configure the JWT bearer handler used to validate access tokens:
 
@@ -1474,6 +1484,8 @@ builder.Services.AddMsalAuthentication(options =>
 ```
 
 The <xref:Microsoft.Extensions.DependencyInjection.MsalWebAssemblyServiceCollectionExtensions.AddMsalAuthentication%2A> method accepts a callback to configure the parameters required to authenticate an app. The values required for configuring the app can be obtained from the Azure Portal AAD configuration when you register the app.
+
+### App settings (**`Client`** project)
 
 Configuration is supplied by the `wwwroot/appsettings.json` file:
 

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -419,7 +419,8 @@ Run the app from the Server project. When using Visual Studio, either:
 * <xref:blazor/security/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
-* [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
+* [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)* * * * [Security best practices for application properties in Azure Active Directory](/azure/active-directory/develop/security-best-practices-for-app-registration)
+
 
 :::moniker-end
 
@@ -827,6 +828,7 @@ Run the app from the Server project. When using Visual Studio, either:
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
+* [Security best practices for application properties in Azure Active Directory](/azure/active-directory/develop/security-best-practices-for-app-registration)
 
 :::moniker-end
 
@@ -1232,6 +1234,7 @@ Run the app from the Server project. When using Visual Studio, either:
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
+* [Security best practices for application properties in Azure Active Directory](/azure/active-directory/develop/security-best-practices-for-app-registration)
 
 :::moniker-end
 
@@ -1629,5 +1632,6 @@ Run the app from the Server project. When using Visual Studio, either:
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
 * [Quickstart: Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app)
+* [Security best practices for application properties in Azure Active Directory](/azure/active-directory/develop/security-best-practices-for-app-registration)
 
 :::moniker-end

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -105,7 +105,7 @@ Configuration is supplied by the `wwwroot/appsettings.json` file:
 ```json
 {
   "AzureAdB2C": {
-    "Authority": "{AAD B2C INSTANCE}{DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
+    "Authority": "{AAD B2C INSTANCE}{TENANT DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
     "ClientId": "{CLIENT ID}",
     "ValidateAuthority": false
   }
@@ -286,7 +286,7 @@ Configuration is supplied by the `wwwroot/appsettings.json` file:
 ```json
 {
   "AzureAdB2C": {
-    "Authority": "{AAD B2C INSTANCE}{DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
+    "Authority": "{AAD B2C INSTANCE}{TENANT DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
     "ClientId": "{CLIENT ID}",
     "ValidateAuthority": false
   }
@@ -467,7 +467,7 @@ Configuration is supplied by the `wwwroot/appsettings.json` file:
 ```json
 {
   "AzureAdB2C": {
-    "Authority": "{AAD B2C INSTANCE}{DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
+    "Authority": "{AAD B2C INSTANCE}{TENANT DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
     "ClientId": "{CLIENT ID}",
     "ValidateAuthority": false
   }
@@ -644,7 +644,7 @@ Configuration is supplied by the `wwwroot/appsettings.json` file:
 ```json
 {
   "AzureAdB2C": {
-    "Authority": "{AAD B2C INSTANCE}{DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
+    "Authority": "{AAD B2C INSTANCE}{TENANT DOMAIN}/{SIGN UP OR SIGN IN POLICY}",
     "ClientId": "{CLIENT ID}",
     "ValidateAuthority": false
   }

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory.md
@@ -173,6 +173,7 @@ For more information, see the following sections of the *Additional scenarios* a
 * <xref:blazor/security/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
+* [Security best practices for application properties in Azure Active Directory](/azure/active-directory/develop/security-best-practices-for-app-registration)
 
 :::moniker-end
 
@@ -337,6 +338,7 @@ For more information, see the following sections of the *Additional scenarios* a
 * <xref:blazor/security/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
+* [Security best practices for application properties in Azure Active Directory](/azure/active-directory/develop/security-best-practices-for-app-registration)
 
 :::moniker-end
 
@@ -501,6 +503,7 @@ For more information, see the following sections of the *Additional scenarios* a
 * <xref:blazor/security/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
+* [Security best practices for application properties in Azure Active Directory](/azure/active-directory/develop/security-best-practices-for-app-registration)
 
 :::moniker-end
 
@@ -661,5 +664,6 @@ For more information, see the following sections of the *Additional scenarios* a
 * <xref:blazor/security/webassembly/aad-groups-roles>
 * <xref:security/authentication/azure-active-directory/index>
 * [Microsoft identity platform documentation](/azure/active-directory/develop/)
+* [Security best practices for application properties in Azure Active Directory](/azure/active-directory/develop/security-best-practices-for-app-registration)
 
 :::moniker-end


### PR DESCRIPTION
Addresses #28001 

cc: @mrpmorris ... I did find two small-ish problems to fix. The `appsettings.json` file for the server API didn't have the right config in the part of the file that *wasn't being described by the text in that part of the article*. I'm not sure if that confused anyone. No one wrote in to me about it. Second, the `Scopes` entry for the file wasn't included in earlier updates since the release of 6.0. I'm fixing these two problems on this PR, and I will take this live immediately.

I'm also making additional changes here to clarify the guidance. It's always been tricky in this node of articles to lay out this ***very complex*** 😰 guidance. I plan to do more work on this article (and INCLUDES files in use) later today and tomorrow morning. The round of updates will be less significant than the fixes that I'm putting into the article right now, which I want to get up on the live site quickly.