### PR TITLE
Fixing typo in links to previous/next pages

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model.md
@@ -493,8 +493,8 @@ Because the `Model` object is strongly typed as an `IEnumerable<Movie>` object, 
 * [Globalization and localization](xref:fundamentals/localization)
 
 > [!div class="step-by-step"]
-> [Previous Adding a View]((~/tutorials/first-mvc-app/adding-view.md)
-> [Next Working with SQL]((~/tutorials/first-mvc-app/working-with-sql.md)
+> [Previous: Adding a View](~/tutorials/first-mvc-app/adding-view.md)
+> [Next: Working with SQL](~/tutorials/first-mvc-app/working-with-sql.md)
 
 :::moniker-end
 


### PR DESCRIPTION
Removed a ```(``` that broke the links to the previous/next pages and added a colon so that the links are consistent with other pages.
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->