### PR TITLE
Fixing paths for apache error and access logs

### DIFF
--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -156,8 +156,8 @@ Create a configuration file, named *helloapp.conf*, for the app:
     ProxyPassReverse / http://127.0.0.1:5000/
     ServerName www.example.com
     ServerAlias *.example.com
-    ErrorLog ${APACHE_LOG_DIR}helloapp-error.log
-    CustomLog ${APACHE_LOG_DIR}helloapp-access.log common
+    ErrorLog ${APACHE_LOG_DIR}/helloapp-error.log
+    CustomLog ${APACHE_LOG_DIR}/helloapp-access.log common
 </VirtualHost>
 ```
 


### PR DESCRIPTION
Paths were saved to:
/var/log/apache2helloapp-error.log
/var/log/apache2helloapp-access.log

Instead, it should be:
/var/log/apache2/helloapp-error.log
/var/log/apache2/helloapp-access.log



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->