### PR TITLE
upgrade not migrate /1

### DIFF
--- a/aspnetcore/migration/inc/adapters.md
+++ b/aspnetcore/migration/inc/adapters.md
@@ -14,7 +14,7 @@ uid: migration/inc/adapters
 
 The main use case of the adapters in the [dotnet/systemweb-adapters](https://github.com/dotnet/systemweb-adapters) repository is to help developers who have taken a reliance on `System.Web` types within their class libraries as they want to move to ASP.NET Core.
 
-An important feature of the adapters is the adapters allow the library to be used from ***both*** ASP.NET Framework and ASP.NET Core projects. Migrating multiple ASP.NET Framework apps to ASP.NET Core often involves intermediate states where not all the apps have been fully migrated. By using the `System.Web` adapters, the library can be used both from ASP.NET Core callers and ASP.NET Framework callers that haven't been upgraded.
+An important feature of the adapters is the adapters allow the library to be used from ***both*** ASP.NET Framework and ASP.NET Core projects. Migrating multiple ASP.NET Framework apps to ASP.NET Core often involves intermediate states where not all the apps have been fully updated. By using the `System.Web` adapters, the library can be used both from ASP.NET Core callers and ASP.NET Framework callers that haven't been upgraded.
 
 Let's take a look at an example using the adapters moving from .NET Framework to ASP.NET Core.
 

--- a/aspnetcore/migration/inc/adapters.md
+++ b/aspnetcore/migration/inc/adapters.md
@@ -14,7 +14,7 @@ uid: migration/inc/adapters
 
 The main use case of the adapters in the [dotnet/systemweb-adapters](https://github.com/dotnet/systemweb-adapters) repository is to help developers who have taken a reliance on `System.Web` types within their class libraries as they want to move to ASP.NET Core.
 
-An important feature of the adapters is the adapters allow the library to be used from ***both*** ASP.NET Framework and ASP.NET Core projects. Migrating multiple ASP.NET Framework apps to ASP.NET Core often involves intermediate states where not all the apps have been fully updated. By using the `System.Web` adapters, the library can be used both from ASP.NET Core callers and ASP.NET Framework callers that haven't been upgraded.
+An important feature of the adapters is the adapters allow the library to be used from ***both*** ASP.NET Framework and ASP.NET Core projects. Updating multiple ASP.NET Framework apps to ASP.NET Core often involves intermediate states where not all the apps have been fully updated. By using the `System.Web` adapters, the library can be used both from ASP.NET Core callers and ASP.NET Framework callers that haven't been upgraded.
 
 Let's take a look at an example using the adapters moving from .NET Framework to ASP.NET Core.
 

--- a/aspnetcore/migration/inc/overview.md
+++ b/aspnetcore/migration/inc/overview.md
@@ -41,7 +41,7 @@ To migrate business logic that relies on `HttpContext`, the libraries need to be
 
 Once the ASP.NET Core app using YARP is set up, you can start migrating routes from ASP.NET Framework to ASP.NET Core. For example, WebAPI or MVC controller action methods,handlers, or some other implementation of a route. If the route is available in the ASP.NET Core app, it's matched and served.
 
-During the migration process, additional services and infrastructure are identified that must be migrated to run on .NET Core. Options listed in order of maintainability include:
+During the migration process, additional services and infrastructure are identified that must be updated to run on .NET Core. Options listed in order of maintainability include:
 
 1. Move the code to shared libraries
 1. Link the code in the new project

--- a/aspnetcore/migration/inc/overview.md
+++ b/aspnetcore/migration/inc/overview.md
@@ -14,11 +14,11 @@ uid: migration/inc/overview
 
 # Incremental ASP.NET to ASP.NET Core update
 
-Updating an app from ASP.NET Framework to ASP.NET Core is non-trivial for the majority of production apps. These apps often incorporate new technologies as they become available and are often composed of many legacy decisions. This article provides guidance and links to tools for migrating ASP.NET Framework apps to ASP.NET Core with as little change as possible.
+Updating an app from ASP.NET Framework to ASP.NET Core is non-trivial for the majority of production apps. These apps often incorporate new technologies as they become available and are often composed of many legacy decisions. This article provides guidance and links to tools for updating ASP.NET Framework apps to ASP.NET Core with as little change as possible.
 
 One of the larger challenges is the pervasive use of <xref:System.Web.HttpContext> throughout a code base. Without the incremental approach and tools, a large scale rewrite is required to remove the `System.Web.HttpContext` dependency. The adapters in [dotnet/systemweb-adapters](https://github.com/dotnet/systemweb-adapters) provide a set of runtime helpers to access the types used in the ASP.NET Framework app in a way that works in ASP.NET Core with minimal changes.
 
-A complete migration may take considerable effort depending on the size of the app, dependencies, and non-portable APIs used. In order to keep deploying an app to production while working on migrating, the best pattern is to follow is the [Strangler Fig pattern](/azure/architecture/patterns/strangler-fig). The *Strangler Fig pattern* allows for continual development on the old system with an incremental approach to replacing specific pieces of functionality with new services. This document describes how to apply the Strangler Fig pattern to an ASP.NET app migrating towards ASP.NET Core.
+A complete migration may take considerable effort depending on the size of the app, dependencies, and non-portable APIs used. In order to keep deploying an app to production while working on updating, the best pattern is to follow is the [Strangler Fig pattern](/azure/architecture/patterns/strangler-fig). The *Strangler Fig pattern* allows for continual development on the old system with an incremental approach to replacing specific pieces of functionality with new services. This document describes how to apply the Strangler Fig pattern to an ASP.NET app updating towards ASP.NET Core.
 
 If you'd like to skip this overview article and get started, see [Get started](xref:migration/inc/start).
 
@@ -30,7 +30,7 @@ Before starting the migration, the app targets ASP.NET Framework and runs on Win
 
 Migration starts by introducing a new app based on ASP.NET Core that becomes the entry point. Incoming requests go to the ASP.NET Core app, which either handles the request or proxies the request to the .NET Framework app via [YARP](https://microsoft.github.io/reverse-proxy/). At first, the majority of code providing responses is in the .NET Framework app, but the ASP.NET Core app is now set up to start migrating routes:
 
-![start migrating routes](~/migration/inc/overview/static/nop.png)
+![start updating routes](~/migration/inc/overview/static/nop.png)
 
 To migrate business logic that relies on `HttpContext`, the libraries need to be built with `Microsoft.AspNetCore.SystemWebAdapters`. Building the libraries with `Microsoft.AspNetCore.SystemWebAdapters` allows:
 
@@ -39,7 +39,7 @@ To migrate business logic that relies on `HttpContext`, the libraries need to be
 
 ![Microsoft.AspNetCore.SystemWebAdapters](~/migration/inc/overview/static/sys_adapt.png)
 
-Once the ASP.NET Core app using YARP is set up, you can start migrating routes from ASP.NET Framework to ASP.NET Core. For example, WebAPI or MVC controller action methods,handlers, or some other implementation of a route. If the route is available in the ASP.NET Core app, it's matched and served.
+Once the ASP.NET Core app using YARP is set up, you can start updating routes from ASP.NET Framework to ASP.NET Core. For example, WebAPI or MVC controller action methods,handlers, or some other implementation of a route. If the route is available in the ASP.NET Core app, it's matched and served.
 
 During the migration process, additional services and infrastructure are identified that must be updated to run on .NET Core. Options listed in order of maintainability include:
 

--- a/aspnetcore/migration/inc/overview.md
+++ b/aspnetcore/migration/inc/overview.md
@@ -32,7 +32,7 @@ Migration starts by introducing a new app based on ASP.NET Core that becomes the
 
 ![start updating routes](~/migration/inc/overview/static/nop.png)
 
-To migrate business logic that relies on `HttpContext`, the libraries need to be built with `Microsoft.AspNetCore.SystemWebAdapters`. Building the libraries with `Microsoft.AspNetCore.SystemWebAdapters` allows:
+To migrate business logic that relies on `HttpContext`, the libraries need to be built with `Microsoft.AspNetCore.SystemWebAdapters`. Building the libraries with `SystemWebAdapters` allows:
 
 * The libraries to be built against .NET Framework, .NET Core, or .NET Standard 2.0.
 * Ensures that the libraries are using APIs that are available on both ASP.NET Framework and ASP.NET Core.

--- a/aspnetcore/migration/inc/overview.md
+++ b/aspnetcore/migration/inc/overview.md
@@ -58,7 +58,7 @@ Once the ASP.NET Framework app is no longer needed and deleted:
 
 ![final pic](~/migration/inc/overview/static/final.png)
 
-[Microsoft Project Migrations](https://marketplace.visualstudio.com/items?itemName=WebToolsTeam.aspnetprojectmigrations) is an experimental [Visual Studio extension](/visualstudio/ide/finding-and-using-visual-studio-extensions) that can assist in incremental migration from ASP.NET Framework to ASP.NET Core.
+The Visual Studio extension [.NET Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant) can help upgrade ASP.NET Framework web apps to ASP.NET Core. For more information see the blog post [Upgrading your .NET projects with Visual Studio](https://devblogs.microsoft.com/dotnet/upgrade-assistant-now-in-visual-studio/).
 
 ## System.Web Adapters
 

--- a/aspnetcore/migration/inc/overview.md
+++ b/aspnetcore/migration/inc/overview.md
@@ -1,6 +1,6 @@
 ---
-title: Incremental ASP.NET to ASP.NET Core Migration
-description: Incremental ASP.NET to ASP.NET Core Migration
+title: Incremental ASP.NET to ASP.NET Core update
+description: Incremental ASP.NET to ASP.NET Core migration
 author: rick-anderson
 ms.author: riande
 monikerRange: '>= aspnetcore-6.0'
@@ -12,9 +12,9 @@ uid: migration/inc/overview
 
 <!-- see mermaid.txt to change diagrams -->
 
-# Incremental ASP.NET to ASP.NET Core migration
+# Incremental ASP.NET to ASP.NET Core update
 
-Migrating an app from ASP.NET Framework to ASP.NET Core is non-trivial for the majority of production apps. These apps often incorporate new technologies as they become available and are often composed of many legacy decisions. This article provides guidance and links to tools for migrating ASP.NET Framework apps to ASP.NET Core with as little change as possible.
+Updating an app from ASP.NET Framework to ASP.NET Core is non-trivial for the majority of production apps. These apps often incorporate new technologies as they become available and are often composed of many legacy decisions. This article provides guidance and links to tools for migrating ASP.NET Framework apps to ASP.NET Core with as little change as possible.
 
 One of the larger challenges is the pervasive use of <xref:System.Web.HttpContext> throughout a code base. Without the incremental approach and tools, a large scale rewrite is required to remove the `System.Web.HttpContext` dependency. The adapters in [dotnet/systemweb-adapters](https://github.com/dotnet/systemweb-adapters) provide a set of runtime helpers to access the types used in the ASP.NET Framework app in a way that works in ASP.NET Core with minimal changes.
 

--- a/aspnetcore/migration/inc/session.md
+++ b/aspnetcore/migration/inc/session.md
@@ -14,7 +14,7 @@ uid: migration/inc/session
 
 ## Session State
 
-Session state in ASP.NET Framework provided a number of features that ASP.NET Core does not provide. In order to migrate from ASP.NET Framework to Core, the adapters provide mechanisms to enable populating session state with similar behavior as `System.Web` did. Some of the differences between framework and core are:
+Session state in ASP.NET Framework provided a number of features that ASP.NET Core does not provide. In order to update from ASP.NET Framework to Core, the adapters provide mechanisms to enable populating session state with similar behavior as `System.Web` did. Some of the differences between framework and core are:
 
 - ASP.NET Framework would lock session usage within a session, so subsequent requests in a session are handled in a serial fashion. This is different than ASP.NET Core that does not provide any of these guarantees.
 - ASP.NET Framework would serialize and deserialize objects automatically (unless being done in-memory). ASP.NET Core provides a mechanism to store a `byte[]` given a key. Any object serialization/deserialization has to be done manually by the user.

--- a/aspnetcore/migration/inc/start.md
+++ b/aspnetcore/migration/inc/start.md
@@ -20,14 +20,7 @@ To understand how this is helpful in the migration process, see [Incremental ASP
 
 ## Set up ASP.NET Core Project
 
-1. Install the [experimental Visual Studio extension](https://marketplace.visualstudio.com/items?itemName=WebToolsTeam.aspnetprojectmigrations) that helps configure the solution.
-2. Right click the ASP.NET Framework app and select **Migrate Project**:
-   ![Migrate Menu](~/migration/inc/start/static/migrate_menu.png)
-1. This will open a menu that will offer to start a migration. Click the link to begin:
-   ![Migrate Options](~/migration/inc/start/static/migrate_options.png)
-1. A wizard will now appear that allows you to create a new project or select an existing project.
-   ![Migrate Wizard](~/migration/inc/start/static/migrate_wizard.png)
-1. After completing the wizard, you have an ASP.NET Core project that proxies requests to routes that do not exist there onto the ASP.NET Framework app.
+Install the Visual Studio extension [.NET Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant). For more information see the blog post [Upgrading your .NET projects with Visual Studio](https://devblogs.microsoft.com/dotnet/upgrade-assistant-now-in-visual-studio/). <!-- TODO: update  https://github.com/dotnet/AspNetCore.Docs/issues/28608 -->
 
 ## Upgrade supporting libraries
 

--- a/aspnetcore/migration/inc/start.md
+++ b/aspnetcore/migration/inc/start.md
@@ -52,4 +52,4 @@ It is possible to share authentication between the original ASP.NET app and the 
 
 ## General Usage Guidance
 
-There are a number of differences between ASP.NET and ASP.NET Core that the adapters are able to help migrate. However, there are some features that require an opt-in as they incur some cost. There are also behaviors that cannot be adapted. See [usage guidance](xref:migration/inc/usage_guidance) for a list of these.
+There are a number of differences between ASP.NET and ASP.NET Core that the adapters are able to help update. However, there are some features that require an opt-in as they incur some cost. There are also behaviors that cannot be adapted. See [usage guidance](xref:migration/inc/usage_guidance) for a list of these.

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -6,16 +6,15 @@ ms.author: riande
 ms.date: 10/18/2019
 uid: migration/proper-to-2x/index
 ---
-# Migrate from ASP.NET Framework to ASP.NET Core
-
-By [Isaac Levin](https://isaaclevin.com)
+# Upgrade from ASP.NET Framework to ASP.NET Core
 
  :::moniker range=">= aspnetcore-7.0"
 
-Most non-trivial ASP.NET Framework apps should consider using the [incremental migration](xref:migration/inc/overview) approach. For more information, see [Incremental ASP.NET to ASP.NET Core migration](/aspnet/core/migration/inc/overview).
+Most non-trivial ASP.NET Framework apps should consider using the [incremental upgrade](xref:migration/inc/overview) approach. For more information, see [Incremental ASP.NET to ASP.NET Core upgrade](/aspnet/core/migration/inc/overview).
 
 Visual Studio has tooling to help migrate ASP.NET apps to ASP.NET Core. For more information, see [Migrating from ASP.NET to ASP.NET Core in Visual Studio](/aspnet/core/migration/inc/overview).
 
+The Visual Studio [.NET Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant) chan help upgrade ASP.NET Framework web apps to ASP.NET Core. For more information 
 The [.NET Upgrade Assistant](https://dotnet.microsoft.com/platform/upgrade-assistant) is a command-line tool that can help migrate ASP.NET to ASP.NET Core. For more information, see [Overview of the .NET Upgrade Assistant](/dotnet/architecture/porting-existing-aspnet-apps/) and [Upgrade an ASP.NET MVC app to .NET 6 with the .NET Upgrade Assistant](/dotnet/core/porting/upgrade-assistant-aspnetmvc).
 
 ## URI decoding differences between ASP.NET to ASP.NET Core

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -10,6 +10,12 @@ uid: migration/proper-to-2x/index
 
  :::moniker range=">= aspnetcore-7.0"
 
+## Why upgrade to the latest .NET
+
+ASP.NET Core is the modern web framework for .NET. While ASP.NET Core has many similarities to ASP.NET in the .NET Framework, it is a completely new framework completely rewritten. ASP.NET apps migrated to ASP.NET Core can benefit from improved performance and access to the latest web development features.
+
+## ASP.NET Framework update approaches
+
 Most non-trivial ASP.NET Framework apps should consider using the [incremental upgrade](xref:migration/inc/overview) approach. For more information, see [Incremental ASP.NET to ASP.NET Core upgrade](/aspnet/core/migration/inc/overview).
 
 <!--

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -12,10 +12,9 @@ uid: migration/proper-to-2x/index
 
 Most non-trivial ASP.NET Framework apps should consider using the [incremental upgrade](xref:migration/inc/overview) approach. For more information, see [Incremental ASP.NET to ASP.NET Core upgrade](/aspnet/core/migration/inc/overview).
 
-Visual Studio has tooling to help migrate ASP.NET apps to ASP.NET Core. For more information, see [Migrating from ASP.NET to ASP.NET Core in Visual Studio](/aspnet/core/migration/inc/overview).
-
-The Visual Studio [.NET Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant) chan help upgrade ASP.NET Framework web apps to ASP.NET Core. For more information 
-The [.NET Upgrade Assistant](https://dotnet.microsoft.com/platform/upgrade-assistant) is a command-line tool that can help migrate ASP.NET to ASP.NET Core. For more information, see [Overview of the .NET Upgrade Assistant](/dotnet/architecture/porting-existing-aspnet-apps/) and [Upgrade an ASP.NET MVC app to .NET 6 with the .NET Upgrade Assistant](/dotnet/core/porting/upgrade-assistant-aspnetmvc).
+<!--
+Visual Studio has tooling to help migrate ASP.NET apps to ASP.NET Core. For more information, see [Upgrading your .NET projects with Visual Studio](https://devblogs.microsoft.com/dotnet/upgrade-assistant-now-in-visual-studio/).  Update this link to https://learn.microsoft.com/en-us/dotnet/core/porting/ when those doc's are updated.-->
+The Visual Studio extension [.NET Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant) can help upgrade ASP.NET Framework web apps to ASP.NET Core. For more information see the blog post [Upgrading your .NET projects with Visual Studio](https://devblogs.microsoft.com/dotnet/upgrade-assistant-now-in-visual-studio/).
 
 ## URI decoding differences between ASP.NET to ASP.NET Core
 
@@ -36,10 +35,11 @@ To generate the value for `HttpRequest.Url`, use `new Uri(this.AspNetCoreHttpReq
 
 See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/27611).
 
+<!-- remove these comments when the topic is updated
 ## Additional resources
 
 - [Overview of porting from .NET Framework to .NET](/dotnet/core/porting/libraries)
-
+-->
 :::moniker-end
 
 [!INCLUDE[](~/migration/proper-to-2x/includes/index5.md)]

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate from ASP.NET to ASP.NET Core
+title: Update from ASP.NET to ASP.NET Core
 author: isaacrlevin
 description: Guidance for migrating existing ASP.NET MVC or Web API apps to ASP.NET Core.web
 ms.author: riande
@@ -12,15 +12,15 @@ uid: migration/proper-to-2x/index
 
 ## Why upgrade to the latest .NET
 
-ASP.NET Core is the modern web framework for .NET. While ASP.NET Core has many similarities to ASP.NET in the .NET Framework, it is a completely new framework completely rewritten. ASP.NET apps migrated to ASP.NET Core can benefit from improved performance and access to the latest web development features.
+ASP.NET Core is the modern web framework for .NET. While ASP.NET Core has many similarities to ASP.NET in the .NET Framework, it is a completely new framework completely rewritten. ASP.NET apps updated to ASP.NET Core can benefit from improved performance and access to the latest web development features.
 
 ## ASP.NET Framework update approaches
 
-Most non-trivial ASP.NET Framework apps should consider using the [incremental upgrade](xref:migration/inc/overview) approach. For more information, see [Incremental ASP.NET to ASP.NET Core upgrade](/aspnet/core/migration/inc/overview).
+Most non-trivial ASP.NET Framework apps should consider using the [incremental upgrade](/aspnet/core/migration/inc/overview) approach. For more information, see [Incremental ASP.NET to ASP.NET Core upgrade](/aspnet/core/migration/inc/overview).
 
-<!--
-Visual Studio has tooling to help migrate ASP.NET apps to ASP.NET Core. For more information, see [Upgrading your .NET projects with Visual Studio](https://devblogs.microsoft.com/dotnet/upgrade-assistant-now-in-visual-studio/).  Update this link to https://learn.microsoft.com/en-us/dotnet/core/porting/ when those doc's are updated.-->
 The Visual Studio extension [.NET Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant) can help upgrade ASP.NET Framework web apps to ASP.NET Core. For more information see the blog post [Upgrading your .NET projects with Visual Studio](https://devblogs.microsoft.com/dotnet/upgrade-assistant-now-in-visual-studio/).
+
+<!-- TODO: replace link to blog to article when the blog is migrated -->
 
 ## URI decoding differences between ASP.NET to ASP.NET Core
 
@@ -41,7 +41,7 @@ To generate the value for `HttpRequest.Url`, use `new Uri(this.AspNetCoreHttpReq
 
 See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/27611).
 
-<!-- remove these comments when the topic is updated
+<!-- remove these comments when the following overview topic is updated
 ## Additional resources
 
 - [Overview of porting from .NET Framework to .NET](/dotnet/core/porting/libraries)

--- a/aspnetcore/migration/proper-to-2x/index.md
+++ b/aspnetcore/migration/proper-to-2x/index.md
@@ -12,7 +12,7 @@ uid: migration/proper-to-2x/index
 
 ## Why upgrade to the latest .NET
 
-ASP.NET Core is the modern web framework for .NET. While ASP.NET Core has many similarities to ASP.NET in the .NET Framework, it is a completely new framework completely rewritten. ASP.NET apps updated to ASP.NET Core can benefit from improved performance and access to the latest web development features.
+ASP.NET Core is the modern web framework for .NET. While ASP.NET Core has many similarities to ASP.NET in the .NET Framework, it's a new framework that's completely rewritten. ASP.NET apps updated to ASP.NET Core can benefit from improved performance and access to the latest web development features and capabilities.
 
 ## ASP.NET Framework update approaches
 


### PR DESCRIPTION
***TL:DR***

1. Replace experimental VS extension with the .NET Upgrade Assistant VS extension. This is a stop gap, in another PR I'll add full instructions on using .NET Upgrade Assistant VS extension.
2. Replace `migrate` with `update`.  There are a couple instances of  `migrate` left where it sounded better, but I replaced most.

Fixes #28448
Fixes #28447
Fixes #28562
Fixes #28611

[Internal review URL 1](https://review.learn.microsoft.com/en-us/aspnet/core/migration/proper-to-2x/index?view=aspnetcore-8.0&branch=pr-en-us-28592)
