### PR TITLE
Fix an example and add an example

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -95,6 +95,45 @@ When the **`Trigger .NET static method`** button is selected, the browser's deve
 Array(3) [ 1, 2, 3 ]
 ```
 
+Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+
+To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
+
+```html
+<script>
+  window.returnArrayAsync = (startPosition) => {
+    DotNet.invokeMethodAsync('BlazorSample', 'ReturnArrayAsync', startPosition)
+      .then(data => {
+        console.log(data);
+      });
+    };
+</script>
+```
+
+In the `CallDotNetExample1` component, change the function call to include a starting position. The following example uses a value of `5`:
+
+```html
+<button onclick="returnArrayAsync(5)">
+    ...
+</button>
+```
+
+The component's invokable `ReturnArrayAsync` method receives the starting position and constructs the array from it. The array is returned for logging to the console:
+
+```csharp
+[JSInvokable]
+public static Task<int[]> ReturnArrayAsync(int startPosition)
+{
+    return Task.FromResult(Enumerable.Range(startPosition, 3).ToArray());
+}
+```
+
+After the app is recompiled and the browser is refreshed, the following output appears in the browser's console when the button is selected:
+
+```console
+Array(3) [ 5, 6, 7 ]
+```
+
 By default, the .NET method identifier for the JS call is the .NET method name, but you can specify a different identifier using the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) constructor. In the following example, `DifferentMethodName` is the assigned method identifier for the `ReturnArrayAsync` method:
 
 ```csharp
@@ -132,7 +171,7 @@ DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject',
 
 ```csharp
 [JSInvokable]
-public void ReceiveWindowObject(IJSObjectReference objRef)
+public static void ReceiveWindowObject(IJSObjectReference objRef)
 {
     ...
 }
@@ -977,6 +1016,45 @@ When the **`Trigger .NET static method`** button is selected, the browser's deve
 Array(3) [ 1, 2, 3 ]
 ```
 
+Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+
+To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
+
+```html
+<script>
+  window.returnArrayAsync = (startPosition) => {
+    DotNet.invokeMethodAsync('BlazorSample', 'ReturnArrayAsync', startPosition)
+      .then(data => {
+        console.log(data);
+      });
+    };
+</script>
+```
+
+In the `CallDotNetExample1` component, change the function call to include a starting position. The following example uses a value of `5`:
+
+```html
+<button onclick="returnArrayAsync(5)">
+    ...
+</button>
+```
+
+The component's invokable `ReturnArrayAsync` method receives the starting position and constructs the array from it. The array is returned for logging to the console:
+
+```csharp
+[JSInvokable]
+public static Task<int[]> ReturnArrayAsync(int startPosition)
+{
+    return Task.FromResult(Enumerable.Range(startPosition, 3).ToArray());
+}
+```
+
+After the app is recompiled and the browser is refreshed, the following output appears in the browser's console when the button is selected:
+
+```console
+Array(3) [ 5, 6, 7 ]
+```
+
 By default, the .NET method identifier for the JS call is the .NET method name, but you can specify a different identifier using the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) constructor. In the following example, `DifferentMethodName` is the assigned method identifier for the `ReturnArrayAsync` method:
 
 ```csharp
@@ -1014,7 +1092,7 @@ DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject',
 
 ```csharp
 [JSInvokable]
-public void ReceiveWindowObject(IJSObjectReference objRef)
+public static void ReceiveWindowObject(IJSObjectReference objRef)
 {
     ...
 }
@@ -1837,6 +1915,45 @@ When the **`Trigger .NET static method`** button is selected, the browser's deve
 Array(3) [ 1, 2, 3 ]
 ```
 
+Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+
+To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
+
+```html
+<script>
+  window.returnArrayAsync = (startPosition) => {
+    DotNet.invokeMethodAsync('BlazorSample', 'ReturnArrayAsync', startPosition)
+      .then(data => {
+        console.log(data);
+      });
+    };
+</script>
+```
+
+In the `CallDotNetExample1` component, change the function call to include a starting position. The following example uses a value of `5`:
+
+```html
+<button onclick="returnArrayAsync(5)">
+    ...
+</button>
+```
+
+The component's invokable `ReturnArrayAsync` method receives the starting position and constructs the array from it. The array is returned for logging to the console:
+
+```csharp
+[JSInvokable]
+public static Task<int[]> ReturnArrayAsync(int startPosition)
+{
+    return Task.FromResult(Enumerable.Range(startPosition, 3).ToArray());
+}
+```
+
+After the app is recompiled and the browser is refreshed, the following output appears in the browser's console when the button is selected:
+
+```console
+Array(3) [ 5, 6, 7 ]
+```
+
 By default, the .NET method identifier for the JS call is the .NET method name, but you can specify a different identifier using the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) constructor. In the following example, `DifferentMethodName` is the assigned method identifier for the `ReturnArrayAsync` method:
 
 ```csharp
@@ -1874,7 +1991,7 @@ DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject',
 
 ```csharp
 [JSInvokable]
-public void ReceiveWindowObject(IJSObjectReference objRef)
+public static void ReceiveWindowObject(IJSObjectReference objRef)
 {
     ...
 }
@@ -2307,6 +2424,84 @@ When the **`Trigger .NET static method`** button is selected, the browser's deve
 Array(3) [ 1, 2, 3 ]
 ```
 
+Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+
+To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
+
+```html
+<script>
+  window.returnArrayAsync = (startPosition) => {
+    DotNet.invokeMethodAsync('BlazorSample', 'ReturnArrayAsync', startPosition)
+      .then(data => {
+        console.log(data);
+      });
+    };
+</script>
+```
+
+In the `CallDotNetExample1` component, change the function call to include a starting position. The following example uses a value of `5`:
+
+```html
+<button onclick="returnArrayAsync(5)">
+    ...
+</button>
+```
+
+The component's invokable `ReturnArrayAsync` method receives the starting position and constructs the array from it. The array is returned for logging to the console:
+
+```csharp
+[JSInvokable]
+public static Task<int[]> ReturnArrayAsync(int startPosition)
+{
+    return Task.FromResult(Enumerable.Range(startPosition, 3).ToArray());
+}
+```
+
+After the app is recompiled and the browser is refreshed, the following output appears in the browser's console when the button is selected:
+
+```console
+Array(3) [ 5, 6, 7 ]
+```
+
+Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+
+To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
+
+```html
+<script>
+  window.returnArrayAsync = (startPosition) => {
+    DotNet.invokeMethodAsync('BlazorSample', 'ReturnArrayAsync', startPosition)
+      .then(data => {
+        console.log(data);
+      });
+    };
+</script>
+```
+
+In the `CallDotNetExample1` component, change the function call to include a starting position. The following example uses a value of `5`:
+
+```html
+<button onclick="returnArrayAsync(5)">
+    ...
+</button>
+```
+
+The component's invokable `ReturnArrayAsync` method receives the starting position and constructs the array from it. The array is returned for logging to the console:
+
+```csharp
+[JSInvokable]
+public static Task<int[]> ReturnArrayAsync(int startPosition)
+{
+    return Task.FromResult(Enumerable.Range(startPosition, 3).ToArray());
+}
+```
+
+After the app is recompiled and the browser is refreshed, the following output appears in the browser's console when the button is selected:
+
+```console
+Array(3) [ 5, 6, 7 ]
+```
+
 By default, the .NET method identifier for the JS call is the .NET method name, but you can specify a different identifier using the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) constructor. In the following example, `DifferentMethodName` is the assigned method identifier for the `ReturnArrayAsync` method:
 
 ```csharp
@@ -2344,7 +2539,7 @@ DotNet.invokeMethodAsync('{ASSEMBLY NAME}', 'ReceiveWindowObject',
 
 ```csharp
 [JSInvokable]
-public void ReceiveWindowObject(IJSObjectReference objRef)
+public static void ReceiveWindowObject(IJSObjectReference objRef)
 {
     ...
 }

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -95,7 +95,7 @@ When the **`Trigger .NET static method`** button is selected, the browser's deve
 Array(3) [ 1, 2, 3 ]
 ```
 
-Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+Pass data to a .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
 
 To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
 
@@ -1016,7 +1016,7 @@ When the **`Trigger .NET static method`** button is selected, the browser's deve
 Array(3) [ 1, 2, 3 ]
 ```
 
-Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+Pass data to a .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
 
 To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
 
@@ -2424,7 +2424,7 @@ When the **`Trigger .NET static method`** button is selected, the browser's deve
 Array(3) [ 1, 2, 3 ]
 ```
 
-Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+Pass data to a .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
 
 To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
 
@@ -2463,7 +2463,7 @@ After the app is recompiled and the browser is refreshed, the following output a
 Array(3) [ 5, 6, 7 ]
 ```
 
-Pass data to the `ReturnArrayAsync` .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
+Pass data to a .NET method when calling the `invokeMethodAsync` function by passing the data as arguments.
 
 To demonstrate passing data to .NET, make the preceding `returnArrayAsync` JS function receive a starting position when the function is called and pass the value as an argument to the `invokeMethodAsync` function:
 


### PR DESCRIPTION
Fixes #28618

Thanks @dunxz! 🚀 ...

* I fix the MIA `static` modifier. Good 👁️ on that one. *Thanks for the shout out!*
* I add an example of passing a value to the JS FN ... then have `invokeMethodAsync` call the .NET method with that as an argument. It builds on the preceding example, so the dev just needs to change a couple of lines of code from that example if they want to see it in action. I'm careful to call out that they need to build/refresh to see it; although, Hot Reload folks should be fine ... that should be automatic for them.
* WRT naming, no 🎲🎲 on the JS FN rename for `sayHello{X}`, as I found out that it's used for multiple examples here. That's not really a big deal. The important thing is that the names on both sides, JS and .NET, don't collide and cause a 💥 at compile-time or runtime. I'm going to leave that naming as it is.

Thanks again for the issue. This is a nice fix and enhancement to the doc. If you have feedback, you can add a comment here. I'm going to merge this immediately after this builds. I'm 🏃🏃🏃🏃😅 on a bunch of work items right now, so I'd like to get this in and done. I can put a patch PR on it if needed. 