### PR TITLE
Run quest nightly

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,5 +1,7 @@
 name: "bulk quest import"
 on:
+  schedule:
+    - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
   workflow_dispatch:
     inputs:
       reason:
@@ -11,7 +13,6 @@ jobs:
   bulk-import:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       issues: write
 
     steps:
@@ -21,7 +22,6 @@ jobs:
           echo "Reason: ${{ github.event.inputs.reason }}"
 
       - name: bulk-sequester
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         id: bulk-sequester
         uses: dotnet/docs-tools/actions/sequester@main
         env:

--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -1,8 +1,5 @@
 name: "quest import"
 on:
-  issues:
-    types:
-      [ labeled, closed, reopened, assigned, unassigned ]
   workflow_dispatch:
     inputs:
       reason:
@@ -23,7 +20,6 @@ jobs:
       contains(github.event.issue.labels.*.name, 'seQUESTered')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
       issues: write
 
     steps:


### PR DESCRIPTION
Quest runs nightly, rather than on each label update.

The following changes make that happen:

- The bulk action runs once a day, at a hopefully convenient time.
- The single item workflow runs only in response to a workflow dispatch event (user started)
- For security reasons, limit the permissions to write *issues*, not *contents*
