### PR TITLE
Protect class instance invokable methods

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -355,7 +355,7 @@ For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#ja
 
 ## Avoid trimming JavaScript-invokable .NET methods
 
-[Runtime relinking](xref:blazor/host-and-deploy/webassembly#runtime-relinking) trims class instance JavaScript-invokable .NET methods unless they're protected. For more information, see <xref:blazor/js-interop/call-dotnet-from-javascript#avoid-trimming-javascript-invokable-net-methods>.
+[Runtime relinking](xref:blazor/host-and-deploy/webassembly#runtime-relinking) trims class instance JavaScript-invokable .NET methods unless they're explicitly preserved. For more information, see <xref:blazor/js-interop/call-dotnet-from-javascript#avoid-trimming-javascript-invokable-net-methods>.
 
 ## Build, pack, and ship to NuGet
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -353,6 +353,10 @@ Blazor enables JavaScript isolation in standard [JavaScript modules](https://dev
 
 For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#javascript-isolation-in-javascript-modules>.
 
+## Avoid trimming JavaScript-invokable .NET methods
+
+[Runtime relinking](xref:blazor/host-and-deploy/webassembly#runtime-relinking) trims class instance JavaScript-invokable .NET methods unless they're protected. For more information, see <xref:blazor/js-interop/call-dotnet-from-javascript#avoid-trimming-javascript-invokable-net-methods>.
+
 ## Build, pack, and ship to NuGet
 
 Because Razor class libraries that contain Razor components are standard .NET libraries, packing and shipping them to NuGet is no different from packing and shipping any library to NuGet. Packing is performed using the [`dotnet pack`](/dotnet/core/tools/dotnet-pack) command in a command shell:

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -69,6 +69,9 @@ Runtime relinking requires installation of the .NET WebAssembly build tools. For
 
 With the .NET WebAssembly build tools installed, runtime relinking is performed automatically when an app is **published** in the `Release` configuration. The size reduction is particularly dramatic when disabling globalization. For more information, see <xref:blazor/globalization-localization#invariant-globalization>.
 
+> [!IMPORTANT]
+> Runtime relinking trims class instance JavaScript-invokable .NET methods unless they're protected. For more information, see <xref:blazor/js-interop/call-dotnet-from-javascript#avoid-trimming-javascript-invokable-net-methods>.
+
 ## Customize how boot resources are loaded
 
 Customize how boot resources are loaded using the `loadBootResource` API. For more information, see <xref:blazor/fundamentals/startup#load-boot-resources>.
@@ -1142,6 +1145,9 @@ One of the largest parts of a Blazor WebAssembly app is the WebAssembly-based .N
 Runtime relinking requires installation of the .NET WebAssembly build tools. For more information, see <xref:blazor/tooling#net-webassembly-build-tools>.
 
 With the .NET WebAssembly build tools installed, runtime relinking is performed automatically when an app is **published** in the `Release` configuration. The size reduction is particularly dramatic when disabling globalization. For more information, see <xref:blazor/globalization-localization#invariant-globalization>.
+
+> [!IMPORTANT]
+> Runtime relinking trims class instance JavaScript-invokable .NET methods unless they're protected. For more information, see <xref:blazor/js-interop/call-dotnet-from-javascript#avoid-trimming-javascript-invokable-net-methods>.
 
 ## Customize how boot resources are loaded
 

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -231,6 +231,33 @@ The following sections of this article demonstrate various approaches for invoki
 * [Class instance examples](#class-instance-examples)
 * [Component instance .NET method helper class](#component-instance-net-method-helper-class)
 
+## Avoid trimming JavaScript-invokable .NET methods
+
+*This section applies to Blazor WebAssembly apps with [ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) and [runtime relinking](xref:blazor/host-and-deploy/webassembly#runtime-relinking) enabled.*
+
+Several of the examples in the following sections are based on a class instance approach, where the JavaScript-invokable .NET method marked with the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) is a member of a class that isn't a Razor component. When such .NET methods are located in a Razor component, they're protected from [runtime relinking/trimming](xref:blazor/host-and-deploy/webassembly#runtime-relinking). In order to protect the .NET methods from trimming outside of Razor components, implement the methods with the [`DynamicDependency` attribute](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) on the class's constructor, as the following example demonstrates:
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop;
+
+public class ExampleClass {
+
+    [DynamicDependency(nameof(ExampleJSInvokableMethod))]
+    public ExampleClass()
+    {
+    }
+
+    [JSInvokable]
+    public string ExampleJSInvokableMethod()
+    {
+        ...
+    }
+}
+```
+
+For more information, see [Prepare .NET libraries for trimming: DynamicDependency](/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#dynamicdependency).
+
 ## Pass a `DotNetObjectReference` to an individual JavaScript function
 
 The example in this section demonstrates how to pass a <xref:Microsoft.JSInterop.DotNetObjectReference> to an individual JavaScript (JS) function.

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -1179,6 +1179,31 @@ The following sections of this article demonstrate various approaches for invoki
 * [Class instance examples](#class-instance-examples)
 * [Component instance .NET method helper class](#component-instance-net-method-helper-class)
 
+## Avoid trimming JavaScript-invokable .NET methods
+
+*This section applies to Blazor WebAssembly apps with [ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) and [runtime relinking](xref:blazor/host-and-deploy/webassembly#runtime-relinking) enabled.*
+
+Several of the examples in the following sections are based on a class instance approach, where the JavaScript-invokable .NET method marked with the [`[JSInvokable]` attribute](xref:Microsoft.JSInterop.JSInvokableAttribute) is a member of a class that isn't a Razor component. When such .NET methods are located in a Razor component, they're protected from [runtime relinking/trimming](xref:blazor/host-and-deploy/webassembly#runtime-relinking). In order to protect the .NET methods from trimming outside of Razor components, implement the methods with the [`DynamicDependency` attribute](xref:System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute) on the class's constructor, as the following example demonstrates:
+
+```csharp
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop;
+
+public class ExampleClass {
+
+    [DynamicDependency(nameof(ExampleJSInvokableMethod))]
+    public ExampleClass()
+    {
+    }
+
+    [JSInvokable]
+    public string ExampleJSInvokableMethod()
+    {
+        ...
+    }
+}
+```
+
 ## Pass a `DotNetObjectReference` to an individual JavaScript function
 
 The example in this section demonstrates how to pass a <xref:Microsoft.JSInterop.DotNetObjectReference> to an individual JavaScript (JS) function.


### PR DESCRIPTION
Fixes #28630

Thanks @ScarletKuro! 🚀 ... This might be a bit *rough*, but I couldn't wait until next Tuesday. See what you think of this. After we get the lingo hammered out sufficiently, I'll ping for engineering review.

You'll see some repeats of text here. It's just due to a type of versioning that we use. Ignore the duplicate sections/text.

<!-- PREVIEW-TABLE-START -->
#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/class-libraries.md](https://github.com/dotnet/AspNetCore.Docs/blob/0e11d66277d5a6cd6a9bb46fdc11e32df7351a12/aspnetcore/blazor/components/class-libraries.md) | [aspnetcore/blazor/components/class-libraries](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries?branch=pr-en-us-28631) |
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/0e11d66277d5a6cd6a9bb46fdc11e32df7351a12/aspnetcore/blazor/host-and-deploy/webassembly.md) | [aspnetcore/blazor/host-and-deploy/webassembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-28631) |
| [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/0e11d66277d5a6cd6a9bb46fdc11e32df7351a12/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md) | [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?branch=pr-en-us-28631) |

<!-- PREVIEW-TABLE-END -->