### PR TITLE
Doc HTTP_PORTS, HTTPS_PORTS

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/includes/webapplication.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/webapplication.md
@@ -86,6 +86,17 @@ The preceding samples can use `ASPNETCORE_URLS`
 ASPNETCORE_URLS=http://*:3000;https://+:5000;http://0.0.0.0:5005
 ```
 
+### Listen on all interfaces using ASPNETCORE_HTTPS_PORTS
+
+The preceding samples can use `ASPNETCORE_HTTPS_PORTS` and `ASPNETCORE_HTTP_PORTS`.
+
+```
+ASPNETCORE_HTTP_PORTS=3000;5005
+ASPNETCORE_HTTPS_PORTS=5000
+```
+
+For more information, see [Configure endpoints for the ASP.NET Core Kestrel web server](xref:fundamentals/servers/kestrel/endpoints)
+
 ### Specify HTTPS with development certificate
 
 [!code-csharp[](~/fundamentals/minimal-apis/7.0-samples/WebMinAPIs/Program.cs?name=snippet_cert)]

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -64,7 +64,7 @@ HTTP/2 is enabled by default. If an HTTP/2 connection isn't established, the con
 
 ## HTTP/3 support
 
-[HTTP/3](https://quicwg.org/base-drafts/draft-ietf-quic-http.html) is enabled for ASP.NET Core apps when the following base requirements are met:
+[HTTP/3](https://quicwg.org/base-drafts/v2-samples/draft-ietf-quic-http.html) is enabled for ASP.NET Core apps when the following base requirements are met:
 
 * Windows Server 2022/Windows 11 or later
 * An `https` url binding is used.

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -170,7 +170,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
 
    [!INCLUDE [http-ports](~/includes/http-ports.md)]
 
-   The HTTP_PORTS and HTTPS_PORTS configuration keys are equivalent to top-level wildcard bindings. They're convenient for development and container scenarios, but avoid wildcards when running on a machine that may also host other services.
+   These configuration keys are equivalent to top-level wildcard bindings. They're convenient for development and container scenarios, but avoid wildcards when running on a machine that may also host other services.
 
 1. Preregister URL prefixes on the server.
 

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -168,6 +168,8 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
    > [!WARNING]
    > Top-level wildcard bindings (`http://*:80/` and `http://+:80`) should **not** be used. Top-level wildcard bindings create app security vulnerabilities. This applies to both strong and weak wildcards. Use explicit host names or IP addresses rather than wildcards. Subdomain wildcard binding (for example, `*.mysub.com`) isn't a security risk if you control the entire parent domain (as opposed to `*.com`, which is vulnerable). For more information, see [RFC 9110: Section 7.2: Host and :authority](https://www.rfc-editor.org/rfc/rfc9110#field.host).
 
+   [!INCLUDE [http-ports](~/includes/http-ports.md)]
+
 1. Preregister URL prefixes on the server.
 
    The built-in tool for configuring HTTP.sys is *netsh.exe*. *netsh.exe* is used to reserve URL prefixes and assign X.509 certificates. The tool requires administrator privileges.

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -5,7 +5,7 @@ description: Learn about HTTP.sys, a web server for ASP.NET Core on Windows. Bui
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/10/2023
+ms.date: 03/13/2023
 uid: fundamentals/servers/httpsys
 ---
 # HTTP.sys web server implementation in ASP.NET Core
@@ -96,7 +96,7 @@ HTTP.sys delegates to kernel mode authentication with the Kerberos authenticatio
 
 Call the <xref:Microsoft.AspNetCore.Hosting.WebHostBuilderHttpSysExtensions.UseHttpSys*> extension method when building the host, specifying any required <xref:Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions>. The following example sets options to their default values:
 
-[!code-csharp[](httpsys/samples/3.x/SampleApp/Program.cs?name=snippet1&highlight=5-13)]
+[!code-csharp[](~/fundamentals/servers/httpsys/samples/3.x/SampleApp/Program.cs?name=snippet1&highlight=5-13)]
 
 Additional HTTP.sys configuration is handled through [registry settings](https://support.microsoft.com/help/820129/http-sys-registry-settings-for-windows).
 
@@ -119,7 +119,7 @@ An exception is thrown if the app attempts to configure the limit on a request a
 
 If the app should override <xref:Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.MaxRequestBodySize> per-request, use the <xref:Microsoft.AspNetCore.Http.Features.IHttpMaxRequestBodySizeFeature>:
 
-[!code-csharp[](httpsys/samples/3.x/SampleApp/Startup.cs?name=snippet1&highlight=6-7)]
+[!code-csharp[](~/fundamentals/servers/httpsys/samples/3.x/SampleApp/Startup.cs?name=snippet1&highlight=6-7)]
 
 If using Visual Studio, make sure the app isn't configured to run IIS or IIS Express.
 
@@ -157,7 +157,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
 
    The following code example shows how to use <xref:Microsoft.AspNetCore.Server.HttpSys.HttpSysOptions.UrlPrefixes> with the server's local IP address `10.0.0.4` on port 443:
 
-   [!code-csharp[](httpsys/samples_snapshot/3.x/Program.cs?highlight=7)]
+   [!code-csharp[](~/fundamentals/servers/httpsys/samples_snapshot/3.x/Program.cs?highlight=7)]
 
    An advantage of `UrlPrefixes` is that an error message is generated immediately for improperly formatted prefixes.
 

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -5,7 +5,7 @@ description: Learn about HTTP.sys, a web server for ASP.NET Core on Windows. Bui
 monikerRange: '>= aspnetcore-2.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/13/2023
+ms.date: 03/15/2023
 uid: fundamentals/servers/httpsys
 ---
 # HTTP.sys web server implementation in ASP.NET Core
@@ -169,6 +169,8 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
    > Top-level wildcard bindings (`http://*:80/` and `http://+:80`) should **not** be used. Top-level wildcard bindings create app security vulnerabilities. This applies to both strong and weak wildcards. Use explicit host names or IP addresses rather than wildcards. Subdomain wildcard binding (for example, `*.mysub.com`) isn't a security risk if you control the entire parent domain (as opposed to `*.com`, which is vulnerable). For more information, see [RFC 9110: Section 7.2: Host and :authority](https://www.rfc-editor.org/rfc/rfc9110#field.host).
 
    [!INCLUDE [http-ports](~/includes/http-ports.md)]
+
+   The HTTP_PORTS and HTTPS_PORTS configuration keys are equivalent to top-level wildcard bindings. They're convenient for development and container scenarios, but avoid wildcards when running on a machine that may also host other services.
 
 1. Preregister URL prefixes on the server.
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -26,7 +26,7 @@ The value provided using these approaches can be one or more HTTP and HTTPS endp
 
 For more information on these approaches, see [Server URLs](xref:fundamentals/host/web-host#server-urls) and [Override configuration](xref:fundamentals/host/web-host#override-configuration).
 
-
+[!INCLUDE [http-ports](~/includes/http-ports.md)]
 
 A development certificate is created:
 

--- a/aspnetcore/includes/http-ports.md
+++ b/aspnetcore/includes/http-ports.md
@@ -1,4 +1,4 @@
-Apps and containers are often given only a port to listen on, like port 80, without additional constraints like host or path. HTTP_PORTS and HTTPS_PORTS are config keys that specify the listening ports for the Kestrel and Http.sys servers. These keys may be specified as environment variables defined with the `DOTNET_` or `ASPNETCORE_` prefixes, or specified directly through any other config input, such as `appsettings.json`. Each is a semicolon-delimited list of port values, as shown in the following example:
+Apps and containers are often given only a port to listen on, like port 80, without additional constraints like host or path. HTTP_PORTS and HTTPS_PORTS are config keys that specify the listening ports for the Kestrel and HTTP.sys servers. These keys may be specified as environment variables defined with the `DOTNET_` or `ASPNETCORE_` prefixes, or specified directly through any other config input, such as `appsettings.json`. Each is a semicolon-delimited list of port values, as shown in the following example:
 
 ```
 ASPNETCORE_HTTP_PORTS=80;8080

--- a/aspnetcore/includes/http-ports.md
+++ b/aspnetcore/includes/http-ports.md
@@ -1,4 +1,4 @@
-Apps and containers are often given only a port to listen on, like port 80, without additional constraints like host or path. HTTP_PORTS and HTTPS_PORTS are config keys that specify the listening ports for the Kestrel and HttpSys servers. These may be specified as environment variables defined with the `DOTNET_` or `ASPNETCORE_` prefixes, or specified directly through any other config input, such as `appsettings.json`. Each is a semicolon-delimited list of port values, as shown in the following example:
+Apps and containers are often given only a port to listen on, like port 80, without additional constraints like host or path. HTTP_PORTS and HTTPS_PORTS are config keys that specify the listening ports for the Kestrel and HttpSys servers. These keys may be specified as environment variables defined with the `DOTNET_` or `ASPNETCORE_` prefixes, or specified directly through any other config input, such as `appsettings.json`. Each is a semicolon-delimited list of port values, as shown in the following example:
 
 ```
 ASPNETCORE_HTTP_PORTS=80;8080

--- a/aspnetcore/includes/http-ports.md
+++ b/aspnetcore/includes/http-ports.md
@@ -1,4 +1,4 @@
-Apps and containers are often given only a port to listen on, like port 80, without additional constraints like host or path. HTTP_PORTS and HTTPS_PORTS are config keys that specify the listening ports for the Kestrel and HttpSys servers. These keys may be specified as environment variables defined with the `DOTNET_` or `ASPNETCORE_` prefixes, or specified directly through any other config input, such as `appsettings.json`. Each is a semicolon-delimited list of port values, as shown in the following example:
+Apps and containers are often given only a port to listen on, like port 80, without additional constraints like host or path. HTTP_PORTS and HTTPS_PORTS are config keys that specify the listening ports for the Kestrel and Http.sys servers. These keys may be specified as environment variables defined with the `DOTNET_` or `ASPNETCORE_` prefixes, or specified directly through any other config input, such as `appsettings.json`. Each is a semicolon-delimited list of port values, as shown in the following example:
 
 ```
 ASPNETCORE_HTTP_PORTS=80;8080


### PR DESCRIPTION
Fixes #27156 

The *http-ports.md* include file was added in an earlier PR, so to see all of it expand the diff manually or use the Kestrel endpoints internal preview or HTTP.sys internal preview.

@Tratcher 

> This would also work with Http.Sys though we have a warning there not to use wildcards.

It looks awkward to have text explaining how to conveniently specify ports-only right next to a warning not to use wildcards for URLs. Is there something we should say to make it look less like we're contradicting ourselves?

<!-- PREVIEW-TABLE-START -->

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/httpsys.md](https://github.com/dotnet/AspNetCore.Docs/blob/d4f9d1b491e631b4b216fed2f9fcab826c2fe24a/aspnetcore/fundamentals/servers/httpsys.md) | [aspnetcore/fundamentals/servers/httpsys](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/httpsys?branch=pr-en-us-28653) |
| [aspnetcore/fundamentals/servers/kestrel/endpoints.md](https://github.com/dotnet/AspNetCore.Docs/blob/d4f9d1b491e631b4b216fed2f9fcab826c2fe24a/aspnetcore/fundamentals/servers/kestrel/endpoints.md) | [aspnetcore/fundamentals/servers/kestrel/endpoints](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?branch=pr-en-us-28653) |


<!-- PREVIEW-TABLE-END -->

[Additional internal review URL, for minimal API quick reference, WebApplication section.](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/webapplication?view=aspnetcore-8.0)