### PR TITLE
Remove @bind:{get|set|after} feature NOTEs

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -47,11 +47,6 @@ To execute asynchronous logic after binding, use `@bind:after="{EVENT}"` with a 
 
 Using an event callback parameter (`[Parameter] public EventCallback<string> ValueChanged { get; set; }`) with `@bind:after` isn't supported. Instead, pass a method that returns an <xref:System.Action> or <xref:System.Threading.Tasks.Task> to `@bind:after`.
 
-> [!IMPORTANT]
-> The `@bind:after` feature is receiving further updates at this time. To take advantage of the latest updates, confirm that you've installed the [latest SDK](https://dotnet.microsoft.com/download). Visual Studio updates to support the feature are planned for the mid-February Visual Studio release.
->
-> For more information, see [Blazor `@bind:after` not working on .NET 7 RTM release (dotnet/aspnetcore #44957)](https://github.com/dotnet/aspnetcore/issues/44957).
-
 In the following example:
 
 * The `<input>` element's `value` is bound to the value of `searchText` synchronously.
@@ -114,11 +109,6 @@ Components support two-way data binding by defining a pair of parameters:
 
 * `@bind:get`: Specifies the value to bind.
 * `@bind:set`: Specifies a callback for when the value changes.
-
-> [!IMPORTANT]
-> The `@bind:get` and `@bind:set` features are receiving further updates at this time. To take advantage of the latest updates, confirm that you've installed the [latest SDK](https://dotnet.microsoft.com/download/dotnet/7.0). Visual Studio updates to support the feature are planned for the mid-February Visual Studio release.
->
-> For more information, see [Blazor `@bind:after` not working on .NET 7 RTM release (dotnet/aspnetcore #44957)](https://github.com/dotnet/aspnetcore/issues/44957).
 
 The `@bind:get` and `@bind:set` modifiers are always used together.
 
@@ -438,18 +428,6 @@ In the following example, the `PasswordUpdated` method executes asynchronously a
 
 ## Bind across more than two components
 
-<!-- HOLD: See https://github.com/dotnet/AspNetCore.Docs/issues/27848
-
-> [!IMPORTANT]
-> The `@bind:get` and `@bind:set` features demonstrated in this section are receiving further updates at this time. To take advantage of the latest updates, confirm that you've installed the [latest SDK](https://dotnet.microsoft.com/download/dotnet/7.0).
->
-> For more information, see the following resources:
->
-> * [Blazor `@bind:after` not working on .NET 7 RTM release (dotnet/aspnetcore #44957)](https://github.com/dotnet/aspnetcore/issues/44957)
-> * [`BindGetSetAfter701` sample app (javiercn/BindGetSetAfter701 GitHub repository)](https://github.com/javiercn/BindGetSetAfter701)
->
-> To see a working version of the guidance in this section that doesn't rely on `@bind:get`/`@bind:set` modifiers, see the 6.0 version of this article.
-
 You can bind parameters through any number of nested components, but you must respect the one-way flow of data:
 
 * Change notifications *flow up the hierarchy*.
@@ -473,32 +451,6 @@ In the following `NestedChild` component, the `NestedGrandchild` component:
 `Shared/NestedGrandchild.razor`:
 
 :::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Shared/data-binding/NestedGrandchild.razor":::
-
-For an alternative approach suited to sharing data in memory and across components that aren't necessarily nested, see <xref:blazor/state-management>.
-
--->
-
-You can bind parameters through any number of nested components, but you must respect the one-way flow of data:
-
-* Change notifications *flow up the hierarchy*.
-* New parameter values *flow down the hierarchy*.
-
-A common and recommended approach is to only store the underlying data in the parent component to avoid any confusion about what state must be updated, as shown in the following example.
-
-`Pages/Parent2.razor`:
-
-:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/data-binding/Parent2.razor":::
-
-`Shared/NestedChild.razor`:
-
-:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Shared/data-binding/NestedChild.razor":::
-
-> [!WARNING]
-> Generally, avoid creating components that write directly to their own component parameters. The preceding `NestedChild` component makes use of a `BoundValue` property instead of writing directly to its `ChildMessage` parameter. For more information, see <xref:blazor/components/index#overwritten-parameters>.
-
-`Shared/NestedGrandchild.razor`:
-
-:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Shared/data-binding/NestedGrandchild.razor":::
 
 For an alternative approach suited to sharing data in memory and across components that aren't necessarily nested, see <xref:blazor/state-management>.
 


### PR DESCRIPTION
Fixes #27848

Thanks for the issue, @MisinformedDNA! 🚀 ... This should be resolved now 🤞🍀 with the latest update to VS.

<!-- PREVIEW-TABLE-START -->
#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/data-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/9230d1733c9b0419865790f1b0bc0f6c0cd6005e/aspnetcore/blazor/components/data-binding.md) | [aspnetcore/blazor/components/data-binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?branch=pr-en-us-28683) |

<!-- PREVIEW-TABLE-END -->