### PR TITLE
Component parameter value guidance updates

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -290,8 +290,8 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@` prefix, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
-* Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
+* Use the `@` prefix with nonliterals, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
+* Always avoid `@` for literals, outside of Razor expressions. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
 
@@ -1822,8 +1822,8 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@` prefix, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
-* Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
+* Use the `@` prefix with nonliterals, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
+* Always avoid `@` for literals, outside of Razor expressions. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
 
@@ -3295,8 +3295,8 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@` prefix, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
-* Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
+* Use the `@` prefix with nonliterals, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
+* Always avoid `@` for literals, outside of Razor expressions. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
 
@@ -4318,8 +4318,8 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@` prefix, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
-* Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
+* Use the `@` prefix with nonliterals, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
+* Always avoid `@` for literals, outside of Razor expressions. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -281,7 +281,7 @@ The following `ParameterParent2` component displays four instances of the preced
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
+The `@` prefix is required for string-typed parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -1813,7 +1813,7 @@ The following `ParameterParent2` component displays four instances of the preced
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
+The `@` prefix is required for string-typed parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -3286,7 +3286,7 @@ The following `ParameterParent2` component displays four instances of the preced
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
+The `@` prefix is required for string-typed parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -4309,7 +4309,7 @@ The following `ParameterParent2` component displays four instances of the preced
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
+The `@` prefix is required for string-typed parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -281,7 +281,6 @@ The following `ParameterParent2` component displays four instances of the preced
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
 Quotes around parameter attribute values are optional in most cases per the HTML5 specification. For example, `Value=this` is supported, instead of `Value="this"`. However, we recommend using quotes because it's easier to remember and widely adopted across web-based technologies.
@@ -1801,9 +1800,9 @@ The following rendered HTML markup from the `ParameterParent` component shows `P
 </div>
 ```
 
-Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value.
+Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value. The value of the attribute can typically be any C# expression that matches the type of the parameter. The value of the attribute can optionally lead with a [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax), but it isn't required.
 
-A leading [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax) isn't required for component parameters of any type. A leading `@` symbol is optional for non-string parameters and is only required for string parameters if you want a C# context instead of assigning a string literal value.
+If the component parameter is of type string, then the attribute value is instead treated as a C# string literal by default. If you want to specify a C# expression instead, then use the `@` prefix.
 
 The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
 
@@ -1811,8 +1810,6 @@ The following `ParameterParent2` component displays four instances of the preced
 * The result of the `GetTitle` C# method.
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
-
-The `@` prefix is required for string-typed parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -3274,9 +3271,9 @@ The following rendered HTML markup from the `ParameterParent` component shows `P
 </div>
 ```
 
-Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value.
+Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value. The value of the attribute can typically be any C# expression that matches the type of the parameter. The value of the attribute can optionally lead with a [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax), but it isn't required.
 
-A leading [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax) isn't required for component parameters of any type. A leading `@` symbol is optional for non-string parameters and is only required for string parameters if you want a C# context instead of assigning a string literal value.
+If the component parameter is of type string, then the attribute value is instead treated as a C# string literal by default. If you want to specify a C# expression instead, then use the `@` prefix.
 
 The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
 
@@ -3284,8 +3281,6 @@ The following `ParameterParent2` component displays four instances of the preced
 * The result of the `GetTitle` C# method.
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
-
-The `@` prefix is required for string-typed parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -4297,9 +4292,9 @@ The following rendered HTML markup from the `ParameterParent` component shows `P
 </div>
 ```
 
-Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value.
+Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value. The value of the attribute can typically be any C# expression that matches the type of the parameter. The value of the attribute can optionally lead with a [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax), but it isn't required.
 
-A leading [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax) isn't required for component parameters of any type. A leading `@` symbol is optional for non-string parameters and is only required for string parameters if you want a C# context instead of assigning a string literal value.
+If the component parameter is of type string, then the attribute value is instead treated as a C# string literal by default. If you want to specify a C# expression instead, then use the `@` prefix.
 
 The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
 
@@ -4307,8 +4302,6 @@ The following `ParameterParent2` component displays four instances of the preced
 * The result of the `GetTitle` C# method.
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
-
-The `@` prefix is required for string-typed parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -270,9 +270,9 @@ The following rendered HTML markup from the `ParameterParent` component shows `P
 </div>
 ```
 
-Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value.
+Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value. The value of the attribute can typically be any C# expression that matches the type of the parameter. The value of the attribute can optionally lead with a [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax), but it isn't required.
 
-A leading [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax) isn't required for component parameters of any type. A leading `@` symbol is optional for non-string parameters and is only required for string parameters if you want a C# context instead of assigning a string literal value.
+If the component parameter is of type string, then the attribute value is instead treated as a C# string literal by default. If you want to specify a C# expression instead, then use the `@` prefix.
 
 The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
 
@@ -281,7 +281,6 @@ The following `ParameterParent2` component displays four instances of the preced
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string-typed parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -270,16 +270,18 @@ The following rendered HTML markup from the `ParameterParent` component shows `P
 </div>
 ```
 
-Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value using [Razor's reserved `@` symbol](xref:mvc/views/razor#razor-syntax). The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
+Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value.
+
+A leading [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax) isn't required for component parameters of any type. A leading `@` symbol is optional for non-string parameters and is only required for string parameters if you want a C# context instead of assigning a string literal value.
+
+The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
 
 * The value of the `title` field.
 * The result of the `GetTitle` C# method.
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
-
-Outside of string parameters, we recommend the use of the `@` prefix for nonliterals, even when they aren't strictly required.
+The `@` prefix is required for string parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -288,7 +290,7 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@` prefix, even when it's optional. Examples: `Title="@title"`, where `title` is a string-typed variable. `Count="@ct"`, where `ct` is a number-typed variable.
+* Nonliterals always use the `@` prefix, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
 * Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
@@ -296,18 +298,26 @@ Throughout the documentation, code examples:
 :::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Pages/index/ParameterParent2.razor":::
 
 > [!NOTE]
-> When assigning a C# member to a component parameter, prefix the member with the `@` symbol and never prefix the parameter's HTML attribute.
+> When assigning a C# member to a component parameter, don't prefix the parameter's HTML attribute with `@`.
 >
-> Correct:
+> Correct (`Title` is a string parameter, `Count` is a number-typed parameter):
 >
 > ```razor
-> <ParameterChild Title="@title" />
+> <ParameterChild Title="@title" Count="@ct" />
+> ```
+>
+> ```razor
+> <ParameterChild Title="@title" Count="ct" />
 > ```
 >
 > Incorrect:
 >
 > ```razor
-> <ParameterChild @Title="title" />
+> <ParameterChild @Title="@title" @Count="@ct" />
+> ```
+>
+> ```razor
+> <ParameterChild @Title="@title" @Count="ct" />
 > ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:
@@ -1792,16 +1802,18 @@ The following rendered HTML markup from the `ParameterParent` component shows `P
 </div>
 ```
 
-Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value using [Razor's reserved `@` symbol](xref:mvc/views/razor#razor-syntax). The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
+Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value.
+
+A leading [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax) isn't required for component parameters of any type. A leading `@` symbol is optional for non-string parameters and is only required for string parameters if you want a C# context instead of assigning a string literal value.
+
+The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
 
 * The value of the `title` field.
 * The result of the `GetTitle` C# method.
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
-
-Outside of string parameters, we recommend the use of the `@` prefix for nonliterals, even when they aren't strictly required.
+The `@` prefix is required for string parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -1810,7 +1822,7 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@` prefix, even when it's optional. Examples: `Title="@title"`, where `title` is a string-typed variable. `Count="@ct"`, where `ct` is a number-typed variable.
+* Nonliterals always use the `@` prefix, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
 * Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
@@ -1818,18 +1830,26 @@ Throughout the documentation, code examples:
 :::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/index/ParameterParent2.razor":::
 
 > [!NOTE]
-> When assigning a C# member to a component parameter, prefix the member with the `@` symbol and never prefix the parameter's HTML attribute.
+> When assigning a C# member to a component parameter, don't prefix the parameter's HTML attribute with `@`.
 >
-> Correct:
+> Correct (`Title` is a string parameter, `Count` is a number-typed parameter):
 >
 > ```razor
-> <ParameterChild Title="@title" />
+> <ParameterChild Title="@title" Count="@ct" />
+> ```
+>
+> ```razor
+> <ParameterChild Title="@title" Count="ct" />
 > ```
 >
 > Incorrect:
 >
 > ```razor
-> <ParameterChild @Title="title" />
+> <ParameterChild @Title="@title" @Count="@ct" />
+> ```
+>
+> ```razor
+> <ParameterChild @Title="@title" @Count="ct" />
 > ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:
@@ -3255,16 +3275,18 @@ The following rendered HTML markup from the `ParameterParent` component shows `P
 </div>
 ```
 
-Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value using [Razor's reserved `@` symbol](xref:mvc/views/razor#razor-syntax). The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
+Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value.
+
+A leading [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax) isn't required for component parameters of any type. A leading `@` symbol is optional for non-string parameters and is only required for string parameters if you want a C# context instead of assigning a string literal value.
+
+The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
 
 * The value of the `title` field.
 * The result of the `GetTitle` C# method.
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
-
-Outside of string parameters, we recommend the use of the `@` prefix for nonliterals, even when they aren't strictly required.
+The `@` prefix is required for string parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -3273,7 +3295,7 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@` prefix, even when it's optional. Examples: `Title="@title"`, where `title` is a string-typed variable. `Count="@ct"`, where `ct` is a number-typed variable.
+* Nonliterals always use the `@` prefix, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
 * Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
@@ -3281,18 +3303,26 @@ Throughout the documentation, code examples:
 :::code language="razor" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/Pages/index/ParameterParent2.razor":::
 
 > [!NOTE]
-> When assigning a C# member to a component parameter, prefix the member with the `@` symbol and never prefix the parameter's HTML attribute.
+> When assigning a C# member to a component parameter, don't prefix the parameter's HTML attribute with `@`.
 >
-> Correct:
+> Correct (`Title` is a string parameter, `Count` is a number-typed parameter):
 >
 > ```razor
-> <ParameterChild Title="@title" />
+> <ParameterChild Title="@title" Count="@ct" />
+> ```
+>
+> ```razor
+> <ParameterChild Title="@title" Count="ct" />
 > ```
 >
 > Incorrect:
 >
 > ```razor
-> <ParameterChild @Title="title" />
+> <ParameterChild @Title="@title" @Count="@ct" />
+> ```
+>
+> ```razor
+> <ParameterChild @Title="@title" @Count="ct" />
 > ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:
@@ -4268,16 +4298,18 @@ The following rendered HTML markup from the `ParameterParent` component shows `P
 </div>
 ```
 
-Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value using [Razor's reserved `@` symbol](xref:mvc/views/razor#razor-syntax). The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
+Assign a C# field, property, or result of a method to a component parameter as an HTML attribute value.
+
+A leading [Razor reserved `@` symbol](xref:mvc/views/razor#razor-syntax) isn't required for component parameters of any type. A leading `@` symbol is optional for non-string parameters and is only required for string parameters if you want a C# context instead of assigning a string literal value.
+
+The following `ParameterParent2` component displays four instances of the preceding `ParameterChild` component and sets their `Title` parameter values to:
 
 * The value of the `title` field.
 * The result of the `GetTitle` C# method.
 * The current local date in long format with <xref:System.DateTime.ToLongDateString%2A>, which uses an [implicit C# expression](xref:mvc/views/razor#implicit-razor-expressions).
 * The `panelData` object's `Title` property.
 
-The `@` prefix is required for string parameters. Otherwise, the framework assumes that a string literal is set.
-
-Outside of string parameters, we recommend the use of the `@` prefix for nonliterals, even when they aren't strictly required.
+The `@` prefix is required for string parameters in a C# context. Otherwise, the framework assumes that a string literal is set. The `@` prefix is ***never*** required for other, non-literal types.
 
 We don't recommend the use of the `@` prefix for literals (for example, boolean values), keywords (for example, `this`), or `null`, but you can choose to use them if you wish. For example, `IsFixed="@true"` is uncommon but supported.
 
@@ -4286,7 +4318,7 @@ Quotes around parameter attribute values are optional in most cases per the HTML
 Throughout the documentation, code examples:
 
 * Always use quotes. Example: `Value="this"`.
-* Nonliterals always use the `@` prefix, even when it's optional. Examples: `Title="@title"`, where `title` is a string-typed variable. `Count="@ct"`, where `ct` is a number-typed variable.
+* Nonliterals always use the `@` prefix, ***even when it's optional***. Example: `Count="@ct"`, where `ct` is a number-typed variable. `Count="ct"` is a valid stylistic approach, but the documentation and examples don't adopt the convention.
 * Literals, outside of Razor expressions, always avoid `@`. Example: `IsFixed="true"`.
 
 `Pages/ParameterParent2.razor`:
@@ -4294,18 +4326,26 @@ Throughout the documentation, code examples:
 :::code language="razor" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/Pages/index/ParameterParent2.razor":::
 
 > [!NOTE]
-> When assigning a C# member to a component parameter, prefix the member with the `@` symbol and never prefix the parameter's HTML attribute.
+> When assigning a C# member to a component parameter, don't prefix the parameter's HTML attribute with `@`.
 >
-> Correct:
+> Correct (`Title` is a string parameter, `Count` is a number-typed parameter):
 >
 > ```razor
-> <ParameterChild Title="@title" />
+> <ParameterChild Title="@title" Count="@ct" />
+> ```
+>
+> ```razor
+> <ParameterChild Title="@title" Count="ct" />
 > ```
 >
 > Incorrect:
 >
 > ```razor
-> <ParameterChild @Title="title" />
+> <ParameterChild @Title="@title" @Count="@ct" />
+> ```
+>
+> ```razor
+> <ParameterChild @Title="@title" @Count="ct" />
 > ```
 
 Unlike in Razor pages (`.cshtml`), Blazor can't perform asynchronous work in a Razor expression while rendering a component. This is because Blazor is designed for rendering interactive UIs. In an interactive UI, the screen must always display something, so it doesn't make sense to block the rendering flow. Instead, asynchronous work is performed during one of the [asynchronous lifecycle events](xref:blazor/components/lifecycle). After each asynchronous lifecycle event, the component may render again. The following Razor syntax is **not** supported:


### PR DESCRIPTION
Fixes #28694

This topic is one of the handful that hasn't been reached to drop the *Whole-topic Versioning*, so there are four copies of the text here. Resolving topics down to ***one copy*** 👍 is an on-going task this year, and I'll get to this topic soon enough! 😄

The `ParameterParent2` component is in the Blazor sample app. Steve, I kept it the way that it was with separate `Title` assignments to plainly demonstrate that they all work to the reader. This is the first time that a new-to-Blazor dev is seeing this. I understand that from the framework's perspective that there's no difference in these assignments.

https://github.com/dotnet/blazor-samples/blob/main/7.0/BlazorSample_WebAssembly/Pages/index/ParameterParent2.razor

<!-- PREVIEW-TABLE-START -->

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/3f69826dca1257e74d9c00cc7e234d2c319dd6d4/aspnetcore/blazor/components/index.md) | [aspnetcore/blazor/components/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/index?branch=pr-en-us-28696) |


<!-- PREVIEW-TABLE-END -->