### PR TITLE
Remove ConfigureAppConfiguration usages

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -490,7 +490,7 @@ When an environment variable is discovered and loaded into configuration with an
 
 The <xref:Microsoft.Extensions.Configuration.Ini.IniConfigurationProvider> loads configuration from INI file key-value pairs at runtime.
 
-The following code clears all the configuration providers and adds several configuration providers:
+The following code adds several configuration providers:
 [!code-csharp[](~/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs?name=snippet_ini)]
 
 In the preceding code, settings in the `MyIniConfig.ini` and  `MyIniConfig.{Environment}.ini` files are overridden by settings in the:
@@ -553,7 +553,7 @@ The following code from the [sample download](https://github.com/dotnet/AspNetCo
 
 The <xref:Microsoft.Extensions.Configuration.Xml.XmlConfigurationProvider> loads configuration from XML file key-value pairs at runtime.
 
-The following code clears all the configuration providers and adds several configuration providers:
+The following code adds several configuration providers:
 
 [!code-csharp[](~/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs?name=snippet_xml)]
 

--- a/aspnetcore/fundamentals/configuration/index/includes/index6.md
+++ b/aspnetcore/fundamentals/configuration/index/includes/index6.md
@@ -471,7 +471,7 @@ When an environment variable is discovered and loaded into configuration with an
 
 The <xref:Microsoft.Extensions.Configuration.Ini.IniConfigurationProvider> loads configuration from INI file key-value pairs at runtime.
 
-The following code clears all the configuration providers and adds several configuration providers:
+The following code adds several configuration providers:
 [!code-csharp[](~/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs?name=snippet_ini)]
 
 In the preceding code, settings in the `MyIniConfig.ini` and  `MyIniConfig.{Environment}.ini` files are overridden by settings in the:
@@ -534,7 +534,7 @@ The following code from the [sample download](https://github.com/dotnet/AspNetCo
 
 The <xref:Microsoft.Extensions.Configuration.Xml.XmlConfigurationProvider> loads configuration from XML file key-value pairs at runtime.
 
-The following code clears all the configuration providers and adds several configuration providers:
+The following code adds several configuration providers:
 
 [!code-csharp[](~/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs?name=snippet_xml)]
 

--- a/aspnetcore/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs
+++ b/aspnetcore/fundamentals/configuration/index/samples/6.x/ConfigSample/Program.cs
@@ -216,23 +216,13 @@ app.Run();
 #region snippet_ini
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.Sources.Clear();
+builder.Configuration
+    .AddIniFile("MyIniConfig.ini", optional: true, reloadOnChange: true)
+    .AddIniFile($"MyIniConfig.{builder.Environment.EnvironmentName}.ini",
+                optional: true, reloadOnChange: true);
 
-    var env = hostingContext.HostingEnvironment;
-
-    config.AddIniFile("MyIniConfig.ini", optional: true, reloadOnChange: true)
-          .AddIniFile($"MyIniConfig.{env.EnvironmentName}.ini",
-                         optional: true, reloadOnChange: true);
-
-    config.AddEnvironmentVariables();
-
-    if (args != null)
-    {
-        config.AddCommandLine(args);
-    }
-});
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
 
 builder.Services.AddRazorPages();
 
@@ -258,23 +248,13 @@ app.Run();
 #region snippet_xml
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.Sources.Clear();
+builder.Configuration
+    .AddXmlFile("MyXMLFile.xml", optional: true, reloadOnChange: true)
+    .AddXmlFile($"MyXMLFile.{builder.Environment.EnvironmentName}.xml",
+                optional: true, reloadOnChange: true);
 
-    var env = hostingContext.HostingEnvironment;
-
-    config.AddXmlFile("MyXMLFile.xml", optional: true, reloadOnChange: true)
-          .AddXmlFile($"MyXMLFile.{env.EnvironmentName}.xml",
-                         optional: true, reloadOnChange: true);
-
-    config.AddEnvironmentVariables();
-
-    if (args != null)
-    {
-        config.AddCommandLine(args);
-    }
-});
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
 
 builder.Services.AddRazorPages();
 
@@ -308,19 +288,9 @@ var Dict = new Dictionary<string, string>
            {"Logging:LogLevel:Default", "Warning"}
         };
 
-builder.Host.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.Sources.Clear();
-
-    config.AddInMemoryCollection(Dict);
-
-    config.AddEnvironmentVariables();
-
-    if (args != null)
-    {
-        config.AddCommandLine(args);
-    }
-});
+builder.Configuration.AddInMemoryCollection(Dict);
+builder.Configuration.AddEnvironmentVariables();
+builder.Configuration.AddCommandLine(args);
 
 builder.Services.AddRazorPages();
 
@@ -346,43 +316,10 @@ app.Run();
 #region snippet_sub
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.AddJsonFile("MySubsection.json",
-                       optional: true,
-                       reloadOnChange: true);
-});
-
-builder.Services.AddRazorPages();
-
-var app = builder.Build();
-#endregion
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler("/Error");
-    app.UseHsts();
-}
-
-app.UseHttpsRedirection();
-app.UseStaticFiles();
-
-app.UseRouting();
-
-app.UseAuthorization();
-
-app.MapRazorPages();
-
-app.Run();
-#elif RAY
-#region snippet_ray
-var builder = WebApplication.CreateBuilder(args);
-
-builder.Host.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.AddJsonFile("MyArray.json",
-                        optional: true,
-                        reloadOnChange: true);
-});
+builder.Configuration
+    .AddJsonFile("MySubsection.json",
+                 optional: true,
+                 reloadOnChange: true);
 
 builder.Services.AddRazorPages();
 
@@ -408,12 +345,10 @@ app.Run();
 #region snippet_ba
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.ConfigureAppConfiguration((hostingContext, config) =>
-{
-    config.AddJsonFile("MyArray.json",
-                        optional: true,
-                        reloadOnChange: true); ;
-});
+builder.Configuration
+    .AddJsonFile("MyArray.json",
+                 optional: true,
+                 reloadOnChange: true);
 
 builder.Services.AddRazorPages();
 


### PR DESCRIPTION
We should avoid calling `builder.Host` where we can. See https://github.com/dotnet/aspnetcore/issues/40681#issuecomment-1470017165

<!-- PREVIEW-TABLE-START -->
#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/configuration/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/3ccc33f0ffe92a366b3b3932da97e3cc6700ea7f/aspnetcore/fundamentals/configuration/index.md) | [aspnetcore/fundamentals/configuration/index](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/index?branch=pr-en-us-28697) |

<!-- PREVIEW-TABLE-END -->