### PR TITLE
Remark on Blazor custom elements moving

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -5074,6 +5074,14 @@ For more information, see the following articles:
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-6.0"
+
+## Blazor custom elements
+
+Coverage on Blazor custom elements has been moved to <xref:blazor/components/js-spa-frameworks#blazor-custom-elements>.
+
+:::moniker-end
+
 <!--Reference links in article-->
 [1]: <xref:mvc/views/razor#code>
 [2]: <xref:mvc/views/razor#using>


### PR DESCRIPTION
Addresses https://github.com/dotnet/aspnetcore/issues/47273#issuecomment-1478243167

> Perhaps adding the link (only) from the previous article would help.

I have it here, but I don't recommend that we do this. It can have the undesirable side-effect of search engines indexing the empty (linking) section and showing it earlier in search results than we would like.

It's also likely that our own docs search tool will index it earlier than the actual content location because the *Components* overview (`blazor/components/index.md`) appears earlier in the file list on the repo alphabetically than the JS/SPA doc (`blazor/components/js-spa-frameworks.md`) ... I think that's how they set the order of search results.

I don't understand how Nicholas "searched for a good hour and could not find the official documentation" when the docs search tool brings it right up as the first search result. Even searching the web for "Blazor custom elements" brings up our correct page for *Use Razor components in JavaScript apps and SPA frameworks* as the 8th search result ... or with `site:learn.microsoft.com` as the 1st search result.

It also sets a bad precedent for the future: We need to strip out sections from overview topics from time-to-time to shorten them. Are we going to keep adding sections like this every time we move content out to shorten an overview? Over time, this will get messy.

Are you sure want to proceed with this?