### PR TITLE
Correct bad package references

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -50,7 +50,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package is provided by the .NET shared framework and doesn't require adding a package reference to the app.
 
@@ -677,7 +677,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package is provided by the .NET shared framework and doesn't require adding a package reference to the app.
 
@@ -1304,7 +1304,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 Confirm or add a package reference for [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json).
 
@@ -1935,7 +1935,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 Confirm or add a package reference for [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json).
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -50,7 +50,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for <xref:System.Net.Http.HttpClient?displayProperty=fullName> and <xref:System.Net.Http.HttpContent?displayProperty=fullName> that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package is provided by the .NET shared framework and doesn't require adding a package reference to the app.
 
@@ -677,7 +677,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for <xref:System.Net.Http.HttpClient?displayProperty=fullName> and <xref:System.Net.Http.HttpContent?displayProperty=fullName> that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package is provided by the .NET shared framework and doesn't require adding a package reference to the app.
 
@@ -1304,7 +1304,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for <xref:System.Net.Http.HttpClient?displayProperty=fullName> and <xref:System.Net.Http.HttpContent?displayProperty=fullName> that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 Confirm or add a package reference for [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json).
 
@@ -1935,7 +1935,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for <xref:System.Net.Http.HttpClient?displayProperty=fullName> and <xref:System.Net.Http.HttpContent?displayProperty=fullName> that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 Confirm or add a package reference for [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json).
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -50,7 +50,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http.HttpClient) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package is provided by the .NET shared framework and doesn't require adding a package reference to the app.
 
@@ -677,7 +677,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http.HttpClient) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package is provided by the .NET shared framework and doesn't require adding a package reference to the app.
 
@@ -1304,7 +1304,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http.HttpClient) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 Confirm or add a package reference for [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json).
 
@@ -1935,7 +1935,7 @@ For guidance on how to create a server-side web API, see <xref:tutorials/first-w
 
 ## Package
 
-The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http.HttpClient) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
+The [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json) package provides extension methods for [`System.Net.Http.HttpClient`](https://www.nuget.org/packages/System.Net.Http) and [`System.Net.Http.HttpContent`](https://www.nuget.org/packages/System.Net.Http.HttpContent) that perform automatic serialization and deserialization using [`System.Text.Json`](https://www.nuget.org/packages/System.Text.Json).
 
 Confirm or add a package reference for [`System.Net.Http.Json`](https://www.nuget.org/packages/System.Net.Http.Json).
 


### PR DESCRIPTION
# 😈 

`System.Net.Http.HttpClient`/`System.Net.Http.HttpContent` aren't packages ... the API is merely in the `System.Net.Http` package.

This was just added yesterday to `main` and ***has NOT merged to `live`***, so I'm fixing this ***before*** it hits the live site 😅.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/call-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/b0191895da0719003984a9325424d93b51324b08/aspnetcore/blazor/call-web-api.md) | [aspnetcore/blazor/call-web-api](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/call-web-api?branch=pr-en-us-28729) |


<!-- PREVIEW-TABLE-END -->