### PR TITLE
Remove prefix from script tag helper attribute "src"

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/script-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/script-tag-helper.md
@@ -34,6 +34,10 @@ Don't use the `<script>` element's [defer](https://developer.mozilla.org/docs/We
 
 See [Script Tag Helper](xref:Microsoft.AspNetCore.Mvc.TagHelpers.ScriptTagHelper) for all the Script Tag Helper attributes, properties, and methods.
 
+### src
+
+Address of the external script to use.
+
 ### asp-append-version
 
 When `asp-append-version` is specified with a `true` value along with a `src` attribute, a unique version is generated.
@@ -59,10 +63,6 @@ The script method defined in the primary script to use for the fallback test. Fo
 ### asp-order
 
 When a set of `ITagHelper` instances are executed, their `Init(TagHelperContext)` methods are first invoked in the specified order; then their `ProcessAsync(TagHelperContext, TagHelperOutput)` methods are invoked in the specified order. Lower values are executed first.
-
-### asp-src
-
-Address of the external script to use.
 
 ### asp-src-exclude
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/script-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/script-tag-helper.md
@@ -40,7 +40,7 @@ Address of the external script to use.
 
 ### asp-append-version
 
-When `asp-append-version` is specified with a `true` value along with a `src` attribute, a unique version is generated.
+When `asp-append-version` is specified with a `true` value along with a [`src`](https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.TagHelpers/src/ScriptTagHelper.cs#L116) attribute, a unique version is generated.
 
 [!INCLUDE[](~/includes/th_version.md)]
 


### PR DESCRIPTION
Document the script tag helper attribute "src" instead of the non-existent attribute "asp-src". Move description of said attribute to the top, similar to link tag helper's "href" attribute.

Fixes #28818
<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/views/tag-helpers/built-in/script-tag-helper.md](https://github.com/dotnet/AspNetCore.Docs/blob/9c97679221b65da183bd31bce0b2984d77638432/aspnetcore/mvc/views/tag-helpers/built-in/script-tag-helper.md) | [aspnetcore/mvc/views/tag-helpers/built-in/script-tag-helper](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/built-in/script-tag-helper?branch=pr-en-us-28802) |


<!-- PREVIEW-TABLE-END -->