### PR TITLE
Some H3s to H2s and H5s to H4s

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -57,7 +57,7 @@ A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCor
 
 [!INCLUDE [route handling](~/fundamentals/minimal-apis/includes/route-handlers.md)]
 
-## Parameter Binding
+## Parameter binding
 
 [!INCLUDE [parameter binding](~/fundamentals/minimal-apis/includes/parameter-binding.md)]
 

--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -49,9 +49,11 @@ The following sections cover request handling: routing, parameter binding, and r
 
 ## Routing
 
-A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapMethods%2A>:
+A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapMethods%2A> where `{Verb}` is a camel-cased HTTP method like `Get`, `Post`, `Put` or `Delete`:
 
 [!code-csharp[](~/fundamentals/minimal-apis/7.0-samples/WebMinAPIs/Program.cs?name=snippet_r1)]
+
+The <xref:System.Delegate> arguments passed to these methods are called "route handlers".
 
 ### Route Handlers
 

--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -45,11 +45,9 @@ The following table lists some of the middleware frequently used with minimal AP
 | [Static Files](xref:fundamentals/static-files) | Provides support for serving static files and directory browsing. | <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A>, <xref:Microsoft.AspNetCore.Builder.FileServerExtensions.UseFileServer%2A> |
 | [WebSockets](xref:fundamentals/websockets) | Enables the WebSockets protocol. | <xref:Microsoft.AspNetCore.Builder.WebSocketMiddlewareExtensions.UseWebSockets%2A> |
 
-## Request handling
+The following sections cover request handling: routing, parameter binding, and responses.
 
-The following sections cover routing, parameter binding, and responses.
-
-### Routing
+## Routing
 
 A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapMethods%2A>:
 
@@ -59,7 +57,7 @@ A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCor
 
 [!INCLUDE [route handling](~/fundamentals/minimal-apis/includes/route-handlers.md)]
 
-### Parameter Binding
+## Parameter Binding
 
 [!INCLUDE [parameter binding](~/fundamentals/minimal-apis/includes/parameter-binding.md)]
 
@@ -86,7 +84,7 @@ Route handlers support the following types of return values:
 |--|--|--|
 |`IResult` | The framework calls [IResult.ExecuteAsync](xref:Microsoft.AspNetCore.Http.IResult.ExecuteAsync%2A)| Decided by the `IResult` implementation
 |`string` | The framework writes the string directly to the response | `text/plain`
-| `T` (Any other type) | The framework will JSON serialize the response| `application/json`
+| `T` (Any other type) | The framework JSON-serializes the response| `application/json`
 
 For a more in-depth guide to route handler return values see <xref:fundamentals/minimal-apis/responses>
 
@@ -114,26 +112,26 @@ The following example uses the built-in result types to customize the response:
 
 [!code-csharp[](~/fundamentals/minimal-apis/7.0-samples/todo/Program.cs?name=snippet_getCustom)]
 
-##### JSON
+#### JSON
 
 ```csharp
 app.MapGet("/hello", () => Results.Json(new { Message = "Hello World" }));
 ```
 
-##### Custom Status Code
+#### Custom Status Code
 
 ```csharp
 app.MapGet("/405", () => Results.StatusCode(405));
 ```
 
-##### Text
+#### Text
 
 ```csharp
 app.MapGet("/text", () => Results.Text("This is some text"));
 ```
 <a name="stream7"></a>
 
-##### Stream
+#### Stream
 
 ```csharp
 var proxyClient = new HttpClient();
@@ -147,13 +145,13 @@ app.MapGet("/pokemon", async () =>
 
 See <xref:fundamentals/minimal-apis/responses#stream7> for more examples.
 
-##### Redirect
+#### Redirect
 
 ```csharp
 app.MapGet("/old-path", () => Results.Redirect("/new-path"));
 ```
 
-##### File
+#### File
 
 ```csharp
 app.MapGet("/download", () => Results.File("myfile.text"));
@@ -233,7 +231,12 @@ Moved to uid: tutorials/min-web-api
 
 ## See also
 
-[OpenAPI support in minimal APIs](xref:fundamentals/minimal-apis/openapi)
+* <xref:fundamentals/minimal-apis/openapi>
+* <xref:fundamentals/minimal-apis/responses>
+* <xref:fundamentals/minimal-apis/min-api-filters>
+* <xref:fundamentals/minimal-apis/handle-errors>
+* <xref:fundamentals/minimal-apis/security>
+* <xref:fundamentals/minimal-apis/test-min-api>
 
 :::moniker-end
 

--- a/aspnetcore/fundamentals/minimal-apis/includes/route-handlers.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/route-handlers.md
@@ -1,18 +1,18 @@
 Route handlers are methods that execute when the route matches. Route handlers can be a function of any shape, including synchronous or asynchronous. Route handlers can be a lambda expression, a local function, an instance method or a static method.
 
-#### Lambda expression
+### Lambda expression
 
 [!code-csharp[](~/fundamentals/minimal-apis/7.0-samples/WebMinAPIs/Program.cs?name=snippet_le)]
 
-#### Local function
+### Local function
 
 [!code-csharp[](~/fundamentals/minimal-apis/7.0-samples/WebMinAPIs/Program.cs?name=snippet_lf)]
 
-#### Instance method
+### Instance method
 
 [!code-csharp[](~/fundamentals/minimal-apis/7.0-samples/WebMinAPIs/Program.cs?name=snippet_im)]
 
-#### Static method
+### Static method
 
 [!code-csharp[](~/fundamentals/minimal-apis/7.0-samples/WebMinAPIs/Program.cs?name=snippet_sm)]
 

--- a/aspnetcore/fundamentals/minimal-apis/includes/webapplication.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/webapplication.md
@@ -163,7 +163,7 @@ The following code sets the content root, application name, and environment:
 
 For more information, see <xref:fundamentals/index?view=aspnetcore-6.0>
 
-### Change the content root, app name, and environment by environment variables or command line
+### Change the content root, app name, and environment by using environment variables or command line
 
 The following table shows the environment variable and command-line argument used to change the content root, app name, and environment:
 

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -38,7 +38,7 @@ Hello World
 
 |Behavior|Content-Type|
 |--|--|
-| The framework will JSON serialize the response.| `application/json`
+| The framework JSON-serializes the response.| `application/json`
 
 Consider the following route handler, which returns an anonymous type containing a `Message` string property.
 

--- a/aspnetcore/fundamentals/minimal-apis/route-handlers.md
+++ b/aspnetcore/fundamentals/minimal-apis/route-handlers.md
@@ -16,6 +16,8 @@ A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCor
 
 The <xref:System.Delegate> arguments passed to these methods are called "route handlers".
 
+## Route handlers
+
 [!INCLUDE [route handling](includes/route-handlers.md)]
 
 ## Parameter binding

--- a/aspnetcore/includes/route-groups.md
+++ b/aspnetcore/includes/route-groups.md
@@ -24,7 +24,7 @@ Adding filters or metadata to a group behaves the same way as adding them indivi
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/7.0-samples/todo-group/Program.cs" id="snippet_NestedMapGroup2":::
 
-In the above example, the outer filter will log the incoming request before the inner filter even though it was added second. Because the filters were applied to different groups, the order they were added relative to each other does not matter. The order filters are added do matter if applied to the same group or specific endpoint.
+In the above example, the outer filter will log the incoming request before the inner filter even though it was added second. Because the filters were applied to different groups, the order they were added relative to each other does not matter. The order filters are added does matter if applied to the same group or specific endpoint.
 
 A request to `/outer/inner/` will log the following:
 


### PR DESCRIPTION
Fixes #27480

Promoting most H3 headings to H2 (#27709) didn't work out well - the flat internal toc got to be too long and the heading levels got too far removed from the content structure. This PR just replaces one of the H2s with two of them: it divides up Request handling into Routing and Parameter binding. H2s are appropriate for those two major sections, which are also separate articles. The PR also contains some general cleanup.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis.md](https://github.com/dotnet/AspNetCore.Docs/blob/cf07a36ee3f0a17421bd4827079bb650cc9b3865/aspnetcore/fundamentals/minimal-apis.md) | [aspnetcore/fundamentals/minimal-apis](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?branch=pr-en-us-28820) |
| [aspnetcore/fundamentals/minimal-apis/responses.md](https://github.com/dotnet/AspNetCore.Docs/blob/cf07a36ee3f0a17421bd4827079bb650cc9b3865/aspnetcore/fundamentals/minimal-apis/responses.md) | [aspnetcore/fundamentals/minimal-apis/responses](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/responses?branch=pr-en-us-28820) |
| [aspnetcore/fundamentals/minimal-apis/route-handlers.md](https://github.com/dotnet/AspNetCore.Docs/blob/cf07a36ee3f0a17421bd4827079bb650cc9b3865/aspnetcore/fundamentals/minimal-apis/route-handlers.md) | [aspnetcore/fundamentals/minimal-apis/route-handlers](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/route-handlers?branch=pr-en-us-28820) |


<!-- PREVIEW-TABLE-END -->