### PR TITLE
Additional element reference guidance

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -261,7 +261,7 @@ The following example shows capturing a reference to the `username` `<input>` el
 > [!WARNING]
 > Only use an element reference to mutate the contents of an empty element that doesn't interact with Blazor. This scenario is useful when a third-party API supplies content to the element. Because Blazor doesn't interact with the element, there's no possibility of a conflict between Blazor's representation of the element and the Document Object Model (DOM).
 >
-> In the following example, it's *dangerous* to mutate the contents of the unordered list (`ul`) because Blazor interacts with the DOM to populate this element's list items (`<li>`) from the `Todos` object:
+> In the following example, it's *dangerous* to mutate the contents of the unordered list (`ul`) using `MyList` via JS interop because Blazor interacts with the DOM to populate this element's list items (`<li>`) from the `Todos` object:
 >
 > ```razor
 > <ul @ref="MyList">
@@ -272,7 +272,10 @@ The following example shows capturing a reference to the `username` `<input>` el
 > </ul>
 > ```
 >
-> If JS interop mutates the contents of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM.
+>
+> Using the `MyList` element reference to merely read DOM content or trigger an event is supported.
+>
+> If JS interop *mutates the contents* of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM. Modifying the contents of the list via JS interop with the `MyList` element reference is ***not supported***.
 >
 > For more information, see <xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom>.
 
@@ -1058,7 +1061,9 @@ The following example shows capturing a reference to the `username` `<input>` el
 > </ul>
 > ```
 >
-> If JS interop mutates the contents of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM.
+> Using the `MyList` element reference to merely read DOM content or trigger an event is supported.
+>
+> If JS interop *mutates the contents* of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM. Modifying the contents of the list via JS interop with the `MyList` element reference is ***not supported***.
 >
 > For more information, see <xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom>.
 
@@ -1887,7 +1892,9 @@ The following example shows capturing a reference to the `username` `<input>` el
 > </ul>
 > ```
 >
-> If JS interop mutates the contents of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM.
+> Using the `MyList` element reference to merely read DOM content or trigger an event is supported.
+>
+> If JS interop *mutates the contents* of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM. Modifying the contents of the list via JS interop with the `MyList` element reference is ***not supported***.
 >
 > For more information, see <xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom>.
 
@@ -2467,7 +2474,9 @@ The following example shows capturing a reference to the `username` `<input>` el
 > </ul>
 > ```
 >
-> If JS interop mutates the contents of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM.
+> Using the `MyList` element reference to merely read DOM content or trigger an event is supported.
+>
+> If JS interop *mutates the contents* of element `MyList` and Blazor attempts to apply diffs to the element, the diffs won't match the DOM. Modifying the contents of the list via JS interop with the `MyList` element reference is ***not supported***.
 >
 > For more information, see <xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom>.
 


### PR DESCRIPTION
Fixes #28783

Thanks @NightProgramming! 🚀 ... Per Steve's suggestion, we're just going to state in passing that reading the DOM or triggering events isn't a concern. I'll make a minor change to one line to make it utterly clear that it's modifying the content via JS interop with the element reference that's the concern here for where Blazor is interacting with the content. 

WRT the "empty element" aspects, we'll stick with what we have and tell (imply anyway) that it literally should be read as "***empty***" in these contexts. That's all that the product unit is guaranteeing ... "***so far it works***" could very easily turn into a 💥😢😄 per Steve's remarks. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md](https://github.com/dotnet/AspNetCore.Docs/blob/efbba955b3070ff262911f7876d3c81c807a20a9/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md) | [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?branch=pr-en-us-28829) |

<!-- PREVIEW-TABLE-END -->