### PR TITLE
Do not recommend Blazor WASM extension for debugging in VSCode

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -45,9 +45,7 @@ Debugging requires either of the following browsers:
 
 Ensure that firewalls or proxies don't block communication with the debug proxy (`NodeJS` process). For more information, see the [Firewall configuration](#firewall-configuration) section.
 
-Visual Studio Code users require the following extensions:
-
-* [C# for Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
+Visual Studio Code users require the [C# for Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
 Visual Studio for Mac requires version 8.8 (build 1532) or later:
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -445,8 +445,6 @@ Ensure that firewalls or proxies don't block communication with the debug proxy 
 
 Visual Studio Code users require the [C# for Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
-After opening a project in VS Code, you may receive a notification that additional setup is required to enable debugging. If requested, install the required extensions from the Visual Studio Marketplace. To inspect the installed extensions, open **View** > **Extensions** from the menu bar or select the **Extensions** icon in the **Activity** sidebar.
-
 Visual Studio for Mac requires version 8.8 (build 1532) or later:
 
 Install the latest release of Visual Studio for Mac by selecting the **Download Visual Studio for Mac** button at [Microsoft: Visual Studio for Mac](https://visualstudio.microsoft.com/vs/mac/).

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -48,9 +48,6 @@ Ensure that firewalls or proxies don't block communication with the debug proxy 
 Visual Studio Code users require the following extensions:
 
 * [C# for Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
-* [Blazor WASM Debugging Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.blazorwasm-companion) (when using the C# for Visual Studio Code Extension version 1.23.9 or later)
-
-After opening a project in VS Code, you may receive a notification that additional setup is required to enable debugging. If requested, install the required extensions from the Visual Studio Marketplace. To inspect the installed extensions, open **View** > **Extensions** from the menu bar or select the **Extensions** icon in the **Activity** sidebar.
 
 Visual Studio for Mac requires version 8.8 (build 1532) or later:
 

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -443,10 +443,7 @@ Debugging requires either of the following browsers:
 
 Ensure that firewalls or proxies don't block communication with the debug proxy (`NodeJS` process). For more information, see the [Firewall configuration](#firewall-configuration) section.
 
-Visual Studio Code users require the following extensions:
-
-* [C# for Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp)
-* [Blazor WASM Debugging Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.blazorwasm-companion) (when using the C# for Visual Studio Code Extension version 1.23.9 or later)
+Visual Studio Code users require the [C# for Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp).
 
 After opening a project in VS Code, you may receive a notification that additional setup is required to enable debugging. If requested, install the required extensions from the Visual Studio Marketplace. To inspect the installed extensions, open **View** > **Extensions** from the menu bar or select the **Extensions** icon in the **Activity** sidebar.
 


### PR DESCRIPTION
Blazor WASM Debug extension for VSCode is no longer needed for debugging Blazor WASM applications.
This PR removes that recommendation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/debug.md](https://github.com/dotnet/AspNetCore.Docs/blob/3a5b6f03834183f40c3493a5a916f5664825f110/aspnetcore/blazor/debug.md) | [aspnetcore/blazor/debug](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/debug?branch=pr-en-us-28841) |


<!-- PREVIEW-TABLE-END -->