### PR TITLE
Fix typo in index.md

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -407,7 +407,7 @@ The preferred way to read hierarchical configuration data is using the options p
 Configuration keys:
 
 * Are case-insensitive. For example, `ConnectionString` and `connectionstring` are treated as equivalent keys.
-* If a key and value is set in more than one configuration providers, the value from the last provider added is used. For more information, see [Default configuration](#default).
+* If a key and value is set in more than one configuration provider, the value from the last provider added is used. For more information, see [Default configuration](#default).
 * Hierarchical keys
   * Within the Configuration API, a colon separator (`:`) works on all platforms.
   * In environment variables, a colon separator may not work on all platforms. A double underscore, `__`, is supported by all platforms and is automatically converted into a colon `:`.


### PR DESCRIPTION
The sentence:

> ...in more than one configuration **providers**

Should read:

> ...in more than one configuration **provider**



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/configuration/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/7729840b1e2bf19be9c6c1e3a23ee015bcd2e667/aspnetcore/fundamentals/configuration/index.md) | [aspnetcore/fundamentals/configuration/index](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/index?branch=pr-en-us-28854) |

<!-- PREVIEW-TABLE-END -->