### PR TITLE
Add gRPC native AOT page

### DIFF
--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -26,7 +26,7 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
 
     [!code-xml[](~/grpc/native-aot/Server.csproj?highlight=5)]
 
-02. Publish the app for a specific runtime identifier using `dotnet publish -r <RID>`.
+02. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.
 
 The app will be available in the publish directory and will contain all the code needed to run in it.
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -14,9 +14,7 @@ By [James Newton-King](https://twitter.com/jamesnk)
 gRPC supports [.NET native ahead-of-time (AOT)](/dotnet/core/deploying/native-aot/) in .NET 8. Native AOT enables publishing gRPC client and server apps as small, fast native executables.
 
 > [!WARNING]
-> In .NET 8, not all ASP.NET Core features are compatible with native AOT.
->
-> For more information, see [ASP.NET Core and native AOT compatibility](xref:fundamentals/native-aot#aspnet-core-and-native-aot-compatibility).
+> In .NET 8, not all ASP.NET Core features are compatible with native AOT. For more information, see [ASP.NET Core and native AOT compatibility](xref:fundamentals/native-aot#aspnet-core-and-native-aot-compatibility).
 
 ## Get started
 
@@ -32,11 +30,19 @@ The app is available in the publish directory and contains all the code needed t
 
 Native AOT analysis includes all of the app's code and the libraries the app depends on. Review native AOT warnings and take corrective steps. It's a good idea to test publishing apps frequently to discover issues early in the development lifecycle.
 
+## Optimize publish size
+
+A native AOT executable contains just the code from external dependencies required to support the app. Unused code is automatically trimmed away.
+
+The publish size of an ASP.NET Core gRPC service can be optimized by creating the host builder with `WebApplication.CreateSlimBuilder()`. This builder provides a minimal list of features required to run an ASP.NET Core app.
+
+[!code-csharp[](~/grpc/native-aot/Program.cs?highlight=1)]
+
 ## Benefits of using native AOT
 
 Apps published with native AOT have:
 
-* Smaller disk footprint
+* Minimized disk footprint
 * Reduced startup time
 * Reduce memory demand
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -22,11 +22,11 @@ gRPC supports [.NET native ahead-of-time (AOT)](/dotnet/core/deploying/native-ao
 
 AOT compilation happens when the app is published. Native AOT is enabled with the `PublishAot` option.
 
-01. Add `<PublishAot>true</PublishAot>` to the gRPC client or server app's project file. This will enable native AOT compilation during publish and enable dynamic code usage analysis during build and editing.
+1. Add `<PublishAot>true</PublishAot>` to the gRPC client or server app's project file. This will enable native AOT compilation during publish and enable dynamic code usage analysis during build and editing.
 
     [!code-xml[](~/grpc/native-aot/Server.csproj?highlight=5)]
 
-02. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.
+2. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.
 
 The app is available in the publish directory and contains all the code needed to run in it.
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -28,7 +28,7 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
 
 02. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.
 
-The app will be available in the publish directory and will contain all the code needed to run in it.
+The app is available in the publish directory and contains all the code needed to run in it.
 
 Native AOT analysis includes all of the app's code and the libraries the app depends on. Review native AOT warnings and take corrective steps. It's a good idea to test publishing apps frequently to discover issues early in the development lifecycle.
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -40,7 +40,7 @@ Apps published with native AOT have:
 * Reduced startup time
 * Reduce memory demand
 
-For more information, and examples of the benefits that native AOT provides, see [Benefits of using native AOT with ASP.NET Core](xref:fundamentals/native-aot#benefits-of-using-native-aot-with-aspnet-core).
+For more information and examples of the benefits that native AOT provides, see [Benefits of using native AOT with ASP.NET Core](xref:fundamentals/native-aot#benefits-of-using-native-aot-with-aspnet-core).
 
 ## Additional resources
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -18,7 +18,7 @@ gRPC supports [.NET native ahead-of-time (AOT)](/dotnet/core/deploying/native-ao
 >
 > For more information, see [ASP.NET Core and native AOT compatibility](xref:fundamentals/native-aot#aspnet-core-and-native-aot-compatibility).
 
-## Getting started
+## Get started
 
 AOT compilation happens when the app is published. Native AOT is enabled with the `PublishAot` option.
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -14,7 +14,9 @@ By [James Newton-King](https://twitter.com/jamesnk)
 gRPC supports [.NET native ahead-of-time (AOT)](/dotnet/core/deploying/native-aot/) in .NET 8. Native AOT enables publishing gRPC client and server apps as small, fast native executables.
 
 > [!WARNING]
-> In .NET 8, not all ASP.NET Core features are compatible with native AOT. For more information, see [ASP.NET Core and native AOT compatibility](xref:fundamentals/native-aot#aspnet-core-and-native-aot-compatibility).
+> In .NET 8, not all ASP.NET Core features are compatible with native AOT.
+>
+> For more information, see [ASP.NET Core and native AOT compatibility](xref:fundamentals/native-aot#aspnet-core-and-native-aot-compatibility).
 
 ## Getting started
 
@@ -22,21 +24,7 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
 
 01. Add `<PublishAot>true</PublishAot>` to the gRPC client or server app's project file. This will enable native AOT compilation during publish and enable dynamic code usage analysis during build and editing.
 
-    ```xml
-    <Project Sdk="Microsoft.NET.Sdk.Web">
-    
-      <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <PublishAot>true</PublishAot>
-      </PropertyGroup>
-    
-      <ItemGroup>
-        <PackageReference Include="Grpc.AspNetCore" Version="2.51.0" />
-        <PackageReference Include="Google.Protobuf" Version="3.22.0" />
-      </ItemGroup>
-    
-    </Project>
-    ```
+    [!code-xml[](~/grpc/native-aot/Server.csproj?highlight=5)]
 
 02. Publish the app for a specific runtime identifier using `dotnet publish -r <RID>`.
 
@@ -46,7 +34,11 @@ Native AOT analysis includes all of the app's code and the libraries the app dep
 
 ## Benefits of using native AOT
 
-Apps published with native AOT should have a smaller disk footprint, reduced startup time and reduce memory demand.
+Apps published with native AOT have:
+
+* Smaller disk footprint
+* Reduced startup time
+* Reduce memory demand
 
 For more information, and examples of the benefits that native AOT provides, see [Benefits of using native AOT with ASP.NET Core](xref:fundamentals/native-aot#benefits-of-using-native-aot-with-aspnet-core).
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -1,0 +1,56 @@
+---
+title: gRPC and native AOT
+author: jamesnk
+description: Learn about support for gRPC with .NET native ahead-of-time (AOT).
+monikerRange: '>= aspnetcore-8.0'
+ms.author: jamesnk
+ms.date: 04/06/2023
+uid: grpc/native-aot
+---
+# gRPC and native AOT
+
+By [James Newton-King](https://twitter.com/jamesnk)
+
+gRPC supports [.NET native ahead-of-time (AOT)](/dotnet/core/deploying/native-aot/) in .NET 8. Native AOT enables publishing gRPC client and server apps as small, fast native executables.
+
+> [!WARNING]
+> In .NET 8, not all ASP.NET Core features are compatible with native AOT. For more information, see [ASP.NET Core and native AOT compatibility](xref:fundamentals/native-aot#aspnet-core-and-native-aot-compatibility).
+
+## Getting started
+
+AOT compilation happens when the app is published. Native AOT is enabled with the `PublishAot` option.
+
+01. Add `<PublishAot>true</PublishAot>` to the gRPC client or server app's project file. This will enable native AOT compilation during publish and enable dynamic code usage analysis during build and editing.
+
+    ```xml
+    <Project Sdk="Microsoft.NET.Sdk.Web">
+    
+      <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <PublishAot>true</PublishAot>
+      </PropertyGroup>
+    
+      <ItemGroup>
+        <PackageReference Include="Grpc.AspNetCore" Version="2.51.0" />
+        <PackageReference Include="Google.Protobuf" Version="3.22.0" />
+      </ItemGroup>
+    
+    </Project>
+    ```
+
+02. Publish the app for a specific runtime identifier using `dotnet publish -r <RID>`.
+
+The app will be available in the publish directory and will contain all the code needed to run in it.
+
+Native AOT analysis includes all of the app's code and the libraries the app depends on. Review native AOT warnings and take corrective steps. It's a good idea to test publishing apps frequently to discover issues early in the development lifecycle.
+
+## Benefits of using native AOT
+
+Apps published with native AOT should have a smaller disk footprint, reduced startup time and reduce memory demand.
+
+For more information, and examples of the benefits that native AOT provides, see [Benefits of using native AOT with ASP.NET Core](xref:fundamentals/native-aot#benefits-of-using-native-aot-with-aspnet-core).
+
+## Additional resources
+
+* <xref:fundamentals/native-aot>
+* [Native AOT deployment](/dotnet/core/deploying/native-aot/)

--- a/aspnetcore/grpc/native-aot/Program.cs
+++ b/aspnetcore/grpc/native-aot/Program.cs
@@ -1,0 +1,6 @@
+var builder = WebApplication.CreateSlimBuilder(args);
+builder.Services.AddGrpc();
+
+var app = builder.Build();
+app.MapGrpcService<GreeterService>();
+app.Run();

--- a/aspnetcore/grpc/native-aot/Server.csproj
+++ b/aspnetcore/grpc/native-aot/Server.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.51.0" />
+    <PackageReference Include="Google.Protobuf" Version="3.22.0" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -913,6 +913,8 @@ items:
         uid: grpc/security
       - name: Performance best practices
         uid: grpc/performance
+      - name: Native AOT
+        uid: grpc/native-aot
       - name: Inter-process communication
         items:
           - name: Overview


### PR DESCRIPTION
Add gRPC specific page for native AOT. Will add links to it from the fundamentals AOT page later.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/native-aot.md](https://github.com/dotnet/AspNetCore.Docs/blob/121040d72cdb98708c785da4c4374407542be30d/aspnetcore/grpc/native-aot.md) | [aspnetcore/grpc/native-aot](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/native-aot?branch=pr-en-us-28899) |


<!-- PREVIEW-TABLE-END -->