### PR TITLE
Mention the aot flag in gRPC template

### DIFF
--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -24,7 +24,7 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
 
     [!code-xml[](~/grpc/native-aot/Server.csproj?highlight=5)]
 
-    Native AOT can also be enabled by specifying the `-aot` flag when creating a gRPC app from the template: `dotnet new grpc -aot`
+    Native AOT can also be enabled by specifying the `-aot` flag with the ASP.NET Core gRPC template: `dotnet new grpc -aot`
 
 2. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -27,7 +27,7 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
     Native AOT can also be enabled by specifying the `-aot` option with the ASP.NET Core gRPC template:
 
     ```dotnetcli
-    dotnet new grpc -aot`
+    dotnet new grpc -aot
     ```
 
 2. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -24,7 +24,11 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
 
     [!code-xml[](~/grpc/native-aot/Server.csproj?highlight=5)]
 
-    Native AOT can also be enabled by specifying the `-aot` option with the ASP.NET Core gRPC template: `dotnet new grpc -aot`
+    Native AOT can also be enabled by specifying the `-aot` option with the ASP.NET Core gRPC template:
+
+    ```dotnetcli
+    dotnet new grpc -aot`
+    ```
 
 2. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -24,7 +24,7 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
 
     [!code-xml[](~/grpc/native-aot/Server.csproj?highlight=5)]
 
-    Native AOT can also be enabled by specifying the `-aot` flag with the ASP.NET Core gRPC template: `dotnet new grpc -aot`
+    Native AOT can also be enabled by specifying the `-aot` option with the ASP.NET Core gRPC template: `dotnet new grpc -aot`
 
 2. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.
 

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -24,6 +24,8 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
 
     [!code-xml[](~/grpc/native-aot/Server.csproj?highlight=5)]
 
+    Native AOT can also be enabled by specifying the `-aot` flag when creating a gRPC app from the template: `dotnet new grpc -aot`
+
 2. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.
 
 The app is available in the publish directory and contains all the code needed to run in it.


### PR DESCRIPTION
I forgot the gRPC template has an aot flag.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/native-aot.md](https://github.com/dotnet/AspNetCore.Docs/blob/71dce5ae4ff7a615292f03a53af34e0e679f54f3/aspnetcore/grpc/native-aot.md) | [aspnetcore/grpc/native-aot](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/native-aot?branch=pr-en-us-28904) |


<!-- PREVIEW-TABLE-END -->