### PR TITLE
APIs overview: Remove IFormFile support from minimal APIs limitations list

### DIFF
--- a/aspnetcore/fundamentals/apis.md
+++ b/aspnetcore/fundamentals/apis.md
@@ -30,7 +30,6 @@ Both API projects refer to the following class:
 Minimal APIs have many of the same capabilities as controller-based APIs. They support the configuration and customization needed to scale to multiple APIs, handle complex routes, apply authorization rules, and control the content of API responses. There are a few capabilities available with controller-based APIs that are not yet supported or implemented by minimal APIs. These include:
 
 - No built-in support for model binding (<xref:Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinderProvider>, <xref:Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder>). Support can be added with a custom binding shim.
-- No support for binding from forms. This includes binding <xref:Microsoft.AspNetCore.Http.IFormFile>.
 - No built-in support for validation (<xref:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IModelValidator>).
 - No support for [application parts](xref:mvc/extensibility/app-parts) or the [application model](xref:mvc/controllers/application-model). There's no way to apply or build your own conventions.
 - No built-in view rendering support. We recommend using [Razor Pages](xref:tutorials/razor-pages/razor-pages-start) for rendering views.

--- a/aspnetcore/fundamentals/apis.md
+++ b/aspnetcore/fundamentals/apis.md
@@ -30,6 +30,9 @@ Both API projects refer to the following class:
 Minimal APIs have many of the same capabilities as controller-based APIs. They support the configuration and customization needed to scale to multiple APIs, handle complex routes, apply authorization rules, and control the content of API responses. There are a few capabilities available with controller-based APIs that are not yet supported or implemented by minimal APIs. These include:
 
 - No built-in support for model binding (<xref:Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinderProvider>, <xref:Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder>). Support can be added with a custom binding shim.
+<!--
+- No support for binding from forms. This includes binding <xref:Microsoft.AspNetCore.Http.IFormFile>.
+-->
 - No built-in support for validation (<xref:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IModelValidator>).
 - No support for [application parts](xref:mvc/extensibility/app-parts) or the [application model](xref:mvc/controllers/application-model). There's no way to apply or build your own conventions.
 - No built-in view rendering support. We recommend using [Razor Pages](xref:tutorials/razor-pages/razor-pages-start) for rendering views.


### PR DESCRIPTION
Removing limitation "No support for binding from forms. This includes binding IFormFile"

According to [What's new in ASP.NET Core 7.0](https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-7.0?source=recommendations&view=aspnetcore-7.0#file-uploads-using-iformfile-and-iformfilecollection) 
> Minimal APIs now support file upload with IFormFile and IFormFileCollection.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/apis.md](https://github.com/dotnet/AspNetCore.Docs/blob/48b0251bfa55d313b3f37ddd8676418b817d609f/aspnetcore/fundamentals/apis.md) | [aspnetcore/fundamentals/apis](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/apis?branch=pr-en-us-28908) |


<!-- PREVIEW-TABLE-END -->