### PR TITLE
Update check-for-build-warnings.yml

### DIFF
--- a/.github/workflows/check-for-build-warnings.yml
+++ b/.github/workflows/check-for-build-warnings.yml
@@ -13,6 +13,7 @@ jobs:
         issues: write
         pull-requests: write
     steps:
+    - uses: actions/checkout@v3
     - uses: dotnet/docs-actions/actions/status-checker@main
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Enable the reading of H1s to use in place of the file name for the generated preview table.