### PR TITLE
Dispatch exceptions to the sync context

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -810,7 +810,13 @@ catch (Exception ex)
 }
 ```
 
-For an example use of `DispatchExceptionAsync` API, implement the timer notification example in the [Invoke component methods externally to update state](#invoke-component-methods-externally-to-update-state) section. The example uses a timer outside of Blazor's synchronization context, where an unhandled exception normally doesn't reach Blazor's synchronization context and isn't processed by Blazor's error handling mechanisms, such as an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
+For an example use of `DispatchExceptionAsync` API, implement the timer notification example in the [Invoke component methods externally to update state](#invoke-component-methods-externally-to-update-state) section. In a Blazor app, add the following files from the timer notification example and register the services in `Program.cs` as the text explains:
+
+* `TimerService.cs`
+* `NotifierService.cs`
+* `Pages/ReceiveNotifications.razor`
+
+The example uses a timer outside of Blazor's synchronization context, where an unhandled exception normally doesn't reach Blazor's synchronization context and isn't processed by Blazor's error handling mechanisms, such as an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
 
 First, change the code in `TimerService.cs` to create an artificial exception outside of Blazor's synchronization context. In the `while` loop of `TimerService.cs`, throw an exception when the `elapsedCount` reaches a value of two:
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -810,9 +810,9 @@ catch (Exception ex)
 }
 ```
 
-For an example use of `DispatchExceptionAsync` API, implement the timer notification example in the [Invoke component methods externally to update state](#invoke-component-methods-externally-to-update-state) section. The example uses a timer outside of Blazor's synchronization context, where an exception normally doesn't reach Blazor's synchronization context and isn't processed by Blazor's error handling mechanisms, such as an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
+For an example use of `DispatchExceptionAsync` API, implement the timer notification example in the [Invoke component methods externally to update state](#invoke-component-methods-externally-to-update-state) section. The example uses a timer outside of Blazor's synchronization context, where an unhandled exception normally doesn't reach Blazor's synchronization context and isn't processed by Blazor's error handling mechanisms, such as an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
 
-First, change the code in `TimerService.cs` to create an artificial exception outside of Blazor's synchronization context. In the `while` loop of `TimerService.cs`, throw an exception when the `elapsedCount` reaches a value of `2`:
+First, change the code in `TimerService.cs` to create an artificial exception outside of Blazor's synchronization context. In the `while` loop of `TimerService.cs`, throw an exception when the `elapsedCount` reaches a value of two:
 
 ```csharp
 if (elapsedCount == 2)

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -783,11 +783,15 @@ In the preceding example:
 > [!IMPORTANT]
 > If a Razor component defines an event that's triggered from a background thread, the component might be required to capture and restore the execution context (<xref:System.Threading.ExecutionContext>) at the time the handler is registered. For more information, see [Calling `InvokeAsync(StateHasChanged)` causes page to fallback to default culture (dotnet/aspnetcore #28521)](https://github.com/dotnet/aspnetcore/issues/28521).
 
+:::moniker-end
+
 :::moniker range=">= aspnetcore-8.0"
 
 To dispatch caught exceptions from the background `TimerService` to the component to treat the exceptions like normal lifecycle event exceptions, see [Handle caught exceptions outside of a Razor component's lifecycle](xref:blazor/fundamentals/handle-errors#handle-caught-exceptions-outside-of-a-razor-components-lifecycle) in the *Handle errors* article.
 
 :::moniker-end
+
+:::moniker range=">= aspnetcore-7.0"
 
 ## Use `@key` to control the preservation of elements and components
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -840,7 +840,7 @@ Place an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundarie
 </article>
 ```
 
-Normally, the preceding error boundary doesn't react to unhandled exceptions thrown outside of Blazor's synchronization context. If you run the app at this point, the exception is thrown when the elapsed count reaches a value of two, but the error boundary doesn't show the error content.
+If you run the app at this point, the exception is thrown when the elapsed count reaches a value of two. However, the UI doesn't change. The error boundary doesn't show the error content.
 
 Change the `OnNotify` method of the `ReceiveNotification` component (`Pages/ReceiveNotification.razor`):
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -783,9 +783,13 @@ In the preceding example:
 > [!IMPORTANT]
 > If a Razor component defines an event that's triggered from a background thread, the component might be required to capture and restore the execution context (<xref:System.Threading.ExecutionContext>) at the time the handler is registered. For more information, see [Calling `InvokeAsync(StateHasChanged)` causes page to fallback to default culture (dotnet/aspnetcore #28521)](https://github.com/dotnet/aspnetcore/issues/28521).
 
+:::moniker-end
+
 :::moniker range=">= aspnetcore-8.0"
 
 ### Dispatch exceptions to Blazor's synchronization context
+
+<!-- ************** NOTE: https://github.com/dotnet/aspnetcore/pull/46074#issuecomment-1398108853 -->
 
 Use `DispatchExceptionAsync` to process caught exceptions thrown outside of Blazor's synchronization context (for example, outside of Blazor's lifecycle events). This permits the app's code to treat the exceptions as through they're lifecycle method exceptions. Thereafter, Blazor's error handling approaches are supported, such as [error boundaries](xref:blazor/fundamentals/handle-errors#error-boundaries).
 
@@ -865,6 +869,8 @@ When the timer service executes and reaches a count of two, the unhandled except
 > :::no-loc text="Oh, dear! Oh, my! - George Takei":::
 
 :::moniker-end
+
+:::moniker range=">= aspnetcore-7.0"
 
 ## Use `@key` to control the preservation of elements and components
 

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -783,6 +783,89 @@ In the preceding example:
 > [!IMPORTANT]
 > If a Razor component defines an event that's triggered from a background thread, the component might be required to capture and restore the execution context (<xref:System.Threading.ExecutionContext>) at the time the handler is registered. For more information, see [Calling `InvokeAsync(StateHasChanged)` causes page to fallback to default culture (dotnet/aspnetcore #28521)](https://github.com/dotnet/aspnetcore/issues/28521).
 
+:::moniker range=">= aspnetcore-8.0"
+
+### Dispatch exceptions to Blazor's synchronization context
+
+Use `DispatchExceptionAsync` to process caught exceptions thrown outside of Blazor's synchronization context (for example, outside of Blazor's lifecycle events). This permits the app's code to treat the exceptions as through they're lifecycle method exceptions. Thereafter, Blazor's error handling approaches are supported, such as [error boundaries](xref:blazor/fundamentals/handle-errors#error-boundaries).
+
+To dispatch exceptions to Blazor's synchronization context, use a `try-catch` block to pass the exception to `DispatchExceptionAsync` and await the result:
+
+```csharp
+try
+{
+    await InvokeAsync(() =>
+    {
+        ...
+    });
+}
+catch (Exception ex)
+{
+    await DispatchExceptionAsync(ex);
+}
+```
+
+For an example use of `DispatchExceptionAsync` API, implement the timer notification example in the [Invoke component methods externally to update state](#invoke-component-methods-externally-to-update-state) section. The example uses a timer outside of Blazor's synchronization context, where an exception normally doesn't affect Blazor's error handling mechanisms, such as an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
+
+First, change the code in `TimerService.cs` to create an artificial exception outside of Blazor's synchronization context. In the `while (await timer.WaitForNextTickAsync())` loop of `TimerService.cs`, throw an exception when the `elapsedCount` reaches a value of `2`:
+
+```csharp
+if (elapsedCount == 2)
+{
+    throw new Exception("I threw an exception! Somebody help me!");
+}
+```
+
+Place an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries) in the app's main layout.
+
+`Shared/MainLayout.razor`:
+
+```razor
+<article class="content px-4">
+    <ErrorBoundary>
+        <ChildContent>
+            @Body
+        </ChildContent>
+        <ErrorContent>
+            <p class="alert alert-danger" role="alert">
+                Oh, dear! Oh, my! - George Takei
+            </p>
+        </ErrorContent>
+    </ErrorBoundary>
+</article>
+```
+
+Normally, the preceding error boundary doesn't react to unhandled exceptions thrown outside of Blazor's synchronization context.
+
+Change the `OnNotify` method of the `ReceiveNotification` component (`Pages/ReceiveNotification.razor`):
+
+* Wrap the call to `InvokeAsync` in a `try-catch` block.
+* Pass any <xref:System.Exception> to `DispatchExceptionAsync` and await the result.
+
+```csharp
+public async Task OnNotify(string key, int value)
+{
+    try
+    {
+        await InvokeAsync(() =>
+        {
+            lastNotification = (key, value);
+            StateHasChanged();
+        });
+    }
+    catch (Exception ex)
+    {
+        await DispatchExceptionAsync(ex);
+    }
+}
+```
+
+When the timer service executes and reaches a count of two, the unhandled exception is dispatched to the Razor component, which in turn triggers the error boundary to display the error content:
+
+> :::no-loc text="Oh, dear! Oh, my! - George Takei":::
+
+:::moniker-end
+
 ## Use `@key` to control the preservation of elements and components
 
 When rendering a list of elements or components and the elements or components subsequently change, Blazor must decide which of the previous elements or components are retained and how model objects should map to them. Normally, this process is automatic and sufficient for general rendering, but there are often cases where controlling the process using the [`@key`][5] directive attribute is required.

--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -789,9 +789,10 @@ In the preceding example:
 
 ### Dispatch exceptions to Blazor's synchronization context
 
-<!-- ************** NOTE: https://github.com/dotnet/aspnetcore/pull/46074#issuecomment-1398108853 -->
+Use `ComponentBase.DispatchExceptionAsync` in Razor components to process exceptions thrown outside of Blazor's synchronization context. This permits the app's code to treat the exceptions as through they're lifecycle method exceptions. Thereafter, Blazor's error handling mechanisms, such as [error boundaries](xref:blazor/fundamentals/handle-errors#error-boundaries), can process the exceptions.
 
-Use `DispatchExceptionAsync` to process caught exceptions thrown outside of Blazor's synchronization context (for example, outside of Blazor's lifecycle events). This permits the app's code to treat the exceptions as through they're lifecycle method exceptions. Thereafter, Blazor's error handling approaches are supported, such as [error boundaries](xref:blazor/fundamentals/handle-errors#error-boundaries).
+> [!NOTE]
+> `ComponentBase.DispatchExceptionAsync` is used in Razor component files (`.razor`) that inherit from <xref:Microsoft.AspNetCore.Components.ComponentBase>. When creating components that [implement <xref:Microsoft.AspNetCore.Components.IComponent> directly](#component-classes), use `RenderHandle.DispatchExceptionAsync`.
 
 To dispatch exceptions to Blazor's synchronization context, use a `try-catch` block to pass the exception to `DispatchExceptionAsync` and await the result:
 
@@ -809,9 +810,9 @@ catch (Exception ex)
 }
 ```
 
-For an example use of `DispatchExceptionAsync` API, implement the timer notification example in the [Invoke component methods externally to update state](#invoke-component-methods-externally-to-update-state) section. The example uses a timer outside of Blazor's synchronization context, where an exception normally doesn't affect Blazor's error handling mechanisms, such as an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
+For an example use of `DispatchExceptionAsync` API, implement the timer notification example in the [Invoke component methods externally to update state](#invoke-component-methods-externally-to-update-state) section. The example uses a timer outside of Blazor's synchronization context, where an exception normally doesn't reach Blazor's synchronization context and isn't processed by Blazor's error handling mechanisms, such as an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
 
-First, change the code in `TimerService.cs` to create an artificial exception outside of Blazor's synchronization context. In the `while (await timer.WaitForNextTickAsync())` loop of `TimerService.cs`, throw an exception when the `elapsedCount` reaches a value of `2`:
+First, change the code in `TimerService.cs` to create an artificial exception outside of Blazor's synchronization context. In the `while` loop of `TimerService.cs`, throw an exception when the `elapsedCount` reaches a value of `2`:
 
 ```csharp
 if (elapsedCount == 2)
@@ -839,11 +840,11 @@ Place an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundarie
 </article>
 ```
 
-Normally, the preceding error boundary doesn't react to unhandled exceptions thrown outside of Blazor's synchronization context.
+Normally, the preceding error boundary doesn't react to unhandled exceptions thrown outside of Blazor's synchronization context. If you run the app at this point, the exception is thrown when the elapsed count reaches a value of two, but the error boundary doesn't show the error content.
 
 Change the `OnNotify` method of the `ReceiveNotification` component (`Pages/ReceiveNotification.razor`):
 
-* Wrap the call to `InvokeAsync` in a `try-catch` block.
+* Wrap the call to <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType> in a `try-catch` block.
 * Pass any <xref:System.Exception> to `DispatchExceptionAsync` and await the result.
 
 ```csharp

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -66,6 +66,8 @@ In a Blazor WebAssembly app, customize the experience in the `wwwroot/index.html
 
 The `blazor-error-ui` element is normally hidden due to the presence of the `display: none` style of the `blazor-error-ui` CSS class in the site's stylesheet (`wwwroot/css/site.css` for Blazor Server or `wwwroot/css/app.css` for Blazor WebAssembly). When an error occurs, the framework applies `display: block` to the element.
 
+:::moniker-end
+
 :::moniker range=">= aspnetcore-8.0"
 
 ## Handle caught exceptions outside of a Razor component's lifecycle

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -66,8 +66,6 @@ In a Blazor WebAssembly app, customize the experience in the `wwwroot/index.html
 
 The `blazor-error-ui` element is normally hidden due to the presence of the `display: none` style of the `blazor-error-ui` CSS class in the site's stylesheet (`wwwroot/css/site.css` for Blazor Server or `wwwroot/css/app.css` for Blazor WebAssembly). When an error occurs, the framework applies `display: block` to the element.
 
-:::moniker-end
-
 :::moniker range=">= aspnetcore-8.0"
 
 ## Handle caught exceptions outside of a Razor component's lifecycle

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -70,7 +70,7 @@ The `blazor-error-ui` element is normally hidden due to the presence of the `dis
 
 ## Handle caught exceptions outside of a Razor component's lifecycle
 
-Use `ComponentBase.DispatchExceptionAsync` in a Razor component to process exceptions thrown outside of the component's lifecycle call stack. This permits the component's code to treat exceptions as through they're lifecycle method exceptions. Thereafter, Blazor's error handling mechanisms, such as [error boundaries](xref:blazor/fundamentals/handle-errors#error-boundaries), can process the exceptions.
+Use `ComponentBase.DispatchExceptionAsync` in a Razor component to process exceptions thrown outside of the component's lifecycle call stack. This permits the component's code to treat exceptions as though they're lifecycle method exceptions. Thereafter, Blazor's error handling mechanisms, such as [error boundaries](xref:blazor/fundamentals/handle-errors#error-boundaries), can process the exceptions.
 
 > [!NOTE]
 > `ComponentBase.DispatchExceptionAsync` is used in Razor component files (`.razor`) that inherit from <xref:Microsoft.AspNetCore.Components.ComponentBase>. When creating components that [implement <xref:Microsoft.AspNetCore.Components.IComponent> directly](xref:blazor/components/index#component-classes), use `RenderHandle.DispatchExceptionAsync`.


### PR DESCRIPTION
Fixes #28933

Notes ...

* I felt building off of the prior example makes sense. Presumably, many readers will have just tested out the prior section's example, so they can just build on that experience to see this API in action.

  Here's what this new example builds off of ...

  https://learn.microsoft.com/en-us/aspnet/core/blazor/components/?view=aspnetcore-7.0#invoke-component-methods-externally-to-update-state

* There's one thing in Steve's remarks that I don't understand ...

  > ... the premise that you have an exception already implies you caught it. If you don't catch an external exception, then you have an unhandled exception which has nothing to do with Blazor.

  Cross-ref: https://github.com/dotnet/aspnetcore/issues/46068#issuecomment-1398207040

  ***... but*** error boundaries (getting them to light up here) is about trapping unhandled exceptions. The example that I have on this PR is throwing in the `TimerService` to show how the exception can be forwarded to the Blazor sync context.

  ... also Halter said right after that ...

  > This is not something you'd want to do by default when the caller to InvokeAsync may be able to handle the exception gracefully.

  ... but again, you can do both. You can take action on it, just in the sense that you're processing it in the external code (e.g., log it), and then flow it ***unhandled*** to Blazor for the error boundary to trip on purpose. I don't see why this isn't a valid approach.

  I guess what I'm saying is that if these PU remarks are right, we don't want to show this example based on an exception in `TimerService` ... `TimerService` should handle its exceptions entirely and flow back something to the caller for processing in the Razor component on an error, not allow the unhandled exception to trip the error boundary. What I have here might be considered as an implied ***anti-pattern*** 🙈 and should be replaced with a different example.

  Besides that, is there some other or additional scenario that you'd like to show? I like this one, but I'm just pitching it as a possibility because the prior example is so good (IMO) and feeds right into the usefulness of this API AFAICT.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/c969e6921acbe0ddf72a21ffb8d116c2352ee66b/aspnetcore/blazor/components/index.md) | [ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/index?branch=pr-en-us-28936) |
| [aspnetcore/blazor/fundamentals/handle-errors.md](https://github.com/dotnet/AspNetCore.Docs/blob/c969e6921acbe0ddf72a21ffb8d116c2352ee66b/aspnetcore/blazor/fundamentals/handle-errors.md) | [aspnetcore/blazor/fundamentals/handle-errors](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/handle-errors?branch=pr-en-us-28936) |


<!-- PREVIEW-TABLE-END -->