### PR TITLE
Fix Azure SignalR config key

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -168,10 +168,10 @@ To configure an app for the Azure SignalR Service, the app must support *sticky 
   * In `appsettings.json`:
 
     ```json
-    "Azure:SignalR:StickyServerMode": "Required"
+    "Azure:SignalR:ServerStickyMode": "Required"
     ```
 
-  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__StickyServerMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
+  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
 
 > [!NOTE]
 > The following error is thrown by an app that hasn't enabled sticky sessions for Azure SignalR Service:
@@ -549,10 +549,10 @@ To configure an app for the Azure SignalR Service, the app must support *sticky 
   * In `appsettings.json`:
 
     ```json
-    "Azure:SignalR:StickyServerMode": "Required"
+    "Azure:SignalR:ServerStickyMode": "Required"
     ```
 
-  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__StickyServerMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
+  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
 
 > [!NOTE]
 > The following error is thrown by an app that hasn't enabled sticky sessions for Azure SignalR Service:
@@ -839,10 +839,10 @@ To configure an app for the Azure SignalR Service, the app must support *sticky 
   * In `appsettings.json`:
 
     ```json
-    "Azure:SignalR:StickyServerMode": "Required"
+    "Azure:SignalR:ServerStickyMode": "Required"
     ```
 
-  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__StickyServerMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
+  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
 
 > [!NOTE]
 > The following error is thrown by an app that hasn't enabled sticky sessions for Azure SignalR Service:
@@ -1145,10 +1145,10 @@ To configure an app for the Azure SignalR Service, the app must support *sticky 
   * In `appsettings.json`:
 
     ```json
-    "Azure:SignalR:StickyServerMode": "Required"
+    "Azure:SignalR:ServerStickyMode": "Required"
     ```
 
-  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__StickyServerMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
+  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
 
 > [!NOTE]
 > The following error is thrown by an app that hasn't enabled sticky sessions for Azure SignalR Service:


### PR DESCRIPTION
StickyServerMode -> ServerStickyMode

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/server.md](https://github.com/dotnet/AspNetCore.Docs/blob/b896ea43ac6d222181f11d55ec3cb2ea1c9b86e5/aspnetcore/blazor/host-and-deploy/server.md) | [Host and deploy Blazor Server](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/server?branch=pr-en-us-28939) |

<!-- PREVIEW-TABLE-END -->