### PR TITLE
Mention required nuget package in remote app doc

### DIFF
--- a/aspnetcore/migration/inc/remote-app-setup.md
+++ b/aspnetcore/migration/inc/remote-app-setup.md
@@ -23,8 +23,8 @@ To enable the ASP.NET Core app to communicate with the ASP.NET app, it's necessa
 ### ASP.NET app configuration
 
 To set up the ASP.NET app to be able to receive requests from the ASP.NET Core app:
-1. Install the nuget package `Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices`
-2. Call the `AddRemoteApp` extension method on the `ISystemWebAdapterBuilder` as shown here.
+1. Install the nuget package [`Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices`](https://www.nuget.org/packages/Microsoft.AspNetCore.SystemWebAdapters)
+2. Call the `AddRemoteApp` extension method on the `ISystemWebAdapterBuilder`:
 
 ```CSharp
 SystemWebAdapterConfiguration.AddSystemWebAdapters(this)

--- a/aspnetcore/migration/inc/remote-app-setup.md
+++ b/aspnetcore/migration/inc/remote-app-setup.md
@@ -22,7 +22,9 @@ To enable the ASP.NET Core app to communicate with the ASP.NET app, it's necessa
 
 ### ASP.NET app configuration
 
-To set up the ASP.NET app to be able to receive requests from the ASP.NET Core app, call the `AddRemoteApp` extension method on the `ISystemWebAdapterBuilder` as shown here.
+To set up the ASP.NET app to be able to receive requests from the ASP.NET Core app:
+1. Install the nuget package `Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices`
+2. Call the `AddRemoteApp` extension method on the `ISystemWebAdapterBuilder` as shown here.
 
 ```CSharp
 SystemWebAdapterConfiguration.AddSystemWebAdapters(this)


### PR DESCRIPTION
I can't find anywhere in the current docs where it says to install this package. Just using the sample code will yield `The name 'SystemWebAdapterConfiguration' does not exist in the current context`


***EDIT by @Rick-Anderson***
Fixes #28976


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/inc/remote-app-setup.md](https://github.com/dotnet/AspNetCore.Docs/blob/33f0ba20b98e21e56508f7e606b673e22a103f31/aspnetcore/migration/inc/remote-app-setup.md) | [Remote app setup](https://review.learn.microsoft.com/en-us/aspnet/core/migration/inc/remote-app-setup?branch=pr-en-us-28966) |


<!-- PREVIEW-TABLE-END -->