### PR TITLE
Fix syntax error in remote app setup sample code

### DIFF
--- a/aspnetcore/migration/inc/remote-app-setup.md
+++ b/aspnetcore/migration/inc/remote-app-setup.md
@@ -44,7 +44,7 @@ builder.Services.AddSystemWebAdapters()
     .AddRemoteAppClient(options =>
     {
         options.RemoteAppUrl = new(builder.Configuration["ReverseProxy:Clusters:fallbackCluster:Destinations:fallbackApp:Address"]);
-        options.ApiKey = builder.Configuration("RemoteAppApiKey");
+        options.ApiKey = builder.Configuration["RemoteAppApiKey"];
     });
 ```
 


### PR DESCRIPTION
Use indexer rather than method syntax for `builder.Configuration`



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/inc/remote-app-setup.md](https://github.com/dotnet/AspNetCore.Docs/blob/02e25ec4e92b1a31b28f90239c856d674e34d192/aspnetcore/migration/inc/remote-app-setup.md) | [Remote app setup](https://review.learn.microsoft.com/en-us/aspnet/core/migration/inc/remote-app-setup?branch=pr-en-us-28967) |

<!-- PREVIEW-TABLE-END -->