### PR TITLE
Initial URL for BlazorWebView

### DIFF
--- a/aspnetcore/blazor/hybrid/routing.md
+++ b/aspnetcore/blazor/hybrid/routing.md
@@ -112,6 +112,48 @@ blazorWebView.UrlLoading +=
 
 :::zone-end
 
+:::moniker range=">= aspnetcore-8.0"
+
+## Get or set a path for initial navigation
+
+Use the `BlazorWebView.StartPath` property to get or set the path for initial navigation within the Blazor navigation context when the Razor component is finished loading. The default start path is the relative root URL path (`/`).
+
+:::zone pivot="maui"
+
+In the `MainPage` XAML markup (`MainPage.xaml`), specify the start path. The following example sets the path to a welcome page at `/welcome`:
+
+```xaml
+<BlazorWebView ... StartPath="/welcome" ...>
+    ...
+<BlazorWebView>
+```
+
+:::zone-end
+
+:::zone pivot="wpf"
+
+In the `MainWindow` designer (`MainWindow.xaml`), specify the start path. The following example sets the path to a welcome page at `/welcome`:
+
+```xaml
+<blazor:BlazorWebView ... StartPath="/welcome" ...>
+    ...
+</blazor:BlazorWebView>
+```
+
+:::zone-end
+
+:::zone pivot="winforms"
+
+Inside the `Form1` constructor of the `Form1.cs` file, specify the start path. The following example sets the path to a welcome page at `/welcome`:
+
+```csharp
+blazorWebView1.StartPath = "/welcome";
+```
+
+:::zone-end
+
+:::moniker-end
+
 :::zone pivot="maui"
 
 ## Navigation among pages and Razor components
@@ -238,4 +280,3 @@ Coverage of deep linking support is forthcoming. In the meantime, see [Support d
 :::zone-end
 
 :::moniker-end
-


### PR DESCRIPTION
Fixes #28965

cc: @mkArtakMSFT ... I can see that Surayya did the PR ... I'll ping for review.

Notes:

* Do we want to use this language to describe the default start path? ...

  > The default start path is the relative root URL path (`/`).

  ... because I'm not aware if it's possible for these apps to have a different base path. I'll modify to your best choice of language there.

* Just FYI ... Across the Hybrid docs, we use the approach for setting properties on a `BlazorWebView` that the tutorials adopt. In the case where the dev is looking at the XAML markup code, we show the setting on the element, not via the designer property tools. In the WinForms case, we set those properties in C#, so that's what we place here. We assume the reader used our tutorials, so we assume they'll work with the properties across the docs the same way as the tutorials have them work with them. Just letting you know. This is subject to change later perhaps, but this is the approach we're using thus far. 