### PR TITLE
Render components outside of ASPNETCORE

### DIFF
--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -1,7 +1,7 @@
 ---
 title: Render Razor components outside of ASP.NET Core
 author: guardrex
-description: 
+description: Render Razor components outside of the context of an HTTP request.
 monikerRange: '>= aspnetcore-8.0'
 ms.author: riande
 ms.custom: mvc
@@ -10,7 +10,7 @@ uid: blazor/components/render-outside-of-aspnetcore
 ---
 # Render Razor components outside of ASP.NET Core
 
-Razor components can be rendered outside of the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for a generated email or static site content.
+Razor components can be rendered outside of the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for generating email or static site content.
 
 In the following example, a Razor component is rendered to an HTML string from a console app:
 

--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -14,77 +14,75 @@ Razor components can be rendered outside of the context of an HTTP request. You 
 
 In the following example, a Razor component is rendered to an HTML string from a console app:
 
-1. In a command shell, create a new console app project:
+In a command shell, create a new console app project:
 
-   ```dotnetcli
-   dotnet new console -o ConsoleApp1
-   cd ConsoleApp1
-   ```
+```dotnetcli
+dotnet new console -o ConsoleApp1
+cd ConsoleApp1
+```
 
-1. In a command shell in the `ConsoleApp1` folder, add package references for <xref:Microsoft.AspNetCore.Components.Web?displayProperty=fullName> and <xref:Microsoft.Extensions.Logging?displayProperty=fullName> to the console app:
+In a command shell in the `ConsoleApp1` folder, add package references for <xref:Microsoft.AspNetCore.Components.Web?displayProperty=fullName> and <xref:Microsoft.Extensions.Logging?displayProperty=fullName> to the console app:
 
-   ```dotnetcli
-   dotnet add package Microsoft.AspNetCore.Components.Web --prerelease
-   dotnet add package Microsoft.Extensions.Logging --prerelease
-   ```
+```dotnetcli
+dotnet add package Microsoft.AspNetCore.Components.Web --prerelease
+dotnet add package Microsoft.Extensions.Logging --prerelease
+```
 
-1. In the console app's project file (`ConsoleApp1.csproj`), update the console app project to use the Razor SDK:
+In the console app's project file (`ConsoleApp1.csproj`), update the console app project to use the Razor SDK:
 
-   ```diff
-   - <Project Sdk="Microsoft.NET.Sdk">
-   + <Project Sdk="Microsoft.NET.Sdk.Razor">
-   ```
+```diff
+- <Project Sdk="Microsoft.NET.Sdk">
++ <Project Sdk="Microsoft.NET.Sdk.Razor">
+```
 
-1. In a command shell, add a Razor component to the project:
+In a command shell, add a Razor component to the project:
 
-   ```dotnetcli
-   dotnet new razorcomponent -n Component1
-   ```
+```dotnetcli
+dotnet new razorcomponent -n Component1
+```
 
-   ```razor
-   <h1>Component1</h1>
+```razor
+<h1>Component1</h1>
 
-   <p>Hello from Component1!</p>
+<p>Hello from Component1!</p>
 
-   @code {
+@code {
 
-   }
-   ```
+}
+```
 
-1. Update `Program.cs`:
+Update `Program.cs`:
 
-   * Set up dependency injection (<xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>/<xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider%2A>) and logging (<xref:Microsoft.Extensions.DependencyInjection.LoggingServiceCollectionExtensions.AddLogging%2A>/<xref:Microsoft.Extensions.Logging.ILoggerFactory>).
-   * Create an `HtmlRenderer` and render the `Component1` component by calling `RenderComponentAsync`.
-   
-   Any calls to `RenderComponentAsync` must be made in the context of calling `InvokeAsync` on a component dispatcher. A component dispatcher is available from the `HtmlRender.Dispatcher` property.
+* Set up dependency injection (<xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>/<xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider%2A>) and logging (<xref:Microsoft.Extensions.DependencyInjection.LoggingServiceCollectionExtensions.AddLogging%2A>/<xref:Microsoft.Extensions.Logging.ILoggerFactory>).
+* Create an `HtmlRenderer` and render the `Component1` component by calling `RenderComponentAsync`.
 
-   ```csharp
-   using Microsoft.AspNetCore.Components;
-   using Microsoft.AspNetCore.Components.Web;
-   using Microsoft.Extensions.DependencyInjection;
-   using Microsoft.Extensions.Logging;
-   using ConsoleApp1;
+Any calls to `RenderComponentAsync` must be made in the context of calling `InvokeAsync` on a component dispatcher. A component dispatcher is available from the `HtmlRender.Dispatcher` property.
 
-   IServiceCollection services = new ServiceCollection();
-   services.AddLogging();
+```csharp
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ConsoleApp1;
 
-   IServiceProvider serviceProvider = services.BuildServiceProvider();
-   ILoggerFactory loggerFactory = 
-       serviceProvider.GetRequiredService<ILoggerFactory>();
+IServiceCollection services = new ServiceCollection();
+services.AddLogging();
 
-   await using var htmlRenderer = new HtmlRenderer(serviceProvider, loggerFactory);
+IServiceProvider serviceProvider = services.BuildServiceProvider();
+ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
 
-   var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
-   {
-       var parameters = ParameterView.Empty;
-       var output = 
-           await htmlRenderer.RenderComponentAsync<Component1>(parameters);
-       return output.ToHtmlString();
-   });
+await using var htmlRenderer = new HtmlRenderer(serviceProvider, loggerFactory);
 
-   Console.WriteLine(html);
-   ```
+var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+{
+    var parameters = ParameterView.Empty;
+    var output = await htmlRenderer.RenderComponentAsync<Component1>(parameters);
+    return output.ToHtmlString();
+});
 
-1. Alternatively, you can write the HTML to a <xref:System.IO.TextWriter> by calling `output.WriteHtmlTo(textWriter)`.
+Console.WriteLine(html);
+```
+
+Alternatively, you can write the HTML to a <xref:System.IO.TextWriter> by calling `output.WriteHtmlTo(textWriter)`.
 
 The task returned by `RenderComponentAsync` completes when the component is fully rendered, including completing any asynchronous lifecycle methods. If you want to observe the rendered HTML earlier, call `BeginRenderComponentAsync` instead. Then, wait for the component rendering to complete by awaiting `WaitForQuiescenceAsync` on the returned `HtmlComponent` instance.

--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -1,0 +1,90 @@
+---
+title: Render Razor components outside of ASP.NET Core
+author: guardrex
+description: 
+monikerRange: '>= aspnetcore-8.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 04/14/2023
+uid: blazor/components/render-outside-of-aspnetcore
+---
+# Render Razor components outside of ASP.NET Core
+
+Razor components can be rendered outside of the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for a generated email or static site content.
+
+In the following example, a Razor component is rendered to an HTML string from a console app:
+
+1. In a command shell, create a new console app project:
+
+   ```dotnetcli
+   dotnet new console -o ConsoleApp1
+   cd ConsoleApp1
+   ```
+
+1. In a command shell in the `ConsoleApp1` folder, add package references for <xref:Microsoft.AspNetCore.Components.Web?displayProperty=fullName> and <xref:Microsoft.Extensions.Logging?displayProperty=fullName> to the console app:
+
+   ```dotnetcli
+   dotnet add package Microsoft.AspNetCore.Components.Web --prerelease
+   dotnet add package Microsoft.Extensions.Logging --prerelease
+   ```
+
+1. In the console app's project file (`ConsoleApp1.csproj`), update the console app project to use the Razor SDK:
+
+   ```diff
+   - <Project Sdk="Microsoft.NET.Sdk">
+   + <Project Sdk="Microsoft.NET.Sdk.Razor">
+   ```
+
+1. In a command shell, add a Razor component to the project:
+
+   ```dotnetcli
+   dotnet new razorcomponent -n Component1
+   ```
+
+   ```razor
+   <h1>Component1</h1>
+
+   <p>Hello from Component1!</p>
+
+   @code {
+
+   }
+   ```
+
+1. Update `Program.cs`:
+
+   * Set up dependency injection (<xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>/<xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider%2A>) and logging (<xref:Microsoft.Extensions.DependencyInjection.LoggingServiceCollectionExtensions.AddLogging%2A>/<xref:Microsoft.Extensions.Logging.ILoggerFactory>).
+   * Create an `HtmlRenderer` and render the `Component1` component by calling `RenderComponentAsync`.
+   
+   Any calls to `RenderComponentAsync` must be made in the context of calling `InvokeAsync` on a component dispatcher. A component dispatcher is available from the `HtmlRender.Dispatcher` property.
+
+   ```csharp
+   using Microsoft.AspNetCore.Components;
+   using Microsoft.AspNetCore.Components.Web;
+   using Microsoft.Extensions.DependencyInjection;
+   using Microsoft.Extensions.Logging;
+   using ConsoleApp1;
+
+   IServiceCollection services = new ServiceCollection();
+   services.AddLogging();
+
+   IServiceProvider serviceProvider = services.BuildServiceProvider();
+   ILoggerFactory loggerFactory = 
+       serviceProvider.GetRequiredService<ILoggerFactory>();
+
+   await using var htmlRenderer = new HtmlRenderer(serviceProvider, loggerFactory);
+
+   var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
+   {
+       var parameters = ParameterView.Empty;
+       var output = 
+           await htmlRenderer.RenderComponentAsync<Component1>(parameters);
+       return output.ToHtmlString();
+   });
+
+   Console.WriteLine(html);
+   ```
+
+1. Alternatively, you can write the HTML to a <xref:System.IO.TextWriter> by calling `output.WriteHtmlTo(textWriter)`.
+
+The task returned by `RenderComponentAsync` completes when the component is fully rendered, including completing any asynchronous lifecycle methods. If you want to observe the rendered HTML earlier, call `BeginRenderComponentAsync` instead. Then, wait for the component rendering to complete by awaiting `WaitForQuiescenceAsync` on the returned `HtmlComponent` instance.

--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -5,12 +5,12 @@ description: Render Razor components outside of the context of an HTTP request.
 monikerRange: '>= aspnetcore-8.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/14/2023
+ms.date: 04/20/2023
 uid: blazor/components/render-outside-of-aspnetcore
 ---
 # Render Razor components outside of ASP.NET Core
 
-Razor components can be rendered outside of the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for generating email or static site content.
+Razor components can be rendered outside of the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for generating email content, generating static site content, or for building a content templating engine.
 
 In the following example, a Razor component is rendered to an HTML string from a console app:
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -461,6 +461,8 @@ items:
                 uid: blazor/components/class-libraries
               - name: JavaScript apps and SPA frameworks
                 uid: blazor/components/js-spa-frameworks
+              - name: Components outside of ASP.NET Core
+                uid: blazor/components/render-outside-of-aspnetcore
               - name: Built-in components
                 uid: blazor/components/built-in-components
           - name: Globalization and localization


### PR DESCRIPTION
Fixes #28980

Notes:

* The content doesn't really fit into Blazor-specific docs, so I create an article for it in the *Components* node. I also didn't want to try and tack this on to the *Components* node overview article because that article is already *toooo looong* 😩. I'm actually going to be looking for ways to shorten it further, not make it longer. We can move the content of this new article later easily enough. The nice thing here is to have the content work done (or mostly done).
* Code tested working locally here.
* I have a tracking item in my 8.0 tracking issue to strip out the `--prerelease` options at RTM.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md](https://github.com/dotnet/AspNetCore.Docs/blob/7e92944b73d166387a62910347813a1120e722d9/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md) | [aspnetcore/blazor/components/render-components-outside-of-aspnetcore](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-components-outside-of-aspnetcore?branch=pr-en-us-28981) |


<!-- PREVIEW-TABLE-END -->