### PR TITLE
Blazor WASM SIMD support

### DIFF
--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -527,7 +527,23 @@ The .NET WebAssembly build tools are based on [Emscripten](https://emscripten.or
 * For the **ASP.NET and web development** workload in the Visual Studio installer, select the **.NET WebAssembly build tools** option from the list of optional components.
 * Execute `dotnet workload install wasm-tools` in an administrative command shell.
 
-When [Ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) is used, [WebAssembly Single Instruction, Multiple Data (SIMD)](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) is supported, **except for Apple Safari at this time**. Use the `<WasmEnableSIMD>` property in the app's project file (`.csproj`) with a value of `true`:
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
+
+When [ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) is used, [WebAssembly Single Instruction, Multiple Data (SIMD)](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) is enabled by default for all major browsers. SIMD can improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction.
+
+```xml
+<PropertyGroup>
+  <RunAOTCompilation>true</RunAOTCompilation>
+</PropertyGroup>
+```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
+
+When [ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) is used, [WebAssembly Single Instruction, Multiple Data (SIMD)](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) is supported for all major browsers, except Apple Safari. SIMD can improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction. Use the `<WasmEnableSIMD>` property in the app's project file (`.csproj`) with a value of `true`:
 
 ```xml
 <PropertyGroup>
@@ -535,6 +551,10 @@ When [Ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#a
   <RunAOTCompilation>true</RunAOTCompilation>
 </PropertyGroup>
 ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0"
 
 To enable WebAssembly exception handling, use the `<WasmEnableExceptionHandling>` property in the app's project file (`.csproj`) with a value of `true`:
 

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -543,7 +543,7 @@ When [ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#a
 
 :::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
 
-When [ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) is used, [WebAssembly Single Instruction, Multiple Data (SIMD)](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) is supported for all major browsers, except Apple Safari. SIMD can improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction. Use the `<WasmEnableSIMD>` property in the app's project file (`.csproj`) with a value of `true`:
+When [ahead-of-time (AOT) compilation](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) is used, [WebAssembly Single Instruction, Multiple Data (SIMD)](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) is supported for all major browsers. SIMD can improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction. Use the `<WasmEnableSIMD>` property in the app's project file (`.csproj`) with a value of `true`:
 
 ```xml
 <PropertyGroup>


### PR DESCRIPTION
Fixes #28996

I left the remark about Apple Safari in the 7.0 version of this content. Was 7.0 ever patched to support SIMD for Safari with `<WasmEnableSIMD>` enabled?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tooling.md](https://github.com/dotnet/AspNetCore.Docs/blob/4193ea6793fa539ea51bc556f8b6044c40122e7f/aspnetcore/blazor/tooling.md) | [Tooling for ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tooling?branch=pr-en-us-28997) |


<!-- PREVIEW-TABLE-END -->