### PR TITLE
Model validation non-nullable reference types typo

### DIFF
--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -92,7 +92,7 @@ For an example of the policy to use camel-casing, see [`Program.cs` on GitHub](h
 
 ## Non-nullable reference types and [Required] attribute
 
-The validation system treats non-nullable parameters or bound properties as if they had a `[Required(AllowEmptyStrings = true)]` attribute. By [enabling `Nullable` contexts](/dotnet/csharp/nullable-references#nullable-contexts), MVC implicitly starts validating non-nullable properties or parameters as if they had been attributed with the `[Required(AllowEmptyStrings = true)]` attribute. Consider the following code:
+The validation system treats non-nullable parameters or bound properties as if they had a `[Required(AllowEmptyStrings = true)]` attribute. By [enabling `Nullable` contexts](/dotnet/csharp/nullable-references#nullable-contexts), MVC implicitly starts validating non-nullable properties or parameters as if they had been attributed with the `[Required(AllowEmptyStrings = false)]` attribute. Consider the following code:
 
 ```csharp
 public class Person


### PR DESCRIPTION
If I am reading this correctly, it looks like this is a typo.
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/models/validation.md](https://github.com/dotnet/AspNetCore.Docs/blob/6e590bafe38059545383479c12bc7f603563124b/aspnetcore/mvc/models/validation.md) | [Model validation in ASP.NET Core MVC and Razor Pages](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/models/validation?branch=pr-en-us-29000) |

<!-- PREVIEW-TABLE-END -->