### PR TITLE
Update Duende IdS INCLUDE reference

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -33,7 +33,7 @@ ASP.NET Core Identity isn't related to the [Microsoft identity platform](/azure/
 * An evolution of the Azure Active Directory (Azure AD) developer platform.
 * An alternative identity solution for authentication and authorization in ASP.NET Core apps.
 
-[!INCLUDE[](~/includes/IdentityServer4.md)]
+[!INCLUDE[](~/includes/DuendeIdentityServer.md)]
 
 [View or download the sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/security/authentication/identity/sample) ([how to download](xref:index#how-to-download-a-sample)).
 


### PR DESCRIPTION
Fixes #23048

I was globally addressing some issue labels and turned up this old-ish issue that needed a final push over the finish line. The change is just to use the new Duende IdS INCLUDE over the prior IdS 4 INCLUDE (which we keep b/c it's used in pre-6.0 content versions). This is the only spot to update AFAICT. The newer one just has the added bit about the possible license fee that they instituted at that time ...

https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/includes/DuendeIdentityServer.md

I won't have further updates to this ... it can be merged immediately after approval.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/identity.md](https://github.com/dotnet/AspNetCore.Docs/blob/f70b8e94f6b269bca44fa54a2947d2f71aed9372/aspnetcore/security/authentication/identity.md) | [[.NET Core CLI](#tab/netcore-cli)](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/identity?branch=pr-en-us-29005) |

<!-- PREVIEW-TABLE-END -->