### PR TITLE
Move Servers to a top-level TOC section

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -250,8 +250,6 @@ items:
             uid: fundamentals/host/generic-host
           - name: Web Host
             uid: fundamentals/host/web-host
-      - name: Servers
-        uid: fundamentals/servers/index
       - name: Configuration
         uid: fundamentals/configuration/index
       - name: Options
@@ -1127,6 +1125,90 @@ items:
             href: /azure/visual-studio/vs-storage-aspnet5-getting-started-queues?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
           - name: Table storage
             href: /azure/visual-studio/vs-storage-aspnet5-getting-started-tables?toc=/aspnet/core/toc.json&bc=/aspnet/core/breadcrumb/toc.json
+  - name: Servers
+    items:
+      - name: Overview
+        displayName: kestrel, iis, http.sys, httpsys, servers
+        uid: fundamentals/servers/index
+      - name: Kestrel
+        items:
+          - name: Overview
+            displayName: deploy, publish, server, kestrel
+            uid: fundamentals/servers/kestrel
+          - name: Endpoints
+            displayName: deploy, publish, server, Kestrel
+            uid: fundamentals/servers/kestrel/endpoints
+          - name: Options
+            displayName: deploy, publish, server, Kestrel
+            uid: fundamentals/servers/kestrel/options
+          - name: Diagnostics
+            displayName: diagnostics
+            uid: fundamentals/servers/kestrel/diagnostics
+          - name: HTTP/2
+            displayName: deploy, publish, server, Kestrel
+            uid: fundamentals/servers/kestrel/http2
+          - name: HTTP/3
+            displayName: HTTP/3, kestrel
+            uid: fundamentals/servers/kestrel/http3
+          - name: When to use a reverse proxy
+            displayName: deploy, publish, server, Kestrel
+            uid: fundamentals/servers/kestrel/when-to-use-a-reverse-proxy
+          - name: Host filtering
+            displayName: deploy, publish, server, Kestrel
+            uid: fundamentals/servers/kestrel/host-filtering
+          - name: Request draining
+            displayName: deploy, publish, server, Kestrel
+            uid: fundamentals/servers/kestrel/request-draining
+      - name: IIS
+        items:
+          - name: Overview
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/index
+          - name: ASP.NET Core Module
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/aspnet-core-module
+          - name: In-process hosting
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/in-process-hosting
+          - name: Out-of-process hosting
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/out-of-process-hosting
+          - name: Hosting Bundle
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/hosting-bundle
+          - name: web.config file
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/web-config
+          - name: IIS support in Visual Studio
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/development-time-iis-support
+          - name: IIS Modules
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/modules
+          - name: Logging and diagnostics
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/logging-and-diagnostics
+          - name: Troubleshoot
+            displayName: deploy, publish, server, iis
+            uid: test/troubleshoot-azure-iis
+          - name: Errors reference
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/azure-iis-errors-reference
+          - name: Advanced configuration
+            displayName: deploy, publish, server, iis, ancm, aspnetcoremodule
+            uid: host-and-deploy/iis/advanced
+          - name: Transform web.config
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/transform-webconfig
+          - name: HTTP/2
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/protocols
+          - name: HTTP/3
+            displayName: deploy, publish, server, iis
+            uid: host-and-deploy/iis/http3
+      - name: HTTP.sys
+        displayName: deploy, publish, server, httpsys
+        uid: fundamentals/servers/httpsys
   - name: Host and deploy
     displayName: publish
     items:
@@ -1180,89 +1262,9 @@ items:
           - name: Next steps
             displayName: azure, deploy, publish
             href: /dotnet/architecture/devops-for-aspnet-developers/next-steps
-      - name: Kestrel
-        displayName: deploy, publish, server, Kestrel
-        items:
-          - name: Overview
-            displayName: deploy, publish, server
-            uid: fundamentals/servers/kestrel
-          - name: Endpoints
-            displayName: deploy, publish, server, Kestrel
-            uid: fundamentals/servers/kestrel/endpoints
-          - name: Options
-            displayName: deploy, publish, server, Kestrel
-            uid: fundamentals/servers/kestrel/options
-          - name: Diagnostics
-            displayName: diagnostics
-            uid: fundamentals/servers/kestrel/diagnostics
-          - name: HTTP/2
-            displayName: deploy, publish, server, Kestrel
-            uid: fundamentals/servers/kestrel/http2
-          - name: HTTP/3
-            displayName: HTTP/3, kestrel
-            uid: fundamentals/servers/kestrel/http3
-          - name: When to use a reverse proxy
-            displayName: deploy, publish, server, Kestrel
-            uid: fundamentals/servers/kestrel/when-to-use-a-reverse-proxy
-          - name: Host filtering
-            displayName: deploy, publish, server, Kestrel
-            uid: fundamentals/servers/kestrel/host-filtering
-          - name: Request draining
-            displayName: deploy, publish, server, Kestrel
-            uid: fundamentals/servers/kestrel/request-draining
-      - name: IIS
-        displayName: deploy, publish
-        items:
-          - name: Overview
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/index
-          - name: Publish to IIS tutorial
-            uid: tutorials/publish-to-iis
-          - name: ASP.NET Core Module
-            displayName: deploy, publish
-            uid: host-and-deploy/aspnet-core-module
-          - name: In-process hosting
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/in-process-hosting
-          - name: Out-of-process hosting
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/out-of-process-hosting
-          - name: Hosting Bundle
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/hosting-bundle
-          - name: web.config file
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/web-config
-          - name: IIS support in Visual Studio
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/development-time-iis-support
-          - name: IIS Modules
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/modules
-          - name: Logging and diagnostics
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/logging-and-diagnostics
-          - name: Troubleshoot
-            displayName: deploy, publish
-            uid: test/troubleshoot-azure-iis
-          - name: Errors reference
-            displayName: deploy, publish
-            uid: host-and-deploy/azure-iis-errors-reference
-          - name: Advanced
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/advanced
-          - name: Transform web.config
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/transform-webconfig
-          - name: HTTP/2
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/protocols
-          - name: HTTP/3
-            displayName: deploy, publish
-            uid: host-and-deploy/iis/http3
-      - name: HTTP.sys
-        displayName: deploy, publish, server
-        uid: fundamentals/servers/httpsys
+      - name: Publish to IIS tutorial
+        displayName: deploy
+        uid: tutorials/publish-to-iis
       - name: Windows service
         displayName: deploy, publish
         uid: host-and-deploy/windows-service


### PR DESCRIPTION
Fixes #28988 

>No page summarizes the different servers. We can add an `Overview` page if there is a dedicated `Servers` section. 

We have an overview of the servers in `Fundamentals` - I moved that to the `Overview` node of the new top-level `Servers` section. This overview article already [compares Kestrel to HTTP.sys](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/?view=aspnetcore-8.0&branch=pr-en-us-29008&tabs=windows#kestrel-vs-httpsys), and we can add comparison section(s) to address #28948.

[Internal review URL](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/?view=aspnetcore-8.0&branch=pr-en-us-29008&tabs=windows)