### PR TITLE
Fix Remote App Setup method name and HttpModule

### DIFF
--- a/aspnetcore/migration/inc/remote-app-setup.md
+++ b/aspnetcore/migration/inc/remote-app-setup.md
@@ -24,7 +24,7 @@ To enable the ASP.NET Core app to communicate with the ASP.NET app, it's necessa
 
 To set up the ASP.NET app to be able to receive requests from the ASP.NET Core app:
 1. Install the nuget package [`Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices`](https://www.nuget.org/packages/Microsoft.AspNetCore.SystemWebAdapters)
-2. Call the `AddRemoteApp` extension method on the `ISystemWebAdapterBuilder`:
+2. Call the `AddRemoteAppServer` extension method on the `ISystemWebAdapterBuilder`:
 
 ```CSharp
 SystemWebAdapterConfiguration.AddSystemWebAdapters(this)
@@ -35,7 +35,17 @@ SystemWebAdapterConfiguration.AddSystemWebAdapters(this)
     });
 ```
 
-In the options configuration method passed to the `AddRemoteApp` call, you must specify an API key which is used to secure the endpoint so that only trusted callers can make requests to it (this same API key will be provided to the ASP.NET Core app when it is configured). The API key is a string and must be parsable as a GUID (128-bit hex number). Hyphens in the key are optional.
+In the options configuration method passed to the `AddRemoteAppServer` call, you must specify an API key which is used to secure the endpoint so that only trusted callers can make requests to it (this same API key will be provided to the ASP.NET Core app when it is configured). The API key is a string and must be parsable as a GUID (128-bit hex number). Hyphens in the key are optional.
+
+3. Add the `SystemWebAdapterModule` HttpModule to your web.config if it wasn't already added by the [.Net Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant):
+
+```
+  <system.webServer>
+    <modules>
+      <remove name="SystemWebAdapterModule" />
+      <add name="SystemWebAdapterModule" type="Microsoft.AspNetCore.SystemWebAdapters.SystemWebAdapterModule, Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices" preCondition="managedHandler" />
+      
+```
 
 ### ASP.NET Core app
 

--- a/aspnetcore/migration/inc/remote-app-setup.md
+++ b/aspnetcore/migration/inc/remote-app-setup.md
@@ -35,9 +35,13 @@ SystemWebAdapterConfiguration.AddSystemWebAdapters(this)
     });
 ```
 
-In the options configuration method passed to the `AddRemoteAppServer` call, you must specify an API key which is used to secure the endpoint so that only trusted callers can make requests to it (this same API key will be provided to the ASP.NET Core app when it is configured). The API key is a string and must be parsable as a GUID (128-bit hex number). Hyphens in the key are optional.
+In the options configuration method passed to the `AddRemoteAppServer` call, an API key must be specified. The API key is:
 
-3. [Optional] Add the `SystemWebAdapterModule` module to your web.config if it wasn't already added by NuGet (such as using SDK style projects for ASP.NET Core).
+* Used to secure the endpoint so that only trusted callers can make requests to it.
+* The same API key provided to the ASP.NET Core app when it is configured.
+* A string and must be parsable as a [GUID](/dotnet/api/system.guid). Hyphens in the key are optional.
+
+3. **Optional :** Add the `SystemWebAdapterModule` module to to the `web.config` if it wasn't already added by NuGet. The `SystemWebAdapterModule` module added automatically when using SDK style projects for ASP.NET Core.
 
 ```diff
   <system.webServer>

--- a/aspnetcore/migration/inc/remote-app-setup.md
+++ b/aspnetcore/migration/inc/remote-app-setup.md
@@ -41,7 +41,7 @@ In the options configuration method passed to the `AddRemoteAppServer` call, an 
 * The same API key provided to the ASP.NET Core app when it is configured.
 * A string and must be parsable as a [GUID](/dotnet/api/system.guid). Hyphens in the key are optional.
 
-3. **Optional :** Add the `SystemWebAdapterModule` module to to the `web.config` if it wasn't already added by NuGet. The `SystemWebAdapterModule` module added automatically when using SDK style projects for ASP.NET Core.
+3. **Optional :** Add the `SystemWebAdapterModule` module to to the `web.config` if it wasn't already added by NuGet. The `SystemWebAdapterModule` module is not added automatically when using SDK style projects for ASP.NET Core.
 
 ```diff
   <system.webServer>

--- a/aspnetcore/migration/inc/remote-app-setup.md
+++ b/aspnetcore/migration/inc/remote-app-setup.md
@@ -37,15 +37,15 @@ SystemWebAdapterConfiguration.AddSystemWebAdapters(this)
 
 In the options configuration method passed to the `AddRemoteAppServer` call, you must specify an API key which is used to secure the endpoint so that only trusted callers can make requests to it (this same API key will be provided to the ASP.NET Core app when it is configured). The API key is a string and must be parsable as a GUID (128-bit hex number). Hyphens in the key are optional.
 
-3. Add the `SystemWebAdapterModule` HttpModule to your web.config if it wasn't already added by the [.Net Upgrade Assistant](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.upgradeassistant):
+3. [Optional] Add the `SystemWebAdapterModule` module to your web.config if it wasn't already added by NuGet (such as using SDK style projects for ASP.NET Core).
 
-```
+```diff
   <system.webServer>
     <modules>
-      <remove name="SystemWebAdapterModule" />
-      <add name="SystemWebAdapterModule" type="Microsoft.AspNetCore.SystemWebAdapters.SystemWebAdapterModule, Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices" preCondition="managedHandler" />
-      
-```
++      <remove name="SystemWebAdapterModule" />
++      <add name="SystemWebAdapterModule" type="Microsoft.AspNetCore.SystemWebAdapters.SystemWebAdapterModule, Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices" preCondition="managedHandler" />
+    </modules>
+</system.webServer>
 
 ### ASP.NET Core app
 

--- a/aspnetcore/migration/inc/remote-app-setup.md
+++ b/aspnetcore/migration/inc/remote-app-setup.md
@@ -50,6 +50,7 @@ In the options configuration method passed to the `AddRemoteAppServer` call, an 
 +      <add name="SystemWebAdapterModule" type="Microsoft.AspNetCore.SystemWebAdapters.SystemWebAdapterModule, Microsoft.AspNetCore.SystemWebAdapters.FrameworkServices" preCondition="managedHandler" />
     </modules>
 </system.webServer>
+```
 
 ### ASP.NET Core app
 


### PR DESCRIPTION
It seems that the .Net Upgrade Assistant no longer automatically adds the HttpModule. Regardless, this article doesn't seem to assume the use of that tool, so it should describe all the required pieces.

***@Rick-Anderson edit: Fixes #29151***

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/inc/remote-app-setup.md](https://github.com/dotnet/AspNetCore.Docs/blob/e1973edb8d5691cc9561f7d9306d00fc65180f41/aspnetcore/migration/inc/remote-app-setup.md) | [Remote app setup](https://review.learn.microsoft.com/en-us/aspnet/core/migration/inc/remote-app-setup?branch=pr-en-us-29020) |


<!-- PREVIEW-TABLE-END -->