### PR TITLE
Clarify ANCM .NET version support

### DIFF
--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -25,7 +25,7 @@ For more information and configuration guidance, see the following topics:
 
 ## Install ASP.NET Core Module (ANCM)
 
-The ASP.NET Core Module (ANCM) is installed with the .NET Core Runtime from the [.NET Core Hosting Bundle](xref:host-and-deploy/iis/hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
+The ASP.NET Core Module (ANCM) is installed with the .NET Core Runtime from the [.NET Core Hosting Bundle](xref:host-and-deploy/iis/hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 
@@ -141,7 +141,7 @@ The ASP.NET Core Module can also:
 
 ## How to install and use the ASP.NET Core Module (ANCM)
 
-For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
+For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 
@@ -558,7 +558,7 @@ The ASP.NET Core Module can also:
 
 ## How to install and use the ASP.NET Core Module (ANCM)
 
-For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
+For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 

--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -25,7 +25,7 @@ For more information and configuration guidance, see the following topics:
 
 ## Install ASP.NET Core Module (ANCM)
 
-The ASP.NET Core Module (ANCM) is installed with the .NET Core Runtime from the [.NET Core Hosting Bundle](xref:host-and-deploy/iis/hosting-bundle). The ASP.NET Core Module is forward and backward compatible with LTS releases of .NET.
+The ASP.NET Core Module (ANCM) is installed with the .NET Core Runtime from the [.NET Core Hosting Bundle](xref:host-and-deploy/iis/hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 
@@ -141,7 +141,7 @@ The ASP.NET Core Module can also:
 
 ## How to install and use the ASP.NET Core Module (ANCM)
 
-For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with LTS releases of .NET.
+For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 
@@ -558,7 +558,7 @@ The ASP.NET Core Module can also:
 
 ## How to install and use the ASP.NET Core Module (ANCM)
 
-For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with LTS releases of .NET.
+For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 

--- a/aspnetcore/host-and-deploy/aspnet-core-module.md
+++ b/aspnetcore/host-and-deploy/aspnet-core-module.md
@@ -25,7 +25,7 @@ For more information and configuration guidance, see the following topics:
 
 ## Install ASP.NET Core Module (ANCM)
 
-The ASP.NET Core Module (ANCM) is installed with the .NET Core Runtime from the [.NET Core Hosting Bundle](xref:host-and-deploy/iis/hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle).
+The ASP.NET Core Module (ANCM) is installed with the .NET Core Runtime from the [.NET Core Hosting Bundle](xref:host-and-deploy/iis/hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 
@@ -141,7 +141,7 @@ The ASP.NET Core Module can also:
 
 ## How to install and use the ASP.NET Core Module (ANCM)
 
-For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle).
+For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 
@@ -558,7 +558,7 @@ The ASP.NET Core Module can also:
 
 ## How to install and use the ASP.NET Core Module (ANCM)
 
-For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle).
+For instructions on how to install the ASP.NET Core Module, see [Install the .NET Core Hosting Bundle](xref:host-and-deploy/iis/index#install-the-net-core-hosting-bundle). The ASP.NET Core Module is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
 
 [!INCLUDE[](~/includes/announcements.md)]
 

--- a/aspnetcore/host-and-deploy/iis/hosting-bundle.md
+++ b/aspnetcore/host-and-deploy/iis/hosting-bundle.md
@@ -45,6 +45,8 @@ To obtain an earlier version of the installer:
 
 > [!WARNING]
 > Some installers contain release versions that have reached their end of life (EOL) and are no longer supported by Microsoft. For more information, see the [support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
+>
+> The [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module) is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
 
 ## Options
 

--- a/aspnetcore/host-and-deploy/iis/hosting-bundle.md
+++ b/aspnetcore/host-and-deploy/iis/hosting-bundle.md
@@ -46,7 +46,7 @@ To obtain an earlier version of the installer:
 > [!WARNING]
 > Some installers contain release versions that have reached their end of life (EOL) and are no longer supported by Microsoft. For more information, see the [support policy](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).
 >
-> The [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module) is forward and backward compatible with [in-support LTS releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
+> The [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module) is forward and backward compatible with [in-support releases of .NET](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle).
 
 ## Options
 


### PR DESCRIPTION
Fixes #29019

Thanks @jovton! 🚀 

The main update is to the ANCM doc, but I also added the remark to the WARNING note in the hosting models doc. I suppose it can be a warning given that if either or both the ANCM and framework apps are mixed and matched ***out of LTS support***, there could be some 🐉🐉🐉 lurking in production 😨.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/aspnet-core-module.md](https://github.com/dotnet/AspNetCore.Docs/blob/02f2d08bf46b74ed4f80fe34d0c1a31abc738765/aspnetcore/host-and-deploy/aspnet-core-module.md) | [ASP.NET Core Module (ANCM) for IIS](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/aspnet-core-module?branch=pr-en-us-29021) |
| [aspnetcore/host-and-deploy/iis/hosting-bundle.md](https://github.com/dotnet/AspNetCore.Docs/blob/02f2d08bf46b74ed4f80fe34d0c1a31abc738765/aspnetcore/host-and-deploy/iis/hosting-bundle.md) | [The .NET Core Hosting Bundle](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/hosting-bundle?branch=pr-en-us-29021) |


<!-- PREVIEW-TABLE-END -->