### PR TITLE
Fix confusing statement

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -343,7 +343,7 @@ For chromium browsers on Linux:
 
   The path in the preceding command is specific for Ubuntu. For other distributions, select an appropriate path or use the path for the Certificate Authorities (CAs).
 
-* Create a JSON file at `/usr/lib/firefox/distribution/policies.json` with the following contents:
+* Create a JSON file at `/usr/lib/firefox/distribution/policies.json` with the following command:
 
 ```sh
 cat <<EOF | sudo tee /usr/lib/firefox/distribution/policies.json


### PR DESCRIPTION
The text made it appear as one should put the bash script into the policies.json file

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/enforcing-ssl.md](https://github.com/dotnet/AspNetCore.Docs/blob/f7ddc2a9725a7b573343c0ef888f8d5852d538ee/aspnetcore/security/enforcing-ssl.md) | [[.NET Core CLI](#tab/netcore-cli) ](https://review.learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?branch=pr-en-us-29037) |

<!-- PREVIEW-TABLE-END -->