### PR TITLE
Non-routable components query param processing

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -573,10 +573,12 @@ For more information on obtaining the state associated with the target history e
 
 :::moniker range=">= aspnetcore-6.0"
 
-Use the [`[SupplyParameterFromQuery]` attribute](xref:Microsoft.AspNetCore.Components.SupplyParameterFromQueryAttribute) with the [`[Parameter]` attribute](xref:Microsoft.AspNetCore.Components.ParameterAttribute) to specify that a component parameter of a routable component can come from the query string.
+Use the [`[SupplyParameterFromQuery]` attribute](xref:Microsoft.AspNetCore.Components.SupplyParameterFromQueryAttribute) with the [`[Parameter]` attribute](xref:Microsoft.AspNetCore.Components.ParameterAttribute) to specify that a component parameter of a *routable* component can come from the query string.
 
 > [!NOTE]
 > Component parameters can only receive query parameter values in routable components with an [`@page`](xref:mvc/views/razor#page) directive.
+>
+> Only routable components directly receive query parameters in order to avoid subverting top-down information flow and to make parameter processing order clear, both by the framework and by the app. This design avoids subtle bugs in app code that's written assuming specific parameter processing order. You're free to define custom cascading parameters or directly assign to regular component parameters in order to pass query parameter values to non-routable components.
 
 Component parameters supplied from the query string support the following types:
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -578,7 +578,7 @@ Use the [`[SupplyParameterFromQuery]` attribute](xref:Microsoft.AspNetCore.Compo
 > [!NOTE]
 > Component parameters can only receive query parameter values in routable components with an [`@page`](xref:mvc/views/razor#page) directive.
 >
-> Only routable components directly receive query parameters in order to avoid subverting top-down information flow and to make parameter processing order clear, both by the framework and by the app. This design avoids subtle bugs in app code that's written assuming specific parameter processing order. You're free to define custom cascading parameters or directly assign to regular component parameters in order to pass query parameter values to non-routable components.
+> Only routable components directly receive query parameters in order to avoid subverting top-down information flow and to make parameter processing order clear, both by the framework and by the app. This design avoids subtle bugs in app code that was written assuming a specific parameter processing order. You're free to define custom cascading parameters or directly assign to regular component parameters in order to pass query parameter values to non-routable components.
 
 Component parameters supplied from the query string support the following types:
 


### PR DESCRIPTION
Fixes #29027

Thanks @OnSive! 🚀 ... I'll leave this up for a couple of hours for you to take a look. I digest what Steve said down to just enough basic info that I think readers will get it without getting into the weeds. The important final point is that devs can define their own cascading or regular params as needed, so I close the added paragraph on that point. If I do go ahead and merge this before you see it, you can leave feedback here if you feel I left something important out or wrote something confusing in the paragraph. If changes are needed, I'll patch this paragraph on a new PR.

Also, I'll note that *sometimes* we cross-link the PU repo issue/PR remarks. I don't think that we need to do that in this case. I think the simplified remark on this docs PR for the reasoning is *probably* good enough, and I'm concerned about bikeshedding on the PU's issue, where devs may write and ping incessantly about it. I'm sure the PU will hear further feedback on this subject without the article virtually daring devs to add more discourse on it to that issue. It's better to cross-link in situations where it would take a lot of doc space to explain out a complex subject discussed over several comments (a discussion) in a PU issue and where it's unlikely that devs will leave lots of comments and feedback over there.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0f09a766e3f088a0ec6f2f7448db0d391452ec2/aspnetcore/blazor/fundamentals/routing.md) | [ASP.NET Core Blazor routing and navigation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?branch=pr-en-us-29039) |


<!-- PREVIEW-TABLE-END -->