### PR TITLE
Repair bad root component param guidance

### DIFF
--- a/aspnetcore/blazor/hybrid/root-component-parameters.md
+++ b/aspnetcore/blazor/hybrid/root-component-parameters.md
@@ -23,7 +23,7 @@ The `RootComponent` class of a `BlazorWebView` defines a `Parameters` property o
 The following example passes a view model to the root component, which further passes the view model as a cascading type to a Razor component in the Blazor portion of the app. The example is based on the keypad example in the .NET MAUI documentation:
 
 * [Data binding and MVVM: Commanding (.NET MAUI documentation)](/dotnet/maui/xaml/fundamentals/mvvm#commanding): Explains data binding with MVVM using a keypad example.
-* [.NET MAUI Samples](https://github.com/dotnet/maui-samples): Provides sample code for `KeypadViewModel.cs`, which is required for this article's example. Implement the `Views/KeypadPage.xaml`/`Views/KeypadPage.xaml.cs` in the app if you wish to see the view model used in a content page.
+* [.NET MAUI XAML Samples](https://github.com/dotnet/maui-samples/): Provides sample code for `KeypadViewModel.cs`, which is required for this article's example.
 
 Although the keypad example focuses on implementing the MVVM pattern in .NET MAUI Blazor Hybrid apps:
 
@@ -32,7 +32,7 @@ Although the keypad example focuses on implementing the MVVM pattern in .NET MAU
 
 Place the view model into the .NET MAUI Blazor Hybrid app. The view model is available from the .NET MAUI sample app:
 
-[`KeypadViewModel.cs` (`dotnet/maui-samples` GitHub repository)](https://github.com/dotnet/maui-samples/blob/main/6.0/XAML/Fundamentals/XamlSamples/ViewModels/KeypadViewModel.cs)
+[`KeypadViewModel.cs` (`dotnet/maui-samples` GitHub repository)](https://github.com/dotnet/maui-samples/): Locate the `KeypadViewModel.cs` file at the following path in the sample app: `XAML/XamlSamples/XamlSamples/ViewModels/`.
 
 Change the namespace of `KeypadViewModel.cs` file to match the app's root namespace. In the following example, the app's root namespace is `MauiBlazor`:
 

--- a/aspnetcore/blazor/hybrid/root-component-parameters.md
+++ b/aspnetcore/blazor/hybrid/root-component-parameters.md
@@ -5,7 +5,7 @@ description: Learn how to pass an optional dictionary of parameters to the root 
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
 ms.custom: "mvc"
-ms.date: 01/31/2023
+ms.date: 04/20/2023
 uid: blazor/hybrid/root-component-parameters
 ---
 # Pass root component parameters in ASP.NET Core Blazor Hybrid
@@ -68,34 +68,29 @@ public MainPage()
 }
 ```
 
-In the `Main` component (`Main.razor`), add a parameter matching the type of the object passed to the root component:
-
-```razor
-@code {
-    [Parameter]
-    public KeypadViewModel KeypadViewModel { get; set; }
-}
-```
-
 The following example [cascades](xref:blazor/components/cascading-values-and-parameters) the object (`KeypadViewModel`) down component hierarchies in the Blazor portion of the app as a [`CascadingValue`](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component).
 
-In the `MainLayout` component (`MainLayout.razor`), add an `@code` block with a field for the type, which is `KeypadViewModel` in this example:
+In the `Main` component (`Main.razor`):
 
-```razor
-@code {
-    private KeypadViewModel keypadViewModel = new();
-}
-```
+* Add a parameter matching the type of the object passed to the root component:
 
-Wrap the `<article>` element of `MainLayout` with a [`CascadingValue` component](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component) for the view model:
+  ```razor
+  @code {
+      [Parameter]
+      public KeypadViewModel KeypadViewModel { get; set; }
+  }
+  ```
 
-```razor
-<CascadingValue Value="@keypadViewModel">
-    <article class="content px-4">
-        @Body
-    </article>
-</CascadingValue>
-```
+* Cascade the `KeypadViewModel` with the [`CascadingValue` component](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component). Update the `<Found>` XAML content to the following markup:
+
+  ```xaml
+  <Found Context="routeData">
+      <CascadingValue Value="@KeypadViewModel">
+          <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+          <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
+      </CascadingValue>
+  </Found>
+  ```
 
 At this point, the cascaded type is available to Razor components throughout the app as a [`CascadingParameter`](xref:Microsoft.AspNetCore.Components.CascadingParameterAttribute).
 


### PR DESCRIPTION
Fixes #29009

Thanks @UnusualJustin! 🚀 

Let's look at this carefully because it's (obviously) a bit tricky. I think my app turned out a bit different than your suggestion, @UnusualJustin, in that you suggested a change in `MainLayout.razor` that I don't need to cascade this param. In a nutshell on the PR, the new guidance is ***only to*** ...

In the `Main` component (`Main.razor`):

* Add a parameter matching the type of the object passed to the root component:

  ```razor
  @code {
      [Parameter]
      public KeypadViewModel KeypadViewModel { get; set; }
  }
  ```

* Cascade the `KeypadViewModel` with the [`CascadingValue` component](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component). Update the `<Found>` XAML content to the following markup:

  ```xaml
  <Found Context="routeData">
      <CascadingValue Value="@KeypadViewModel">
          <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
          <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
      </CascadingValue>
  </Found>
  ```

... and ***that's it.*** There's no need to do anything with the `MainLayout` component (unless one wanted to use the cascaded value there, which we don't in this example).

*Yes! Indeed!* Please check the updated guidance on the PR carefully. I do find this a bit tricky, partially because I'm just not used to Hybrid apps yet ... *being a silly web dev!* 🤣 I'm learning tho! 👍 

***OH!*** ... and there will be another commit here in a sec. I think I want to update the sample link at the top of the article to make sure that devs find the model.

**UPDATE**: I changed my mind about cross-linking. The MAUI sample app doesn't have the file (or example) in the 7.0 version. I've placed the view model into this topic. It will be safe and stable to go this way with it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/root-component-parameters.md](https://github.com/dotnet/AspNetCore.Docs/blob/b20f34f659434075134b2ff8cf18daf06d57e0db/aspnetcore/blazor/hybrid/root-component-parameters.md) | [Pass root component parameters in ASP.NET Core Blazor Hybrid](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/root-component-parameters?branch=pr-en-us-29041) |


<!-- PREVIEW-TABLE-END -->