### PR TITLE
RequestHeader set "X-Forwarded-Proto"

### DIFF
--- a/aspnetcore/host-and-deploy/linux-apache.md
+++ b/aspnetcore/host-and-deploy/linux-apache.md
@@ -147,7 +147,7 @@ Create a configuration file, named *helloapp.conf*, for the app:
 
 ```
 <VirtualHost *:*>
-    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
+    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}s
 </VirtualHost>
 
 <VirtualHost *:80>
@@ -196,6 +196,8 @@ Restart Apache:
 sudo systemctl restart httpd
 sudo systemctl enable httpd
 ```
+
+For more information on header directive values, see [Apache Module mod_headers](https://httpd.apache.org/docs/2.4/mod/mod_headers.html).
 
 ## Monitor the app
 


### PR DESCRIPTION
Fixes #29079

See [Config Apache](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/linux-apache?branch=pr-en-us-29081&view=aspnetcore-7.0#configure-apache)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/linux-apache.md](https://github.com/dotnet/AspNetCore.Docs/blob/61c9058f6ad028c440b52f0167b94e778f09fe91/aspnetcore/host-and-deploy/linux-apache.md) | [The default value is 90 seconds for most distributions.](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/linux-apache?branch=pr-en-us-29081) |

<!-- PREVIEW-TABLE-END -->