### PR TITLE
gPRC Troublehsooting Update version 6-7 HTTP/3 support statement and fix include

### DIFF
--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -5,7 +5,7 @@ description: Troubleshoot errors when using gRPC on .NET Core.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: jamesnk
 ms.custom: mvc
-ms.date: 04/04/2023
+ms.date: 04/26/2023
 uid: grpc/troubleshoot
 ---
 
@@ -269,5 +269,5 @@ Alternatively, a client factory can be configured with `Http3Handler` by using <
 
 :::moniker-end
 
-[!INCLUDE[](~/grpc/includes/troubleshoot3-7.md)]
+[!INCLUDE[](~/grpc/troubleshoot/includes/troubleshoot3-7.md)]
 

--- a/aspnetcore/grpc/troubleshoot/includes/troubleshoot3-7.md
+++ b/aspnetcore/grpc/troubleshoot/includes/troubleshoot3-7.md
@@ -215,7 +215,7 @@ Alternatively, a client factory can be configured with `SubdirectoryHandler` by 
 
 The .NET gRPC client supports HTTP/3 with .NET 6 or later. If the server sends an `alt-svc` response header to the client that indicates the server supports HTTP/3, the client will automatically upgrade its connection to HTTP/3. For information about how to enable HTTP/3 on the server, see <xref:fundamentals/servers/kestrel/http3>.
 
-HTTP/3 support is in preview in .NET 6, and needs to be enabled via a configuration flag in the project file:
+HTTP/3 support in .NET 8 is enabled by default. HTTP/3 support in .NET 6 and .NET 7 needs to be enabled via a configuration flag in the project file:
 
 ```xml
 <ItemGroup>


### PR DESCRIPTION
Fixes #28597
Fixes #2867 with one added detail but mostly addressed through pr #28876

Minor updates.
- Update version 6-7 to remove reference to "preview" reference and clarify HTTP/3 needs to be enabled for .NET 6 & 7 while it is enabled by default for .NET 8.
- - Moved include for version 3-7 to its own troubleshooting folder and updated reference in version 8.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/troubleshoot.md](https://github.com/dotnet/AspNetCore.Docs/blob/9366c9617e36449434031a0944ff25aa4fe166b7/aspnetcore/grpc/troubleshoot.md) | [Troubleshoot gRPC on .NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?branch=pr-en-us-29095) |

<!-- PREVIEW-TABLE-END -->