### PR TITLE
Blazor built-in components article versioning

### DIFF
--- a/aspnetcore/blazor/components/built-in-components.md
+++ b/aspnetcore/blazor/components/built-in-components.md
@@ -12,11 +12,43 @@ uid: blazor/components/built-in-components
 
 [!INCLUDE[](~/includes/not-latest-version.md)]
 
-This article lists the Razor components that are provided by the Blazor framework.
-
-:::moniker range=">= aspnetcore-7.0"
-
 The following built-in Razor components are provided by the Blazor framework:
+
+:::moniker range=">= aspnetcore-8.0"
+
+* [`App`](xref:blazor/project-structure)
+* [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)
+* [`AuthorizeView`](xref:blazor/security/index#authorizeview-component)
+* [`CascadingValue`](xref:blazor/components/cascading-values-and-parameters#cascadingvalue-component)
+* [`DynamicComponent`](xref:blazor/components/dynamiccomponent)
+* [`ErrorBoundary`](xref:blazor/fundamentals/handle-errors#error-boundaries)
+* [`FocusOnNavigate`](xref:blazor/fundamentals/routing#focus-an-element-on-navigation)
+* [`HeadContent`](xref:blazor/components/control-head-content)
+* [`HeadOutlet`](xref:blazor/components/control-head-content)
+* [`InputCheckbox`](xref:blazor/forms-and-input-components#built-in-input-components)
+* [`InputDate`](xref:blazor/forms-and-input-components#built-in-input-components)
+* [`InputFile`](xref:blazor/file-uploads)
+* [`InputNumber`](xref:blazor/forms-and-input-components#built-in-input-components)
+* [`InputRadio`](xref:blazor/forms-and-input-components#built-in-input-components)
+* [`InputRadioGroup`](xref:blazor/forms-and-input-components#built-in-input-components)
+* [`InputSelect`](xref:blazor/forms-and-input-components#built-in-input-components)
+* [`InputText`](xref:blazor/forms-and-input-components#built-in-input-components)
+* [`InputTextArea`](xref:blazor/forms-and-input-components#built-in-input-components)
+* [`LayoutView`](xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component)
+* [`MainLayout`](xref:blazor/components/layouts#mainlayout-component)
+* [`NavLink`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
+* [`NavMenu`](xref:blazor/fundamentals/routing#navlink-and-navmenu-components)
+* [`PageTitle`](xref:blazor/components/control-head-content)
+* [`QuickGrid`](xref:blazor/components/quickgrid)
+* [`Router`](xref:blazor/fundamentals/routing#route-templates)
+* [`RouteView`](xref:blazor/fundamentals/routing#route-templates)
+* [`SectionContent`](xref:blazor/components/sections)
+* [`SectionOutlet`](xref:blazor/components/sections)
+* [`Virtualize`](xref:blazor/components/virtualization)
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0>"
 
 * [`App`](xref:blazor/project-structure)
 * [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)
@@ -50,8 +82,6 @@ The following built-in Razor components are provided by the Blazor framework:
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
 
-The following built-in Razor components are provided by the Blazor framework:
-
 * [`App`](xref:blazor/project-structure)
 * [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)
 * [`AuthorizeView`](xref:blazor/security/index#authorizeview-component)
@@ -83,8 +113,6 @@ The following built-in Razor components are provided by the Blazor framework:
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-The following built-in Razor components are provided by ASP.NET Core:
-
 * [`App`](xref:blazor/project-structure)
 * [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)
 * [`AuthorizeView`](xref:blazor/security/index#authorizeview-component)
@@ -109,8 +137,6 @@ The following built-in Razor components are provided by ASP.NET Core:
 :::moniker-end
 
 :::moniker range="< aspnetcore-5.0"
-
-The following built-in Razor components are provided by the Blazor framework:
 
 * [`App`](xref:blazor/project-structure)
 * [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)

--- a/aspnetcore/blazor/components/built-in-components.md
+++ b/aspnetcore/blazor/components/built-in-components.md
@@ -48,7 +48,7 @@ The following built-in Razor components are provided by the Blazor framework:
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0>"
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
 
 * [`App`](xref:blazor/project-structure)
 * [`Authentication`](xref:blazor/security/webassembly/index#authentication-component)


### PR DESCRIPTION
Addresses #28001 

Adds `SectionContent`/`SectionOutlet` components (8.0) for the new [Blazor Sections article](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/sections?view=aspnetcore-8.0).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/built-in-components.md](https://github.com/dotnet/AspNetCore.Docs/blob/70234187cf3c6335dfe02445f4312a69a81d1961/aspnetcore/blazor/components/built-in-components.md) | [ASP.NET Core built-in Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/built-in-components?branch=pr-en-us-29103) |


<!-- PREVIEW-TABLE-END -->