### PR TITLE
Bugfix code section not displaying

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -886,7 +886,7 @@ In the following code, an <xref:Microsoft.Extensions.Options.IConfigureOptions%6
 
 The following code displays the options values:
 
-[!code-csharp[~/fundamentals/configuration/options/samples/6.x/OptionsSample/Pages/Test2.cshtml.cs?name=snippet)]
+[!code-csharp[](~/fundamentals/configuration/options/samples/6.x/OptionsSample/Pages/Test2.cshtml.cs?name=snippet)]
 
 In the preceding example, the values of `Option1` and `Option2` are specified in `appsettings.json` and then overridden by the configured delegate.
 


### PR DESCRIPTION
Code snippet was instead showing the broken markdown, and I think this change fixes it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/configuration/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/bf67399937e7fc1219e7eda77812588e7e9d2606/aspnetcore/fundamentals/configuration/index.md) | [Configuration in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/index?branch=pr-en-us-29107) |

<!-- PREVIEW-TABLE-END -->