### PR TITLE
Simplify OpenIddict's description

### DIFF
--- a/aspnetcore/security/authentication/community.md
+++ b/aspnetcore/security/authentication/community.md
@@ -16,7 +16,7 @@ This page contains community-provided, open source authentication options for AS
 | ---- | ----------- |
 | [IdentityServer](https://duendesoftware.com/products/identityserver) | IdentityServer is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core. |
 | [Gluu Server](https://gluu.org/) | Enterprise ready, open source software for identity, access management (IAM), and single sign-on (SSO). For more information, see the [Gluu Product Documentation](https://gluu.org/docs/). |
-| [OpenIddict](https://github.com/openiddict/openiddict-core) | Versatile OpenID Connect stack for ASP.NET Core 2.1/3.1/5.0/6.0 and Microsoft.Owin 4.1 (compatible with ASP.NET 4.6.1). |
+| [OpenIddict](https://github.com/openiddict/openiddict-core) | Flexible and versatile OAuth 2.0/OpenID Connect stack for .NET. |
 | [AspNet.Security.OAuth.Providers](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers)  | A collection of security middleware for ASP.NET Core apps to support social authentication  |
 | [AspNet.Security.OpenId.Providers](https://github.com/aspnet-contrib/AspNet.Security.OpenId.Providers) | A collection of security middleware for ASP.NET Core apps to support OpenID 2.0 authentication providers like [Steam](https://steampowered.com/) |
   [Authentik](https://goauthentik.io)|Authentik is an open-source Identity Provider focused on flexibility and versatility|


### PR DESCRIPTION
Keeping the ASP.NET Core versions list up-to-date in OpenIddict's description depends on community contributions and proved to be a painful process. Mentions of ASP.NET Core and Microsoft.Owin are also problematic as OpenIddict now includes a client stack that aims at being a universal .NET client (that can be used in ASP.NET Core and OWIN web apps and but also in console/WPF/WinUI/UWP and Linux desktop apps): listing all the supported environments would make the description messy, so `Flexible and versatile OAuth 2.0/OpenID Connect stack for .NET` seems to be a simpler option.

On a related note, it's not clear at all why non-.NET projects like Gluu Server (built on top of the Janssen Project, which is Java-based) and Authentik (Python-based, AFAICT) are included in this list. This `community.md` page was originally created to list exclusively the authentication projects designed and built for ASP.NET Core: has anything changed in this regard?

Note: I'm OpenIddict's developer.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/community.md](https://github.com/dotnet/AspNetCore.Docs/blob/27f2b956254535c08203988fc114becd206d9eb9/aspnetcore/security/authentication/community.md) | [Community OSS authentication options for ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/community?branch=pr-en-us-29116) |

<!-- PREVIEW-TABLE-END -->