### PR TITLE
Subpath scenario for multiple hosted WASM apps

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -45,7 +45,7 @@ In the following examples:
 * The initial (first) client app is the default client project of the solution created from the Blazor WebAssembly project template.
 * A second client app is added to the solution, `MultipleBlazorApps.SecondClient` in a folder named `SecondClient`.
 * Optionally, the server project (`MultipleBlazorApps.Server`) can serve pages or views as a formal Razor Pages or MVC app.
-* Both client apps use port 5001. The first client app is accessible in a browser at the `/FirstApp` subpath. The second client app is accessible in a browser at the `/SecondApp` subpath. 
+* Both client apps use the default port defined by the `MultipleBlazorApps.Server` project's `Properties/launchSettings.json` file in its `applicationUrl` value. The first client app is accessible in a browser at the `/FirstApp` subpath. The second client app is accessible in a browser at the `/SecondApp` subpath. 
 
 :::zone-end
 
@@ -161,16 +161,6 @@ If you don't plan for the server app to serve pages or views and only serve the 
 
 ```json
 "applicationUrl": "https://localhost:5001;https://localhost:5002",
-```
-
-:::zone-end
-
-:::zone pivot="route-subpath"
-
-In the server app's `Properties/launchSettings.json` file, configure the `applicationUrl` of the Kestrel profile (`MultipleBlazorApps.Server`) to access the client apps (and optionally pages or views of the `MultipleBlazorApps.Server` project) at port 5001.
-
-```json
-"applicationUrl": "https://localhost:5001",
 ```
 
 :::zone-end
@@ -328,7 +318,7 @@ The middleware added to the server app's request processing pipeline earlier mod
 
 :::zone pivot="route-subpath"
 
-The client apps' request to `/WeatherForecast` in the `MultipleBlazorApps.Server` project is to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the route of the client app (`/FirstApp`/`/SecondApp`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
+The client apps' request to `/WeatherForecast` in the `MultipleBlazorApps.Server` project is to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the route of the client app (`/FirstApp` or `/SecondApp`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
 
 :::zone-end
 
@@ -499,9 +489,11 @@ Run the `MultipleBlazorApps.Server` project:
 
 :::zone pivot="route-subpath"
 
-* Access the initial client app at `https://localhost:5001/FirstApp`.
-* Access the added client app at `https://localhost:5001/SecondApp`.
-* If the server app is configured to serve pages or views, access the `Index` page or view at `https://localhost:5001`.
+* Access the initial client app at `https://localhost:{DEFAULT PORT}/FirstApp`.
+* Access the added client app at `https://localhost:{DEFAULT PORT}/SecondApp`.
+* If the server app is configured to serve pages or views, access the `Index` page or view at `https://localhost:{DEFAULT PORT}`.
+
+In the preceding example URLs, the `{DEFAULT PORT}` placeholder is the default port defined by the `MultipleBlazorApps.Server` project's `Properties/launchSettings.json` file in its `applicationUrl` value.
 
 :::zone-end
 

--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -347,13 +347,27 @@ If you plan to serve pages from the server app, add an `Index` Razor page to the
 @page
 @model MultipleBlazorApps.Server.Pages.IndexModel
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = "Home";
 }
 
-<div>
-    <h1>Welcome</h1>
-    <p>Hello from Razor Pages!</p>
-</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Home</title>
+</head>
+<body>
+    <div class="main">
+        <div class="content px-4">
+
+            <div>
+                <h1>Welcome</h1>
+                <p>Hello from Razor Pages!</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
 ```
 
 `Pages/Index.cshtml.cs`:
@@ -396,7 +410,7 @@ namespace MultipleBlazorApps.Server.Pages
 :::moniker-end
 
 > [!NOTE]
-> If the app requires additional Razor Pages assets, such as a layout, styles, scripts, and imports, obtain them from an app created from the Razor Pages project template. For more information, see <xref:razor-pages/index>.
+> The preceding `Index` page is a minimal example purely for demonstration purposes. If the app requires additional Razor Pages assets, such as a layout, styles, scripts, and imports, obtain them from an app created from the Razor Pages project template. For more information, see <xref:razor-pages/index>.
 
 If you plan to serve MVC views from the server app, add an `Index` view and a `Home` controller:
 
@@ -404,13 +418,27 @@ If you plan to serve MVC views from the server app, add an `Index` view and a `H
 
 ```cshtml
 @{
-    ViewData["Title"] = "Home Page";
+    ViewData["Title"] = "Home";
 }
 
-<div>
-    <h1>Welcome</h1>
-    <p>Hello from MVC!</p>
-</div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Home</title>
+</head>
+<body>
+    <div class="main">
+        <div class="content px-4">
+
+            <div>
+                <h1>Welcome</h1>
+                <p>Hello from MVC!</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>
 ```
 
 `Controllers/HomeController.cs`:
@@ -453,7 +481,7 @@ namespace MultipleBlazorApps.Server.Controllers
 :::moniker-end
 
 > [!NOTE]
-> If the app requires additional MVC assets, such as a layout, styles, scripts, and imports, obtain them from an app created from the MVC project template. For more information, see <xref:tutorials/first-mvc-app/start-mvc>.
+> The preceding `Index` view is a minimal example purely for demonstration purposes. If the app requires additional MVC assets, such as a layout, styles, scripts, and imports, obtain them from an app created from the MVC project template. For more information, see <xref:tutorials/first-mvc-app/start-mvc>.
 
 For more information on using the Razor components from either of the client apps in pages or views of the server app, see <xref:blazor/components/prerendering-and-integration?pivots=webassembly>.
 

--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -83,7 +83,7 @@ Physical folder | Project name | Description
 `Server` | `MultipleBlazorApps.Server` | ASP.NET Core server app
 `Shared` | `MultipleBlazorApps.Shared` | Shared resources project
 
-The **:::no-loc text="Server":::** project serves the two Blazor WebAssembly client apps and provides weather data to the client apps' `FetchData` components via an MVC controller. Optionally, the **:::no-loc text="Server":::** project can also serve pages or views, as a traditional Razor Pages or MVC app. Steps to enable serving pages or views are covered later in this article.
+The `MultipleBlazorApps.Server` project serves the two Blazor WebAssembly client apps and provides weather data to the client apps' `FetchData` components via an MVC controller. Optionally, the `MultipleBlazorApps.Server` project can also serve pages or views, as a traditional Razor Pages or MVC app. Steps to enable serving pages or views are covered later in this article.
 
 :::zone pivot="port-domain"
 
@@ -285,7 +285,7 @@ In the server app's `Program.cs` file, remove the following code, which appears 
   });
   ```
 
-* Set the client apps' base path:
+* Set the base path in each client app:
 
   In the first client app's `index.html` file (`Client/wwwroot/index.html`), update the `<base>` tag value to reflect the subpath. The trailing slash is required:
 
@@ -310,19 +310,9 @@ For more information on `UseBlazorFrameworkFiles` and `MapFallbackToFile`, see t
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-:::zone pivot="port-domain"
+Requests from the client apps to `/WeatherForecast` in the server API are either to `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on which client app makes the request. Therefore, the controller routes that return weather data from the server API require a modification to include the path segments.
 
-The middleware added to the server app's request processing pipeline earlier modifies incoming requests to `/WeatherForecast` to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the port (5001/5002) or domain (`firstapp.com`/`secondapp.com`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
-
-:::zone-end
-
-:::zone pivot="route-subpath"
-
-The client apps' request to `/WeatherForecast` in the `MultipleBlazorApps.Server` project is to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the route of the client app (`/FirstApp` or `/SecondApp`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
-
-:::zone-end
-
-In the server app's weather forecast controller (`Controllers/WeatherForecastController.cs`), replace the existing route (`[Route("[controller]")]`) to `WeatherForecastController` with the following routes, which take into account the client apps' base paths added by the middleware (`FirstApp`/`SecondApp`):
+In the server app's weather forecast controller (`Controllers/WeatherForecastController.cs`), replace the existing route (`[Route("[controller]")]`) to `WeatherForecastController` with the following routes, which take into account the client request paths:
 
 ```csharp
 [Route("FirstApp/[controller]")]

--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -320,6 +320,25 @@ For more information on `UseBlazorFrameworkFiles` and `MapFallbackToFile`, see t
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
+:::zone pivot="port-domain"
+
+The middleware added to the server app's request processing pipeline earlier modifies incoming requests to `/WeatherForecast` to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the port (5001/5002) or domain (`firstapp.com`/`secondapp.com`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
+
+:::zone-end
+
+:::zone pivot="route-subpath"
+
+The client apps' request to `/WeatherForecast` in the `MultipleBlazorApps.Server` project is to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the route of the client app (`/FirstApp`/`/SecondApp`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
+
+:::zone-end
+
+In the server app's weather forecast controller (`Controllers/WeatherForecastController.cs`), replace the existing route (`[Route("[controller]")]`) to `WeatherForecastController` with the following routes, which take into account the client apps' base paths added by the middleware (`FirstApp`/`SecondApp`):
+
+```csharp
+[Route("FirstApp/[controller]")]
+[Route("SecondApp/[controller]")]
+```
+
 If you plan to serve pages from the server app, add an `Index` Razor page to the `Pages` folder of the server app:
 
 `Pages/Index.cshtml`:
@@ -435,15 +454,6 @@ namespace MultipleBlazorApps.Server.Controllers
 
 > [!NOTE]
 > If the app requires additional MVC assets, such as a layout, styles, scripts, and imports, obtain them from an app created from the MVC project template. For more information, see <xref:tutorials/first-mvc-app/start-mvc>.
-
-The middleware added to the server app's request processing pipeline earlier modifies incoming requests to `/WeatherForecast` to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the port (5001/5002), domain (`firstapp.com`/`secondapp.com`), or route (`/FirstApp`/`/SecondApp`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
-
-In the server app's weather forecast controller (`Controllers/WeatherForecastController.cs`), replace the existing route (`[Route("[controller]")]`) to `WeatherForecastController` with the following routes, which take into account the client apps' base paths added by the middleware (`FirstApp`/`SecondApp`):
-
-```csharp
-[Route("FirstApp/[controller]")]
-[Route("SecondApp/[controller]")]
-```
 
 For more information on using the Razor components from either of the client apps in pages or views of the server app, see <xref:blazor/components/prerendering-and-integration?pivots=webassembly>.
 

--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -5,7 +5,7 @@ description: Learn how to configure a hosted Blazor WebAssembly app to host mult
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 05/02/2023
+ms.date: 05/04/2023
 uid: blazor/host-and-deploy/multiple-hosted-webassembly
 zone_pivot_groups: blazor-multiple-hosted-wasm-apps
 ---
@@ -17,29 +17,35 @@ This article explains how to configure a hosted Blazor WebAssembly app to host m
 
 ## Configuration
 
-Hosted Blazor [solutions](xref:blazor/tooling#visual-studio-solution-file-sln) can serve multiple Blazor WebAssembly apps.
-
-In the following examples:
+Select the version of this article that matches your hosting requirements, either port/domain hosting (for example, `:5001`/`:5002` or `firstapp.com`/`secondapp.com`) or route subpath hosting (for example, `/FirstApp` and `/SecondApp`).
 
 :::zone pivot="port-domain"
+
+With the current hosting selection, this article covers port/domain hosting (for example, `:5001`/`:5002` or `firstapp.com`/`secondapp.com`).
+
+In the following examples:
 
 * The project name of the hosted Blazor WebAssembly app is `MultipleBlazorApps` in a folder named `MultipleBlazorApps`.
 * The three projects in the solution before a second client app is added are `MultipleBlazorApps.Client` in the `Client` folder, `MultipleBlazorApps.Server` in the `Server` folder, and `MultipleBlazorApps.Shared` in the `Shared` folder.
 * The initial (first) client app is the default client project of the solution created from the Blazor WebAssembly project template.
 * A second client app is added to the solution, `MultipleBlazorApps.SecondClient` in a folder named `SecondClient`.
-* Optionally, the server project (`MultipleBlazorApps.Server`) can serve pages or views as a formal Razor Pages or MVC app.
+* Optionally, the server project (`MultipleBlazorApps.Server`) can serve pages or views as a Razor Pages or MVC app.
 * The first client app is accessible in a browser at port 5001 or with a host of `firstapp.com`. The second client app is accessible in a browser at port 5002 or with a host of `secondapp.com`.
 
 :::zone-end
 
 :::zone pivot="route-subpath"
 
+With the current selection, this article covers route subpath hosting (for example, `/FirstApp` and `/SecondApp`).
+
+In the following examples:
+
 * The project name of the hosted Blazor WebAssembly app is `MultipleBlazorApps` in a folder named `MultipleBlazorApps`.
 * The three projects in the solution before a second client app is added are `MultipleBlazorApps.Client` in the `Client` folder, `MultipleBlazorApps.Server` in the `Server` folder, and `MultipleBlazorApps.Shared` in the `Shared` folder.
 * The initial (first) client app is the default client project of the solution created from the Blazor WebAssembly project template.
 * A second client app is added to the solution, `MultipleBlazorApps.SecondClient` in a folder named `SecondClient`.
 * Optionally, the server project (`MultipleBlazorApps.Server`) can serve pages or views as a formal Razor Pages or MVC app.
-* Both client apps use port 5001. The first client app is accessible in a browser at the `/FirstApp` subpath. The second client app is accessible in a browser at the `/FirstApp` subpath. 
+* Both client apps use port 5001. The first client app is accessible in a browser at the `/FirstApp` subpath. The second client app is accessible in a browser at the `/SecondApp` subpath. 
 
 :::zone-end
 
@@ -61,32 +67,47 @@ Use an existing hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-
 
 Use a folder for the solution named `MultipleBlazorApps` and name the project `MultipleBlazorApps`.
 
-Initial projects in the solution and their folders:
+Create a new folder in the solution named `SecondClient`. In the new folder, add a second Blazor WebAssembly client app named `MultipleBlazorApps.SecondClient`. Add the project as a standalone Blazor WebAssembly app. To create a standalone Blazor WebAssembly app, don't pass the `-ho|--hosted` option if using the .NET CLI or don't use the **ASP.NET Core Hosted** checkbox if using Visual Studio.
 
-* `MultipleBlazorApps.Client` is a Blazor WebAssembly client app in the `Client` folder.
-* `MultipleBlazorApps.Server` is an ASP.NET Core server app that serves Blazor WebAssembly apps) in the `Server` folder. Optionally, the server app can also serve pages or views, as a traditional Razor Pages or MVC app.
-* `MultipleBlazorApps.Shared` is a shared resources project for the client and server projects in the `Shared` folder.
+Make the following changes to the `MultipleBlazorApps.SecondClient` project:
 
-In the client app's project file (`MultipleBlazorApps.Client.csproj`), add a [`<StaticWebAssetBasePath>` property](xref:blazor/fundamentals/static-files#static-web-asset-base-path) to a `<PropertyGroup>` with a value of `FirstApp` to set the base path for the project's static assets:
+* Copy the `FetchData` component (`Pages/FetchData.razor`) from the `Client/Pages` folder to the `SecondClient/Pages` folder. This step is required because a standalone Blazor WebAssembly app doesn't call a **:::no-loc text="Server":::** project's controller for weather data, it uses a static data file. By copying the `FetchData` component to the added project, the second client app also makes a web API call to the server API for weather data.
+* Delete the `SecondClient/wwwroot/sample-data` folder, as the `weather.json` file in the folder isn't used.
+
+The following table describes the solution's folders and project names after the `SecondClient` folder and `MultipleBlazorApps.SecondClient` project are added.
+
+Physical folder | Project name | Description
+--- | --- | ---
+`Client` | `MultipleBlazorApps.Client` | Blazor WebAssembly client app
+`SecondClient` | `MultipleBlazorApps.SecondClient` | Blazor WebAssembly client app
+`Server` | `MultipleBlazorApps.Server` | ASP.NET Core server app
+`Shared` | `MultipleBlazorApps.Shared` | Shared resources project
+
+The **:::no-loc text="Server":::** project serves the two Blazor WebAssembly client apps and provides weather data to the client apps' `FetchData` components via an MVC controller. Optionally, the **:::no-loc text="Server":::** project can also serve pages or views, as a traditional Razor Pages or MVC app. Steps to enable serving pages or views are covered later in this article.
+
+:::zone pivot="port-domain"
+
+> [!NOTE]
+> The demonstration in this article uses static web asset path names of `FirstApp` for the `MultipleBlazorApps.Client` project and `SecondApp` for the `MultipleBlazorApps.SecondClient` project. The names "`FirstApp`" and "`SecondApp`" are merely for demonstration purposes. Other names are acceptable to distinguish the client apps, such as `App1`/`App2`, `Client1`/`Client2`, `1`/`2`, or any similar naming scheme. 
+>
+> When routing requests to the client apps by a port or a domain, "`FirstApp`" and "`SecondApp`" are used ***internally*** to route requests and serve responses for static assets and aren't seen in the browser's address bar.
+
+:::zone-end
+
+:::zone pivot="route-subpath"
+
+> [!NOTE]
+> The demonstration in this article uses static web asset path names of `FirstApp` for the `MultipleBlazorApps.Client` project and `SecondApp` for the `MultipleBlazorApps.SecondClient` project. The names "`FirstApp`" and "`SecondApp`" are merely for demonstration purposes. Other names are acceptable to distinguish the client apps, such as `App1`/`App2`, `Client1`/`Client2`, `1`/`2`, or any similar naming scheme. 
+>
+> "`FirstApp`" and "`SecondApp`" also appear in the browser's address bar because requests are routed to the two client apps using these names. Other valid URL route segments are supported, and the route segments don't strictly need to match the names used to route static web assets internally. Using "`FirstApp`" and "`SecondApp`" for both the internal static asset routing and app request routing is merely for convenance in this article's examples.
+
+:::zone-end
+
+In the first client app's project file (`MultipleBlazorApps.Client.csproj`), add a [`<StaticWebAssetBasePath>` property](xref:blazor/fundamentals/static-files#static-web-asset-base-path) to a `<PropertyGroup>` with a value of `FirstApp` to set the base path for the project's static assets:
 
 ```xml
 <StaticWebAssetBasePath>FirstApp</StaticWebAssetBasePath>
 ```
-
-> [!NOTE]
-> The demonstration in this section uses web asset path names of `FirstApp` and `SecondApp`, but these specific names are merely for demonstration purposes. Any base path segments that distinguish the client apps are acceptable, such as `App1`/`App2`, `Client1`/`Client2`, `1`/`2`, or any similar naming scheme. These base path segments are used internally to route requests and serve responses and are ***not*** seen in a browser's address bar.
-
-Add a second client app to the solution. Add the project as a standalone Blazor WebAssembly app. To create a standalone Blazor WebAssembly app, don't pass the `-ho|--hosted` option if using the .NET CLI or don't use the **ASP.NET Core Hosted** checkbox if using Visual Studio:
-
-* The solution folder created from the project template contains the following solution file and folders after the `SecondClient` folder is added:
-  * `Client` (folder)
-  * `SecondClient` (folder, created manually)
-  * `Server` (folder)
-  * `Shared` (folder)
-  * `MultipleBlazorApps.sln` (file)
-* Name the new project `MultipleBlazorApps.SecondClient` and create the app in the `SecondClient` folder.
-* Copy the `FetchData` component (`Pages/FetchData.razor`) from the `Client/Pages` folder into the `SecondClient/Pages` folder. This step is required because a standalone Blazor WebAssembly app doesn't call a **:::no-loc text="Server":::** project's controller for weather data, it uses a static data file. By copying the `FetchData` component to the added project, the second client app also makes a web API call for weather data.
-* Delete the `SecondClient/wwwroot/sample-data` folder, as the `weather.json` file in the folder isn't used.
 
 In the `MultipleBlazorApps.SecondClient` app's project file (`MultipleBlazorApps.SecondClient.csproj`):
 
@@ -125,9 +146,9 @@ In the server app's `Properties/launchSettings.json` file, configure the `applic
 
 If you plan to serve pages or views from the server app, use the following `applicationUrl` setting in the `Properties/launchSettings.json` file, which permits the following access:
 
-* The Razor Pages or MVC app responds to requests at port 5000.
-* Responses to requests for the first client are at port 5001.
-* Responses to requests for the second client are at port 5002.
+* Optionally, the Razor Pages or MVC app (`MultipleBlazorApps.Server` project) responds to requests at port 5000.
+* Responses to requests for the first client (`MultipleBlazorApps.Client` project) are at port 5001.
+* Responses to requests for the second client (`MultipleBlazorApps.SecondClient` project) are at port 5002.
 
 ```json
 "applicationUrl": "https://localhost:5000;https://localhost:5001;https://localhost:5002",
@@ -146,18 +167,7 @@ If you don't plan for the server app to serve pages or views and only serve the 
 
 :::zone pivot="route-subpath"
 
-In the server app's `Properties/launchSettings.json` file, configure the `applicationUrl` of the Kestrel profile (`MultipleBlazorApps.Server`) to access the client apps at port 5001.
-
-If you plan to serve pages or views from the server app, use the following `applicationUrl` setting in the `Properties/launchSettings.json` file, which permits the following access:
-
-* The Razor Pages or MVC app responds to requests at port 5000.
-* Responses to requests for the first and second client apps are at port 5001.
-
-```json
-"applicationUrl": "https://localhost:5000;https://localhost:5001",
-```
-
-If you don't plan for the server app to serve pages or views and only serve the Blazor WebAssembly client apps, use the following setting, which permits the first and second client apps respond on port 5001:
+In the server app's `Properties/launchSettings.json` file, configure the `applicationUrl` of the Kestrel profile (`MultipleBlazorApps.Server`) to access the client apps (and optionally pages or views of the `MultipleBlazorApps.Server` project) at port 5001.
 
 ```json
 "applicationUrl": "https://localhost:5001",
@@ -167,10 +177,14 @@ If you don't plan for the server app to serve pages or views and only serve the 
 
 In the server app's `Program.cs` file, remove the following code, which appears after the call to <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A>:
 
-* If you plan to serve pages or views from the server app, delete the following line of code:
+* If you plan to serve pages or views from the server app, delete the following lines of code:
 
   ```diff
   - app.UseBlazorFrameworkFiles();
+  ```
+
+  ```diff
+  - app.MapFallbackToFile("index.html");
   ```
 
 * If you plan for the server app to only serve the Blazor WebAssembly client apps, delete the following code:
@@ -192,6 +206,8 @@ In the server app's `Program.cs` file, remove the following code, which appears 
 
   > [!NOTE]
   > Use of the hosts (`firstapp.com`/`secondapp.com`) on a local system with a local browser requires additional configuration that's beyond the scope of this article. For local testing of this scenario, we recommend using ports. Typical production apps are configured to use subdomains, such as `www.contoso.com` for site visitors and `admin.contoso.com` for administrators. With the proper DNS and server configuration, which is beyond the scope of this article and depends on the technologies used, the app responds to requests at whatever hosts are named in the following code.
+
+  Where you removed the `app.UseBlazorFrameworkFiles();` line from `Program.cs`, place the following code:
 
   ```csharp
   app.MapWhen(ctx => ctx.Request.Host.Port == 5001 || 
@@ -245,6 +261,8 @@ In the server app's `Program.cs` file, remove the following code, which appears 
 
 * Add middleware that maps requests to the client apps. The following example configures the middleware to run when the request subpath is `/FirstApp` for the first client app or `/SecondApp` for the second client app.
 
+  Where you removed the `app.UseBlazorFrameworkFiles();` line from `Program.cs`, place the following code:
+
   ```csharp
   app.MapWhen(ctx => ctx.Request.Path.StartsWithSegments("/FirstApp"), first =>
   {
@@ -276,10 +294,6 @@ In the server app's `Program.cs` file, remove the following code, which appears 
       });
   });
   ```
-
-:::zone-end
-
-:::zone pivot="route-subpath"
 
 * Set the client apps' base path:
 
@@ -422,7 +436,7 @@ namespace MultipleBlazorApps.Server.Controllers
 > [!NOTE]
 > If the app requires additional MVC assets, such as a layout, styles, scripts, and imports, obtain them from an app created from the MVC project template. For more information, see <xref:tutorials/first-mvc-app/start-mvc>.
 
-The middleware added to the server app's request processing pipeline earlier modifies incoming requests to `/WeatherForecast` to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the port (5001/5002) or domain (`firstapp.com`/`secondapp.com`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
+The middleware added to the server app's request processing pipeline earlier modifies incoming requests to `/WeatherForecast` to either `/FirstApp/WeatherForecast` or `/SecondApp/WeatherForecast` depending on the port (5001/5002), domain (`firstapp.com`/`secondapp.com`), or route (`/FirstApp`/`/SecondApp`). Therefore, the controller routes that return weather data from the server app to the client apps require a modification.
 
 In the server app's weather forecast controller (`Controllers/WeatherForecastController.cs`), replace the existing route (`[Route("[controller]")]`) to `WeatherForecastController` with the following routes, which take into account the client apps' base paths added by the middleware (`FirstApp`/`SecondApp`):
 
@@ -431,13 +445,32 @@ In the server app's weather forecast controller (`Controllers/WeatherForecastCon
 [Route("SecondApp/[controller]")]
 ```
 
+For more information on using the Razor components from either of the client apps in pages or views of the server app, see <xref:blazor/components/prerendering-and-integration?pivots=webassembly>.
+
+## Run the app
+
 Run the `MultipleBlazorApps.Server` project:
+
+:::zone pivot="port-domain"
 
 * Access the initial client app at `https://localhost:5001`.
 * Access the added client app at `https://localhost:5002`.
 * If the server app is configured to serve pages or views, access the `Index` page or view at `https://localhost:5000`.
 
-For more information on using the Razor components from either of the client apps in pages or views of the server app, see <xref:blazor/components/prerendering-and-integration?pivots=webassembly>.
+:::zone-end
+
+:::zone pivot="route-subpath"
+
+* Access the initial client app at `https://localhost:5001/FirstApp`.
+* Access the added client app at `https://localhost:5001/SecondApp`.
+* If the server app is configured to serve pages or views, access the `Index` page or view at `https://localhost:5001`.
+
+:::zone-end
+
+> [!IMPORTANT]
+> When running the app with the `dotnet run` command (.NET CLI), confirm that the command shell is open in the `Server` folder of the solution.
+>
+> When using Visual Studio's start button to run the app, confirm that the `MultipleBlazorApps.Server` project set as the startup project (highlighted in Solution Explorer). 
 
 ## Static assets
 

--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -5,8 +5,9 @@ description: Learn how to configure a hosted Blazor WebAssembly app to host mult
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/08/2022
+ms.date: 05/02/2023
 uid: blazor/host-and-deploy/multiple-hosted-webassembly
+zone_pivot_groups: blazor-multiple-hosted-wasm-apps
 ---
 # Multiple hosted ASP.NET Core Blazor WebAssembly apps
 
@@ -18,15 +19,31 @@ This article explains how to configure a hosted Blazor WebAssembly app to host m
 
 Hosted Blazor [solutions](xref:blazor/tooling#visual-studio-solution-file-sln) can serve multiple Blazor WebAssembly apps.
 
-In the following example:
+In the following examples:
+
+:::zone pivot="port-domain"
 
 * The project name of the hosted Blazor WebAssembly app is `MultipleBlazorApps` in a folder named `MultipleBlazorApps`.
 * The three projects in the solution before a second client app is added are `MultipleBlazorApps.Client` in the `Client` folder, `MultipleBlazorApps.Server` in the `Server` folder, and `MultipleBlazorApps.Shared` in the `Shared` folder.
-* The initial (first) client app is the default client project of the solution created from the Blazor WebAssembly project template. The first client app is accessible in a browser at port 5001 or with a host of `firstapp.com`.
-* A second client app is added to the solution, `MultipleBlazorApps.SecondClient` in a folder named `SecondClient`. The second client app is accessible in a browser at port 5002 or with a host of `secondapp.com`.
+* The initial (first) client app is the default client project of the solution created from the Blazor WebAssembly project template.
+* A second client app is added to the solution, `MultipleBlazorApps.SecondClient` in a folder named `SecondClient`.
 * Optionally, the server project (`MultipleBlazorApps.Server`) can serve pages or views as a formal Razor Pages or MVC app.
+* The first client app is accessible in a browser at port 5001 or with a host of `firstapp.com`. The second client app is accessible in a browser at port 5002 or with a host of `secondapp.com`.
 
-The example shown in this section requires additional configuration for:
+:::zone-end
+
+:::zone pivot="route-subpath"
+
+* The project name of the hosted Blazor WebAssembly app is `MultipleBlazorApps` in a folder named `MultipleBlazorApps`.
+* The three projects in the solution before a second client app is added are `MultipleBlazorApps.Client` in the `Client` folder, `MultipleBlazorApps.Server` in the `Server` folder, and `MultipleBlazorApps.Shared` in the `Shared` folder.
+* The initial (first) client app is the default client project of the solution created from the Blazor WebAssembly project template.
+* A second client app is added to the solution, `MultipleBlazorApps.SecondClient` in a folder named `SecondClient`.
+* Optionally, the server project (`MultipleBlazorApps.Server`) can serve pages or views as a formal Razor Pages or MVC app.
+* Both client apps use port 5001. The first client app is accessible in a browser at the `/FirstApp` subpath. The second client app is accessible in a browser at the `/FirstApp` subpath. 
+
+:::zone-end
+
+The examples shown in this article require additional configuration for:
 
 * Accessing the apps directly at the example host domains, `firstapp.com` and `secondapp.com`.
 * Certificates for the client apps to enable TLS/HTTPS security.
@@ -34,7 +51,7 @@ The example shown in this section requires additional configuration for:
   * Integration of Razor components into pages or views.
   * Prerendering Razor components.
 
-The preceding configurations are beyond the scope of this demonstration. For more information, see the following resources:
+The preceding configurations are beyond the scope of this article. For more information, see the following resources:
 
 * [Host and deploy articles](xref:host-and-deploy/index)
 * <xref:security/enforcing-ssl>
@@ -61,13 +78,15 @@ In the client app's project file (`MultipleBlazorApps.Client.csproj`), add a [`<
 
 Add a second client app to the solution. Add the project as a standalone Blazor WebAssembly app. To create a standalone Blazor WebAssembly app, don't pass the `-ho|--hosted` option if using the .NET CLI or don't use the **ASP.NET Core Hosted** checkbox if using Visual Studio:
 
-* Name the project `MultipleBlazorApps.SecondClient` and place the app into a folder named `SecondClient`.
 * The solution folder created from the project template contains the following solution file and folders after the `SecondClient` folder is added:
   * `Client` (folder)
-  * `SecondClient` (folder)
+  * `SecondClient` (folder, created manually)
   * `Server` (folder)
   * `Shared` (folder)
   * `MultipleBlazorApps.sln` (file)
+* Name the new project `MultipleBlazorApps.SecondClient` and create the app in the `SecondClient` folder.
+* Copy the `FetchData` component (`Pages/FetchData.razor`) from the `Client/Pages` folder into the `SecondClient/Pages` folder. This step is required because a standalone Blazor WebAssembly app doesn't call a **:::no-loc text="Server":::** project's controller for weather data, it uses a static data file. By copying the `FetchData` component to the added project, the second client app also makes a web API call for weather data.
+* Delete the `SecondClient/wwwroot/sample-data` folder, as the `weather.json` file in the folder isn't used.
 
 In the `MultipleBlazorApps.SecondClient` app's project file (`MultipleBlazorApps.SecondClient.csproj`):
 
@@ -91,7 +110,9 @@ In the server app's project file (`Server/MultipleBlazorApps.Server.csproj`), cr
 <ProjectReference Include="..\SecondClient\MultipleBlazorApps.SecondClient.csproj" />
 ```
 
-In the server app's `Properties/launchSettings.json` file, configure the `applicationUrl` of the Kestrel profile (`MultipleBlazorApps.Server`) to access the client apps at two ports.
+:::zone pivot="port-domain"
+
+In the server app's `Properties/launchSettings.json` file, configure the `applicationUrl` of the Kestrel profile (`MultipleBlazorApps.Server`) to access the client apps at ports 5001 and 5002. If you configure your local environment to use the example domains, URLs for `applicationUrl` can use `firstapp.com` and `secondapp.com` and not use the ports.
 
 > [!NOTE]
 > The use of ports in this demonstration allows access to the client projects in a local browser without the need to configure a local hosting environment so that web browsers can access the client apps via the host configurations, `firstapp.com` and `secondapp.com`. In production scenarios, a typical configuration is to use subdomains to distinguish the client apps.
@@ -121,6 +142,29 @@ If you don't plan for the server app to serve pages or views and only serve the 
 "applicationUrl": "https://localhost:5001;https://localhost:5002",
 ```
 
+:::zone-end
+
+:::zone pivot="route-subpath"
+
+In the server app's `Properties/launchSettings.json` file, configure the `applicationUrl` of the Kestrel profile (`MultipleBlazorApps.Server`) to access the client apps at port 5001.
+
+If you plan to serve pages or views from the server app, use the following `applicationUrl` setting in the `Properties/launchSettings.json` file, which permits the following access:
+
+* The Razor Pages or MVC app responds to requests at port 5000.
+* Responses to requests for the first and second client apps are at port 5001.
+
+```json
+"applicationUrl": "https://localhost:5000;https://localhost:5001",
+```
+
+If you don't plan for the server app to serve pages or views and only serve the Blazor WebAssembly client apps, use the following setting, which permits the first and second client apps respond on port 5001:
+
+```json
+"applicationUrl": "https://localhost:5001",
+```
+
+:::zone-end
+
 In the server app's `Program.cs` file, remove the following code, which appears after the call to <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuilderExtensions.UseHttpsRedirection%2A>:
 
 * If you plan to serve pages or views from the server app, delete the following line of code:
@@ -142,15 +186,12 @@ In the server app's `Program.cs` file, remove the following code, which appears 
   - app.MapFallbackToFile("index.html");
   ```
 
-* Add middleware that maps requests to the client apps. The following example configures the middleware to run when:
+:::zone pivot="port-domain"
 
-  * The request port is either 5001 for the first client app or 5002 for the second client app.
-  * The request host is either `firstapp.com` for the first client app or `secondapp.com` for the second client app.
+* Add middleware that maps requests to the client apps. The following example configures the middleware to run when the request port is either 5001 for the first client app or 5002 for the second client app, or the request host is either `firstapp.com` for the first client app or `secondapp.com` for the second client app.
 
   > [!NOTE]
   > Use of the hosts (`firstapp.com`/`secondapp.com`) on a local system with a local browser requires additional configuration that's beyond the scope of this article. For local testing of this scenario, we recommend using ports. Typical production apps are configured to use subdomains, such as `www.contoso.com` for site visitors and `admin.contoso.com` for administrators. With the proper DNS and server configuration, which is beyond the scope of this article and depends on the technologies used, the app responds to requests at whatever hosts are named in the following code.
-
-  Place the following code where the code was removed earlier in the `Program.cs` file:
 
   ```csharp
   app.MapWhen(ctx => ctx.Request.Host.Port == 5001 || 
@@ -197,6 +238,64 @@ In the server app's `Program.cs` file, remove the following code, which appears 
       });
   });
   ```
+
+:::zone-end
+
+:::zone pivot="route-subpath"
+
+* Add middleware that maps requests to the client apps. The following example configures the middleware to run when the request subpath is `/FirstApp` for the first client app or `/SecondApp` for the second client app.
+
+  ```csharp
+  app.MapWhen(ctx => ctx.Request.Path.StartsWithSegments("/FirstApp"), first =>
+  {
+      first.UseBlazorFrameworkFiles("/FirstApp");
+      first.UseStaticFiles();
+      first.UseStaticFiles("/FirstApp");
+      first.UseRouting();
+
+      first.UseEndpoints(endpoints =>
+      {
+          endpoints.MapControllers();
+          endpoints.MapFallbackToFile("/FirstApp/{*path:nonfile}",
+              "FirstApp/index.html");
+      });
+  });
+
+  app.MapWhen(ctx => ctx.Request.Path.StartsWithSegments("/SecondApp"), second =>
+  {
+      second.UseBlazorFrameworkFiles("/SecondApp");
+      second.UseStaticFiles();
+      second.UseStaticFiles("/SecondApp");
+      second.UseRouting();
+
+      second.UseEndpoints(endpoints =>
+      {
+          endpoints.MapControllers();
+          endpoints.MapFallbackToFile("/SecondApp/{*path:nonfile}",
+              "SecondApp/index.html");
+      });
+  });
+  ```
+
+:::zone-end
+
+:::zone pivot="route-subpath"
+
+* Set the client apps' base path:
+
+  In the first client app's `index.html` file (`Client/wwwroot/index.html`), update the `<base>` tag value to reflect the subpath. The trailing slash is required:
+
+  ```html
+  <base href="/FirstApp/" />
+  ```
+
+  In the second client app's `index.html` file (`SecondClient/wwwroot/index.html`), update the `<base>` tag value to reflect the subpath. The trailing slash is required:
+
+  ```html
+  <base href="/SecondApp/" />
+  ```
+
+:::zone-end
 
 For more information on <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A>, see <xref:blazor/fundamentals/static-files#static-file-middleware>.
 
@@ -345,7 +444,7 @@ For more information on using the Razor components from either of the client app
 When an asset is in a client app's `wwwroot` folder, provide the static asset request path in components:
 
 ```html
-<img alt="..." src="/{PATH AND FILE NAME}" />
+<img alt="..." src="{PATH AND FILE NAME}" />
 ```
 
 The `{PATH AND FILE NAME}` placeholder is the path and file name under `wwwroot`.
@@ -353,7 +452,7 @@ The `{PATH AND FILE NAME}` placeholder is the path and file name under `wwwroot`
 For example, the source for a Jeep image (`jeep-yj.png`) in the `vehicle` folder of `wwwroot`:
 
 ```html
-<img alt="Jeep Wrangler YJ" src="/vehicle/jeep-yj.png" />
+<img alt="Jeep Wrangler YJ" src="vehicle/jeep-yj.png" />
 ```
 
 ## Razor class library (RCL) support

--- a/aspnetcore/zone-pivot-groups.yml
+++ b/aspnetcore/zone-pivot-groups.yml
@@ -58,3 +58,11 @@ groups:
       title: Graph SDK v5
     - id: named-client-graph-api
       title: Named HttpClient with Graph API
+- id: blazor-multiple-hosted-wasm-apps
+  title: Hosting approach
+  prompt: Choose a hosting approach for the client apps
+  pivots:
+    - id: port-domain
+      title: Port/domain hosting (5001/5002 or firstapp.com/secondapp.com)
+    - id: route-subpath
+      title: Route subpath hosting (/FirstApp and /SecondApp)

--- a/aspnetcore/zone-pivot-groups.yml
+++ b/aspnetcore/zone-pivot-groups.yml
@@ -63,6 +63,6 @@ groups:
   prompt: Choose a hosting approach for the client apps
   pivots:
     - id: port-domain
-      title: Port/domain hosting (5001/5002 or firstapp.com/secondapp.com)
+      title: Port/domain hosting
     - id: route-subpath
-      title: Route subpath hosting (/FirstApp and /SecondApp)
+      title: Route subpath hosting


### PR DESCRIPTION
Fixes #29043

**UPDATE**: Javier, I think you'll be too busy to look at all of the updates in detail. TL;DR the main points are that: (1) I can't get your approach to work, but my approach works here, so I'll go with my approach for now. Perhaps, I should ping you after .NET 8 releases to discuss it further and see if the 🦖 approach is *sane enough* 😵 to keep 😄. (2) I'm adding your hosting concept (hosting at subpaths) to the existing domain/port coverage, which is still working 🎉. I think using pivots for the coverage is best.

Notes

* I can't get the [sample app](https://github.com/javiercn/BlazorMultipleApps/tree/main/BlazorMultipleApps) to run locally for the 2nd client. It 💥404s 💥 ... https://github.com/dotnet/AspNetCore.Docs/issues/29043#issuecomment-1530035513.
* I've 🙈 ***RexHacked!***&trade; 🙈 an approach for subpaths that works here. We're not too far apart on config:
  * The supplied sample app uses a call to `UsePathBase` in the 2nd middleware, but I don't do that. It breaks my approach.
  * The supplied sample app just uses standard (no subpath) calls to `first.UseStaticFiles();` and `second.UseStaticFiles();` for each middleware, but my approach places a `first.UseStaticFiles("/FirstApp");` and `second.UseStaticFiles("/SecondApp");` with the subpath for each.
  * Other than those two deltas, I think we have the same config.
* I tried to avoid using pivots at first, but that looked scary for readers 😨. There's a lot of detailed config here, and there was too much risk to readers using this guidance and getting the ***two separate approaches*** mixed up in their own test solutions. I think using pivots keeps the readers focused on one approach or the other.
* ~I haven't dealt with setting up the apps in VS yet. This still relies on using the .NET CLI. Since I can't use pivots again to cover VS vs. CLI, I'll see about adding a NOTE or remark on using VS to get the second client app added to the solution. It's a bit tricky. We need VS to create the app with the right folder name in the right spot in the solution and with the correct app name. I'll see if I can work that out Wednesday morning and get it in here.~

  **UPDATE**: I ***think*** that I've sufficiently covered .NET CLI and VS tooling options in the guidance. I'll keep an 👂 open for reader feedback on it.
* Before adding this, I had static asset paths (for example, image paths) with a leading forward slash. That was fine for the port/domain example. The image is at the root in that approach. For example ...

  ```html
  <img alt="Jeep Wrangler YJ" src="/jeep-yj.png" />
  ```

  :x: That's not good for the new approach, and I now feel it's even better for the domain/path approach to make it relative. Certainly for the new approach, we don't want to request from the root (e.g., `https://localhost:5001/jeep-yj.png`). Going with ...

  ```html
  <img alt="Jeep Wrangler YJ" src="jeep-yj.png" />
  ```

  ... works makes the path to the image correct at `https://localhost:5001/FirstApp/jeep-yj.png` or `https://localhost:5001/SecondApp/jeep-yj.png`.

* ... and many other small enhancements to the guidance were made.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/a5fca3bd9db948b728360cc3cafed09bb78a1074/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md) | [Multiple hosted ASP.NET Core Blazor WebAssembly apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/multiple-hosted-webassembly?branch=pr-en-us-29142) |


<!-- PREVIEW-TABLE-END -->