### PR TITLE
typo fix

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/includes/route-handlers.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/route-handlers.md
@@ -1,4 +1,4 @@
-Route handlers are methods that execute when the route matches. Route handlers can be a function of any type, including synchronous or asynchronous. Route handlers can be a lambda expression, a local function, an instance method or a static method.
+Route handlers are methods that execute when the route matches. Route handlers can be a lambda expression, a local function, an instance method or a static method. Route handlers can be synchronous or asynchronous. 
 
 ### Lambda expression
 


### PR DESCRIPTION
As mentioned in the issue, the word `type` describes better than `shape`. So, making the necessary changes

Fixes #27475

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|


<!-- PREVIEW-TABLE-END -->