### PR TITLE
Expand example to show passing parameters

### DIFF
--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -74,7 +74,7 @@ await using var htmlRenderer = new HtmlRenderer(serviceProvider, loggerFactory);
 
 var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
 {
-    var dictionary = new Dictionary<string, object>
+    var dictionary = new Dictionary<string, object?>
     {
         { "Message", "Hello from Render Component Example!" }
     };

--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -5,7 +5,7 @@ description: Render Razor components outside of the context of an HTTP request.
 monikerRange: '>= aspnetcore-8.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/20/2023
+ms.date: 05/10/2023
 uid: blazor/components/render-outside-of-aspnetcore
 ---
 # Render Razor components outside of ASP.NET Core
@@ -35,19 +35,18 @@ In the console app's project file (`ConsoleApp1.csproj`), update the console app
 + <Project Sdk="Microsoft.NET.Sdk.Razor">
 ```
 
-In a command shell, add a Razor component to the project:
+Add the following `RenderComponentExample` component to the project.
 
-```dotnetcli
-dotnet new razorcomponent -n Component1
-```
+`RenderComponentExample.razor`:
 
 ```razor
-<h1>Component1</h1>
+<h1>Render Component Example</h1>
 
-<p>Hello from Component1!</p>
+<p>@Message</p>
 
 @code {
-
+    [Parameter]
+    public required string Message { get; set; }
 }
 ```
 
@@ -75,13 +74,23 @@ await using var htmlRenderer = new HtmlRenderer(serviceProvider, loggerFactory);
 
 var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
 {
-    var parameters = ParameterView.Empty;
-    var output = await htmlRenderer.RenderComponentAsync<Component1>(parameters);
+    var dictionary = new Dictionary<string, object>
+    {
+        { "Message", "Hello from Render Component Example!" }
+    };
+
+    var parameters = ParameterView.FromDictionary(dictionary);
+    var output = 
+        await htmlRenderer.RenderComponentAsync<RenderComponentExample>(parameters);
+
     return output.ToHtmlString();
 });
 
 Console.WriteLine(html);
 ```
+
+> [!NOTE]
+> Pass `ParameterView.Empty` to `RenderComponentAsync` when rendering the component without passing parameters.
 
 Alternatively, you can write the HTML to a <xref:System.IO.TextWriter> by calling `output.WriteHtmlTo(textWriter)`.
 

--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -90,7 +90,7 @@ Console.WriteLine(html);
 ```
 
 > [!NOTE]
-> Pass `ParameterView.Empty` to `RenderComponentAsync` when rendering the component without passing parameters.
+> Pass <xref:Microsoft.AspNetCore.Components.ParameterView.Empty?displayProperty=nameWithType> to `RenderComponentAsync` when rendering the component without passing parameters.
 
 Alternatively, you can write the HTML to a <xref:System.IO.TextWriter> by calling `output.WriteHtmlTo(textWriter)`.
 

--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -46,7 +46,7 @@ Add the following `RenderComponentExample` component to the project.
 
 @code {
     [Parameter]
-    public required string Message { get; set; }
+    public string Message { get; set; }
 }
 ```
 

--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -35,12 +35,12 @@ In the console app's project file (`ConsoleApp1.csproj`), update the console app
 + <Project Sdk="Microsoft.NET.Sdk.Razor">
 ```
 
-Add the following `RenderComponentExample` component to the project.
+Add the following `RenderMessage` component to the project.
 
-`RenderComponentExample.razor`:
+`RenderMessage.razor`:
 
 ```razor
-<h1>Render Component Example</h1>
+<h1>Render Message</h1>
 
 <p>@Message</p>
 
@@ -53,7 +53,7 @@ Add the following `RenderComponentExample` component to the project.
 Update `Program.cs`:
 
 * Set up dependency injection (<xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>/<xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider%2A>) and logging (<xref:Microsoft.Extensions.DependencyInjection.LoggingServiceCollectionExtensions.AddLogging%2A>/<xref:Microsoft.Extensions.Logging.ILoggerFactory>).
-* Create an `HtmlRenderer` and render the `Component1` component by calling `RenderComponentAsync`.
+* Create an `HtmlRenderer` and render the `RenderMessage` component by calling `RenderComponentAsync`.
 
 Any calls to `RenderComponentAsync` must be made in the context of calling `InvokeAsync` on a component dispatcher. A component dispatcher is available from the `HtmlRender.Dispatcher` property.
 
@@ -80,8 +80,7 @@ var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
     };
 
     var parameters = ParameterView.FromDictionary(dictionary);
-    var output = 
-        await htmlRenderer.RenderComponentAsync<RenderComponentExample>(parameters);
+    var output = await htmlRenderer.RenderComponentAsync<RenderMessage>(parameters);
 
     return output.ToHtmlString();
 });

--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -76,7 +76,7 @@ var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
 {
     var dictionary = new Dictionary<string, object?>
     {
-        { "Message", "Hello from Render Component Example!" }
+        { "Message", "Hello from the Render Message component!" }
     };
 
     var parameters = ParameterView.FromDictionary(dictionary);


### PR DESCRIPTION
Fixes #29228

Thanks @sulmar! 🚀 ... How about we just expand the existing example, as I have on this PR, to show it? I add a NOTE at the end about passing an empty `ParameterView` for the no params case.

... and btw ... I didn't think the `EditorRequired` attribute was required ... is that what you're seeing there?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md](https://github.com/dotnet/AspNetCore.Docs/blob/74dafd7edf55f493cbfbe158ce8499828aff4e4d/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md) | [Render Razor components outside of ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-components-outside-of-aspnetcore?branch=pr-en-us-29231) |


<!-- PREVIEW-TABLE-END -->