### PR TITLE
Add public to class Todo

### DIFF
--- a/aspnetcore/tutorials/min-web-api/samples/6.x/todo/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/6.x/todo/Program.cs
@@ -128,7 +128,7 @@ app.MapDelete("/todoitems/{id}", async (int id, TodoDb db) =>
 app.Run();
 
 #region snippet_model
-class Todo
+public class Todo
 {
     public int Id { get; set; }
     public string? Name { get; set; }


### PR DESCRIPTION
When adding public class TodoItemDTO, this message may display in Visual Studio: Inconsistent accessibility: parameter type: 'Todo' is less accessible than the method 'TodoItemDTO.TodoItemDTO (todo).

Adding public to class makes this message go away.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->