### PR TITLE
Fixing bad link

### DIFF
--- a/aspnetcore/security/authentication/azure-active-directory/index.md
+++ b/aspnetcore/security/authentication/azure-active-directory/index.md
@@ -13,7 +13,7 @@ These tutorials and samples demonstrate authentication in ASP.NET Core using Mic
 
 ## Application Scenarios
 
-* [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app](/azure/active-directory/develop/web-app-quickstart?pivots=devlang-aspnet&tabs=windows)
+* [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app](/azure/active-directory/develop/web-app-quickstart?pivots=devlang-aspnet-core&tabs=windows)
 * [Web app that signs in users](/azure/active-directory/develop/scenario-web-app-sign-user-overview?tabs=aspnetcore)
 * [Web app that calls web APIs](/azure/active-directory/develop/scenario-web-app-call-api-overview)
 * [Protected web API](/azure/active-directory/develop/scenario-protected-web-api-overview)

--- a/aspnetcore/security/authentication/azure-active-directory/index.md
+++ b/aspnetcore/security/authentication/azure-active-directory/index.md
@@ -13,7 +13,7 @@ These tutorials and samples demonstrate authentication in ASP.NET Core using Mic
 
 ## Application Scenarios
 
-* [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app](/azure/active-directory/develop/quickstart-v2-aspnet-core-webapp)
+* [Quickstart: Add sign-in with Microsoft to an ASP.NET Core web app](/azure/active-directory/develop/web-app-quickstart?pivots=devlang-aspnet&tabs=windows)
 * [Web app that signs in users](/azure/active-directory/develop/scenario-web-app-sign-user-overview?tabs=aspnetcore)
 * [Web app that calls web APIs](/azure/active-directory/develop/scenario-web-app-call-api-overview)
 * [Protected web API](/azure/active-directory/develop/scenario-protected-web-api-overview)


### PR DESCRIPTION
The old link goes to:
Welcome! This probably isn't the page you were expecting. 

I am just making a guess as to where this is supposed to go: https://learn.microsoft.com/en-us/azure/active-directory/develop/web-app-quickstart?pivots=devlang-aspnet&tabs=windows


Fixes #29304

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/azure-active-directory/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/47f3a5424a0748847bc8fe57a0b2556e2f4f20fd/aspnetcore/security/authentication/azure-active-directory/index.md) | [Azure Active Directory with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/azure-active-directory/index?branch=pr-en-us-29301) |


<!-- PREVIEW-TABLE-END -->