### PR TITLE
Add docs for using Grpc.Tools on unsupport platforms

### DIFF
--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -286,7 +286,7 @@ Alternatively, a client factory can be configured with `Http3Handler` by using <
 
 ## Building gRPC on Alpine Linux
 
-The `Grpc.Tools` package [generates .NET types from `.proto` files](xref:grpc/basics#generated-c-assets) using a bundled native binary called `protoc`. Additional steps are required to build gRPC apps on platforms that aren't supported by `Grpc.Tools` bundled native binaries, such as Alpine Linux.
+The `Grpc.Tools` package [generates .NET types from `.proto` files](xref:grpc/basics#generated-c-assets) using a bundled native binary called `protoc`. Additional steps are required to build gRPC apps on platforms that aren't supported by the native binaries in `Grpc.Tools`, such as Alpine Linux.
 
 ### Generate code ahead of time
 
@@ -321,7 +321,7 @@ apk add grpc-plugins  # Alpine Linux specific package installer
 export PROTOBUF_PROTOC=/usr/bin/protoc
 export GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
 
-# When the dotnet build runs the Grpc.Tools NuGet package will
+# When dotnet build runs, the Grpc.Tools NuGet package will
 # use the binaries pointed to by the environment variables
 dotnet build
 ```

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -293,21 +293,21 @@ The `Grpc.Tools` package [generates .NET types from `.proto` files](xref:grpc/ba
 One solution is to generate code ahead of time.
 
 1. Move `.proto` files and the `Grpc.Tools` package reference to a new project.
-2. Publish the project as a NuGet package and upload it to a NuGet feed.
-3. Update the app to reference the NuGet package.
+1. Publish the project as a NuGet package and upload it to a NuGet feed.
+1. Update the app to reference the NuGet package.
 
-The app no longer requires `Grpc.Tools` to build when code is generated ahead of time.
+With the preceding steps, the app no longer requires `Grpc.Tools` to build because code is generated ahead of time.
 
 ### Customize `Grpc.Tools` native binaries
 
-`Grpc.Tools` supports using custom native binaries. This feature allows gRPC tooling to run on environments its bundled native binaries don't support.
+`Grpc.Tools` supports using custom native binaries. This feature allows gRPC tooling to run in environments its bundled native binaries don't support.
 
-Build or acquire `protoc` and `grpc_csharp_plugin` native binaries and configure `Grpc.Tools` to use them. Configure native binaries by setting environment variables:
+Build or acquire `protoc` and `grpc_csharp_plugin` native binaries and configure `Grpc.Tools` to use them. Configure native binaries by setting the following environment variables:
 
 * `PROTOBUF_PROTOC` - Full path to the protocol buffers compiler
 * `GRPC_PROTOC_PLUGIN` - Full path to the grpc_csharp_plugin
 
-For Alpine Linux, there are community-provided packages for the protocol buffers compiler and gRPC plugins: https://pkgs.alpinelinux.org/packages?name=grpc-plugins
+For Alpine Linux, there are community-provided packages for the protocol buffers compiler and gRPC plugins at [https://pkgs.alpinelinux.org/](https://pkgs.alpinelinux.org/packages?name=grpc-plugins).
 
 ```sh
 # Build or install the binaries for your architecture.
@@ -321,8 +321,8 @@ apk add grpc-plugins  # Alpine Linux specific package installer
 export PROTOBUF_PROTOC=/usr/bin/protoc
 export GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
 
-# When dotnet build runs, the Grpc.Tools NuGet package will
-# use the binaries pointed to by the environment variables
+# When dotnet build runs, the Grpc.Tools NuGet package
+# uses the binaries pointed to by the environment variables.
 dotnet build
 ```
 

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -284,6 +284,50 @@ var reply = await client.SayHelloAsync(new HelloRequest { Name = ".NET" });
 
 Alternatively, a client factory can be configured with `Http3Handler` by using <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddHttpMessageHandler%2A>.
 
+## Building gRPC on Alpine Linux
+
+The `Grpc.Tools` package [generates .NET types from `.proto` files](xref:grpc/basics#generated-c-assets) using a bundled native binary called `protoc`. Additional steps are required to build gRPC apps on platforms that aren't supported by `Grpc.Tools` bundled native binaries, such as Alpine Linux.
+
+### Generate code ahead of time
+
+One solution is to generate code ahead of time.
+
+1. Move `.proto` files and the `Grpc.Tools` package reference to a new project.
+2. Publish the project as a NuGet package and upload it to a NuGet feed.
+3. Update the app to reference the NuGet package.
+
+The app no longer requires `Grpc.Tools` to build when code is generated ahead of time.
+
+### Customize `Grpc.Tools` native binaries
+
+`Grpc.Tools` supports using custom native binaries. This feature allows gRPC tooling to run on environments its bundled native binaries don't support.
+
+Build or acquire `protoc` and `grpc_csharp_plugin` native binaries and configure `Grpc.Tools` to use them. Configure native binaries by setting environment variables:
+
+* `PROTOBUF_PROTOC` - Full path to the protocol buffers compiler
+* `GRPC_PROTOC_PLUGIN` - Full path to the grpc_csharp_plugin
+
+For Alpine Linux, there are community-provided packages for the protocol buffers compiler and gRPC plugins: https://pkgs.alpinelinux.org/packages?name=grpc-plugins
+
+```sh
+# Build or install the binaries for your architecture.
+
+# e.g. for Alpine Linux the grpc-plugins package can be used
+#  See https://pkgs.alpinelinux.org/package/edge/community/x86_64/grpc-plugins
+apk add grpc-plugins  # Alpine Linux specific package installer
+
+# Set environment variables for the built/installed protoc
+# and grpc_csharp_plugin binaries
+export PROTOBUF_PROTOC=/usr/bin/protoc
+export GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
+
+# When the dotnet build runs the Grpc.Tools NuGet package will
+# use the binaries pointed to by the environment variables
+dotnet build
+```
+
+For more information about using `Grpc.Tools` with unsupported architectures, see the [gRPC build integration documentation](https://github.com/grpc/grpc/blob/master/src/csharp/BUILD-INTEGRATION.md#using-grpctools-with-unsupported-architectures).
+
 :::moniker-end
 
 [!INCLUDE[](~/grpc/troubleshoot/includes/troubleshoot3-7.md)]

--- a/aspnetcore/grpc/troubleshoot/includes/troubleshoot3-7.md
+++ b/aspnetcore/grpc/troubleshoot/includes/troubleshoot3-7.md
@@ -277,6 +277,50 @@ var reply = await client.SayHelloAsync(new HelloRequest { Name = ".NET" });
 
 Alternatively, a client factory can be configured with `Http3Handler` by using <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddHttpMessageHandler%2A>.
 
+## Building gRPC on Alpine Linux
+
+The `Grpc.Tools` package [generates .NET types from `.proto` files](xref:grpc/basics#generated-c-assets) using a bundled native binary called `protoc`. Additional steps are required to build gRPC apps on platforms that aren't supported by `Grpc.Tools` bundled native binaries, such as Alpine Linux.
+
+### Generate code ahead of time
+
+One solution is to generate code ahead of time.
+
+1. Move `.proto` files and the `Grpc.Tools` package reference to a new project.
+2. Publish the project as a NuGet package and upload it to a NuGet feed.
+3. Update the app to reference the NuGet package.
+
+The app no longer requires `Grpc.Tools` to build when code is generated ahead of time.
+
+### Customize `Grpc.Tools` native binaries
+
+`Grpc.Tools` supports using custom native binaries. This feature allows gRPC tooling to run on environments its bundled native binaries don't support.
+
+Build or acquire `protoc` and `grpc_csharp_plugin` native binaries and configure `Grpc.Tools` to use them. Configure native binaries by setting environment variables:
+
+* `PROTOBUF_PROTOC` - Full path to the protocol buffers compiler
+* `GRPC_PROTOC_PLUGIN` - Full path to the grpc_csharp_plugin
+
+For Alpine Linux, there are community-provided packages for the protocol buffers compiler and gRPC plugins: https://pkgs.alpinelinux.org/packages?name=grpc-plugins
+
+```sh
+# Build or install the binaries for your architecture.
+
+# e.g. for Alpine Linux the grpc-plugins package can be used
+#  See https://pkgs.alpinelinux.org/package/edge/community/x86_64/grpc-plugins
+apk add grpc-plugins  # Alpine Linux specific package installer
+
+# Set environment variables for the built/installed protoc
+# and grpc_csharp_plugin binaries
+export PROTOBUF_PROTOC=/usr/bin/protoc
+export GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
+
+# When the dotnet build runs the Grpc.Tools NuGet package will
+# use the binaries pointed to by the environment variables
+dotnet build
+```
+
+For more information about using `Grpc.Tools` with unsupported architectures, see the [gRPC build integration documentation](https://github.com/grpc/grpc/blob/master/src/csharp/BUILD-INTEGRATION.md#using-grpctools-with-unsupported-architectures).
+
 :::moniker-end
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 

--- a/aspnetcore/grpc/troubleshoot/includes/troubleshoot3-7.md
+++ b/aspnetcore/grpc/troubleshoot/includes/troubleshoot3-7.md
@@ -279,7 +279,7 @@ Alternatively, a client factory can be configured with `Http3Handler` by using <
 
 ## Building gRPC on Alpine Linux
 
-The `Grpc.Tools` package [generates .NET types from `.proto` files](xref:grpc/basics#generated-c-assets) using a bundled native binary called `protoc`. Additional steps are required to build gRPC apps on platforms that aren't supported by `Grpc.Tools` bundled native binaries, such as Alpine Linux.
+The `Grpc.Tools` package [generates .NET types from `.proto` files](xref:grpc/basics#generated-c-assets) using a bundled native binary called `protoc`. Additional steps are required to build gRPC apps on platforms that aren't supported by the native binaries in `Grpc.Tools`, such as Alpine Linux.
 
 ### Generate code ahead of time
 
@@ -314,7 +314,7 @@ apk add grpc-plugins  # Alpine Linux specific package installer
 export PROTOBUF_PROTOC=/usr/bin/protoc
 export GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
 
-# When the dotnet build runs the Grpc.Tools NuGet package will
+# When dotnet build runs, the Grpc.Tools NuGet package will
 # use the binaries pointed to by the environment variables
 dotnet build
 ```

--- a/aspnetcore/grpc/troubleshoot/includes/troubleshoot3-7.md
+++ b/aspnetcore/grpc/troubleshoot/includes/troubleshoot3-7.md
@@ -286,21 +286,21 @@ The `Grpc.Tools` package [generates .NET types from `.proto` files](xref:grpc/ba
 One solution is to generate code ahead of time.
 
 1. Move `.proto` files and the `Grpc.Tools` package reference to a new project.
-2. Publish the project as a NuGet package and upload it to a NuGet feed.
-3. Update the app to reference the NuGet package.
+1. Publish the project as a NuGet package and upload it to a NuGet feed.
+1. Update the app to reference the NuGet package.
 
-The app no longer requires `Grpc.Tools` to build when code is generated ahead of time.
+With the preceding steps, the app no longer requires `Grpc.Tools` to build because code is generated ahead of time.
 
 ### Customize `Grpc.Tools` native binaries
 
-`Grpc.Tools` supports using custom native binaries. This feature allows gRPC tooling to run on environments its bundled native binaries don't support.
+`Grpc.Tools` supports using custom native binaries. This feature allows gRPC tooling to run in environments its bundled native binaries don't support.
 
-Build or acquire `protoc` and `grpc_csharp_plugin` native binaries and configure `Grpc.Tools` to use them. Configure native binaries by setting environment variables:
+Build or acquire `protoc` and `grpc_csharp_plugin` native binaries and configure `Grpc.Tools` to use them. Configure native binaries by setting the following environment variables:
 
 * `PROTOBUF_PROTOC` - Full path to the protocol buffers compiler
 * `GRPC_PROTOC_PLUGIN` - Full path to the grpc_csharp_plugin
 
-For Alpine Linux, there are community-provided packages for the protocol buffers compiler and gRPC plugins: https://pkgs.alpinelinux.org/packages?name=grpc-plugins
+For Alpine Linux, there are community-provided packages for the protocol buffers compiler and gRPC plugins at [https://pkgs.alpinelinux.org/](https://pkgs.alpinelinux.org/packages?name=grpc-plugins).
 
 ```sh
 # Build or install the binaries for your architecture.
@@ -314,8 +314,8 @@ apk add grpc-plugins  # Alpine Linux specific package installer
 export PROTOBUF_PROTOC=/usr/bin/protoc
 export GRPC_PROTOC_PLUGIN=/usr/bin/grpc_csharp_plugin
 
-# When dotnet build runs, the Grpc.Tools NuGet package will
-# use the binaries pointed to by the environment variables
+# When dotnet build runs, the Grpc.Tools NuGet package
+# uses the binaries pointed to by the environment variables.
 dotnet build
 ```
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2048

FYI @tonydnewell

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/troubleshoot.md](https://github.com/dotnet/AspNetCore.Docs/blob/bceca0cb2b415e434a6ebba83abcbcd45f8963b1/aspnetcore/grpc/troubleshoot.md) | [Troubleshoot gRPC on .NET](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?branch=pr-en-us-29314) |


<!-- PREVIEW-TABLE-END -->