### PR TITLE
Blazor - hosted-with-azure-active-directory.md - No audience

### DIFF
--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md
@@ -171,7 +171,7 @@ This section describes the parts of a solution generated from the Blazor WebAsse
 
 *This section pertains to the solution's **:::no-loc text="Server":::** app.*
 
-The `appsettings.json` file contains the options to configure the JWT bearer handler used to validate access tokens. Add the following audience entry to the `AzureAd` configuration:
+The `appsettings.json` file contains the options to configure the JWT bearer handler used to validate access tokens. Add the following `AzureAd` configuration section:
 
 ```json
 {


### PR DESCRIPTION
The configuration change in `appsettings.json` (Server) is no longer related to the "audience" but the paragraph describes general configuration change needed.

Relates to #29032, cc @guardrex.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md](https://github.com/dotnet/AspNetCore.Docs/blob/cf737e30f90005d1e18fbc1d8ce8960e0f572465/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory.md) | [Secure a hosted ASP.NET Core Blazor WebAssembly app with Azure Active Directory](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/hosted-with-azure-active-directory?branch=pr-en-us-29315) |

<!-- PREVIEW-TABLE-END -->