### PR TITLE
Fix typo

### DIFF
--- a/aspnetcore/mvc/models/model-binding.md
+++ b/aspnetcore/mvc/models/model-binding.md
@@ -650,7 +650,7 @@ To use the built-in XML input formatters:
 
 An input formatter takes full responsibility for reading data from the request body. To customize this process, configure the APIs used by the input formatter. This section describes how to customize the `System.Text.Json`-based input formatter to understand a custom type named `ObjectId`. 
 
-Consider the following model, which contains a custom `ObjectId` property named `Id`:
+Consider the following model, which contains a custom `ObjectId` property named `ObjectId`:
 
 :::code language="csharp" source="model-binding/samples/6.x/ModelBindingSample/Snippets/InstructorObjectId.cs" id="snippet_Class" highlight="4":::
 

--- a/aspnetcore/mvc/models/model-binding.md
+++ b/aspnetcore/mvc/models/model-binding.md
@@ -650,7 +650,7 @@ To use the built-in XML input formatters:
 
 An input formatter takes full responsibility for reading data from the request body. To customize this process, configure the APIs used by the input formatter. This section describes how to customize the `System.Text.Json`-based input formatter to understand a custom type named `ObjectId`. 
 
-Consider the following model, which contains a custom `ObjectId` property named `ObjectId`:
+Consider the following model, which contains a custom `ObjectId` property:
 
 :::code language="csharp" source="model-binding/samples/6.x/ModelBindingSample/Snippets/InstructorObjectId.cs" id="snippet_Class" highlight="4":::
 
@@ -1283,7 +1283,7 @@ To use the built-in XML input formatters:
 
 An input formatter takes full responsibility for reading data from the request body. To customize this process, configure the APIs used by the input formatter. This section describes how to customize the `System.Text.Json`-based input formatter to understand a custom type named `ObjectId`. 
 
-Consider the following model, which contains a custom `ObjectId` property named `Id`:
+Consider the following model, which contains a custom `ObjectId` property:
 
 :::code language="csharp" source="model-binding/samples/6.x/ModelBindingSample/Snippets/InstructorObjectId.cs" id="snippet_Class" highlight="4":::
 


### PR DESCRIPTION
Property is named `ObjectId` in the example shown.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/models/model-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/ba87cef77f45651edc314569018c9e019fff4912/aspnetcore/mvc/models/model-binding.md) | [Model Binding in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/models/model-binding?branch=pr-en-us-29323) |


<!-- PREVIEW-TABLE-END -->