### PR TITLE
Fixed highlight for // Using a custom DI container.

### DIFF
--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -159,7 +159,7 @@ In the preceding code, the ` if (env.IsDevelopment())` block is removed because 
 
 When using a custom dependency injection (DI) container, add the following highlighted code:
 
-[!code-csharp[](~/migration/50-to-60/samples/WebRP31to60/Program.cs?name=snippet_60a&highlight=11-13)]
+[!code-csharp[](~/migration/50-to-60/samples/WebRP31to60/Program.cs?name=snippet_60a&highlight=12-14)]
 
 [!code-csharp[](~/migration/50-to-60/samples/WebRP31to60/Startup.cs?name=snippet_60a&highlight=17-21)]
 


### PR DESCRIPTION
The highlight for the code starting `// Using a custom DI container.` was off by one line.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->