### PR TITLE
Removing Preview Feature from dev tunnels, it is no longer required

### DIFF
--- a/aspnetcore/test/dev-tunnels.md
+++ b/aspnetcore/test/dev-tunnels.md
@@ -22,8 +22,7 @@ Some of the scenarios that dev tunnels enable:
 
 ## Prerequisites
 
-* [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) version 17.5 or later with the **ASP.NET and web development** workload installed. You need to be signed in to Visual Studio to create and use dev tunnels. The feature isn't available in Visual Studio for Mac.
-* Dev tunnels preview feature enabled. Select **Tools** > **Options** > **Environment** > **Preview Features** > **Enable dev tunnels for Web Applications**.
+* [Visual Studio 2022](https://visualstudio.microsoft.com/vs/) version 17.6 or later with the **ASP.NET and web development** workload installed. You need to be signed in to Visual Studio to create and use dev tunnels. The feature isn't available in Visual Studio for Mac.
 * One or more ASP.NET Core projects. This article uses a solution with two sample projects to demonstrate the feature.
 
 ## Create a tunnel


### PR DESCRIPTION
dev tunnels has GAed in 17.6, the Preview Feature option has been removed and it's enabled by default. Updated the doc to reflect that.

cc @tdykstra 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/dev-tunnels.md](https://github.com/dotnet/AspNetCore.Docs/blob/6eefdb89458c1786b41e759594f24dea9ec45dbc/aspnetcore/test/dev-tunnels.md) | [How to use dev tunnels in Visual Studio 2022 with ASP.NET Core apps](https://review.learn.microsoft.com/en-us/aspnet/core/test/dev-tunnels?branch=pr-en-us-29334) |

<!-- PREVIEW-TABLE-END -->