### PR TITLE
NIT Migrations INCLUDE lingo change

### DIFF
--- a/aspnetcore/includes/scaffold-identity/migrations.md
+++ b/aspnetcore/includes/scaffold-identity/migrations.md
@@ -41,7 +41,7 @@ dotnet ef database update
 
 ---
 
-You can confirm the application of an Identity schema with the following command:
+You can confirm the application of an Identity schema with the following command. The output of the command includes an "`applied`" column to show which migrations are applied to the database.
 
 # [Visual Studio](#tab/visual-studio)
 
@@ -64,5 +64,3 @@ dotnet ef migrations list
 If more than one database context exists, specify the context with the `--context` parameter.
 
 ---
-
-The output of the command includes an "`applied`" column to show which migrations are applied to the database.

--- a/aspnetcore/includes/scaffold-identity/migrations.md
+++ b/aspnetcore/includes/scaffold-identity/migrations.md
@@ -41,7 +41,7 @@ dotnet ef database update
 
 ---
 
-You can confirm if the Identity schema has been applied with either:
+You can confirm if the Identity schema has been applied with the following command:
 
 # [Visual Studio](#tab/visual-studio)
 

--- a/aspnetcore/includes/scaffold-identity/migrations.md
+++ b/aspnetcore/includes/scaffold-identity/migrations.md
@@ -41,7 +41,7 @@ dotnet ef database update
 
 ---
 
-You can confirm if the Identity schema has been applied with the following command:
+You can confirm the application of an Identity schema with the following command:
 
 # [Visual Studio](#tab/visual-studio)
 
@@ -51,6 +51,8 @@ In the Visual Studio **Package Manager Console**, execute [`Get-Migration`](/ef/
 Get-Migration
 ```
 
+If more than one database context exists, specify the context with the `-Context` parameter.
+
 # [.NET Core CLI](#tab/netcore-cli)
 
 In a command shell, execute [`dotnet ef migrations list`](/ef/core/managing-schemas/migrations/managing?tabs=dotnet-core-cli#listing-migrations):
@@ -58,6 +60,8 @@ In a command shell, execute [`dotnet ef migrations list`](/ef/core/managing-sche
 ```dotnetcli
 dotnet ef migrations list
 ```
+
+If more than one database context exists, specify the context with the `--context` parameter.
 
 ---
 

--- a/aspnetcore/includes/scaffold-identity/migrations.md
+++ b/aspnetcore/includes/scaffold-identity/migrations.md
@@ -65,4 +65,4 @@ If more than one database context exists, specify the context with the `--contex
 
 ---
 
-The output of the command includes an "applied" (**:::no-loc text="applied":::**) column to show which migrations are applied to the database.
+The output of the command includes an "`applied`" column to show which migrations are applied to the database.


### PR DESCRIPTION
It doesn't read well with "either" when only one command is shown by a single tab control.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|


<!-- PREVIEW-TABLE-END -->