### PR TITLE
Update building-net-docker-images.md - Indent Error

### DIFF
--- a/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
+++ b/aspnetcore/host-and-deploy/docker/building-net-docker-images.md
@@ -123,7 +123,7 @@ In some scenarios, you might want to deploy an app to a container by copying its
   * Linux:
 
     ```dotnetcli
-  dotnet published/aspnetapp.dll
+    dotnet published/aspnetapp.dll
     ```
 
 * Browse to `http://localhost:5000` to see the home page.


### PR DESCRIPTION
Fix a little indent error in a linux code example.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/docker/building-net-docker-images.md](https://github.com/dotnet/AspNetCore.Docs/blob/42bfee49dadcdf5df33e972ae210a835597c758e/aspnetcore/host-and-deploy/docker/building-net-docker-images.md) | [Docker images for ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/docker/building-net-docker-images?branch=pr-en-us-29425) |

<!-- PREVIEW-TABLE-END -->