### PR TITLE
Pass the RequestAborted token to async APIs like Task.Delay

### DIFF
--- a/aspnetcore/performance/timeouts.md
+++ b/aspnetcore/performance/timeouts.md
@@ -15,7 +15,7 @@ By [Tom Dykstra](https://github.com/tdykstra)
 
 Apps can apply timeout limits selectively to requests. ASP.NET Core servers don't do this by default since request processing times vary widely by scenario. For example, WebSockets, static files, and calling expensive APIs would each require a different timeout limit. So ASP.NET Core provides middleware that configures timeouts per endpoint as well as a global timeout.
 
-When a timeout limit is hit, a <xref:System.Threading.CancellationToken> in <xref:Microsoft.AspNetCore.Http.HttpContext.RequestAborted?displayProperty=nameWithType> has <xref:System.Threading.CancellationToken.IsCancellationRequested> set to `true`. The request is not aborted automatically. It's up to the app to check `RequestAborted` and decide how to handle the timeout.
+When a timeout limit is hit, a <xref:System.Threading.CancellationToken> in <xref:Microsoft.AspNetCore.Http.HttpContext.RequestAborted?displayProperty=nameWithType> has <xref:System.Threading.CancellationToken.IsCancellationRequested> set to `true`. <xref:Microsoft.AspNetCore.Http.HttpContext.Abort> isn't automatically called on the request, so the application may still produce a success or failure response. The default behavior if the app doesn't handle the exception and produce a response is to return status code 504.
 
 This article explains how to configure the timeout middleware. The timeout middleware can be used in all types of ASP.NET Core apps: Minimal API, Web API with controllers, MVC, and Razor Pages. The sample app is a Minimal API, but every timeout feature it illustrates is also supported in the other app types.
 
@@ -76,7 +76,7 @@ The `RequestTimeoutPolicy` class has a <xref:Microsoft.AspNetCore.Http.Timeouts.
 
 :::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="definepolicies2" highlight="8-11":::
 
-:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="usepolicy2" :::
+:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="usepolicy2" highlight="12":::
 
 ## Disable timeouts
 

--- a/aspnetcore/performance/timeouts.md
+++ b/aspnetcore/performance/timeouts.md
@@ -4,7 +4,7 @@ description: Learn how to configure and use request timeout middleware in ASP.NE
 author: tdykstra
 ms.author: riande
 monikerRange: '>= aspnetcore-8.0'
-ms.date: 04/24/2023
+ms.date: 06/06/2023
 uid: performance/timeouts
 ---
 # Request timeouts middleware in ASP.NET Core
@@ -36,7 +36,7 @@ Adding the middleware to the app doesn't automatically start triggering timeouts
 
 For minimal API apps, configure an endpoint to time out by calling <xref:Microsoft.AspNetCore.Builder.RequestTimeoutsIEndpointConventionBuilderExtensions.WithRequestTimeout%2A>, or by applying the [`[RequestTimeout]`](xref:Microsoft.AspNetCore.Http.Timeouts.RequestTimeoutAttribute) attribute, as shown in the following example:
 
-:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="oneendpoint" highlight="17,21":::
+:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="oneendpoint" highlight="20,24":::
 
 For apps with controllers, apply the `[RequestTimeout]` attribute to the action method or the controller class. For Razor Pages apps, apply the attribute to the Razor page class.
 
@@ -48,7 +48,7 @@ Create named *policies* to specify timeout configuration that applies to multipl
 
 A timeout can be specified for an endpoint by policy name:
 
-:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="usepolicy" highlight="9":::
+:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="usepolicy" highlight="12":::
 
 The `[RequestTimeout]` attribute can also be used to specify a named policy.
 
@@ -68,7 +68,7 @@ The <xref:Microsoft.AspNetCore.Http.Timeouts.RequestTimeoutPolicy> class has a p
 
 :::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="definepolicies2" highlight="4":::
 
-:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="usedefault2" highlight="4":::
+:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="usedefault2" :::
 
 ## Use a delegate in a policy
 
@@ -76,7 +76,7 @@ The `RequestTimeoutPolicy` class has a <xref:Microsoft.AspNetCore.Http.Timeouts.
 
 :::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="definepolicies2" highlight="8-11":::
 
-:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="usepolicy2" highlight="4,7":::
+:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="usepolicy2" :::
 
 ## Disable timeouts
 
@@ -84,7 +84,7 @@ To disable all timeouts including the default global timeout, use the [`[Disable
 
 :::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="disablebyattr" highlight="1":::
 
-:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="disablebyext" highlight="5":::
+:::code language="csharp" source="~/performance/timeouts/samples/8.x/Program.cs" id="disablebyext" highlight="12":::
 
 ## Cancel a timeout
 

--- a/aspnetcore/performance/timeouts/samples/8.x/Program.cs
+++ b/aspnetcore/performance/timeouts/samples/8.x/Program.cs
@@ -171,7 +171,7 @@ app.MapGet("/", async (HttpContext context) => {
 app.MapGet("/usepolicy2", async (HttpContext context) => {
     try
     {
-        await Task.Delay(TimeSpan.FromSeconds(5), context.RequestAborted);
+        await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
     }
     catch (TaskCanceledException)
     {

--- a/aspnetcore/performance/timeouts/samples/8.x/Program.cs
+++ b/aspnetcore/performance/timeouts/samples/8.x/Program.cs
@@ -136,7 +136,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRequestTimeouts(options => {
     options.DefaultPolicy = new RequestTimeoutPolicy {
         Timeout = TimeSpan.FromMilliseconds(1000),
-        TimeoutStatusCode = 504
+        TimeoutStatusCode = 503
     };
     options.AddPolicy("MyPolicy2", new RequestTimeoutPolicy {
         Timeout = TimeSpan.FromMilliseconds(1000),
@@ -164,7 +164,7 @@ app.MapGet("/", async (HttpContext context) => {
 
     return Results.Content("No timeout!", "text/plain");
 });
-// Returns status code 504 due to default policy.
+// Returns status code 503 due to default policy.
 // </usedefault2>
 
 // <usepolicy2>

--- a/aspnetcore/performance/timeouts/samples/8.x/Program.cs
+++ b/aspnetcore/performance/timeouts/samples/8.x/Program.cs
@@ -1,4 +1,4 @@
-#define policies1 // oneendpoint / policies1 / policies2
+#define policies2 // oneendpoint / policies1 / policies2
 
 #if oneendpoint
 // <oneendpoint>
@@ -11,14 +11,16 @@ var app = builder.Build();
 app.UseRequestTimeouts();
 
 app.MapGet("/", async (HttpContext context) => {
-    await Task.Delay(TimeSpan.FromSeconds(2));
-
-    if (context.RequestAborted.IsCancellationRequested) {
-        return Results.Content("Timeout!", "text/plain");
+    try
+    {
+        await Task.Delay(TimeSpan.FromSeconds(3), context.RequestAborted);
+    } catch (TaskCanceledException)
+    {
+        return Results.Content($"{Timeout!", "text/plain");
     }
 
     return Results.Content("No timeout!", "text/plain");
-}).WithRequestTimeout(TimeSpan.FromSeconds(1));
+}).WithRequestTimeout(TimeSpan.FromSeconds(2));
 // Returns "Timeout!"
 
 app.MapGet("/attribute",
@@ -47,7 +49,7 @@ builder.Services.AddRequestTimeouts();
 builder.Services.AddRequestTimeouts(options => {
     options.DefaultPolicy =
         new RequestTimeoutPolicy { Timeout = TimeSpan.FromMilliseconds(1500) };
-    options.AddPolicy("MyPolicy", TimeSpan.FromSeconds(1));
+    options.AddPolicy("MyPolicy", TimeSpan.FromSeconds(2));
 });
 // </definepolicies>
 
@@ -56,9 +58,12 @@ app.UseRequestTimeouts();
 
 // <usepolicy>
 app.MapGet("/namedpolicy", async (HttpContext context) => {
-    await Task.Delay(TimeSpan.FromSeconds(2));
-
-    if (context.RequestAborted.IsCancellationRequested) {
+    try
+    {
+        await Task.Delay(TimeSpan.FromSeconds(5), context.RequestAborted);
+    }
+    catch (TaskCanceledException)
+    {
         return Results.Content("Timeout!", "text/plain");
     }
 
@@ -116,7 +121,7 @@ builder.Services.AddRequestTimeouts(options => {
         Timeout = TimeSpan.FromMilliseconds(1000),
         WriteTimeoutResponse = async (HttpContext context) => {
             context.Response.ContentType = "text/plain";
-            await context.Response.WriteAsync("Timeout!");
+            await context.Response.WriteAsync("Timeout from MyPolicy2!");
         }
     });
 });
@@ -127,24 +132,33 @@ app.UseRequestTimeouts();
 
 // <usedefault2>
 app.MapGet("/", async (HttpContext context) => {
-    await Task.Delay(TimeSpan.FromSeconds(2));
-
-    context.RequestAborted.ThrowIfCancellationRequested();
-
+    try
+    {
+        await Task.Delay(TimeSpan.FromSeconds(5), context.RequestAborted);
+    }
+    catch (TaskCanceledException)
+    {
+        throw;
+    }
     return Results.Content("No timeout!", "text/plain");
 });
 // Returns status code 504 due to default policy.
 // </usedefault2>
 
 // <usepolicy2>
-app.MapGet("/usepolicy2", async (HttpContext context) => { 
-    await Task.Delay(TimeSpan.FromSeconds(2));
-
-    context.RequestAborted.ThrowIfCancellationRequested();
+app.MapGet("/usepolicy2", async (HttpContext context) => {
+    try
+    {
+        await Task.Delay(TimeSpan.FromSeconds(5), context.RequestAborted);
+    }
+    catch (TaskCanceledException)
+    {
+        throw;
+    }
 
     return Results.Content("No timeout!", "text/plain");
 }).WithRequestTimeout("MyPolicy2");
-// Returns "Timeout!" due to WriteTimeoutResponse in MyPolicy2.
+// Returns "Timeout from MyPolicy2!" due to WriteTimeoutResponse in MyPolicy2.
 // </usepolicy2>
 
 // <canceltimeout>
@@ -152,11 +166,13 @@ app.MapGet("/canceltimeout", async (HttpContext context) => {
     var timeoutFeature = context.Features.Get<IHttpRequestTimeoutFeature>();
     timeoutFeature?.DisableTimeout();
 
-    await Task.Delay(TimeSpan.FromSeconds(2));
-    
-    if (context.RequestAborted.IsCancellationRequested) // is false
+    try
     {
-
+        await Task.Delay(TimeSpan.FromSeconds(2), context.RequestAborted);
+    } 
+    catch (TaskCanceledException)
+    {
+        return Results.Content("Timeout!", "text/plain");
     }
 
     return Results.Content("No timeout!", "text/plain");

--- a/aspnetcore/performance/timeouts/samples/8.x/Program.cs
+++ b/aspnetcore/performance/timeouts/samples/8.x/Program.cs
@@ -13,10 +13,11 @@ app.UseRequestTimeouts();
 app.MapGet("/", async (HttpContext context) => {
     try
     {
-        await Task.Delay(TimeSpan.FromSeconds(3), context.RequestAborted);
-    } catch (TaskCanceledException)
+        await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
+    }
+    catch (TaskCanceledException)
     {
-        return Results.Content($"{Timeout!", "text/plain");
+        return Results.Content("Timeout!", "text/plain");
     }
 
     return Results.Content("No timeout!", "text/plain");
@@ -24,10 +25,13 @@ app.MapGet("/", async (HttpContext context) => {
 // Returns "Timeout!"
 
 app.MapGet("/attribute",
-    [RequestTimeout(milliseconds: 1000)] async (HttpContext context) => {
-        await Task.Delay(TimeSpan.FromSeconds(2));
-
-        if (context.RequestAborted.IsCancellationRequested) {
+    [RequestTimeout(milliseconds: 2000)] async (HttpContext context) => {
+        try
+        {
+            await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
+        }
+        catch (TaskCanceledException)
+        {
             return Results.Content("Timeout!", "text/plain");
         }
 
@@ -60,7 +64,7 @@ app.UseRequestTimeouts();
 app.MapGet("/namedpolicy", async (HttpContext context) => {
     try
     {
-        await Task.Delay(TimeSpan.FromSeconds(5), context.RequestAborted);
+        await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
     }
     catch (TaskCanceledException)
     {
@@ -74,9 +78,12 @@ app.MapGet("/namedpolicy", async (HttpContext context) => {
 
 // <usedefault>
 app.MapGet("/", async (HttpContext context) => {
-    await Task.Delay(TimeSpan.FromSeconds(2));
-
-    if (context.RequestAborted.IsCancellationRequested) {
+    try
+    {
+        await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
+    }
+    catch
+    {
         return Results.Content("Timeout!", "text/plain");
     }
 
@@ -87,7 +94,14 @@ app.MapGet("/", async (HttpContext context) => {
 
 // <disablebyattr>
 app.MapGet("/disablebyattr", [DisableRequestTimeout] async (HttpContext context) => {
-    await Task.Delay(TimeSpan.FromSeconds(2));
+    try
+    {
+        await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
+    }
+    catch
+    {
+        return Results.Content("Timeout!", "text/plain");
+    }
 
     return Results.Content("No timeout!", "text/plain");
 });
@@ -96,7 +110,14 @@ app.MapGet("/disablebyattr", [DisableRequestTimeout] async (HttpContext context)
 
 // <disablebyext>
 app.MapGet("/disablebyext", async (HttpContext context) => {
-    await Task.Delay(TimeSpan.FromSeconds(2));
+    try
+    {
+        await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
+    }
+    catch
+    {
+        return Results.Content("Timeout!", "text/plain");
+    }
 
     return Results.Content("No timeout!", "text/plain");
 }).DisableRequestTimeout();
@@ -134,12 +155,13 @@ app.UseRequestTimeouts();
 app.MapGet("/", async (HttpContext context) => {
     try
     {
-        await Task.Delay(TimeSpan.FromSeconds(5), context.RequestAborted);
+        await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
     }
     catch (TaskCanceledException)
     {
         throw;
     }
+
     return Results.Content("No timeout!", "text/plain");
 });
 // Returns status code 504 due to default policy.
@@ -168,7 +190,7 @@ app.MapGet("/canceltimeout", async (HttpContext context) => {
 
     try
     {
-        await Task.Delay(TimeSpan.FromSeconds(2), context.RequestAborted);
+        await Task.Delay(TimeSpan.FromSeconds(10), context.RequestAborted);
     } 
     catch (TaskCanceledException)
     {


### PR DESCRIPTION
Fixes #29436 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/timeouts.md](https://github.com/dotnet/AspNetCore.Docs/blob/f9c6c534e609038e91427afdeb4eab2b50b98e16/aspnetcore/performance/timeouts.md) | [Request timeouts middleware in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/timeouts?branch=pr-en-us-29443) |


<!-- PREVIEW-TABLE-END -->