### PR TITLE
Warn on port spoofing via the Host header

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -252,6 +252,11 @@ In the server app's `Program.cs` file, remove the following code, which appears 
   });
   ```
 
+  > [!WARNING]
+  > API that relies on the [Host header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Host), such as <xref:Microsoft.AspNetCore.Http.HttpRequest.Host%2A?displayProperty=nameWithType>, is subject to potential spoofing by clients.
+  >
+  > In high security scenarios, consider assigning a value to <xref:Microsoft.AspNetCore.Http.HttpRequest.Host?displayProperty=nameWithType> in [middleware](xref:fundamentals/middleware/write) before <xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A> is called or using <xref:Microsoft.AspNetCore.Http.HttpContext.Connection%2A?displayProperty=nameWithType> (<xref:Microsoft.AspNetCore.Http.ConnectionInfo.LocalPort?displayProperty=nameWithType>) where the ports are checked in the preceding example.
+
 :::zone-end
 
 :::zone pivot="route-subpath"


### PR DESCRIPTION
Addresses #29399

Thanks @hacst! 🚀 ... I don't know how it will play out in the framework or for the rest of the docs, but this addresses use of the Host header in one Blazor example ... the only Blazor example AFAIK.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/1dfd994c70cdd184cf0bdc00d1f45356c9fd5c5c/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md) | [Multiple hosted ASP.NET Core Blazor WebAssembly apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/multiple-hosted-webassembly?branch=pr-en-us-29445) |

<!-- PREVIEW-TABLE-END -->