### PR TITLE
Create a Blazor OOF vacation issue comment workflow

### DIFF
--- a/.github/workflows/oof-blazor-comment.yml
+++ b/.github/workflows/oof-blazor-comment.yml
@@ -18,7 +18,7 @@ jobs:
           body: |
             ### 🏖️ ***OOF*** 🍹 
             
-            Hello! I'm out of the office for a couple of days. This issue has been marked for triage on the `Blazor.Docs` project, and I'll respond as soon as I return from vacation. I'll get back to you *ASAP* 🏃. 
+            Hello! I'm out of the office for a couple of days on vacation. This issue has been marked for triage on the `Blazor.Docs` project, and I'll respond as soon as I return from vacation. I'll get back to you *ASAP* 🏃. 
             
             We only work on documentation on this repo. If you need product support, close this issue and seek assistance through one or more of the following support channels:
             

--- a/.github/workflows/oof-blazor-comment.yml
+++ b/.github/workflows/oof-blazor-comment.yml
@@ -1,0 +1,35 @@
+name: Add comment
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-comment:
+    if: github.event.label.name == 'Blazor'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v2.1.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          body: |
+            ### 🏖️ ***OOF*** 🍹 
+            
+            Hello! I'm out of the office for a couple of days. This issue has been marked for triage on the `Blazor.Docs` project, and I'll respond as soon as I return from vacation. I'll get back to you *ASAP* 🏃. 
+            
+            We only work on documentation on this repo. If you need product support, close this issue and seek assistance through one or more of the following support channels:
+            
+            * [Stack Overflow (tagged: `blazor`)](https://stackoverflow.com/questions/tagged/blazor)
+            * [General ASP.NET Core Slack Team](https://join.slack.com/t/aspnetcore/shared_invite/zt-1b60h73p0-PZPq3YCCaPbB21RcujMSVA)
+            * [Blazor Gitter](https://gitter.im/aspnet/Blazor)
+            
+            If you think that you found a potential bug in the framework or have product feedback, close this issue and open a new issue for the ASP.NET Core product unit at [dotnet/aspnetcore issues](https://github.com/dotnet/aspnetcore/issues). Bug reports require a clear explanation of the problem, usually including a minimal repro project placed on GitHub for the product unit engineers to download and run. If you determine with the product unit that it isn't a bug but merely requires documentation, please re-open this docs issue and place a cross-link to your engineering issue discussion. I'll take it up with you when I return from vacation.
+            
+            For problems or feedback on Visual Studio or Visual Studio for Mac, close this issue and use the [**Report a Problem**](https://docs.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio) or [**Suggest a Feature**](https://docs.microsoft.com/visualstudio/ide/suggest-a-feature) processes from within VS, which open internal issues for VS teams. For more information, see [Visual Studio Feedback](https://developercommunity.visualstudio.com/home) or [How to report a problem in Visual Studio for Mac](https://docs.microsoft.com/visualstudio/mac/report-a-problem).
+            
+            For problems with Visual Studio Code, close this issue and ask for support on community support forums. For bug reports and product feedback, open an issue on the [microsoft/vscode GitHub repo](https://github.com/microsoft/vscode/issues).
+            
+            💃🕺🥳 Happy New Year! 🎈🎆🍾🥂🎉 See you in 2023!

--- a/.github/workflows/oof-blazor-comment.yml
+++ b/.github/workflows/oof-blazor-comment.yml
@@ -31,5 +31,3 @@ jobs:
             For problems or feedback on Visual Studio or Visual Studio for Mac, close this issue and use the [**Report a Problem**](https://docs.microsoft.com/visualstudio/ide/how-to-report-a-problem-with-visual-studio) or [**Suggest a Feature**](https://docs.microsoft.com/visualstudio/ide/suggest-a-feature) processes from within VS, which open internal issues for VS teams. For more information, see [Visual Studio Feedback](https://developercommunity.visualstudio.com/home) or [How to report a problem in Visual Studio for Mac](https://docs.microsoft.com/visualstudio/mac/report-a-problem).
             
             For problems with Visual Studio Code, close this issue and ask for support on community support forums. For bug reports and product feedback, open an issue on the [microsoft/vscode GitHub repo](https://github.com/microsoft/vscode/issues).
-            
-            💃🕺🥳 Happy New Year! 🎈🎆🍾🥂🎉 See you in 2023!


### PR DESCRIPTION
cc: @Rick-Anderson ... I'll run with this for the few days each of the next two weeks and for the full last week of the month. I'll be checking in periodically, and I'll squash 🪲 and react to any PU issues immediately. There's no need for the team to take any action on Blazor issues while I'm out. This will be a typical ***staycation*** type of break. 😆