### PR TITLE
Improve Kestrel endpoints doc

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -490,9 +490,9 @@ Kestrel endpoints support connection middleware. Connection middleware is softwa
 * Chooses whether to pass the request to the next component in the pipeline.
 * Can perform work before and after the next component in the pipeline.
 
-Connection delegates are used to build the connection pipeline. Connection delegates are configured with the https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.listenoptions.use method.
+Connection delegates are used to build the connection pipeline. Connection delegates are configured with the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions.Use%2A?displayProperty=nameWithType> method.
 
-Connection middleware is similar to [ASP.NET Core request middleware](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-7.0). The difference is the connection middleware runs per-connection instead of per-request.
+Connection middleware is similar to <xref:fundamentals/middleware/index>. The difference is the connection middleware runs per-connection instead of per-request.
 
 ### Create custom connection middleware
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -267,6 +267,7 @@ For more information, see <xref:security/authentication/certauth>.
 
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen%2A>
 * <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket%2A>
+* <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenNamedPipe%2A>
 
 When both the `Listen` and [UseUrls](#configure-endpoints-with-urls) APIs are used simultaneously, the `Listen` endpoints override the `UseUrls` endpoints.
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -24,7 +24,9 @@ Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to in
 
 ## Default bindings
 
-ASP.NET Core projects are configured to bind to a random HTTP port between 5000-5300 and a random HTTPS port between 7000-7300. This default configuration is specified in the generated `Properties/launchSettings.json` file and can be overridden. If no ports are specified, Kestrel binds to `http://localhost:5000`.
+ASP.NET Core projects are configured to bind to a random HTTP port between 5000-5300 and a random HTTPS port between 7000-7300. This default configuration is specified in the generated `Properties/launchSettings.json` file and can be overridden. The `launchSetting.json` file is only used in local development.
+
+If there is no endpoint configuration then Kestrel binds to `http://localhost:5000`.
 
 ## Configure endpoints with URLs
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -38,7 +38,7 @@ The following sections explain how to configure endpoints using the:
 
 ### URL formats
 
-The URLs indicate the IP addresses or host addresses with ports and protocols that the server should listen on. URLs can be in any of the following formats.
+The URLs indicate the IP addresses or host addresses with ports and protocols that the server should listen on. The port can be omitted if it's the default for the protocol (typically 80 and 443). URLs can be in any of the following formats.
 
 * IPv4 address with port number
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -355,7 +355,7 @@ For information about dynamic port binding, see [Port 0](#port-0) earlier in thi
 
 ### Connection logging
 
-Call <xref:Microsoft.AspNetCore.Hosting.ListenOptionsConnectionLoggingExtensions.UseConnectionLogging%2A> to emit Debug level logs for byte-level communication on a connection. Connection logging is helpful for troubleshooting problems in low-level communication, such as during TLS encryption and behind proxies. If `UseConnectionLogging` is placed before `UseHttps`, encrypted traffic is logged. If `UseConnectionLogging` is placed after `UseHttps`, decrypted traffic is logged. This is built-in [Connection Middleware](#connection-middleware).
+Call <xref:Microsoft.AspNetCore.Hosting.ListenOptionsConnectionLoggingExtensions.UseConnectionLogging%2A> to emit Debug level logs for byte-level communication on a connection. Connection logging is helpful for troubleshooting problems in low-level communication, such as during TLS encryption and behind proxies. If `UseConnectionLogging` is placed before `UseHttps`, encrypted traffic is logged. If `UseConnectionLogging` is placed after `UseHttps`, decrypted traffic is logged. This is built-in [Connection middleware](#connection-middleware).
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelUseConnectionLogging":::
 
@@ -376,6 +376,7 @@ For information about configuring HTTPS, such as specifying SSL certificates and
 * [Configure certificates in code](#configure-certificates-in-code)
 * [Configure client certificates in code](#configure-client-certificates-in-code)
 * [Configure endpoints using Server Name Indication (SNI)](#configure-endpoints-using-server-name-indication)
+* [Connection middleware)](#connection-middleware)
 * [Configure endpoint protocols](#configure-endpoint-protocols)
 
 Many ASP.NET Core project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
@@ -485,7 +486,7 @@ Kestrel supports additional dynamic TLS configuration via the `TlsHandshakeCallb
 
 When using IIS, the URL bindings for IIS override bindings are set by either `Listen` or `UseUrls`. For more information, see [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module).
 
-## Connection Middleware
+## Connection middleware
 
 Custom connection middleware can filter TLS handshakes on a per-connection basis for specific ciphers if necessary.
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -19,7 +19,7 @@ uid: fundamentals/servers/kestrel/endpoints
 
 Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to incoming requests and routing them to the appropriate middleware. An endpoint in Kestrel is defined by a combination of an address and a protocol.
 
-* The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address, such as localhost or a public IP, along with a port number.
+* The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address with or without a port number. If the port isn't specified, a default port is used, typically 80 for HTTP or 443 for HTTPS. The address can also be a host name, such as `localhost`, which resolves to one or more IP addresses.
 * The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS, or the HTTP version. Endpoints can be configured to support HTTP or HTTPS, depending on the environment (development or production) and the requirements of the application.
 
 ## Default bindings

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -17,7 +17,7 @@ uid: fundamentals/servers/kestrel/endpoints
 
 :::moniker range=">= aspnetcore-8.0"
 
-An endpoint in Kestrel is defined by a combination of address and protocol. The address specifies the network interface and port on which the server will listen for incoming requests. This can be a specific IP address, such as localhost or a public IP, along with a port number. The protocol defines the communication standard that will be used between the client and server, such as HTTP or HTTPS. Endpoints can be configured to support HTTP or HTTPS or both, depending on the environment (development or production) and the requirements of the application. Endpoints in ASP.NET Core Kestrel provide the necessary infrastructure for listening to incoming requests and routing them to the appropriate middleware
+An endpoint in Kestrel is defined by a combination of address and protocol. The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address, such as localhost or a public IP, along with a port number. The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS. Endpoints can be configured to support HTTP or HTTPS or both, depending on the environment (development or production) and the requirements of the application. Endpoints in ASP.NET Core Kestrel provide the necessary infrastructure for listening to incoming requests and routing them to the appropriate middleware
 
 ## Default bindings
 
@@ -125,7 +125,7 @@ The configuration must be scoped to the `Kestrel` configuration section. for exa
 
 The `Configure(IConfiguration, bool)` overload can be used to enable reloading endpoints when the configuration source changes. Reloading endpoint configuration is enabled by default. If a change is signaled, the following steps are taken:
 
-* The new configuration is compared to the old one, and any endpoint without configuration changes is not modified.
+* The new configuration is compared to the old one, and any endpoint without configuration changes isn't modified.
 * Removed or modified endpoints are given 5 seconds to complete processing requests and shut down.
 * New or modified endpoints are started.
 
@@ -193,7 +193,7 @@ As noted earlier, the following example is for `appsettings.json`, but any confi
 
 * Endpoint names are [case-insensitive](xref:fundamentals/configuration/index#configuration-keys-and-values). For example, `HTTPS` and `Https` are equivalent.
 * The `Url` parameter is required for each endpoint. The format for this parameter is the same as the top-level `Urls` configuration parameter except that it's limited to a single value. See [URL formats](#url-formats) earlier in this article.
-* These endpoints replace those defined in the top-level `Urls` configuration rather than adding to them. Endpoints defined in code via `Listen` are cumulative with the endpoints defined in the configuration section.
+* These endpoints replace the ones defined in the top-level `Urls` configuration rather than adding to them. Endpoints defined in code via `Listen` are cumulative with the endpoints defined in the configuration section.
 * The `Certificate` section is optional. If the `Certificate` section isn't specified, the defaults defined in `Certificates:Default` are used. If no defaults are available, the development certificate is used. If there are no defaults and the development certificate isn't present, the server throws an exception and fails to start.
 * The `Certificate` section supports multiple certificate sources.
 * Any number of endpoints may be defined in `Configuration`, as long as they don't cause port conflicts.
@@ -240,7 +240,7 @@ For example, the `Certificates:Default` certificate can be specified as:
 
 <!-- [!INCLUDE [](../../../includes/credentials-warning.md)] -->
 
-The default value is `ClientCertificateMode.NoCertificate` where Kestrel will not request or require a certificate from the client.
+The default value is `ClientCertificateMode.NoCertificate`, where Kestrel won't request or require a certificate from the client.
 
 For more information, see <xref:security/authentication/certauth>.
 
@@ -326,7 +326,7 @@ For a complete list of `UseHttps` overloads, see <xref:Microsoft.AspNetCore.Host
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureHttpsDefaultsClientCertificateMode":::
 
-The default value is <xref:Microsoft.AspNetCore.Server.Kestrel.Https.ClientCertificateMode.NoCertificate>, where Kestrel will not request or require a certificate from the client.
+The default value is <xref:Microsoft.AspNetCore.Server.Kestrel.Https.ClientCertificateMode.NoCertificate>, where Kestrel won't request or require a certificate from the client.
 
 For more information, see <xref:security/authentication/certauth>.
 
@@ -392,7 +392,7 @@ SNI can be configured in two ways:
 
 ### Configure SNI in appsettings.json
 
-Kestrel supports SNI defined in configuration. An endpoint can be configured with an `Sni` object that contains a mapping between host names and HTTPS options. The connection host name is matched to the options and they are used for that connection.
+Kestrel supports SNI defined in configuration. An endpoint can be configured with an `Sni` object that contains a mapping between host names and HTTPS options. The connection host name is matched to the options and they're used for that connection.
 
 The following configuration adds an endpoint named `MySniEndpoint` that uses SNI to select HTTPS options based on the host name:
 
@@ -449,10 +449,10 @@ HTTPS options that can be overridden by SNI:
 The host name supports wildcard matching:
 
 * Exact match. For example, `a.example.org` matches `a.example.org`.
-* Wildcard prefix. If there are multiple wildcard matches then the longest pattern is chosen. For example, `*.example.org` matches `b.example.org` and `c.example.org`.
+* Wildcard prefix. If there are multiple wildcard matches, then the longest pattern is chosen. For example, `*.example.org` matches `b.example.org` and `c.example.org`.
 * Full wildcard. `*` matches everything else, including clients that aren't using SNI and don't send a host name.
 
-The matched SNI configuration is applied to the endpoint for the connection, overriding values on the endpoint. If a connection doesn't match a configured SNI host name then the connection is refused.
+The matched SNI configuration is applied to the endpoint for the connection, overriding values on the endpoint. If a connection doesn't match a configured SNI host name, then the connection is refused.
 
 ### Configure SNI with code
 
@@ -470,13 +470,13 @@ Kestrel supports SNI via the `ServerCertificateSelector` callback. The callback 
 
 #### SNI with `ServerOptionsSelectionCallback`
 
-Kestrel supports additional dynamic TLS configuration via the `ServerOptionsSelectionCallback` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate and TLS configuration. Default certificates and `ConfigureHttpsDefaults` are not used with this callback.
+Kestrel supports additional dynamic TLS configuration via the `ServerOptionsSelectionCallback` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate and TLS configuration. Default certificates and `ConfigureHttpsDefaults` aren't used with this callback.
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ServerOptionsSelectionCallback":::
 
 #### SNI with `TlsHandshakeCallbackOptions`
 
-Kestrel supports additional dynamic TLS configuration via the `TlsHandshakeCallbackOptions.OnConnection` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate, TLS configuration, and other server options. Default certificates and `ConfigureHttpsDefaults` are not used with this callback.
+Kestrel supports additional dynamic TLS configuration via the `TlsHandshakeCallbackOptions.OnConnection` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate, TLS configuration, and other server options. Default certificates and `ConfigureHttpsDefaults` aren't used with this callback.
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_TlsHandshakeCallbackOptions":::
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -22,6 +22,12 @@ Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to in
 * The address specifies the network interface and port on which the server listens for incoming requests.
 * The protocol defines the communication standard between the client and server, such as HTTP or HTTPS, and the HTTP version.
 
+Kestrel offers several options to configure endpoints:
+
+* [Configure endpoints with URLs](#configure-endpoints-with-urls)
+* [Configure endpoints in appsettings.json](#configure-endpoints-in-appsettingsjson)
+* [Configure endpoints in code](#configure-endpoints-in-code)
+
 ## Default bindings
 
 ASP.NET Core projects are configured to bind to a random HTTP port between 5000-5300 and a random HTTPS port between 7000-7300. This default configuration is specified in the generated `Properties/launchSettings.json` file and can be overridden. The `launchSetting.json` file is only used in local development.

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -17,7 +17,10 @@ uid: fundamentals/servers/kestrel/endpoints
 
 :::moniker range=">= aspnetcore-8.0"
 
-An endpoint in Kestrel is defined by a combination of address and protocol. The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address, such as localhost or a public IP, along with a port number. The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS. Endpoints can be configured to support HTTP or HTTPS or both, depending on the environment (development or production) and the requirements of the application. Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to incoming requests and routing them to the appropriate middleware.
+Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to incoming requests and routing them to the appropriate middleware. An endpoint in Kestrel is defined by a combination of address and protocol.
+
+* The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address, such as localhost or a public IP, along with a port number.
+* The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS, or the HTTP version. Endpoints can be configured to support HTTP or HTTPS or both, depending on the environment (development or production) and the requirements of the application.
 
 ## Default bindings
 
@@ -376,7 +379,7 @@ For information about configuring HTTPS, such as specifying SSL certificates and
 * [Configure certificates in code](#configure-certificates-in-code)
 * [Configure client certificates in code](#configure-client-certificates-in-code)
 * [Configure endpoints using Server Name Indication (SNI)](#configure-endpoints-using-server-name-indication)
-* [Connection middleware)](#connection-middleware)
+* [Connection middleware](#connection-middleware)
 * [Configure endpoint protocols](#configure-endpoint-protocols)
 
 Many ASP.NET Core project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
@@ -488,9 +491,18 @@ When using IIS, the URL bindings for IIS override bindings are set by either `Li
 
 ## Connection middleware
 
-Custom connection middleware can filter TLS handshakes on a per-connection basis for specific ciphers if necessary.
+Kestrel endpoints support connection middleware. Connection middleware is software that is assembled into a connection pipeline and runs when Kestrel receives a new connection. Each component:
 
-The following example throws <xref:System.NotSupportedException> for any cipher algorithm that the app doesn't support. Alternatively, define and compare <xref:Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.CipherAlgorithm%2A?displayProperty=nameWithType> to a list of acceptable cipher suites.
+* Chooses whether to pass the request to the next component in the pipeline.
+* Can perform work before and after the next component in the pipeline.
+
+Connection delegates are used to build the connection pipeline. Connection delegates are configured with the https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.listenoptions.use method.
+
+Connection middleware is similar to [ASP.NET Core request middleware](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/?view=aspnetcore-7.0). The difference is the connection middleware runs per-connection instead of per-request.
+
+### Create custom connection middleware
+
+The following example shows a custom connection middleware that can filter TLS handshakes on a per-connection basis for specific ciphers if necessary. The middleware throws <xref:System.NotSupportedException> for any cipher algorithm that the app doesn't support. Alternatively, define and compare <xref:Microsoft.AspNetCore.Connections.Features.ITlsHandshakeFeature.CipherAlgorithm%2A?displayProperty=nameWithType> to a list of acceptable cipher suites.
 
 No encryption is used with a <xref:System.Security.Authentication.CipherAlgorithmType.Null?displayProperty=nameWithType> cipher algorithm.
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -17,10 +17,10 @@ uid: fundamentals/servers/kestrel/endpoints
 
 :::moniker range=">= aspnetcore-8.0"
 
-Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to incoming requests and routing them to the appropriate middleware. An endpoint in Kestrel is defined by a combination of address and protocol.
+Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to incoming requests and routing them to the appropriate middleware. An endpoint in Kestrel is defined by a combination of an address and a protocol.
 
 * The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address, such as localhost or a public IP, along with a port number.
-* The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS, or the HTTP version. Endpoints can be configured to support HTTP or HTTPS or both, depending on the environment (development or production) and the requirements of the application.
+* The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS, or the HTTP version. Endpoints can be configured to support HTTP or HTTPS, depending on the environment (development or production) and the requirements of the application.
 
 ## Default bindings
 
@@ -56,7 +56,7 @@ The URLs indicate the IP addresses or host addresses with ports and protocols th
 
   `[::]` is the IPv6 equivalent of IPv4 `0.0.0.0`.
 
-* Host name with port number
+* Wildcard host with port number
 
   ```
   http://contoso.com:80/

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -63,7 +63,7 @@ The URLs indicate the IP addresses or host addresses with ports and protocols th
   http://*:80/
   ```
 
-  Host names, `*`, and `+`, aren't special. Anything not recognized as a valid IP address or `localhost` binds to all IPv4 and IPv6 IP addresses. To bind different host names to different ASP.NET Core apps on the same port, use [HTTP.sys](xref:fundamentals/servers/httpsys) or a reverse proxy server.
+  Anything not recognized as a valid IP address or `localhost` is treated as a wildcard that binds to all IPv4 and IPv6 addresses. Some people like to use `*` or `+` to be more explicit. To bind different host names to different ASP.NET Core apps on the same port, use [HTTP.sys](xref:fundamentals/servers/httpsys) or a reverse proxy server.
 
   Reverse proxy server examples include IIS, Nginx, and Apache. Hosting in a reverse proxy configuration requires [host filtering](xref:fundamentals/servers/kestrel/host-filtering).
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -12,12 +12,12 @@ uid: fundamentals/servers/kestrel/endpoints
 # Configure endpoints for the ASP.NET Core Kestrel web server
 
 :::moniker range="< aspnetcore-7.0"
-[!INCLUDE [not-latest-version](~/includes/not-latest-version.md)]
+[!INCLUDE [](~/includes/not-latest-version.md)]
 :::moniker-end
 
 :::moniker range=">= aspnetcore-8.0"
 
-An endpoint in Kestrel is defined by a combination of address and protocol. The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address, such as localhost or a public IP, along with a port number. The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS. Endpoints can be configured to support HTTP or HTTPS or both, depending on the environment (development or production) and the requirements of the application. Endpoints in ASP.NET Core Kestrel provide the necessary infrastructure for listening to incoming requests and routing them to the appropriate middleware
+An endpoint in Kestrel is defined by a combination of address and protocol. The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address, such as localhost or a public IP, along with a port number. The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS. Endpoints can be configured to support HTTP or HTTPS or both, depending on the environment (development or production) and the requirements of the application. Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to incoming requests and routing them to the appropriate middleware.
 
 ## Default bindings
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -5,7 +5,7 @@ description: Learn about configuring endpoints with Kestrel, the cross-platform 
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/13/2023
+ms.date: 06/14/2023
 uid: fundamentals/servers/kestrel/endpoints
 ---
 
@@ -367,7 +367,7 @@ To create a development certificate, use the [dev-certs tool](/dotnet/core/tools
 
 The development certificate is available only for the user that generates the certificate. Some browsers require granting explicit permission to trust the local development certificate.
 
-For information about working with SSL certificates, see the following sections of this article:
+For information about configuring HTTPS, such as specifying SSL certificates and SSL/TLS protocols, see the following sections of this article:
 
 * [Configure certificates in appsettings.json](#configure-certificates-in-appsettingsjson)
 * [Configure client certificates in appsettings.json](#configure-client-certificates-in-appsettingsjson)
@@ -376,6 +376,7 @@ For information about working with SSL certificates, see the following sections 
 * [Configure certificates in code](#configure-certificates-in-code)
 * [Configure client certificates in code](#configure-client-certificates-in-code)
 * [Configure endpoints using Server Name Indication (SNI)](#configure-endpoints-using-server-name-indication)
+* [Configure endpoint protocols](#configure-endpoint-protocols)
 
 Many ASP.NET Core project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
 
@@ -494,7 +495,7 @@ No encryption is used with a <xref:System.Security.Authentication.CipherAlgorith
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelMiddleware":::
 
-## Endpoint protocols
+## Configure endpoint protocols
 
 The following configuration examples show `appsettings.json`. However, any configuration source can be used.
 
@@ -593,6 +594,11 @@ On Linux, <xref:System.Net.Security.CipherSuitesPolicy> can be used to filter TL
 SSL protocols are protocols used for encrypting and decrypting traffic between two peers, traditionally a client and a server.
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureHttpsDefaultsSslProtocols":::
+
+## See also
+
+<xref:~/fundamentals/servers/kestrel>
+<xref:~/fundamentals/servers/kestrel/options>
 
 :::moniker-end
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -19,7 +19,7 @@ uid: fundamentals/servers/kestrel/endpoints
 
 Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to incoming requests and routing them to the appropriate middleware. An endpoint in Kestrel is defined by a combination of an address and a protocol.
 
-* The address specifies the network interface and port on which the server listens for incoming requests. This can be a specific IP address with or without a port number. If the port isn't specified, a default port is used, typically 80 for HTTP or 443 for HTTPS. The address can also be a host name, such as `localhost`, which resolves to one or more IP addresses.
+* The address specifies the network interface and port on which the server listens for incoming requests.
 * The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS, or the HTTP version. Endpoints can be configured to support HTTP or HTTPS, depending on the environment (development or production) and the requirements of the application.
 
 ## Default bindings

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -277,6 +277,25 @@ For more information, see <xref:security/authentication/certauth>.
 
 When both the `Listen` and [UseUrls](#configure-endpoints-with-urls) APIs are used simultaneously, the `Listen` endpoints override the `UseUrls` endpoints.
 
+### Bind to a TCP socket
+
+The <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen%2A> method binds to a TCP socket, and an options lambda permits X.509 certificate configuration:
+
+:::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_Listen":::
+
+The example configures HTTPS for an endpoint with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions>. Use the same API to configure other Kestrel settings for specific endpoints.
+
+[!INCLUDE [How to make an X.509 cert](~/includes/make-x509-cert.md)]
+
+### Bind to a Unix socket
+
+Listen on a Unix socket with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket%2A> for improved performance with Nginx, as shown in this example:
+
+:::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ListenUnixSocket":::
+
+* In the Nginx configuration file, set the `server` > `location` > `proxy_pass` entry to `http://unix:/tmp/{KESTREL SOCKET}:/;`. `{KESTREL SOCKET}` is the name of the socket provided to <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket%2A> (for example, `kestrel-test.sock` in the preceding example).
+* Ensure that the socket is writeable by Nginx (for example, `chmod go+w /tmp/kestrel-test.sock`).
+
 ### Change defaults in code
 
 `ConfigureEndpointDefaults` and `ConfigureHttpsDefaults` can be used to change default settings for `ListenOptions` and `HttpsConnectionAdapterOptions`, including overriding the default certificate specified in the prior scenario. `ConfigureEndpointDefaults` and `ConfigureHttpsDefaults` should be called before any endpoints are configured.
@@ -341,25 +360,6 @@ For a complete list of `UseHttps` overloads, see <xref:Microsoft.AspNetCore.Host
 The default value is <xref:Microsoft.AspNetCore.Server.Kestrel.Https.ClientCertificateMode.NoCertificate>, where Kestrel won't request or require a certificate from the client.
 
 For more information, see <xref:security/authentication/certauth>.
-
-### Bind to a TCP socket
-
-The <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Listen%2A> method binds to a TCP socket, and an options lambda permits X.509 certificate configuration:
-
-:::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_Listen":::
-
-The example configures HTTPS for an endpoint with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.ListenOptions>. Use the same API to configure other Kestrel settings for specific endpoints.
-
-[!INCLUDE [How to make an X.509 cert](~/includes/make-x509-cert.md)]
-
-### Bind to a Unix socket
-
-Listen on a Unix socket with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket%2A> for improved performance with Nginx, as shown in this example:
-
-:::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ListenUnixSocket":::
-
-* In the Nginx configuration file, set the `server` > `location` > `proxy_pass` entry to `http://unix:/tmp/{KESTREL SOCKET}:/;`. `{KESTREL SOCKET}` is the name of the socket provided to <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket%2A> (for example, `kestrel-test.sock` in the preceding example).
-* Ensure that the socket is writeable by Nginx (for example, `chmod go+w /tmp/kestrel-test.sock`).
 
 ### Dynamic port binding
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -367,20 +367,26 @@ For information about dynamic port binding, see [Port 0](#port-0) earlier in thi
 
 ## Configure HTTPS
 
-Kestrel supports securing endpoints with HTTPS. The way you configure HTTPS depends on how endpoints are defined.
+Kestrel supports securing endpoints with HTTPS. Data sent over HTTPS is encrypted using Transport Layer Security (TLS) to increase the security of data transferred between the client and server.
 
-If [URL prefixes](#configure-endpoints-with-urls) are used to define endpoints, HTTPS can be used only if a default certificate is provided in HTTPS endpoint configuration. For example, use <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> configuration or a configuration file as shown [earlier in this article](#configure-certificates-in-appsettingsjson).
+HTTPS requires a TLS certificate. The TLS certificate is stored on the server and Kestrel is configured to use it. In a local development environment, an app can use the [ASP.NET Core HTTPS development certificate](xref:security/enforcing-ssl). The development certificate isn't installed in non-development environments, and an app deployed into staging or production environments must be configured to use another certificate.
 
-For more information about configuring HTTPS, such as using configuration or code to specify SSL certificates and SSL/TLS protocols, see the following sections of this article:
+The way you configure HTTPS and the TLS certificate depends on how endpoints are defined:
 
-* [Configure certificates in appsettings.json](#configure-certificates-in-appsettingsjson)
-* [Configure client certificates in appsettings.json](#configure-client-certificates-in-appsettingsjson)
+* If [URL prefixes](#configure-endpoints-with-urls) are used to define endpoints, HTTPS can be used only if a default certificate is provided in HTTPS endpoint configuration. For example, use <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> configuration or a configuration file as shown [earlier in this article](#configure-certificates-in-appsettingsjson).
+
+* If configuration is used to define endpoints, see the sections on configuring certificates by using configuration:
+  * [Configure certificates in appsettings.json](#configure-certificates-in-appsettingsjson)
+  * [Configure client certificates in appsettings.json](#configure-client-certificates-in-appsettingsjson)
+* If code is used to define endpoints, see the sections on configuring certificates in code:
+  * [Configure certificates in code](#configure-certificates-in-code)
+  * [Configure client certificates in code](#configure-client-certificates-in-code)
+
+See also:
+
 * [Certificate sources](#certificate-sources)
 * [Configure HTTPS defaults in code](#configure-https-defaults-in-code)
-* [Configure certificates in code](#configure-certificates-in-code)
-* [Configure client certificates in code](#configure-client-certificates-in-code)
 * [Configure endpoints using Server Name Indication (SNI)](#configure-endpoints-using-server-name-indication)
-* [Connection middleware](#connection-middleware)
 * [Configure endpoint protocols](#configure-endpoint-protocols)
 
 To create a development certificate, use the [dev-certs tool](/dotnet/core/tools/dotnet-dev-certs). The tool is automatically installed when the [.NET SDK](/dotnet/core/sdk) is installed.

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -598,8 +598,8 @@ SSL protocols are protocols used for encrypting and decrypting traffic between t
 
 ## See also
 
-<xref:~/fundamentals/servers/kestrel>
-<xref:~/fundamentals/servers/kestrel/options>
+<xref:fundamentals/servers/kestrel>
+<xref:fundamentals/servers/kestrel/options>
 
 :::moniker-end
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -358,13 +358,11 @@ For information about dynamic port binding, see [Port 0](#port-0) earlier in thi
 
 ## Configure HTTPS
 
+Kestrel supports securing endpoints with HTTPS. The way you configure HTTPS depends on how endpoints are defined.
+
 If [URL prefixes](#configure-endpoints-with-urls) are used to define endpoints, HTTPS can be used only if a default certificate is provided in HTTPS endpoint configuration. For example, use <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> configuration or a configuration file as shown [earlier in this article](#configure-certificates-in-appsettingsjson).
 
-To create a development certificate, use the [dev-certs tool](/dotnet/core/tools/dotnet-dev-certs). The tool is automatically installed when the [.NET SDK](/dotnet/core/sdk) is installed.
-
-The development certificate is available only for the user that generates the certificate. Some browsers require granting explicit permission to trust the local development certificate.
-
-For information about configuring HTTPS, such as specifying SSL certificates and SSL/TLS protocols, see the following sections of this article:
+For more information about configuring HTTPS, such as using configuration or code to specify SSL certificates and SSL/TLS protocols, see the following sections of this article:
 
 * [Configure certificates in appsettings.json](#configure-certificates-in-appsettingsjson)
 * [Configure client certificates in appsettings.json](#configure-client-certificates-in-appsettingsjson)
@@ -375,6 +373,10 @@ For information about configuring HTTPS, such as specifying SSL certificates and
 * [Configure endpoints using Server Name Indication (SNI)](#configure-endpoints-using-server-name-indication)
 * [Connection middleware](#connection-middleware)
 * [Configure endpoint protocols](#configure-endpoint-protocols)
+
+To create a development certificate, use the [dev-certs tool](/dotnet/core/tools/dotnet-dev-certs). The tool is automatically installed when the [.NET SDK](/dotnet/core/sdk) is installed.
+
+The development certificate is available only for the user that generates the certificate. Some browsers require granting explicit permission to trust the local development certificate.
 
 Many ASP.NET Core project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -382,7 +382,9 @@ Many ASP.NET Core project templates configure apps to run on HTTPS by default an
 
 ## Configure endpoints using Server Name Indication
 
-[Server Name Indication (SNI)](https://tools.ietf.org/html/rfc6066#section-3) can be used to host multiple domains on the same IP address and port. For SNI to function, the client sends the host name for the secure session to the server during the TLS handshake so that the server can provide the correct certificate. The client uses the furnished certificate for encrypted communication with the server during the secure session that follows the TLS handshake.
+[Server Name Indication (SNI)](https://tools.ietf.org/html/rfc6066#section-3) can be used to host multiple domains on the same IP address and port. You might want to do this to conserve resources by serving multiple sites from one server.
+
+For SNI to function, the client sends the host name for the secure session to the server during the TLS handshake so that the server can provide the correct certificate. The client uses the furnished certificate for encrypted communication with the server during the secure session that follows the TLS handshake.
 
 All websites must run on the same Kestrel instance. Kestrel doesn't support sharing an IP address and port across multiple instances without a reverse proxy.
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -5,7 +5,7 @@ description: Learn about configuring endpoints with Kestrel, the cross-platform 
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/15/2023
+ms.date: 06/16/2023
 uid: fundamentals/servers/kestrel/endpoints
 ---
 
@@ -480,10 +480,6 @@ Kestrel supports additional dynamic TLS configuration via the `ServerOptionsSele
 Kestrel supports additional dynamic TLS configuration via the `TlsHandshakeCallbackOptions.OnConnection` callback. The callback is invoked once per connection to allow the app to inspect the host name and select the appropriate certificate, TLS configuration, and other server options. Default certificates and `ConfigureHttpsDefaults` aren't used with this callback.
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_TlsHandshakeCallbackOptions":::
-
-## IIS endpoint configuration
-
-When using IIS, the URL bindings for IIS override bindings are set by either `Listen` or `UseUrls`. For more information, see [ASP.NET Core Module](xref:host-and-deploy/aspnet-core-module).
 
 ## Connection middleware
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -5,7 +5,7 @@ description: Learn about configuring endpoints with Kestrel, the cross-platform 
 monikerRange: '>= aspnetcore-5.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/14/2023
+ms.date: 06/15/2023
 uid: fundamentals/servers/kestrel/endpoints
 ---
 
@@ -356,12 +356,6 @@ Listen on a Unix socket with <xref:Microsoft.AspNetCore.Server.Kestrel.Core.Kest
 
 For information about dynamic port binding, see [Port 0](#port-0) earlier in this article.
 
-### Connection logging
-
-Call <xref:Microsoft.AspNetCore.Hosting.ListenOptionsConnectionLoggingExtensions.UseConnectionLogging%2A> to emit Debug level logs for byte-level communication on a connection. Connection logging is helpful for troubleshooting problems in low-level communication, such as during TLS encryption and behind proxies. If `UseConnectionLogging` is placed before `UseHttps`, encrypted traffic is logged. If `UseConnectionLogging` is placed after `UseHttps`, decrypted traffic is logged. This is built-in [Connection middleware](#connection-middleware).
-
-:::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelUseConnectionLogging":::
-
 ## Configure HTTPS
 
 If [URL prefixes](#configure-endpoints-with-urls) are used to define endpoints, HTTPS can be used only if a default certificate is provided in HTTPS endpoint configuration. For example, use <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> configuration or a configuration file as shown [earlier in this article](#configure-certificates-in-appsettingsjson).
@@ -507,6 +501,12 @@ The following example shows a custom connection middleware that can filter TLS h
 No encryption is used with a <xref:System.Security.Authentication.CipherAlgorithmType.Null?displayProperty=nameWithType> cipher algorithm.
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelMiddleware":::
+
+### Connection logging
+
+Call <xref:Microsoft.AspNetCore.Hosting.ListenOptionsConnectionLoggingExtensions.UseConnectionLogging%2A> to emit Debug level logs for byte-level communication on a connection. Connection logging is helpful for troubleshooting problems in low-level communication, such as during TLS encryption and behind proxies. If `UseConnectionLogging` is placed before `UseHttps`, encrypted traffic is logged. If `UseConnectionLogging` is placed after `UseHttps`, decrypted traffic is logged. This is built-in [Connection middleware](#connection-middleware).
+
+:::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigureKestrelUseConnectionLogging":::
 
 ## Configure endpoint protocols
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -20,7 +20,7 @@ uid: fundamentals/servers/kestrel/endpoints
 Endpoints in ASP.NET Core Kestrel provide the infrastructure for listening to incoming requests and routing them to the appropriate middleware. An endpoint in Kestrel is defined by a combination of an address and a protocol.
 
 * The address specifies the network interface and port on which the server listens for incoming requests.
-* The protocol defines the communication standard that is used between the client and server, such as HTTP or HTTPS, or the HTTP version. Endpoints can be configured to support HTTP or HTTPS, depending on the environment (development or production) and the requirements of the application.
+* The protocol defines the communication standard between the client and server, such as HTTP or HTTPS, and the HTTP version.
 
 ## Default bindings
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -246,14 +246,14 @@ For more information, see <xref:security/authentication/certauth>.
 
 ### ConfigurationLoader
 
-<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Configure(Microsoft.Extensions.Configuration.IConfiguration?displayProperty=nameWithType)> returns a <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader> with an <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.Endpoint(System.String,System.Action{Microsoft.AspNetCore.Server.Kestrel.EndpointConfiguration})> method that can be used to supplement a configured endpoint's settings:
+<xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Configure(Microsoft.Extensions.Configuration.IConfiguration)?displayProperty=nameWithType> returns a <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader> with an <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.Endpoint(System.String,System.Action{Microsoft.AspNetCore.Server.Kestrel.EndpointConfiguration})> method that can be used to supplement a configured endpoint's settings:
 
 :::code language="csharp" source="~/fundamentals/servers/kestrel/samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_ConfigurationLoader":::
 
 `KestrelServerOptions.ConfigurationLoader` can be directly accessed to continue iterating on the existing loader, such as the one provided by <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder.WebHost%2A?displayProperty=nameWithType>.
 
 * The configuration section for each endpoint is available on the options in the <xref:Microsoft.AspNetCore.Server.Kestrel.KestrelConfigurationLoader.Endpoint%2A> method so that custom settings may be read.
-* Multiple configurations can be loaded by calling <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Configure(Microsoft.Extensions.Configuration.IConfiguration?displayProperty=nameWithType)> again with another section. Only the last configuration is used, unless `Load` is explicitly called on prior instances. The metapackage doesn't call `Load` so that its default configuration section may be replaced.
+* Multiple configurations can be loaded by calling <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Configure(Microsoft.Extensions.Configuration.IConfiguration)?displayProperty=nameWithType> again with another section. Only the last configuration is used, unless `Load` is explicitly called on prior instances. The metapackage doesn't call `Load` so that its default configuration section may be replaced.
 * `KestrelConfigurationLoader` mirrors the `Listen` family of APIs from `KestrelServerOptions` as `Endpoint` overloads, so code and config endpoints can be configured in the same place. These overloads don't use names and only consume default settings from configuration.
 
 ## Configure endpoints in code
@@ -361,7 +361,7 @@ Call <xref:Microsoft.AspNetCore.Hosting.ListenOptionsConnectionLoggingExtensions
 
 ## Configure HTTPS
 
-If [URL prefixes](#configure-endpoints-with-urls) are used to define endpoints, HTTPS can be used only if a default certificate is provided in HTTPS endpoint configuration. For example, use <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> configuration or a configuration file as shown [earlier in this article](#replace-the-default-certificate-in-appsettingsjson).
+If [URL prefixes](#configure-endpoints-with-urls) are used to define endpoints, HTTPS can be used only if a default certificate is provided in HTTPS endpoint configuration. For example, use <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> configuration or a configuration file as shown [earlier in this article](#configure-certificates-in-appsettingsjson).
 
 To create a development certificate, use the [dev-certs tool](/dotnet/core/tools/dotnet-dev-certs). The tool is automatically installed when the [.NET SDK](/dotnet/core/sdk) is installed.
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -371,10 +371,11 @@ For information about working with SSL certificates, see the following sections 
 
 * [Configure certificates in appsettings.json](#configure-certificates-in-appsettingsjson)
 * [Configure client certificates in appsettings.json](#configure-client-certificates-in-appsettingsjson)
+* [Certificate sources](#certificate-sources)
 * [Configure HTTPS defaults in code](#configure-https-defaults-in-code)
 * [Configure certificates in code](#configure-certificates-in-code)
 * [Configure client certificates in code](#configure-client-certificates-in-code)
-* [Certificate sources](#certificate-sources)
+* [Configure endpoints using Server Name Indication (SNI)](#configure-endpoints-using-server-name-indication)
 
 Many ASP.NET Core project templates configure apps to run on HTTPS by default and include [HTTPS redirection and HSTS support](xref:security/enforcing-ssl).
 

--- a/aspnetcore/includes/credentials-warning.md
+++ b/aspnetcore/includes/credentials-warning.md
@@ -1,0 +1,2 @@
+> [!WARNING]
+> In the preceding example, the certificate password is stored in plain-text in `appsettings.json`. The `$CREDENTIAL_PLACEHOLDER$` token is used as a placeholder for the certificate's password. To store certificate passwords securely in development environments, see [Protect secrets in development](xref:security/app-secrets). To store certificate passwords securely in production environments, see [Azure Key Vault configuration provider](xref:security/key-vault-configuration). Development secrets shouldn't be used for production or test.


### PR DESCRIPTION
Fixes #21117 

The changes are in the .NET 8 version [(internal preview)](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-8.0&branch=pr-en-us-29501)

The H2 headings follow the plan in #21117 except SNI is H2 rather than H3, and one H2 was retained that wasn't listed in the plan: [Connection middleware](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-8.0&branch=pr-en-us-29501#connection-middleware) - as suggested, this will be moved to a separate article in a separate follow-up PR.

This PR does a lot of rearranging of existing content, so the diff frequently gets confused.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/kestrel/endpoints.md](https://github.com/dotnet/AspNetCore.Docs/blob/385602c41e726d8657ac6ebd6e074bf0b96458de/aspnetcore/fundamentals/servers/kestrel/endpoints.md) | [Configure endpoints for the ASP.NET Core Kestrel web server](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?branch=pr-en-us-29501) |


<!-- PREVIEW-TABLE-END -->