### PR TITLE
Correct AOT instructions MacOS and Win

### DIFF
--- a/aspnetcore/fundamentals/aot/native-aot-tutorial.md
+++ b/aspnetcore/fundamentals/aot/native-aot-tutorial.md
@@ -5,8 +5,8 @@ description: Learn about how to publish an ASP.NET Core app using native AOT.
 monikerRange: '>= aspnetcore-8.0'
 ms.topic: tutorial
 ms.author: midenn
-ms.custom: mvc, engagement-fy23
-ms.date: 06/19/2023
+ms.custom: mvc
+ms.date: 05/25/2023
 uid: fundamentals/native-aot-tutorial
 ---
 # Tutorial: Publish an ASP.NET Core app using native AOT
@@ -49,7 +49,7 @@ Create an ASP.NET Core API app that is configured to work with native AOT:
 Run the following commands:
 
 ```dotnetcli
-dotnet new api -aot -o MyFirstAotWebApi && cd MyFirstAotWebApi
+dotnet new api --aot -o MyFirstAotWebApi && cd MyFirstAotWebApi
 ```
 
 Output similar to the following example is displayed:

--- a/aspnetcore/fundamentals/aot/native-aot-tutorial.md
+++ b/aspnetcore/fundamentals/aot/native-aot-tutorial.md
@@ -5,8 +5,8 @@ description: Learn about how to publish an ASP.NET Core app using native AOT.
 monikerRange: '>= aspnetcore-8.0'
 ms.topic: tutorial
 ms.author: midenn
-ms.custom: mvc
-ms.date: 05/25/2023
+ms.custom: mvc, engagement-fy23
+ms.date: 06/19/2023
 uid: fundamentals/native-aot-tutorial
 ---
 # Tutorial: Publish an ASP.NET Core app using native AOT
@@ -49,7 +49,7 @@ Create an ASP.NET Core API app that is configured to work with native AOT:
 Run the following commands:
 
 ```dotnetcli
-dotnet new api --aot -o MyFirstAotWebApi && cd MyFirstAotWebApi
+dotnet new api -aot -o MyFirstAotWebApi && cd MyFirstAotWebApi
 ```
 
 Output similar to the following example is displayed:

--- a/aspnetcore/fundamentals/native-aot.md
+++ b/aspnetcore/fundamentals/native-aot.md
@@ -4,8 +4,8 @@ author: mitchdenny
 description: Learn about ASP.NET Core support for native AOT
 monikerRange: '>= aspnetcore-8.0'
 ms.author: midenn
-ms.custom: mvc
-ms.date: 05/25/2023
+ms.custom: mvc, engagement-fy23
+ms.date: 06/19/2023
 uid: fundamentals/native-aot
 ---
 # ASP.NET Core support for native AOT
@@ -89,7 +89,16 @@ In .NET 8, native AOT is supported by the following ASP.NET Core app types:
 
 ## The API template
 
-The **ASP.NET Core API** template in Visual Studio 2022 has an **Enable native AOT publish** option. The equivalent template and option in the CLI is the `dotnet new api` command and the `--aot` option. This template is intended to produce a project more directly focused on cloud-native, API-first scenarios. The template differs from the **Web API** project template in the following ways:
+The **ASP.NET Core API** template has an option to enable AOT, using the .NET 8.0 SDK or later:
+
+* Visual Studio 2022 has an **Enable native AOT publish option**.
+* CLI uses the `dotnet new api` command and the `-aot` option, as in the following example:
+
+  ```.NET CLI
+  dotnet new api -aot -o MyFirstAotWebApi
+  ```
+
+This template is intended to produce a project more directly focused on cloud-native, API-first scenarios. The template differs from the **Web API** project template in the following ways:
 
 * Uses minimal APIs only, as MVC isn't yet compatible with native AOT.
 * Uses the <xref:Microsoft.AspNetCore.Builder.WebApplication.CreateSlimBuilder> API to ensure only the essential features are enabled by default, minimizing the app's deployed size.

--- a/aspnetcore/fundamentals/native-aot.md
+++ b/aspnetcore/fundamentals/native-aot.md
@@ -92,7 +92,7 @@ In .NET 8, native AOT is supported by the following ASP.NET Core app types:
 The **ASP.NET Core API** template has an option to enable AOT:
 
 * Visual Studio 2022 has an **Enable native AOT publish option**.
-* CLI uses the `dotnet new api` command and the `--aot` option, as in the following example:
+* The CLI uses the `dotnet new api` command and the `--aot` option, as in the following example:
 
   ```.NET CLI
   dotnet new api --aot -o MyFirstAotWebApi

--- a/aspnetcore/fundamentals/native-aot.md
+++ b/aspnetcore/fundamentals/native-aot.md
@@ -89,7 +89,7 @@ In .NET 8, native AOT is supported by the following ASP.NET Core app types:
 
 ## The API template
 
-The **ASP.NET Core API** template has an option to enable AOT, using the .NET 8.0 SDK or later:
+The **ASP.NET Core API** template has an option to enable AOT:
 
 * Visual Studio 2022 has an **Enable native AOT publish option**.
 * CLI uses the `dotnet new api` command and the `-aot` option, as in the following example:

--- a/aspnetcore/fundamentals/native-aot.md
+++ b/aspnetcore/fundamentals/native-aot.md
@@ -92,10 +92,10 @@ In .NET 8, native AOT is supported by the following ASP.NET Core app types:
 The **ASP.NET Core API** template has an option to enable AOT:
 
 * Visual Studio 2022 has an **Enable native AOT publish option**.
-* CLI uses the `dotnet new api` command and the `-aot` option, as in the following example:
+* CLI uses the `dotnet new api` command and the `--aot` option, as in the following example:
 
   ```.NET CLI
-  dotnet new api -aot -o MyFirstAotWebApi
+  dotnet new api --aot -o MyFirstAotWebApi
   ```
 
 This template is intended to produce a project more directly focused on cloud-native, API-first scenarios. The template differs from the **Web API** project template in the following ways:


### PR DESCRIPTION
Fixes #29112 

The instructions work the same using CLI for MacOS and Windows, so no MacOS tab is needed.  I clarified a bit on the cli vs VS template description.

Tested with VS 2022 Preview/.NET 8 and project generation on MacOS with CLI.  Thanks Andy for testing on MacOS for compile/publish.  

Verified diff in the launchSettings.json were correct.  They are on both Win and MacOS and VS and CLI.

Note: VS for Mac 2022 preview is not working with .NET 8 preview yet so there is no VS for Mac specific instruction.  

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/native-aot.md](https://github.com/dotnet/AspNetCore.Docs/blob/8a97c5ae5a73e09a07ae70ae8ff508230b9460b4/aspnetcore/fundamentals/native-aot.md) | [ASP.NET Core support for native AOT](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/native-aot?branch=pr-en-us-29574) |


<!-- PREVIEW-TABLE-END -->