### PR TITLE
API generic return types /2

### DIFF
--- a/aspnetcore/web-api/action-return-types.md
+++ b/aspnetcore/web-api/action-return-types.md
@@ -3,7 +3,7 @@ title: Controller action return types in ASP.NET Core web API
 author: tdykstra
 description: ActionResult vs IActionResult
 monikerRange: '>= aspnetcore-3.1'
-ms.author: scaddie
+ms.author: tdykstra
 ms.custom: mvc
 ms.date: 6/20/2023
 uid: web-api/action-return-types
@@ -29,7 +29,7 @@ This article explains when it's most appropriate to use each return type.
 
 The most basic action returns a primitive or complex data type, for example, `string` or a custom object. Consider the following action, which returns a collection of custom `Product` objects:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ProductsController.cs" id="snippet_Get":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ProductsController.cs" id="snippet_Get":::
 
 Without known conditions to safeguard against, returning a specific type could suffice. The preceding action accepts no parameters, so parameter constraints validation isn't needed.
 
@@ -46,11 +46,11 @@ ASP.NET Core buffers the result of actions that return <xref:System.Collections.
 
 Consider the following action, which returns sale-priced product records as `IEnumerable<Product>`:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ProductsController.cs" id="snippet_GetOnSaleProducts":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ProductsController.cs" id="snippet_GetOnSaleProducts":::
 
 The `IAsyncEnumerable<Product>` equivalent of the preceding action is:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ProductsController.cs" id="snippet_GetOnSaleProductsAsync":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ProductsController.cs" id="snippet_GetOnSaleProductsAsync":::
 
 ## IActionResult type
 
@@ -62,7 +62,7 @@ Because there are multiple return types and paths in this type of action, libera
 
 Consider the following synchronous action in which there are two possible return types:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ActionResultProductsController.cs" id="snippet_GetByIdIActionResult" highlight="7":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ActionResultProductsController.cs" id="snippet_GetByIdIActionResult" highlight="7":::
 
 In the preceding action:
 
@@ -73,7 +73,7 @@ In the preceding action:
 
 Consider the following asynchronous action in which there are two possible return types:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ActionResultProductsController.cs" id="snippet_CreateAsyncIActionResult" highlight="9,15":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ActionResultProductsController.cs" id="snippet_CreateAsyncIActionResult" highlight="9,15":::
 
 In the preceding action:
 
@@ -91,7 +91,7 @@ In the preceding action:
 
 For example, the following model indicates that requests must include the `Name` and `Description` properties. Failure to provide `Name` and `Description` in the request causes model validation to fail.
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Models/Product.cs" id="snippet_ProductClass" highlight="5-6,8-9":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Models/Product.cs" id="snippet_ProductClass" highlight="5-6,8-9":::
 
 If the [`[ApiController]`](xref:Microsoft.AspNetCore.Mvc.ApiControllerAttribute) attribute is applied, model validation errors result in a 400 status code. For more information, see [Automatic HTTP 400 responses](xref:web-api/index#automatic-http-400-responses).
 
@@ -122,7 +122,7 @@ Most actions have a specific return type. Unexpected conditions can occur during
 
 Consider a synchronous action in which there are two possible return types:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ActionResultOfTProductsController.cs" id="snippet_GetByIdActionResultOfT" highlight="7":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ActionResultOfTProductsController.cs" id="snippet_GetByIdActionResultOfT" highlight="7":::
 
 In the preceding action:
 
@@ -133,7 +133,7 @@ In the preceding action:
 
 Consider an asynchronous action in which there are two possible return types:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ActionResultOfTProductsController.cs" id="snippet_CreateAsyncActionResultOfT" highlight="9,15":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ActionResultOfTProductsController.cs" id="snippet_CreateAsyncActionResultOfT" highlight="9,15":::
 
 In the preceding action:
 
@@ -164,7 +164,7 @@ The [Built-in results](/aspnet/core/fundamentals/minimal-apis?view=aspnetcore-7.
 
 Consider the following code:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/IResultProductsController.cs" id="snippet_GetByIdIResult" highlight="7":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/IResultProductsController.cs" id="snippet_GetByIdIResult" highlight="7":::
 
 In the preceding action:
 
@@ -173,7 +173,7 @@ In the preceding action:
 
 Consider the following code:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/IResultProductsController.cs" id="snippet_CreateAsyncIResult" highlight="9,16":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/IResultProductsController.cs" id="snippet_CreateAsyncIResult" highlight="9,16":::
 
 In the preceding action:
 
@@ -194,14 +194,14 @@ The `Results<TResult1, TResultN>` union types implement implicit cast operators 
 
 Consider the following code:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ResultsOfTProductsController.cs" id="snippet_GetByIdResultsOfT" highlight="5":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ResultsOfTProductsController.cs" id="snippet_GetByIdResultsOfT" highlight="5":::
 
 In the preceding action:
 
 * A 404 status code is returned when the product doesn't exist in the database.
 * A 200 status code is returned with the corresponding `Product` object when the product does exist, generated by the [TypedResults.Ok\<T>](<xref:Microsoft.AspNetCore.Http.TypedResults.Ok>).
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/7.x/WebApiSample/Controllers/ResultsOfTProductsController.cs" id="snippet_CreateAsyncResultsOfT" highlight="6,13":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/mvc/action-return-types/8.x/WebApiSample/Controllers/ResultsOfTProductsController.cs" id="snippet_CreateAsyncResultsOfT" highlight="6,13":::
 
 In the preceding action:
 


### PR DESCRIPTION
Fixes #29538

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/web-api/action-return-types.md](https://github.com/dotnet/AspNetCore.Docs/blob/054380c132fd172dfc4c47c8d8e0c5ba694507a3/aspnetcore/web-api/action-return-types.md) | [Controller action return types in ASP.NET Core web API](https://review.learn.microsoft.com/en-us/aspnet/core/web-api/action-return-types?branch=pr-en-us-29578) |

<!-- PREVIEW-TABLE-END -->