### PR TITLE
Add note concerning HTTPS redirection warnings

### DIFF
--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -162,6 +162,9 @@ Create the `WebApplicationFactoryClientOptions` class and pass it to the <xref:M
 
 [!code-csharp[](~/../AspNetCore.Docs.Samples/test/integration-tests/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs?name=snippet1)]
 
+> [!NOTE]
+> To avoid HTTPS redirection warnings in logs when using HTTPS Redirection Middleware, set `BaseAddress = new Uri("https://localhost")`
+
 ## Inject mock services
 
 Services can be overridden in a test with a call to <xref:Microsoft.AspNetCore.TestHost.WebHostBuilderExtensions.ConfigureTestServices%2A> on the host builder.

--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -162,8 +162,7 @@ Create the `WebApplicationFactoryClientOptions` class and pass it to the <xref:M
 
 [!code-csharp[](~/../AspNetCore.Docs.Samples/test/integration-tests/IntegrationTestsSample/tests/RazorPagesProject.Tests/IntegrationTests/IndexPageTests.cs?name=snippet1)]
 
-> [!NOTE]
-> To avoid HTTPS redirection warnings in logs when using HTTPS Redirection Middleware, set `BaseAddress = new Uri("https://localhost")`
+***NOTE:*** To avoid HTTPS redirection warnings in logs when using HTTPS Redirection Middleware, set `BaseAddress = new Uri("https://localhost")`
 
 ## Inject mock services
 


### PR DESCRIPTION
Add a note how to avoid HTTPS redirection warnings when using HTTPS Redirection Middleware

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/integration-tests.md](https://github.com/dotnet/AspNetCore.Docs/blob/0436563c8ae86e9fabb9c621c886779110a09658/aspnetcore/test/integration-tests.md) | [Integration tests in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/test/integration-tests?branch=pr-en-us-29589) |


<!-- PREVIEW-TABLE-END -->