### PR TITLE
Updated version specific package instruction First Web API

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to build a web API with ASP.NET Core.
 ms.author: wpickett
 ms.custom: mvc, engagement-fy23
-ms.date: 05/17/2023
+ms.date: 06/23/2023
 uid: tutorials/first-web-api
 ---
 
@@ -297,9 +297,9 @@ Make sure that all of your changes so far are saved.
 Run the following commands:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 7.0.0
-dotnet add package Microsoft.EntityFrameworkCore.Design -v 7.0.0
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 7.0.0
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
+dotnet add package Microsoft.EntityFrameworkCore.Design
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
 dotnet tool uninstall -g dotnet-aspnet-codegenerator
 dotnet tool install -g dotnet-aspnet-codegenerator
 ```

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -823,10 +823,11 @@ Make sure that all of your changes so far are saved.
 Run the following commands from the project folder, that is, the `TodoApi` folder:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 6.0.14
-dotnet add package Microsoft.EntityFrameworkCore.Design -v 6.0.19
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 6.0.19
-dotnet tool install -g dotnet-aspnet-codegenerator
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 6.*
+dotnet add package Microsoft.EntityFrameworkCore.Design -v 6.*
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 6.*
+dotnet tool uninstall -g dotnet-aspnet-codegenerator
+dotnet tool install -g dotnet-aspnet-codegenerator --version 6.0.14
 dotnet aspnet-codegenerator controller -name TodoItemsController -async -api -m TodoItem -dc TodoContext -outDir Controllers
 ```
 
@@ -1414,10 +1415,11 @@ The preceding code:
 Run the following commands from the project folder, `TodoApi/TodoApi`:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 5.0.2
-dotnet add package Microsoft.EntityFrameworkCore.Design -v 5.0.17
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 5.0.17
-dotnet tool install -g dotnet-aspnet-codegenerator
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 5.*
+dotnet add package Microsoft.EntityFrameworkCore.Design -v 5.*
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 5.*
+dotnet tool uninstall -g dotnet-aspnet-codegenerator
+dotnet tool install -g dotnet-aspnet-codegenerator --version 5.0.2
 dotnet aspnet-codegenerator controller -name TodoItemsController -async -api -m TodoItem -dc TodoContext -outDir Controllers
 ```
 
@@ -1935,10 +1937,10 @@ The preceding code:
 Run the following commands:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 5.0.2
-dotnet add package Microsoft.EntityFrameworkCore.Design -v 5.0.17
-dotnet tool install --global dotnet-aspnet-codegenerator
-dotnet tool update -g Dotnet-aspnet-codegenerator
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 3.* 
+dotnet add package Microsoft.EntityFrameworkCore.Design -v 3.*
+dotnet tool uninstall -g dotnet-aspnet-codegenerator
+dotnet tool install --global dotnet-aspnet-codegenerator -v 3.1.5
 dotnet aspnet-codegenerator controller -name TodoItemsController -async -api -m TodoItem -dc TodoContext -outDir Controllers
 ```
 

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -271,9 +271,9 @@ Make sure that all of your changes so far are saved.
 Run the following commands:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 7.0.0
-dotnet add package Microsoft.EntityFrameworkCore.Design -v 7.0.0
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 7.0.0
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
+dotnet add package Microsoft.EntityFrameworkCore.Design
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
 dotnet tool uninstall -g dotnet-aspnet-codegenerator
 dotnet tool install -g dotnet-aspnet-codegenerator
 ```
@@ -819,12 +819,13 @@ The preceding code:
 
 Make sure that all of your changes so far are saved.
 
+<!-- Keep the package versions to the latest for this topic version for .NET 6 -->
 Run the following commands from the project folder, that is, the `TodoApi` folder:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.EntityFrameworkCore.Design
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 6.0.14
+dotnet add package Microsoft.EntityFrameworkCore.Design -v 6.0.19
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 6.0.19
 dotnet tool install -g dotnet-aspnet-codegenerator
 dotnet aspnet-codegenerator controller -name TodoItemsController -async -api -m TodoItem -dc TodoContext -outDir Controllers
 ```
@@ -1413,9 +1414,9 @@ The preceding code:
 Run the following commands from the project folder, `TodoApi/TodoApi`:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.EntityFrameworkCore.Design
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 5.0.2
+dotnet add package Microsoft.EntityFrameworkCore.Design -v 5.0.17
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 5.0.17
 dotnet tool install -g dotnet-aspnet-codegenerator
 dotnet aspnet-codegenerator controller -name TodoItemsController -async -api -m TodoItem -dc TodoContext -outDir Controllers
 ```
@@ -1934,8 +1935,8 @@ The preceding code:
 Run the following commands:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.EntityFrameworkCore.Design
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 5.0.2
+dotnet add package Microsoft.EntityFrameworkCore.Design -v 5.0.17
 dotnet tool install --global dotnet-aspnet-codegenerator
 dotnet tool update -g Dotnet-aspnet-codegenerator
 dotnet aspnet-codegenerator controller -name TodoItemsController -async -api -m TodoItem -dc TodoContext -outDir Controllers

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -1938,6 +1938,7 @@ Run the following commands:
 
 ```dotnetcli
 dotnet add package Microsoft.EntityFrameworkCore --version 3.1.32
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer --version 3.1.32
 dotnet add package Microsoft.EntityFrameworkCore.InMemory --version 3.1.32
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 3.1.5 
 dotnet add package Microsoft.EntityFrameworkCore.Design -v 3.1.32

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -1937,8 +1937,10 @@ The preceding code:
 Run the following commands:
 
 ```dotnetcli
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 3.* 
-dotnet add package Microsoft.EntityFrameworkCore.Design -v 3.*
+dotnet add package Microsoft.EntityFrameworkCore --version 3.1.32
+dotnet add package Microsoft.EntityFrameworkCore.InMemory --version 3.1.32
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 3.1.5 
+dotnet add package Microsoft.EntityFrameworkCore.Design -v 3.1.32
 dotnet tool uninstall -g dotnet-aspnet-codegenerator
 dotnet tool install --global dotnet-aspnet-codegenerator -v 3.1.5
 dotnet aspnet-codegenerator controller -name TodoItemsController -async -api -m TodoItem -dc TodoContext -outDir Controllers


### PR DESCRIPTION
Fixes #29303 

Updating versions 3-6 to their version specific packages available at the time for VS Code instruction.
Updating version 7 to use the default latest for packages for VS Code.
Testing both Windows and MacOS for each.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/cab32672bdcb160c9cf59ee64996edec3220720d/aspnetcore/tutorials/first-web-api.md) | [Tutorial: Create a web API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?branch=pr-en-us-29634) |


<!-- PREVIEW-TABLE-END -->