### PR TITLE
Added a missing word to "Prevent Cross-Site Scripting (XSS) in ASP.NET Core" article

### DIFF
--- a/aspnetcore/security/cross-site-scripting.md
+++ b/aspnetcore/security/cross-site-scripting.md
@@ -159,7 +159,12 @@ The preceding code generates the following output:
 
 ## Accessing encoders in code
 
-The HTML, JavaScript and URL encoders are available to your code in two ways, you can inject them via [dependency injection](xref:fundamentals/dependency-injection) or you can use the default encoders contained in the `System.Text.Encodings.Web` namespace. If you use the default encoders, then any customizations you applied to character ranges to be treated as safe won't take effect - the default encoders use the safest encoding rules possible.
+The HTML, JavaScript and URL encoders are available to your code in two ways:
+
+* Inject them via [dependency injection](xref:fundamentals/dependency-injection).
+* Use the default encoders contained in the `System.Text.Encodings.Web` namespace.
+
+When using the default encoders, then any customizations applied to character ranges to be treated as safe won't take effect. The default encoders use the safest encoding rules possible.
 
 To use the configurable encoders via DI your constructors should take an *HtmlEncoder*, *JavaScriptEncoder* and *UrlEncoder* parameter as appropriate. For example;
 

--- a/aspnetcore/security/cross-site-scripting.md
+++ b/aspnetcore/security/cross-site-scripting.md
@@ -159,7 +159,7 @@ The preceding code generates the following output:
 
 ## Accessing encoders in code
 
-The HTML, JavaScript and URL encoders are available to your code in two ways, you can inject them via [dependency injection](xref:fundamentals/dependency-injection) or you can use the default encoders contained in the `System.Text.Encodings.Web` namespace. If you use the default encoders, then any  you applied to character ranges to be treated as safe won't take effect - the default encoders use the safest encoding rules possible.
+The HTML, JavaScript and URL encoders are available to your code in two ways, you can inject them via [dependency injection](xref:fundamentals/dependency-injection) or you can use the default encoders contained in the `System.Text.Encodings.Web` namespace. If you use the default encoders, then any customizations you applied to character ranges to be treated as safe won't take effect - the default encoders use the safest encoding rules possible.
 
 To use the configurable encoders via DI your constructors should take an *HtmlEncoder*, *JavaScriptEncoder* and *UrlEncoder* parameter as appropriate. For example;
 


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/cross-site-scripting.md](https://github.com/dotnet/AspNetCore.Docs/blob/1f492cc616815ffdae4f9c9bb7ba7004fe573aa7/aspnetcore/security/cross-site-scripting.md) | [Prevent Cross-Site Scripting (XSS) in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/cross-site-scripting?branch=pr-en-us-29641) |


<!-- PREVIEW-TABLE-END -->