### PR TITLE
Clean up product metadata for 2 samples

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample3-5/readme.md
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample3-5/readme.md
@@ -4,7 +4,6 @@ description: "Sample projects for a gRPC Service and gRPC client on ASP.NET Core
 languages:
 - csharp
 products:
-- dotnet-core
 - aspnet-core
 - vs
 urlFragment: create-grpc-client

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/3.x/TodoApi.Swashbuckle/readme.md
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/3.x/TodoApi.Swashbuckle/readme.md
@@ -4,11 +4,7 @@ description: "Learn how to add Swashbuckle to your ASP.NET Core web API project 
 languages:
 - csharp
 products:
-- dotnet-core
 - aspnet-core
-- vs
-- vs-code
-- vs-mac
 urlFragment: getstarted-swashbuckle-aspnetcore
 ---
 # Get started with Swashbuckle and ASP.NET Core


### PR DESCRIPTION
We're trying to remove the .NET Core label from the site experience. It's not the main technology focus for these samples (neither is VS), so I removed that metadata.

Contributes to https://github.com/dotnet/docs/issues/35970

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/grpc/grpc-start/sample/sample3-5/readme.md](https://github.com/dotnet/AspNetCore.Docs/blob/6c36bbe6878dcdfb51334b5d54bacfc57bf179bb/aspnetcore/tutorials/grpc/grpc-start/sample/sample3-5/readme.md) | [Create a gRPC client and server in ASP.NET Core 3.1](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/grpc/grpc-start/sample/sample3-5/readme?branch=pr-en-us-29647) |
| [aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/3.x/TodoApi.Swashbuckle/readme.md](https://github.com/dotnet/AspNetCore.Docs/blob/6c36bbe6878dcdfb51334b5d54bacfc57bf179bb/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/3.x/TodoApi.Swashbuckle/readme.md) | [Get started with Swashbuckle and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/web-api-help-pages-using-swagger/samples/3.x/TodoApi.Swashbuckle/readme?branch=pr-en-us-29647) |

<!-- PREVIEW-TABLE-END -->