### PR TITLE
Update OpenIddict link

### DIFF
--- a/aspnetcore/security/identity-management-solutions.md
+++ b/aspnetcore/security/identity-management-solutions.md
@@ -23,6 +23,6 @@ The following table provides an overview of various identity management solution
 |**Keycloak**|Container|[OSS (Apache 2.0)](https://github.com/keycloak/keycloak/blob/master/LICENSE.txt)|[https://www.keycloak.org/](https://www.keycloak.org/)|[Keycloak client adapters documentation](https://www.keycloak.org/docs/latest/securing_apps/#client-adapters)|
 |**Microsoft Azure AD**|Managed|[Commercial](https://azure.microsoft.com/pricing/details/active-directory/)|[https://azure.microsoft.com/services/active-directory/](https://azure.microsoft.com/services/active-directory/)|[Azure AD documentation](/azure/active-directory/)|
 |**Okta**|Managed|[Commercial](https://www.okta.com/pricing/)|[https://www.okta.com/](https://www.okta.com/)|[Okta for ASP.NET Core](https://developer.okta.com/code/dotnet/aspnetcore/)|
-|**OpenIddict**|Self host|[OSS (Apache 2.0)](https://github.com/openiddict/openiddict-core/blob/dev/LICENSE.md)|[https://www.openiddict.com/](https://www.openiddict.com/)|[OpenIddict Documentation](https://documentation.openiddict.com/)|
+|**OpenIddict**|Self host|[OSS (Apache 2.0)](https://github.com/openiddict/openiddict-core/blob/dev/LICENSE.md)|[https://github.com/openiddict/openiddict-core](https://github.com/openiddict/openiddict-core)|[OpenIddict Documentation](https://documentation.openiddict.com/)|
 
 Is there a solution that should be added to this list? Do you have a correction, suggestion, or feedback? We welcome your contributions. Learn [how to contribute](https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
@kevinchalet ... `https://www.openiddict.com/` yields a 404 💥. Is the GH address the correct replacement URL?

https://github.com/openiddict/openiddict-core

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/identity-management-solutions.md](https://github.com/dotnet/AspNetCore.Docs/blob/bad527388b33120b3400f6d130cac807d6a9ecf1/aspnetcore/security/identity-management-solutions.md) | [Identity management solutions for .NET web apps](https://review.learn.microsoft.com/en-us/aspnet/core/security/identity-management-solutions?branch=pr-en-us-29660) |

<!-- PREVIEW-TABLE-END -->