### PR TITLE
Document IExceptionHandler

### DIFF
--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -5,7 +5,7 @@ description: Discover how to handle errors in ASP.NET Core apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/29/2023
+ms.date: 06/30/2023
 uid: fundamentals/error-handling
 ---
 # Handle errors in ASP.NET Core
@@ -108,12 +108,12 @@ The following example shows how to register an `IExceptionHandler` implementatio
 When the preceding code runs in the Development environment:
 
 * The `CustomExceptionHandler` is called first to handle an exception.
-* After logging the exception, the `TryHandleException` method returns `false`, so the [developer exception page](#developer-exception-page) is shown. Otherwise, if `TryHandleException` returned `true`, the developer exception page wouldn't be shown.
+* After logging the exception, the `TryHandleException` method returns `false`, so the [developer exception page](#developer-exception-page) is shown.
 
 In other environments:
 
 * The `CustomExceptionHandler` is called first to handle an exception.
-* After logging the exception, the `TryHandleException` method returns `false`, so the [`/Error` page](#exception-handler-page) is shown. Otherwise, if `TryHandleException` returned `true`, the `/Error` page wouldn't be shown.
+* After logging the exception, the `TryHandleException` method returns `false`, so the [`/Error` page](#exception-handler-page) is shown.
 
 <!-- links to this in other docs require sestatuscodepages -->
 <a name="sestatuscodepages"></a>

--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -97,9 +97,11 @@ The following code uses a lambda for exception handling:
 
 `IExceptionHandler` implementations are registered by calling [`IServiceCollection.AddExceptionHandler<T>`](https://source.dot.net/#Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerServiceCollectionExtensions.cs,e74aac24e3e2cbc9). Multiple implementations can be added, and they're called in the order registered. If an exception handler handles a request, it can return `true` to stop processing. If an exception isn't handled by any exception handler, then control falls back to the default behavior and options from the middleware. Different metrics and logs are emitted for handled versus unhandled exceptions.
 
-The following examples show an `IExceptionHandler` implementation and how to register it:
+The following example shows an `IExceptionHandler` implementation:
 
 :::code language="csharp" source="~/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/CustomExceptionHandler.cs":::
+
+The following example shows how to register an `IExceptionHandler` implementation for dependency injection:
 
 :::code language="csharp" source="~/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/Program.cs" id="snippet_RegisterIExceptionHandler" highlight="7":::
 

--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -5,7 +5,7 @@ description: Discover how to handle errors in ASP.NET Core apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 01/18/2023
+ms.date: 06/29/2023
 uid: fundamentals/error-handling
 ---
 # Handle errors in ASP.NET Core
@@ -90,6 +90,28 @@ The following code uses a lambda for exception handling:
 
 > [!WARNING]
 > Do **not** serve sensitive error information to clients. Serving errors is a security risk.
+
+## IExceptionHandler
+
+[IExceptionHandler](https://source.dot.net/#Microsoft.AspNetCore.Diagnostics/ExceptionHandler/IExceptionHandler.cs,adae2915ad0c6dc5) is an interface that gives the developer a callback for handling known exceptions in a central location.
+
+`IExceptionHandler` implementations are registered by calling [`IServiceCollection.AddExceptionHandler<T>`](https://source.dot.net/#Microsoft.AspNetCore.Diagnostics/ExceptionHandler/ExceptionHandlerServiceCollectionExtensions.cs,e74aac24e3e2cbc9). Multiple implementations can be added, and they're called in the order registered. If an exception handler handles a request, it can return `true` to stop processing. If an exception isn't handled by any exception handler, then control falls back to the default behavior and options from the middleware. Different metrics and logs are emitted for handled versus unhandled exceptions.
+
+The following examples show an `IExceptionHandler` implementation and how to register it:
+
+:::code language="csharp" source="~/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/CustomExceptionHandler.cs":::
+
+:::code language="csharp" source="~/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/Program.cs" id="snippet_RegisterIExceptionHandler" highlight="7":::
+
+When the preceding code runs in the Development environment:
+
+* The `CustomExceptionHandler` is called first to handle an exception.
+* After logging the exception, the `TryHandleException` method returns `false`, so the [developer exception page](#developer-exception-page) is shown. Otherwise, if `TryHandleException` returned `true`, the developer exception page wouldn't be shown.
+
+In other environments:
+
+* The `CustomExceptionHandler` is called first to handle an exception.
+* After logging the exception, the `TryHandleException` method returns `false`, so the [`/Error` page](#exception-handler-page) is shown. Otherwise, if `TryHandleException` returned `true`, the `/Error` page wouldn't be shown.
 
 <!-- links to this in other docs require sestatuscodepages -->
 <a name="sestatuscodepages"></a>

--- a/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/CustomExceptionHandler.cs
+++ b/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/CustomExceptionHandler.cs
@@ -15,9 +15,9 @@ namespace ErrorHandlingSample
             CancellationToken cancellationToken)
         {
             var exceptionMessage = exception.Message;
-            logger.LogError("Error Message: {exceptionMessage}", exceptionMessage);
-            logger.LogError("Time of occurrence {time}", DateTime.Now);
+            logger.LogError("Error Message: {exceptionMessage}, Time of occurrence {time}", exceptionMessage, DateTime.UtcNow);
             // Return false to continue with the default behavior
+            // - or - return true to signal that this exception is handled
             return ValueTask.FromResult(false);
         }
     }

--- a/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/CustomExceptionHandler.cs
+++ b/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/CustomExceptionHandler.cs
@@ -15,7 +15,9 @@ namespace ErrorHandlingSample
             CancellationToken cancellationToken)
         {
             var exceptionMessage = exception.Message;
-            logger.LogError("Error Message: {exceptionMessage}, Time of occurrence {time}", exceptionMessage, DateTime.UtcNow);
+            logger.LogError(
+                "Error Message: {exceptionMessage}, Time of occurrence {time}",
+                exceptionMessage, DateTime.UtcNow);
             // Return false to continue with the default behavior
             // - or - return true to signal that this exception is handled
             return ValueTask.FromResult(false);

--- a/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/CustomExceptionHandler.cs
+++ b/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/CustomExceptionHandler.cs
@@ -1,19 +1,23 @@
-﻿using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Diagnostics;
 
 namespace ErrorHandlingSample
 {
     public class CustomExceptionHandler : IExceptionHandler
     {
-        private ILogger<CustomExceptionHandler> logger;
-        public CustomExceptionHandler(ILogger<CustomExceptionHandler> logger){
+        private readonly ILogger<CustomExceptionHandler> logger;
+        public CustomExceptionHandler(ILogger<CustomExceptionHandler> logger)
+        {
             this.logger = logger;
         }
-        public ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+        public ValueTask<bool> TryHandleAsync(
+            HttpContext httpContext,
+            Exception exception,
+            CancellationToken cancellationToken)
         {
             var exceptionMessage = exception.Message;
             logger.LogError("Error Message: {exceptionMessage}", exceptionMessage);
             logger.LogError("Time of occurrence {time}", DateTime.Now);
-            // returned false to continue with the default behavior
+            // Return false to continue with the default behavior
             return ValueTask.FromResult(false);
         }
     }

--- a/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/Program.cs
+++ b/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/Program.cs
@@ -1,6 +1,3 @@
-// <snippet_AddDatabaseDeveloperPageExceptionFilter>
-using ErrorHandlingSample;
-
 // <snippet_RegisterIExceptionHandler>
 using ErrorHandlingSample;
 

--- a/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/Program.cs
+++ b/aspnetcore/fundamentals/error-handling/samples/8.x/ErrorHandlingSample/Program.cs
@@ -1,14 +1,15 @@
 // <snippet_AddDatabaseDeveloperPageExceptionFilter>
 using ErrorHandlingSample;
 
+// <snippet_RegisterIExceptionHandler>
+using ErrorHandlingSample;
+
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 builder.Services.AddRazorPages();
 builder.Services.AddExceptionHandler<CustomExceptionHandler>();
-// </snippet_AddDatabaseDeveloperPageExceptionFilter>
 
-// <snippet_UseExceptionHandler>
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
@@ -16,7 +17,9 @@ if (!app.Environment.IsDevelopment())
     app.UseExceptionHandler("/Error");
     app.UseHsts();
 }
-// </snippet_UseExceptionHandler>
+
+// Remaining Program.cs code omitted for brevity
+// </snippet_RegisterIExceptionHandler>
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();


### PR DESCRIPTION
Fixes #29520 

Best location for the new H2 section seems to be after the sections on Developer exception page and Exception handler page, and before the UseStatusCodePages section.

[Internal review URL](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/error-handling?view=aspnetcore-8.0&branch=pr-en-us-29674#iexceptionhandler) (goes to .NET 8 version and the new section)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/error-handling.md](https://github.com/dotnet/AspNetCore.Docs/blob/078e223bdbe69e841383671f3f4f6c094d6643b5/aspnetcore/fundamentals/error-handling.md) | [Handle errors in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/error-handling?branch=pr-en-us-29674) |


<!-- PREVIEW-TABLE-END -->