### PR TITLE
Named Tuple support

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -779,7 +779,7 @@ Don't use the [`init` accessor](/dotnet/csharp/language-reference/keywords/init)
 
 @code {
     [Parameter]
-    public Tuple<int, string, bool>? Data { get; set; }
+    public (int, string, bool)? Data { get; set; }
 }
 ```
 
@@ -788,16 +788,51 @@ Don't use the [`init` accessor](/dotnet/csharp/language-reference/keywords/init)
 ```csharp
 @page "/render-tuple-parent"
 
-<h1>Render <code>Tuple</code> Parent</h1>
+<h1>Render Tuple Parent</h1>
 
 <RenderTupleChild Data="@data" />
 
 @code {
-    private Tuple<int, string, bool> data = new(999, "I aim to misbehave.", true);
+    private (int, string, bool) data = new(999, "I aim to misbehave.", true);
 }
 ```
     
-Only ***unnamed tuples*** are supported for C# 7.0 or later in Razor components. [Named tuples](/dotnet/csharp/language-reference/builtin-types/value-tuples#tuple-field-names) support in Razor components is planned for a future ASP.NET Core release. For more information, see [Blazor Transpiler issue with named Tuples (dotnet/aspnetcore #28982)](https://github.com/dotnet/aspnetcore/issues/28982).
+[Named tuples](/dotnet/csharp/language-reference/builtin-types/value-tuples#tuple-field-names) are supported, as seen in the following example:
+
+`Shared/RenderNamedTupleChild.razor`:
+
+```razor
+<div class="card w-50" style="margin-bottom:15px">
+    <div class="card-header font-weight-bold"><code>Tuple</code> Card</div>
+    <div class="card-body">
+        <ul>
+            <li>Integer: @Data?.TheInteger</li>
+            <li>String: @Data?.TheString</li>
+            <li>Boolean: @Data?.TheBoolean</li>
+        </ul>
+    </div>
+</div>
+
+@code {
+    [Parameter]
+    public (int TheInteger, string TheString, bool TheBoolean)? Data { get; set; }
+}
+```
+
+`Pages/RenderNamedTupleParent.razor`:
+
+```razor
+@page "/render-named-tuple-parent"
+
+<h1>Render Named Tuple Parent</h1>
+
+<RenderNamedTupleChild Data="@data" />
+
+@code {
+    private (int TheInteger, string TheString, bool TheBoolean) data = 
+        new(999, "I aim to misbehave.", true);
+}
+```
 
 Quote &copy;2005 [Universal Pictures](https://www.uphe.com): [Serenity](https://www.uphe.com/movies/serenity-2005) ([Nathan Fillion](https://www.imdb.com/name/nm0277213/))
 


### PR DESCRIPTION
Fixes #28572

Thanks @LuohuaRain! :rocket:

Now that 17.6 is out, named tuples support can be added to the doc, and I created an example of it to demonstrate how it composes. Also, I think naming the "Tuple" type isn't so good. One nice thing about this is how compact the code is when just placing parentheses around the types (and names).

I'll leave this up until Wednesday morning to give you a chance to take a look, but I need to get it merged ***quickly*** 🏃, as we have a ***TON*** 🐘 of work going on right now for .NET 8. I don't want this to get mired in a nasty 😈 ***merge conflict*** 😈😆. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/eb09bb7ed55e6e3e813d4ce69945f07a647d65d4/aspnetcore/blazor/components/index.md) | [ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/index?branch=pr-en-us-29771) |

<!-- PREVIEW-TABLE-END -->