### PR TITLE
Changing "Trace and/or Information" verbiage to include "Debug"

### DIFF
--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -268,13 +268,13 @@ In the preceding code, the first `Log{LOG LEVEL}` parameter,`MyLogEvents.GetItem
 Call the appropriate `Log{LOG LEVEL}` method to control how much log output is written to a particular storage medium. For example:
 
 * In production:
-  * Logging at the `Trace` or `Information` levels produces a high-volume of detailed log messages. To control costs and not exceed data storage limits, log `Trace` and `Information` level messages to a high-volume, low-cost data store. Consider limiting `Trace` and `Information` to specific categories.
+  * Logging at the `Trace` through `Information` levels produces a high-volume of detailed log messages. To control costs and not exceed data storage limits, log `Trace` through `Information` level messages to a high-volume, low-cost data store. Consider limiting `Trace` through `Information` to specific categories.
   * Logging at `Warning` through `Critical` levels should produce few log messages.
     * Costs and storage limits usually aren't a concern.
     * Few logs allow more flexibility in data store choices.
 * In development:
   * Set to `Warning`.
-  * Add `Trace` or `Information` messages when troubleshooting. To limit output, set `Trace` or `Information` only for the categories under investigation.
+  * Add `Trace` through `Information` messages when troubleshooting. To limit output, set `Trace` through `Information` only for the categories under investigation.
 
 ASP.NET Core writes logs for framework events. For example, consider the log output for:
 

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -268,13 +268,13 @@ In the preceding code, the first `Log{LOG LEVEL}` parameter,`MyLogEvents.GetItem
 Call the appropriate `Log{LOG LEVEL}` method to control how much log output is written to a particular storage medium. For example:
 
 * In production:
-  * Logging at the `Trace` through `Information` levels produces a high-volume of detailed log messages. To control costs and not exceed data storage limits, log `Trace` through `Information` level messages to a high-volume, low-cost data store. Consider limiting `Trace` through `Information` to specific categories.
+  * Logging at the `Trace`, `Debug`, or `Information` levels produces a high-volume of detailed log messages. To control costs and not exceed data storage limits, log `Trace`, `Debug`, or `Information` level messages to a high-volume, low-cost data store. Consider limiting `Trace`, `Debug`, or `Information` to specific categories.
   * Logging at `Warning` through `Critical` levels should produce few log messages.
     * Costs and storage limits usually aren't a concern.
     * Few logs allow more flexibility in data store choices.
 * In development:
   * Set to `Warning`.
-  * Add `Trace` through `Information` messages when troubleshooting. To limit output, set `Trace` through `Information` only for the categories under investigation.
+  * Add `Trace`, `Debug`, or `Information` messages when troubleshooting. To limit output, set `Trace`, `Debug`, or `Information` only for the categories under investigation.
 
 ASP.NET Core writes logs for framework events. For example, consider the log output for:
 


### PR DESCRIPTION
The "Log level" section describes an example scenario that says "`Trace` and `Information`" and "`Trace` or `Information`", suggesting that `Debug` levels are excluded from that example.  This seemed unexpected to me, and I wondered if it may have been reflecting an older version of the defined log levels.  I changed those phrases to instead say "`Trace` through `Information`" to be harmonious with the existing verbiage that says "`Warning` through `Critical`".

Fixes #29822

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/logging/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/0857ef7eae9e76ef60ee87d60cd1eccffec0040b/aspnetcore/fundamentals/logging/index.md) | [Logging in .NET Core and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/index?branch=pr-en-us-29812) |


<!-- PREVIEW-TABLE-END -->