### PR TITLE
Update @typeparam versioning

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -734,8 +734,6 @@ When set to `false` (default), whitespace in the rendered markup from Razor comp
 
 The `@section` directive is used in conjunction with [MVC and Razor Pages layouts](xref:mvc/views/layout) to enable views or pages to render content in different parts of the HTML page. For more information, see <xref:mvc/views/layout>.
 
-:::moniker range=">= aspnetcore-6.0"
-
 ### `@typeparam`
 
 *This scenario only applies to Razor components (`.razor`).*
@@ -745,6 +743,8 @@ The `@typeparam` directive declares a [generic type parameter](/dotnet/csharp/pr
 ```razor
 @typeparam TEntity
 ```
+
+:::moniker range=">= aspnetcore-6.0"
 
 Generic types with [`where`](/dotnet/csharp/language-reference/keywords/where-generic-type-constraint) type constraints are supported:
 
@@ -752,31 +752,12 @@ Generic types with [`where`](/dotnet/csharp/language-reference/keywords/where-ge
 @typeparam TEntity where TEntity : IEntity
 ```
 
-For more information, see the following articles:
-
-* <xref:blazor/components/generic-type-support>
-* <xref:blazor/components/templated-components>
-
 :::moniker-end
-
-:::moniker range="< aspnetcore-6.0"
-
-### `@typeparam`
-
-*This scenario only applies to Razor components (`.razor`).*
-
-The `@typeparam` directive declares a [generic type parameter](/dotnet/csharp/programming-guide/generics/generic-type-parameters) for the generated component class:
-
-```razor
-@typeparam TEntity
-```
 
 For more information, see the following articles:
 
 * <xref:blazor/components/generic-type-support>
 * <xref:blazor/components/templated-components>
-
-:::moniker-end
 
 ### `@using`
 


### PR DESCRIPTION
Addresses #29854

Rick, I'm not sure if this fixes the whole issue.  I noticed the quick copy of the whole section, when I really only needed to version the added bit on generic type params. This PR fixes that bit.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/views/razor.md](https://github.com/dotnet/AspNetCore.Docs/blob/af14b230410a5c5ee59b06cb63e68e4696059a68/aspnetcore/mvc/views/razor.md) | [Razor syntax reference for ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/views/razor?branch=pr-en-us-29857) |

<!-- PREVIEW-TABLE-END -->