### PR TITLE
Update cross-links

### DIFF
--- a/aspnetcore/blazor/components/overwriting-parameters.md
+++ b/aspnetcore/blazor/components/overwriting-parameters.md
@@ -139,16 +139,10 @@ The following revised `Expander` component:
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-6.0"
+For more information on parent-child binding, see the following resources:
 
-For two-way parent-child binding examples, see <xref:blazor/components/data-binding#binding-with-component-parameters>. For additional information, see [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599).
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-6.0"
-
-For additional information, see [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599).
-
-:::moniker-end
+* [Binding with component parameters](xref:blazor/components/data-binding#binding-with-component-parameters)
+* [Bind across more than two components](xref:blazor/components/data-binding#bind-across-more-than-two-components)
+* [Blazor Two Way Binding Error (dotnet/aspnetcore #24599)](https://github.com/dotnet/aspnetcore/issues/24599)
 
 For more information on change detection, including information on the exact types that Blazor checks, see <xref:blazor/components/rendering#rendering-conventions-for-componentbase>.


### PR DESCRIPTION
Addresses #29855

Thanks @uecasm! :rocket: ... I'm placing a link to both sections here, re-organizing the links a bit, and removing the versioning because these links are valid for all doc versions.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/overwriting-parameters.md](https://github.com/dotnet/AspNetCore.Docs/blob/93c4a7be0fba3cc49c112a0e0823d4a34a29b4ef/aspnetcore/blazor/components/overwriting-parameters.md) | [Avoid overwriting parameters in ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/overwriting-parameters?branch=pr-en-us-29858) |

<!-- PREVIEW-TABLE-END -->