### PR TITLE
Blazor Hybrid issue management

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -87,6 +87,16 @@ issues:
         - check:
             - type: metadata-comment
               name: content source
+              value: "(?i).*blazor\/hybrid.*"
+          pass:
+            - labels-remove: ["Blazor"]
+            - labels-add: ["Blazor Hybrid"]
+            - projects-remove: [35]
+            - projects-add: [106]
+            - assignee-add: ["BethMassi"]
+        - check:
+            - type: metadata-comment
+              name: content source
               value: "(?i).*grpc.*"
           pass:
             - labels-add: ["gRPC"]


### PR DESCRIPTION
@Rick-Anderson @tdykstra @wadepickett 

We'll need an additional bit of issue processing for Blazor Hybrid issues, including adding @BethMassi to the assignees so that she can track what comes in and probably react directly to community feedback.

I considered setting up a new `ms.technology` for this, but that's probably overkill. I should be able to make this work with a path check, where I ...

* Swap the label ("Blazor Hybrid" for "Blazor").
* Swap the project ([106](https://github.com/dotnet/AspNetCore.Docs/projects/106) for [35](https://github.com/dotnet/AspNetCore.Docs/projects/35)). We've never tried `projects-remove` before on this repo. If this breaks, then I'll revert this in favor of a new `ms.technology`. 🤞 and 🍀 on this PR's changes working out.
* Assign @BethMassi ... and I'll stay on as an assignee.

I'm going to go ahead and put this in now. I have new issues to open that will make good test cases for this processing. I'll revert quickly if I break anything 🙈😄.