### PR TITLE
Blazor Hybrid issue processing

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -35,6 +35,15 @@ issues:
         - check:
             - type: metadata-comment
               name: technology
+              value: "(?i)aspnetcore-blazorhybrid$"
+          pass:
+            - labels-add: ["Blazor Hybrid"]
+            - projects-add: [106]
+            - labels-remove: [":watch: Not Triaged"]
+            - assignee-add: ["BethMassi", "guardrex"]
+        - check:
+            - type: metadata-comment
+              name: technology
               value: "(?i)aspnetcore-grpc$"
           pass:
             - labels-add: ["gRPC"]
@@ -84,16 +93,6 @@ issues:
             - projects-add: [35]
             - labels-remove: [":watch: Not Triaged"]
             - assignee-add: ["guardrex"]
-        - check:
-            - type: metadata-comment
-              name: content source
-              value: "(?i).*blazor\/hybrid.*"
-          pass:
-            - labels-remove: ["Blazor"]
-            - labels-add: ["Blazor Hybrid"]
-            - projects-remove: [35]
-            - projects-add: [106]
-            - assignee-add: ["BethMassi"]
         - check:
             - type: metadata-comment
               name: content source

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -42,6 +42,7 @@
       "ms.technology": {
         "**/client-side/**/**.md": "aspnetcore-clientside",
         "**/blazor/**/**.md": "aspnetcore-blazor",
+        "**/blazor/hybrid/**/**.md": "aspnetcore-blazorhybrid",
         "**/data/**/**.md": "aspnetcore-data",
         "**/fundamentals/**/**.md": "aspnetcore-fundamentals",
         "**/getting-started/**/**.md": "aspnetcore-getstarted",


### PR DESCRIPTION
@Rick-Anderson @tdykstra @wadepickett @BethMassi 

Well, the last attempt failed in a blaze of glory ... https://github.com/dotnet/AspNetCore.Docs/issues/29872.

I'll try it with a new technology name, ***BUT*** negation (NOT) isn't possible in a DocFX glob pattern, so I'm relying upon an overwrite of the Blazor technology name (`aspnetcore-blazor`) with a new Blazor Hybrid technology name (`aspnetcore-blazorhybrid`). It might work, but I won't be surprised if it fails. I think I have one more idea to try if this fails.