### PR TITLE
Android Web View with emulated device

### DIFF
--- a/aspnetcore/blazor/hybrid/security/security-considerations.md
+++ b/aspnetcore/blazor/hybrid/security/security-considerations.md
@@ -79,7 +79,7 @@ The Android Web View is distributed and updated via the [Google Play Store](http
 
 When using the Android Emulator:
 
-* Use an emulated device with Google Play Services preinstalled.
+* Use an emulated device with **Google Play Services** preinstalled. Emulated devices without Google Play Services preinstalled are ***not*** supported.
 * Install or update Google Chrome from the Google Play Store.
 
 ### iOS/:::no-loc text="Mac Catalyst":::

--- a/aspnetcore/blazor/hybrid/security/security-considerations.md
+++ b/aspnetcore/blazor/hybrid/security/security-considerations.md
@@ -80,7 +80,7 @@ The Android Web View is distributed and updated via the [Google Play Store](http
 When using the Android Emulator:
 
 * Use an emulated device with **Google Play Services** preinstalled. Emulated devices without Google Play Services preinstalled are ***not*** supported.
-* Install or update Google Chrome from the Google Play Store. An emulated device might not have the latest version of Chrome installed, which might result in the device not having the latest version of the Android Web View installed.
+* Install Google Chrome from the Google Play Store. If Google Chrome is already installed, [update Chrome from the Google Play Store](https://support.google.com/chrome/answer/95414?hl=en&co=GENIE.Platform%3DAndroid). If an emulated device doesn't have the latest version of Chrome installed, it might not have the latest version of the Android Web View installed.
 
 ### iOS/:::no-loc text="Mac Catalyst":::
 

--- a/aspnetcore/blazor/hybrid/security/security-considerations.md
+++ b/aspnetcore/blazor/hybrid/security/security-considerations.md
@@ -80,7 +80,7 @@ The Android Web View is distributed and updated via the [Google Play Store](http
 When using the Android Emulator:
 
 * Use an emulated device with **Google Play Services** preinstalled. Emulated devices without Google Play Services preinstalled are ***not*** supported.
-* Install or update Google Chrome from the Google Play Store.
+* Install or update Google Chrome from the Google Play Store. An emulated device might not have the latest version of Chrome installed, which might result in the device not having the latest version of the Android Web View installed.
 
 ### iOS/:::no-loc text="Mac Catalyst":::
 

--- a/aspnetcore/blazor/hybrid/security/security-considerations.md
+++ b/aspnetcore/blazor/hybrid/security/security-considerations.md
@@ -77,6 +77,11 @@ Use one of the following approaches to keep the Web View current in deployed app
 
 The Android Web View is distributed and updated via the [Google Play Store](https://play.google.com/store/apps/details?id=com.google.android.webview). Check the Web View version by reading the [`User-Agent`](https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent) string. Read the Web View's [`navigator.userAgent`](https://developer.mozilla.org/docs/Web/API/Navigator/userAgent) property using [JavaScript interop](xref:blazor/js-interop/index) and optionally cache the value using a singleton service if the user agent string is required outside of a Razor component context.
 
+When using the Android Emulator:
+
+* Use an emulated device with Google Play Services preinstalled.
+* Install or update Google Chrome from the Google Play Store.
+
 ### iOS/:::no-loc text="Mac Catalyst":::
 
 iOS and :::no-loc text="Mac Catalyst"::: both use [`WKWebView`](https://developer.apple.com/documentation/webkit/wkwebview), a Safari-based control, which is updated by the operating system. Similar to the [Android](#android) case, determine the Web View version by reading the Web View's [`User-Agent`](https://developer.mozilla.org/docs/Web/HTTP/Headers/User-Agent) string.


### PR DESCRIPTION
Fixes #26089

btw -- We use contractions across the docs, but we often avoid it to highlight a "not" (... ***not*** ...), such as in a case like this support remark.

~I don't think we need very specific guidance on use of the Google Play Store here for a Chrome update, but let me know if you want something for it. I can probably scare up a cross-link.~ **UPDATE:** I rephrased it and added a link.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/security/security-considerations.md](https://github.com/dotnet/AspNetCore.Docs/blob/3d35ff9c1619f748cb322e1e8acdb45f30ba69ae/aspnetcore/blazor/hybrid/security/security-considerations.md) | [ASP.NET Core Blazor Hybrid security considerations](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/security/security-considerations?branch=pr-en-us-29884) |


<!-- PREVIEW-TABLE-END -->