### PR TITLE
handle-errors: use project file code snippets

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/handle-errrors.md
+++ b/aspnetcore/fundamentals/minimal-apis/handle-errrors.md
@@ -29,15 +29,7 @@ In a Minimal API app, there are two different built-in centralized mechanisms to
 
 This section refers to the following Minimal API app to demonstrate ways to handle exceptions. It throws an exception when the endpoint `/exception` is requested:
 
-``` csharp
-var builder = WebApplication.CreateBuilder(args);
-var app = builder.Build();
-
-app.Map("/exception", () 
-    => { throw new InvalidOperationException("Sample Exception"); });
-
-app.Run();
-```
+:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_ThrowExceptions" highlight="4-7":::
 
 ### Developer Exception Page
 
@@ -82,36 +74,13 @@ In non-development environments, use the [Exception Handler Middleware](xref:fun
 
 For example, the following code changes the app to respond with an [RFC 7807](https://tools.ietf.org/html/rfc7807)-compliant payload to the client. For more information, see [Problem Details](#problem-details) section.
 
-``` csharp
-var builder = WebApplication.CreateBuilder(args);
-var app = builder.Build();
-
-app.UseExceptionHandler(exceptionHandlerApp 
-    => exceptionHandlerApp.Run(async context 
-        => await Results.Problem()
-                     .ExecuteAsync(context)));
-
-app.Map("/exception", () 
-    => { throw new InvalidOperationException("Sample Exception"); });
-
-app.Run();
-```
+:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_WithUseExceptionHandler" highlight="4-7":::
 
 ## Client and Server error responses
 
 Consider the following Minimal API app.
 
-``` csharp
-var builder = WebApplication.CreateBuilder(args);
-var app = builder.Build();
-
-app.Map("/users/{id:int}", (int id) 
-    => id <= 0 ? Results.BadRequest() : Results.Ok(new User(id)) );
-
-app.Run();
-
-public record User(int Id);
-```
+:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_ClientAndServerErrorResponses":::
 
 The `/users` endpoint produces `200 OK` with a `json` representation of `User` when `id` is greater than `0`, otherwise a `400 BAD REQUEST` status code without a response body. For more information about creating a response, see [Create responses in Minimal API apps](/aspnet/core/fundamentals/minimal-apis/responses).
 
@@ -120,21 +89,7 @@ The [`Status Code Pages middleware`](xref:fundamentals/error-handling#sestatusco
 
 For example, the following example changes the app to respond with an [RFC 7807](https://tools.ietf.org/html/rfc7807)-compliant payload to the client for all client and server responses, including routing errors (for example, `404 NOT FOUND`). For more information, see the [Problem Details](#problem-details) section.
 
-``` csharp
-var builder = WebApplication.CreateBuilder(args);
-var app = builder.Build();
-
-app.UseStatusCodePages(async statusCodeContext 
-    =>  await Results.Problem(statusCode: statusCodeContext.HttpContext.Response.StatusCode)
-                 .ExecuteAsync(statusCodeContext.HttpContext));
-
-app.Map("/users/{id:int}", (int id) 
-    => id <= 0 ? Results.BadRequest() : Results.Ok(new User(id)) );
-
-app.Run();
-
-public record User(int Id);
-```
+:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_ClientAndServerErrorResponsesWithUseStatusCodePages" highlight="4-7":::
 
 ## Problem details
 
@@ -144,23 +99,8 @@ Minimal API apps can be configured to generate problem details response for all 
 
 The following code configures the app to generate problem details:
 
-``` csharp
-var builder = WebApplication.CreateBuilder(args);
-builder.Services.AddProblemDetails();
+:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_ProblemDetails" highlight="2":::
 
-var app = builder.Build();
-
-app.UseExceptionHandler();
-app.UseStatusCodePages();
-
-app.Map("/users/{id:int}", (int id) 
-    => id <= 0 ? Results.BadRequest() : Results.Ok(new User(id)) );
-
-app.Map("/exception", () 
-    => { throw new InvalidOperationException("Sample Exception"); });
-
-app.Run();
-```
 
 For more information on using `AddProblemDetails`, see [Problem Details](/aspnet/core/fundamentals/error-handling?view=aspnetcore-7.0&preserve-view=true#pds7)
 
@@ -168,7 +108,7 @@ For more information on using `AddProblemDetails`, see [Problem Details](/aspnet
 
 In the following code, `httpContext.Response.WriteAsync("Fallback: An error occurred.")` returns an error if the <xref:Microsoft.AspNetCore.Http.IProblemDetailsService> implementation isn't able to generate a <xref:Microsoft.AspNetCore.Mvc.ProblemDetails>:
 
-:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_WithUseExceptionHandler" highlight="16":::
+:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_IProblemDetailsServiceWithExceptionFallback" highlight="15":::
 
 The preceding code:
 
@@ -177,7 +117,7 @@ The preceding code:
 
 The following sample is similar to the preceding except that it calls the [`Status Code Pages middleware`](xref:fundamentals/error-handling#usestatuscodepages).
 
-:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_WithStatusCodesPage" highlight="16":::
+:::code language="csharp" source="~/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs" id="snippet_IProblemDetailsServiceWithStatusCodePageFallback" highlight="15":::
 
 :::moniker-end
 

--- a/aspnetcore/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/handle-errrors/sample8/Program.cs
@@ -1,9 +1,92 @@
-#define WithUseExceptionHandler // WithUseExceptionHandler, WithStatusCodesPage
+#define WithUseExceptionHandler // ThrowExceptions, WithUseExceptionHandler, ClientAndServerErrorResponses, ClientAndServerErrorResponsesWithUseStatusCodePages, ProblemDetails, IProblemDetailsServiceWithExceptionFallback, IProblemDetailsServiceWithStatusCodePageFallback
 
-#if WithUseExceptionHandler
+#if ThrowExceptions
+// <snippet_ThrowExceptions>
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/exception", () => 
+{
+    throw new InvalidOperationException("Sample Exception");
+});
+
+app.MapGet("/", () => "Test by calling /exception");
+
+app.Run();
+// </snippet_ThrowExceptions>
+#elif WithUseExceptionHandler
 // <snippet_WithUseExceptionHandler>
 var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
 
+app.UseExceptionHandler(exceptionHandlerApp 
+    => exceptionHandlerApp.Run(async context 
+        => await Results.Problem()
+                     .ExecuteAsync(context)));
+
+app.MapGet("/exception", () => 
+{
+    throw new InvalidOperationException("Sample Exception");
+});
+
+app.MapGet("/", () => "Test by calling /exception");
+
+app.Run();
+// </snippet_WithUseExceptionHandler>
+#elif ClientAndServerErrorResponses
+// <snippet_ClientAndServerErrorResponses>
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/users/{id:int}", (int id) 
+    => id <= 0 ? Results.BadRequest() : Results.Ok(new User(id)));
+
+app.MapGet("/", () => "Test by calling /users/{id:int}");
+
+app.Run();
+
+public record User(int Id);
+// </snippet_ClientAndServerErrorResponses>
+#elif ClientAndServerErrorResponsesWithUseStatusCodePages
+// <snippet_ClientAndServerErrorResponsesWithUseStatusCodePages>
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.UseStatusCodePages(async statusCodeContext 
+    => await Results.Problem(statusCode: statusCodeContext.HttpContext.Response.StatusCode)
+                 .ExecuteAsync(statusCodeContext.HttpContext));
+
+app.MapGet("/users/{id:int}", (int id) 
+    => id <= 0 ? Results.BadRequest() : Results.Ok(new User(id)) );
+
+app.MapGet("/", () => "Test by calling /users/{id:int}");
+
+app.Run();
+
+public record User(int Id);
+// </snippet_ClientAndServerErrorResponsesWithUseStatusCodePages>
+#elif ProblemDetails
+// <snippet_ProblemDetails>
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddProblemDetails();
+
+var app = builder.Build();
+
+app.UseExceptionHandler();
+app.UseStatusCodePages();
+
+app.MapGet("/users/{id:int}", (int id) 
+    => id <= 0 ? Results.BadRequest() : Results.Ok(new User(id)));
+
+app.MapGet("/", () => "Test by calling /users/{id:int}");
+
+app.Run();
+
+public record User(int Id);
+// </snippet_ProblemDetails>
+#elif IProblemDetailsServiceWithExceptionFallback
+// <snippet_IProblemDetailsServiceWithExceptionFallback>
+var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddProblemDetails();
 
 var app = builder.Build();
@@ -22,7 +105,7 @@ app.UseExceptionHandler(exceptionHandlerApp =>
     });
 });
 
-app.MapGet("/exception", () => 
+app.MapGet("/exception", () =>
 {
     throw new InvalidOperationException("Sample Exception");
 });
@@ -30,11 +113,10 @@ app.MapGet("/exception", () =>
 app.MapGet("/", () => "Test by calling /exception");
 
 app.Run();
-// </snippet_WithUseExceptionHandler>
-#elif WithStatusCodesPage
-// <snippet_WithStatusCodesPage>
+// </snippet_IProblemDetailsServiceWithExceptionFallback>
+#elif IProblemDetailsServiceWithStatusCodePageFallback
+// <snippet_IProblemDetailsServiceWithStatusCodePageFallback>
 var builder = WebApplication.CreateBuilder(args);
-
 builder.Services.AddProblemDetails();
 
 var app = builder.Build();
@@ -61,6 +143,7 @@ app.MapGet("/users/{id:int}", (int id) =>
 app.MapGet("/", () => "Test by calling /users/{id:int}");
 
 app.Run();
-// </snippet_WithStatusCodesPage>
-#endif 
+
 public record User(int Id);
+// </snippet_IProblemDetailsServiceWithStatusCodePageFallback>
+#endif 


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #28756

Some changes that I made while copy-pasting the existing snippets into the program file:

- Made sure each snippet compiles (e.g. `User` was sometimes not declared within the snippet)
- Consistency: I added the `/` endpoint in each snippet where it wasn't added before
- Consistency: used `MapGet` in each snippet to create an endpoint (before `Map` and `MapGet` was used)
- Added some code highlighting where I thought it was needed

If you don't mind, I also got the following questions:

- I noticed two ways of referring to snippets `:::code` vs `[!code-csharp[]`, is there a difference and/or preference?
- In this PR I created a section for each snippet, is that the way to go, or is that a better way? I mainly did this otherwise I couldn't hide some parts, but this ends up with some duplication.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/handle-errrors.md](https://github.com/dotnet/AspNetCore.Docs/blob/4e00e6aee1d49316377b0f78f43d68a853849c7d/aspnetcore/fundamentals/minimal-apis/handle-errrors.md) | [How to handle errors in Minimal API apps](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/handle-errrors?branch=pr-en-us-29933) |

<!-- PREVIEW-TABLE-END -->