### PR TITLE
.NET 8 Redis-based output caching

### DIFF
--- a/aspnetcore/performance/caching/distributed.md
+++ b/aspnetcore/performance/caching/distributed.md
@@ -62,7 +62,7 @@ We recommend production apps use the Distributed Redis Cache because it's the mo
 
 [Redis](https://redis.io/) is an open source in-memory data store, which is often used as a distributed cache.  You can configure an [Azure Redis Cache](https://azure.microsoft.com/services/cache/) for an Azure-hosted ASP.NET Core app, and use an Azure Redis Cache for local development.
 
-An app configures the cache implementation using a <xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache> instance (<xref:Microsoft.Extensions.DependencyInjection.StackExchangeRedisCacheServiceCollectionExtensions.AddStackExchangeRedisCache*>).
+An app configures the cache implementation using a <xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache> instance (<xref:Microsoft.Extensions.DependencyInjection.StackExchangeRedisCacheServiceCollectionExtensions.AddStackExchangeRedisCache%2A>). [Use `AddStackExchangeRedisOutputCache` for output caching](xref:performance/caching/output#cache-storage).
 
   1. Create an Azure Cache for Redis.
   1. Copy the Primary connection string (StackExchange.Redis) to [Configuration](xref:fundamentals/configuration/index).

--- a/aspnetcore/performance/caching/distributed.md
+++ b/aspnetcore/performance/caching/distributed.md
@@ -60,9 +60,9 @@ Register an implementation of <xref:Microsoft.Extensions.Caching.Distributed.IDi
 
 We recommend production apps use the Distributed Redis Cache because it's the most performant. For more information see [Recommendations](#recommendations).
 
-[Redis](https://redis.io/) is an open source in-memory data store, which is often used as a distributed cache.  You can configure an [Azure Redis Cache](https://azure.microsoft.com/services/cache/) for an Azure-hosted ASP.NET Core app, and use an Azure Redis Cache for local development.
+[Redis](https://redis.io/) is an open source in-memory data store, which is often used as a distributed cache.  You can configure an [Azure Cache for  Redis](/azure/azure-cache-for-redis/cache-overview) for an Azure-hosted ASP.NET Core app, and use an Azure Cache for Redis for local development.
 
-An app configures the cache implementation using a <xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache> instance (<xref:Microsoft.Extensions.DependencyInjection.StackExchangeRedisCacheServiceCollectionExtensions.AddStackExchangeRedisCache%2A>). [Use `AddStackExchangeRedisOutputCache` for output caching](xref:performance/caching/output#cache-storage).
+An app configures the cache implementation using a <xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCache> instance, by calling <xref:Microsoft.Extensions.DependencyInjection.StackExchangeRedisCacheServiceCollectionExtensions.AddStackExchangeRedisCache%2A>. For [output caching](xref:performance/caching/output#cache-storage), use `AddStackExchangeRedisOutputCache`.
 
   1. Create an Azure Cache for Redis.
   1. Copy the Primary connection string (StackExchange.Redis) to [Configuration](xref:fundamentals/configuration/index).

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -185,7 +185,23 @@ The following properties of <xref:Microsoft.AspNetCore.OutputCaching.OutputCache
 
 ## Cache storage
 
-<xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. We don't recommend <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> for use with output caching. `IDistributedCache` doesn't have atomic features, which are required for tagging. We recommend that you create custom <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> implementations by using direct dependencies on the underlying storage mechanism, such as Redis.
+## Cache storage
+
+<xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. Cached responses are stored in-process, so each server node has a separate and isolated cache that is lost whenever the server process is restarted.
+
+An alternative is to use a Redis backend for output caching. Redis cache provides consistency between server nodes via a shared cache that outlives individual server processes. To use Redis for output caching:
+
+* Install the [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis) NuGet package.
+* Call `builder.AddStackExchangeRedisOutputCache` (not `AddStackExchangeRedisCache`). The available configuration options are identical to the existing [Redis-based distributed caching options](xref:performance/caching/distributed#distributed-redis-cache).
+
+For example:
+
+:::code language="csharp" source="~/performance/caching/output/samples/8.x/Program.cs" id="redis" highlight="1-5":::
+
+* [`options.Configuration`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.Configuration) - A connection string to an on-premises Redis server or to a hosted offering such as [Azure Cache for Redis](/azure/azure-cache-for-redis/). For example, `<instance_name>.redis.cache.windows.net:6380,password=<password>,ssl=True,abortConnect=False` for Azure cache for Redis.
+* [`options.InstanceName`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.InstanceName) - Optional, specifies a logical partition for the cache.
+ 
+We don't recommend <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> for use with output caching. `IDistributedCache` doesn't have atomic features, which are required for tagging. If the built-in support for Redis cache doesn't meet your needs, we recommend that you create custom <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> implementations by using direct dependencies on the underlying storage mechanism.
 
 ## See also
 

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -189,7 +189,7 @@ The following properties of <xref:Microsoft.AspNetCore.OutputCaching.OutputCache
 
 <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. Cached responses are stored in-process, so each server node has a separate and isolated cache that is lost whenever the server process is restarted.
 
-An alternative is to use a Redis backend for output caching. Redis cache provides consistency between server nodes via a shared cache that outlives individual server processes. To use Redis for output caching:
+An alternative is to use a [Redis](xref:performance/caching/distributed#distributed-redis-cache) backend for output caching. Redis cache provides consistency between server nodes via a shared cache that outlives individual server processes. To use Redis for output caching:
 
 * Install the [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis) NuGet package.
 * Call `builder.AddStackExchangeRedisOutputCache` (not `AddStackExchangeRedisCache`). The available configuration options are identical to the existing [Redis-based distributed caching options](xref:performance/caching/distributed#distributed-redis-cache).

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -47,7 +47,7 @@ The following highlighted code configures caching for all of the app's endpoints
 
 :::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies1" highlight="3-4":::
 
-The following highlighted code creates two policies, each specifying a different expiration time. Selected endpoints can use the 20 second expiration, and others can use the 30 second expiration.
+The following highlighted code creates two policies, each specifying a different expiration time. Selected endpoints can use the 20-second expiration, and others can use the 30-second expiration.
 
 :::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies1" highlight="5-8":::
 
@@ -155,7 +155,7 @@ In the preceding tag assignment examples, both endpoints are identified by the `
 
 :::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="evictbytag":::
 
-With this code, an HTTP POST request sent to `https://localhost:<port>/purge/tag-blog` will evict cache entries for these endpoints.
+With this code, an HTTP POST request sent to `https://localhost:<port>/purge/tag-blog` evicts cache entries for these endpoints.
 
 You might want a way to evict all cache entries for all endpoints. To do that, create a base policy for all endpoints as the following code does:
 
@@ -179,26 +179,32 @@ The following example selects the no-locking policy for an endpoint:
 
 The following properties of <xref:Microsoft.AspNetCore.OutputCaching.OutputCacheOptions> let you configure limits that apply to all endpoints:
 
-* <xref:Microsoft.AspNetCore.OutputCaching.OutputCacheOptions.SizeLimit> - Maximum size of cache storage. When this limit is reached, no new responses will be cached until older entries are evicted. Default value is 100 MB.
-* <xref:Microsoft.AspNetCore.OutputCaching.OutputCacheOptions.MaximumBodySize> - If the response body exceeds this limit, it will not be cached. Default value is 64 MB.
+* <xref:Microsoft.AspNetCore.OutputCaching.OutputCacheOptions.SizeLimit> - Maximum size of cache storage. When this limit is reached, no new responses are cached until older entries are evicted. Default value is 100 MB.
+* <xref:Microsoft.AspNetCore.OutputCaching.OutputCacheOptions.MaximumBodySize> - If the response body exceeds this limit, it isn't cached. Default value is 64 MB.
 * <xref:Microsoft.AspNetCore.OutputCaching.OutputCacheOptions.DefaultExpirationTimeSpan> - The expiration time duration that applies when not specified by a policy. Default value is 60 seconds.
 
 ## Cache storage
 
-<xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. Cached responses are stored in-process, so each server node has a separate and isolated cache that is lost whenever the server process is restarted.
+<xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. Cached responses are stored in-process, so each server has a separate cache that is lost whenever the server process is restarted.
 
-An alternative is to use a [Redis](https://redis.io/) backend for output caching. Redis cache provides consistency between server nodes via a shared cache that outlives individual server processes. To use Redis for output caching:
+### Redis cache
+
+An alternative is to use [Redis](https://redis.io/) cache. Redis cache provides consistency between server nodes via a shared cache that outlives individual server processes. To use Redis for output caching:
 
 * Install the [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis) NuGet package.
-* Call `builder.AddStackExchangeRedisOutputCache` (not `AddStackExchangeRedisCache`). The available configuration options are identical to the existing [Redis-based distributed caching options](xref:performance/caching/distributed#distributed-redis-cache).
+* Call `builder.AddStackExchangeRedisOutputCache` (not `AddStackExchangeRedisCache`), and provide a connection string that points to a Redis server.
 
-For example:
+  For example:
 
-:::code language="csharp" source="~/performance/caching/output/samples/8.x/Program.cs" id="redis" highlight="1-5":::
+  :::code language="csharp" source="~/performance/caching/output/samples/8.x/Program.cs" id="redis" highlight="1-5":::
 
-* [`options.Configuration`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.Configuration) - A connection string to an on-premises Redis server or to a hosted offering such as [Azure Cache for Redis](/azure/azure-cache-for-redis/). For example, `<instance_name>.redis.cache.windows.net:6380,password=<password>,ssl=True,abortConnect=False` for Azure cache for Redis.
-* [`options.InstanceName`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.InstanceName) - Optional, specifies a logical partition for the cache.
+  * [`options.Configuration`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.Configuration) - A connection string to an on-premises Redis server or to a hosted offering such as [Azure Cache for Redis](/azure/azure-cache-for-redis/). For example, `<instance_name>.redis.cache.windows.net:6380,password=<password>,ssl=True,abortConnect=False` for Azure cache for Redis.
+  * [`options.InstanceName`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.InstanceName) - Optional, specifies a logical partition for the cache.
  
+  The configuration options are identical to the [Redis-based distributed caching options](xref:performance/caching/distributed#distributed-redis-cache).
+
+### `IDistributedCache` not recommended
+
 We don't recommend <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> for use with output caching. `IDistributedCache` doesn't have atomic features, which are required for tagging. We recommend that you use the built-in support for Redis or create custom <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> implementations by using direct dependencies on the underlying storage mechanism.
 
 ## See also

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -35,7 +35,7 @@ Add the middleware to the request processing pipeline by calling <xref:Microsoft
 
 For minimal API apps, configure an endpoint to do caching by calling [`CacheOutput`](xref:Microsoft.Extensions.DependencyInjection.OutputCacheConventionBuilderExtensions.CacheOutput%2A), or by applying the [`[OutputCache]`](xref:Microsoft.AspNetCore.OutputCaching.OutputCacheAttribute) attribute, as shown in the following examples:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="oneendpoint":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="oneendpoint":::
 
 For apps with controllers, apply the `[OutputCache]` attribute to the action method. For Razor Pages apps, apply the attribute to the Razor page class.
 
@@ -45,15 +45,15 @@ Create *policies* when calling `AddOutputCache` to specify caching configuration
 
 The following highlighted code configures caching for all of the app's endpoints, with expiration time of 10 seconds. If an expiration time isn't specified,  it defaults to one minute.
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies1" highlight="3-4":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies1" highlight="3-4":::
 
 The following highlighted code creates two policies, each specifying a different expiration time. Selected endpoints can use the 20 second expiration, and others can use the 30 second expiration.
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies1" highlight="5-8":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies1" highlight="5-8":::
 
 You can select a policy for an endpoint when calling the `CacheOutput` method or using the `[OutputCache]` attribute:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="selectpolicy":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="selectpolicy":::
 
 For apps with controllers, apply the `[OutputCache]` attribute to the action method. For Razor Pages apps, apply the attribute to the Razor page class.
 
@@ -68,21 +68,21 @@ By default, output caching follows these rules:
 
 The following code applies all of the default caching rules to all of an app's endpoints:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies3":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies3":::
 
 ### Override the default policy
 
 The following code shows how to override the default rules. The highlighted lines in the following custom policy code enable caching for HTTP POST methods and HTTP 301 responses:
 
-:::code language="csharp" source="output/samples/7.x/MyCustomPolicy.cs" highlight="50,68":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/MyCustomPolicy.cs" highlight="50,68":::
 
 To use this custom policy, create a named policy:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies3b":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies3b":::
 
 And select the named policy for an endpoint:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="post":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="post":::
 
 ### Alternative default policy override 
 
@@ -93,11 +93,11 @@ Alternatively, use Dependency Injection (DI) to initialize an instance, with the
 
 For example:
 
-:::code language="csharp" source="output/samples/7.x/MyCustomPolicy2.cs" id="fordi":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/MyCustomPolicy2.cs" id="fordi":::
 
 The remainder of the class is the same as shown previously. Add the custom policy as shown in the following example:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies3c":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies3c":::
 
 The preceding code uses DI to create the instance of the custom policy class. Any public arguments in the constructor are resolved.
 
@@ -107,11 +107,11 @@ When using a custom policy as a base policy, don't call `OutputCache()` (with no
 
 By default, every part of the URL is included as the key to a cache entry, that is, the scheme, host, port, path, and query string. However, you might want to explicitly control the cache key. For example, suppose you have an endpoint that returns a unique response only for each unique value of the `culture` query string. Variation in other parts of the URL, such as other query strings, shouldn't result in different cache entries. You can specify such rules in a policy, as shown in the following highlighted code:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies2" highlight="7":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies2" highlight="7":::
 
 You can then select the `VaryByQuery` policy for an endpoint:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="selectquery":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="selectquery":::
 
 Here are some of the options for controlling the cache key:
 
@@ -119,7 +119,7 @@ Here are some of the options for controlling the cache key:
 * <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.SetVaryByHeader%2A> - Specify one or more HTTP headers to add to the cache key.
 * <xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.VaryByValue%2A>- Specify a value to add to the cache key. The following example uses a value that indicates whether the current server time in seconds is odd or even. A new response is generated only when the number of seconds goes from odd to even or even to odd.
 
-  :::code language="csharp" source="output/samples/7.x/Program.cs" id="varybyvalue":::
+  :::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="varybyvalue":::
 
 Use <xref:Microsoft.AspNetCore.OutputCaching.OutputCacheOptions.UseCaseSensitivePaths?displayProperty=nameWithType> to specify that the path part of the key is case sensitive. The default is case insensitive.
 
@@ -131,7 +131,7 @@ Cache revalidation means the server can return a `304 Not Modified` HTTP status 
 
 The following code illustrates the use of an [`Etag`](https://developer.mozilla.org/docs/Web/HTTP/Headers/ETag) header to enable cache revalidation. If the client sends an [`If-None-Match`](https://developer.mozilla.org/docs/Web/HTTP/Headers/If-None-Match) header with the etag value of an earlier response, and the cache entry is fresh, the server returns [304 Not Modified](https://developer.mozilla.org/docs/Web/HTTP/Status/304) instead of the full response:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="etag":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="etag":::
 
 Another way to do cache revalidation is to check the date of the cache entry creation compared to the date requested by the client. When the request header `If-Modified-Since` is provided, output caching returns 304 if the cached entry is older and isn't expired.
 
@@ -141,25 +141,25 @@ Cache revalidation is automatic in response to these headers sent from the clien
 
 You can use tags to identify a group of endpoints and evict all cache entries for the group. For example, the following code creates a pair of endpoints whose URLs begin with "blog", and tags them "tag-blog":
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="tagendpoint":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="tagendpoint":::
 
 An alternative way to assign tags for the same pair of endpoints is to define a base policy that applies to endpoints that begin with `blog`:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies2" highlight="3-5":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies2" highlight="3-5":::
 
 Another alternative is to call `MapGroup`:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="taggroup":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="taggroup":::
 
 In the preceding tag assignment examples, both endpoints are identified by the `tag-blog` tag. You can then evict the cache entries for those endpoints with a single statement that references that tag:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="evictbytag":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="evictbytag":::
 
 With this code, an HTTP POST request sent to `https://localhost:<port>/purge/tag-blog` will evict cache entries for these endpoints.
 
 You might want a way to evict all cache entries for all endpoints. To do that, create a base policy for all endpoints as the following code does:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies2" highlight="6":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies2" highlight="6":::
 
 This base policy enables you to use the "tag-all" tag to evict everything in cache.
 
@@ -169,11 +169,11 @@ By default, resource locking is enabled to mitigate the risk of [cache stampede 
 
 To disable resource locking, call [SetLocking(false)](xref:Microsoft.AspNetCore.OutputCaching.OutputCachePolicyBuilder.SetLocking%2A) while creating a policy, as shown in the following example:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="policies2" highlight="9":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="policies2" highlight="9":::
 
 The following example selects the no-locking policy for an endpoint:
 
-:::code language="csharp" source="output/samples/7.x/Program.cs" id="selectnolock":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="selectnolock":::
 
 ## Limits
 

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -185,8 +185,6 @@ The following properties of <xref:Microsoft.AspNetCore.OutputCaching.OutputCache
 
 ## Cache storage
 
-## Cache storage
-
 <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. Cached responses are stored in-process, so each server node has a separate and isolated cache that is lost whenever the server process is restarted.
 
 An alternative is to use a [Redis](https://redis.io/) backend for output caching. Redis cache provides consistency between server nodes via a shared cache that outlives individual server processes. To use Redis for output caching:

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -189,7 +189,7 @@ The following properties of <xref:Microsoft.AspNetCore.OutputCaching.OutputCache
 
 <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. Cached responses are stored in-process, so each server node has a separate and isolated cache that is lost whenever the server process is restarted.
 
-An alternative is to use a [Redis](xref:performance/caching/distributed#distributed-redis-cache) backend for output caching. Redis cache provides consistency between server nodes via a shared cache that outlives individual server processes. To use Redis for output caching:
+An alternative is to use a [Redis](https://redis.io/) backend for output caching. Redis cache provides consistency between server nodes via a shared cache that outlives individual server processes. To use Redis for output caching:
 
 * Install the [Microsoft.Extensions.Caching.StackExchangeRedis](https://www.nuget.org/packages/Microsoft.Extensions.Caching.StackExchangeRedis) NuGet package.
 * Call `builder.AddStackExchangeRedisOutputCache` (not `AddStackExchangeRedisCache`). The available configuration options are identical to the existing [Redis-based distributed caching options](xref:performance/caching/distributed#distributed-redis-cache).

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -196,7 +196,7 @@ An alternative is to use [Redis](https://redis.io/) cache. Redis cache provides 
 
   For example:
 
-  :::code language="csharp" source="~/performance/caching/output/samples/8.x/Program.cs" id="redis" highlight="1-5":::
+  :::code language="csharp" source="~/performance/caching/output/samples/8.x/Program.cs" id="redis" highlight="1-6":::
 
   * [`options.Configuration`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.Configuration) - A connection string to an on-premises Redis server or to a hosted offering such as [Azure Cache for Redis](/azure/azure-cache-for-redis/). For example, `<instance_name>.redis.cache.windows.net:6380,password=<password>,ssl=True,abortConnect=False` for Azure cache for Redis.
   * [`options.InstanceName`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.InstanceName) - Optional, specifies a logical partition for the cache.

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -201,7 +201,7 @@ For example:
 * [`options.Configuration`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.Configuration) - A connection string to an on-premises Redis server or to a hosted offering such as [Azure Cache for Redis](/azure/azure-cache-for-redis/). For example, `<instance_name>.redis.cache.windows.net:6380,password=<password>,ssl=True,abortConnect=False` for Azure cache for Redis.
 * [`options.InstanceName`](xref:Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions.InstanceName) - Optional, specifies a logical partition for the cache.
  
-We don't recommend <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> for use with output caching. `IDistributedCache` doesn't have atomic features, which are required for tagging. If the built-in support for Redis cache doesn't meet your needs, we recommend that you create custom <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> implementations by using direct dependencies on the underlying storage mechanism.
+We don't recommend <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> for use with output caching. `IDistributedCache` doesn't have atomic features, which are required for tagging. We recommend that you use the built-in support for Redis or create custom <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> implementations by using direct dependencies on the underlying storage mechanism.
 
 ## See also
 

--- a/aspnetcore/performance/caching/output/includes/output7.md
+++ b/aspnetcore/performance/caching/output/includes/output7.md
@@ -169,7 +169,7 @@ The following properties of <xref:Microsoft.AspNetCore.OutputCaching.OutputCache
 
 ## Cache storage
 
-<xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. We don't recommend <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> for use with output caching. `IDistributedCache` doesn't have atomic features, which are required for tagging. We recommend that you create custom <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> implementations by using direct dependencies on the underlying storage mechanism, such as Redis.
+<xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> is used for storage. By default it's used with <xref:System.Runtime.Caching.MemoryCache>. We don't recommend <xref:Microsoft.Extensions.Caching.Distributed.IDistributedCache> for use with output caching. `IDistributedCache` doesn't have atomic features, which are required for tagging. We recommend that you create custom <xref:Microsoft.AspNetCore.OutputCaching.IOutputCacheStore> implementations by using direct dependencies on the underlying storage mechanism, such as Redis. Or use the [built-in support for Redis cache in .NET 8.](xref:performance/caching/output?view=aspnetcore-8.0&preserve-view=true#cache-storage).
 
 ## See also
 

--- a/aspnetcore/performance/caching/output/samples/8.x/Gravatar.cs
+++ b/aspnetcore/performance/caching/output/samples/8.x/Gravatar.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+public static class Gravatar
+{
+    public static async Task WriteGravatar(HttpContext context)
+    {
+        const string type = "monsterid"; // identicon, monsterid, wavatar
+        const int size = 200;
+        var hash = Guid.NewGuid().ToString("n");
+
+        context.Response.StatusCode = 200;
+        context.Response.ContentType = "text/html";
+        await context.Response.WriteAsync($"<img src=\"https://www.gravatar.com/avatar/{hash}?s={size}&d={type}\"/>");
+        await context.Response.WriteAsync($"<pre>Generated at {DateTime.Now:hh:mm:ss.ff}</pre>");
+    }
+}

--- a/aspnetcore/performance/caching/output/samples/8.x/OCMinimal.csproj
+++ b/aspnetcore/performance/caching/output/samples/8.x/OCMinimal.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0-preview.6.23329.11" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0-preview.6.23329.11" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/performance/caching/output/samples/8.x/Program.cs
+++ b/aspnetcore/performance/caching/output/samples/8.x/Program.cs
@@ -10,7 +10,8 @@ public class Program
         // <redis>
         builder.Services.AddStackExchangeRedisOutputCache(options =>
         {
-            options.Configuration = builder.Configuration.GetConnectionString("MyRedisConStr");
+            options.Configuration = 
+                builder.Configuration.GetConnectionString("MyRedisConStr");
             options.InstanceName = "SampleInstance";
         });
 

--- a/aspnetcore/performance/caching/output/samples/8.x/Program.cs
+++ b/aspnetcore/performance/caching/output/samples/8.x/Program.cs
@@ -9,7 +9,7 @@ public class Program
 
         // Add services to the container.
         builder.Services.AddAuthorization();
-        // <redisoptions>
+        // <redis>
         builder.Services.AddStackExchangeRedisOutputCache(options =>
         {
             options.Configuration = builder.Configuration.GetConnectionString("MyRedisConStr");
@@ -20,7 +20,7 @@ public class Program
             options.AddBasePolicy(builder => 
                 builder.Expire(TimeSpan.FromSeconds(10)));
         });
-        // </redisoptions>
+        // </redis>
         var app = builder.Build();
 
         // Configure the HTTP request pipeline.

--- a/aspnetcore/performance/caching/output/samples/8.x/Program.cs
+++ b/aspnetcore/performance/caching/output/samples/8.x/Program.cs
@@ -7,26 +7,25 @@ public class Program
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        // Add services to the container.
-        builder.Services.AddAuthorization();
         // <redis>
         builder.Services.AddStackExchangeRedisOutputCache(options =>
         {
             options.Configuration = builder.Configuration.GetConnectionString("MyRedisConStr");
             options.InstanceName = "SampleInstance";
         });
+
         builder.Services.AddOutputCache(options =>
         {
             options.AddBasePolicy(builder => 
                 builder.Expire(TimeSpan.FromSeconds(10)));
         });
         // </redis>
+
         var app = builder.Build();
 
         // Configure the HTTP request pipeline.
         app.UseHttpsRedirection();
         app.UseOutputCache();
-        app.UseAuthorization();
 
         app.MapGet("/", Gravatar.WriteGravatar);
 

--- a/aspnetcore/performance/caching/output/samples/8.x/Program.cs
+++ b/aspnetcore/performance/caching/output/samples/8.x/Program.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.OutputCaching;
+
+namespace OCMinimal;
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        // Add services to the container.
+        builder.Services.AddAuthorization();
+        // <redisoptions>
+        builder.Services.AddStackExchangeRedisOutputCache(options =>
+        {
+            options.Configuration = builder.Configuration.GetConnectionString("MyRedisConStr");
+            options.InstanceName = "SampleInstance";
+        });
+        builder.Services.AddOutputCache(options =>
+        {
+            options.AddBasePolicy(builder => 
+                builder.Expire(TimeSpan.FromSeconds(10)));
+        });
+        // </redisoptions>
+        var app = builder.Build();
+
+        // Configure the HTTP request pipeline.
+        app.UseHttpsRedirection();
+        app.UseOutputCache();
+        app.UseAuthorization();
+
+        app.MapGet("/", Gravatar.WriteGravatar);
+
+        app.MapGet("/cached", Gravatar.WriteGravatar).CacheOutput();
+        app.MapGet("/attribute", [OutputCache] (context) => 
+            Gravatar.WriteGravatar(context));
+
+        app.Run();
+    }
+}

--- a/aspnetcore/performance/caching/output/samples/8.x/appsettings.Development.json
+++ b/aspnetcore/performance/caching/output/samples/8.x/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/performance/caching/output/samples/8.x/appsettings.json
+++ b/aspnetcore/performance/caching/output/samples/8.x/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
Fixes #29833 

#### Internal previews with 8.0 selected

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/caching/distributed.md](https://github.com/dotnet/AspNetCore.Docs/blob/30832bf2b45bd5f63cd7bfae69f54317af2c7fd9/aspnetcore/performance/caching/distributed.md) | [Distributed caching in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/caching/distributed?view=aspnetcore-8.0&branch=pr-en-us-29941) |
| [aspnetcore/performance/caching/output.md](https://github.com/dotnet/AspNetCore.Docs/blob/30832bf2b45bd5f63cd7bfae69f54317af2c7fd9/aspnetcore/performance/caching/output.md) | [Output caching middleware in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/caching/output?view=aspnetcore-8.0&branch=pr-en-us-29941) |


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/caching/distributed.md](https://github.com/dotnet/AspNetCore.Docs/blob/30832bf2b45bd5f63cd7bfae69f54317af2c7fd9/aspnetcore/performance/caching/distributed.md) | [Distributed caching in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/caching/distributed?branch=pr-en-us-29941) |
| [aspnetcore/performance/caching/output.md](https://github.com/dotnet/AspNetCore.Docs/blob/30832bf2b45bd5f63cd7bfae69f54317af2c7fd9/aspnetcore/performance/caching/output.md) | [Output caching middleware in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/caching/output?branch=pr-en-us-29941) |


<!-- PREVIEW-TABLE-END -->