### PR TITLE
Create Web API: HTTPS profile instructions

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to build a web API with ASP.NET Core.
 ms.author: wpickett
 ms.custom: mvc, engagement-fy24
-ms.date: 07/18/2023
+ms.date: 07/28/2023
 uid: tutorials/first-web-api
 ---
 
@@ -148,8 +148,30 @@ Visual Studio launches the default browser and navigates to `https://localhost:<
 
 Run the app:
 
-* Press Ctrl+F5 to run the app.
-* Visual Studio Code launches the default browser to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
+* Right-click the *TodoApi.csproj* project, and then select **Open in Integrated Terminal**.
+
+  The **Terminal** window opens with the command prompt at the project directory, which contains the Program.cs and .csproj files.
+
+* Run the following command to start the app on the `https` profile:
+
+  ```dotnetcli
+  dotnet run --launch-profile https
+  ```
+
+ The output shows messages similar to the following, indicating that the app is running and awaiting requests:
+
+   ```bash
+   ...
+   info: Microsoft.Hosting.Lifetime[14]
+         Now listening on: https://localhost:{port}
+   ...
+   ```
+
+* <kbd>Ctrl</kbd>+*click* the HTTPS URL in the output to test the web app in a browser.
+
+* The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
+
+* <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -167,7 +167,7 @@ Run the app:
 
 * The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
 
-* <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
+* Press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -148,10 +148,6 @@ Visual Studio launches the default browser and navigates to `https://localhost:<
 
 Run the app:
 
-* Right-click the *TodoApi.csproj* project, and then select **Open in Integrated Terminal**.
-
-  The **Terminal** window opens with the command prompt at the project directory, which contains the Program.cs and .csproj files.
-
 * Run the following command to start the app on the `https` profile:
 
   ```dotnetcli

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -156,7 +156,7 @@ Run the app:
 
  The output shows messages similar to the following, indicating that the app is running and awaiting requests:
 
-   ```bash
+   ```output
    ...
    info: Microsoft.Hosting.Lifetime[14]
          Now listening on: https://localhost:{port}
@@ -165,7 +165,7 @@ Run the app:
 
 * <kbd>Ctrl</kbd>+*click* the HTTPS URL in the output to test the web app in a browser.
 
-* The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
+* The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>`, so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
 
 After testing the web app in the following instruction, press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut it down.
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -167,7 +167,7 @@ Run the app:
 
 * The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
 
-* Press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
+After testing the web app in the following instruction, press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut it down.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -136,7 +136,7 @@ Run the app:
 
 * The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
 
-* <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
+* Press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -142,6 +142,10 @@ Run the app:
 
 * <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
 
+# [Visual Studio for Mac](#tab/visual-studio-mac)
+
+Select **Debug** > **Start Debugging** to launch the app. Visual Studio for Mac launches a browser and navigates to `https://localhost:<port>`, where `<port>` is a randomly chosen port number. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
+
 ---
 
 The Swagger page `/swagger/index.html` is displayed. Select **GET** > **Try it out** > **Execute**. The page displays:

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -136,7 +136,7 @@ Run the app:
 
 * The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
 
-* Press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
+After testing the web app in the following instruction, press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut it down.
 
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -117,10 +117,6 @@ Visual Studio launches the default browser and navigates to `https://localhost:<
 
 Run the app:
 
-* Right-click the *TodoApi.csproj* project, and then select **Open in Integrated Terminal**.
-
-  The **Terminal** window opens with the command prompt at the project directory, which contains the Program.cs and .csproj files.
-
 * Run the following command to start the app on the `https` profile:
 
   ```dotnetcli

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -117,12 +117,30 @@ Visual Studio launches the default browser and navigates to `https://localhost:<
 
 Run the app:
 
-* Press Ctrl+F5 to run the app.
-* Visual Studio Code launches the default browser to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
+* Right-click the *TodoApi.csproj* project, and then select **Open in Integrated Terminal**.
 
-# [Visual Studio for Mac](#tab/visual-studio-mac)
+  The **Terminal** window opens with the command prompt at the project directory, which contains the Program.cs and .csproj files.
 
-Select **Debug** > **Start Debugging** to launch the app. Visual Studio for Mac launches a browser and navigates to `https://localhost:<port>`, where `<port>` is a randomly chosen port number. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
+* Run the following command to start the app on the `https` profile:
+
+  ```dotnetcli
+  dotnet run --launch-profile https
+  ```
+
+ The output shows messages similar to the following, indicating that the app is running and awaiting requests:
+
+   ```bash
+   ...
+   info: Microsoft.Hosting.Lifetime[14]
+         Now listening on: https://localhost:{port}
+   ...
+   ```
+
+* <kbd>Ctrl</kbd>+*click* the HTTPS URL in the output to test the web app in a browser.
+
+* The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
+
+* <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut down the web app after testing it.
 
 ---
 

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -125,7 +125,7 @@ Run the app:
 
  The output shows messages similar to the following, indicating that the app is running and awaiting requests:
 
-   ```bash
+   ```output
    ...
    info: Microsoft.Hosting.Lifetime[14]
          Now listening on: https://localhost:{port}
@@ -134,7 +134,7 @@ Run the app:
 
 * <kbd>Ctrl</kbd>+*click* the HTTPS URL in the output to test the web app in a browser.
 
-* The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>` so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
+* The default browser is launched to `https://localhost:<port>`, where `<port>` is the randomly chosen port number displayed in the output. There is no endpoint at `https://localhost:<port>`, so the browser returns [HTTP 404 Not Found](https://developer.mozilla.org/docs/Web/HTTP/Status/404). Append `/swagger` to the URL, `https://localhost:<port>/swagger`.
 
 After testing the web app in the following instruction, press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the integrated terminal to shut it down.
 


### PR DESCRIPTION
Fixes #28715

Changed the instruction on VS Code to specify the HTTPS profile for `dotnet run` on the command line.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/5aa54dea1716eaeac547e1b93d05b61a7eda6609/aspnetcore/tutorials/first-web-api.md) | [Tutorial: Create a web API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?branch=pr-en-us-29952) |


<!-- PREVIEW-TABLE-END -->