### PR TITLE
Move Blazor technology assignment down

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -60,7 +60,7 @@
         "**/web-api/**/**.md": "aspnetcore-webapi",
         "whats-new/**/**.md": "aspnetcore-whatsnew",
         "**/blazor/**/**.md": "aspnetcore-blazor",
-        "**/blazor/hybrid/**/**.md": "aspnetcore-blazorhybrid",
+        "**/blazor/hybrid/**/**.md": "aspnetcore-blazorhybrid"
       },
       "ms.topic": {
         "**/getting-started/**/**.md": "tutorial",

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -41,8 +41,6 @@
       },
       "ms.technology": {
         "**/client-side/**/**.md": "aspnetcore-clientside",
-        "**/blazor/**/**.md": "aspnetcore-blazor",
-        "**/blazor/hybrid/**/**.md": "aspnetcore-blazorhybrid",
         "**/data/**/**.md": "aspnetcore-data",
         "**/fundamentals/**/**.md": "aspnetcore-fundamentals",
         "**/getting-started/**/**.md": "aspnetcore-getstarted",
@@ -60,7 +58,9 @@
         "**/test/**/**.md": "aspnetcore-test",
         "**/tutorials/**/**.md": "aspnetcore-tutorials",
         "**/web-api/**/**.md": "aspnetcore-webapi",
-        "whats-new/**/**.md": "aspnetcore-whatsnew"
+        "whats-new/**/**.md": "aspnetcore-whatsnew",
+        "**/blazor/**/**.md": "aspnetcore-blazor",
+        "**/blazor/hybrid/**/**.md": "aspnetcore-blazorhybrid",
       },
       "ms.topic": {
         "**/getting-started/**/**.md": "tutorial",


### PR DESCRIPTION
We can't have Blazor/Blazor Hybrid alphabetically in the list because sub-paths of Blazor node articles include at least one of the segments that apply a different technology to the document, namely a path segment of "security" for a Blazor security article led to the assignment of the `aspnetcore-security` technology 😈. This was avoided in the past by a different rule that relied on the path of the article, but that rule had to be removed so that Blazor Hybrid articles receive the Blazor Hybrid technology (note that the Blazor Hybrid node/folder is within the Blazor node/folder). Because these tech assignments are made on a ***last-assignment-wins strategy***, we need the Blazor tech assignments last in order to get Blazor issue labelling, etc. applied.

cc: @wadepickett @Rick-Anderson @tdykstra