### PR TITLE
Surface new guidance

### DIFF
--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -12,7 +12,9 @@ uid: client-side/dotnet-interop
 
 This article explains how to run .NET from JavaScript (JS) using JS `[JSImport]`/`[JSExport]` interop.
 
-Existing JS apps can use the expanded client-side WebAssembly support in .NET 7 to reuse .NET libraries from JS or to build novel .NET-based apps and frameworks.
+For additional guidance, see the [Configuring and hosting .NET WebAssembly applications](https://github.com/dotnet/runtime/blob/main/src/mono/wasm/features.md) guidance in the .NET Runtime (`dotnet/runtime`) GitHub repository. We plan to update this article to include new information in the cross-linked guidance in the latter part of 2023 or early 2024.
+
+Existing JS apps can use the expanded client-side WebAssembly support in .NET 7 or later to reuse .NET libraries from JS or to build novel .NET-based apps and frameworks.
 
 > [!NOTE]
 > This article focuses on running .NET from JS apps without any dependency on [Blazor](xref:blazor/index). For guidance on using `[JSImport]`/`[JSExport]` interop in Blazor WebAssembly apps, see <xref:blazor/js-interop/import-export-interop>.
@@ -263,6 +265,7 @@ In the preceding example, the `{TARGET FRAMEWORK}` placeholder is the target fra
 
 ## Additional resources
 
+* [Configuring and hosting .NET WebAssembly applications](https://github.com/dotnet/runtime/blob/main/src/mono/wasm/features.md)
 * API documentation
   * [`[JSImport]` attribute](xref:System.Runtime.InteropServices.JavaScript.JSImportAttribute)
   * [`[JSExport]` attribute](xref:System.Runtime.InteropServices.JavaScript.JSExportAttribute)


### PR DESCRIPTION
Addresses #29985

Pavel, I think it's ok if we tell devs to see that content making it clear that I plan to circle around and incorporate guidance from it later this year or early next year. The remark elevates the importance of that content in hopes that devs are less likely to skip looking at it.

On Line 17, the NIT change is just to make it say ".NET 7 or later" where it currently only says ".NET 7".

This PR won't close the issue, so the work item won't get lost. It's tracked by the Blazor GH project.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/client-side/dotnet-interop.md](https://github.com/dotnet/AspNetCore.Docs/blob/67bd00cad2783d229832730db09967e6c49832a9/aspnetcore/client-side/dotnet-interop.md) | [Run .NET from JavaScript](https://review.learn.microsoft.com/en-us/aspnet/core/client-side/dotnet-interop?branch=pr-en-us-29987) |

<!-- PREVIEW-TABLE-END -->