### PR TITLE
Add a cross-link

### DIFF
--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -350,6 +350,8 @@ For more information on NRTs, the MSBuild `Nullable` property, and updating apps
 * [Learn techniques to resolve nullable warnings](/dotnet/csharp/nullable-warnings)
 * [Update a codebase with nullable reference types to improve null diagnostic warnings](/dotnet/csharp/nullable-migration-strategies)
 * [Attributes for null-state static analysis](/dotnet/csharp/language-reference/attributes/nullable-analysis)
+* [default value expressions (C# reference)](/dotnet/csharp/language-reference/operators/default#default-literal)
+* [! (null-forgiving) operator (C# reference)](/dotnet/csharp/language-reference/operators/null-forgiving)
 
 ## ASP.NET Core Module (ANCM)
 

--- a/aspnetcore/migration/50-to-60.md
+++ b/aspnetcore/migration/50-to-60.md
@@ -350,7 +350,6 @@ For more information on NRTs, the MSBuild `Nullable` property, and updating apps
 * [Learn techniques to resolve nullable warnings](/dotnet/csharp/nullable-warnings)
 * [Update a codebase with nullable reference types to improve null diagnostic warnings](/dotnet/csharp/nullable-migration-strategies)
 * [Attributes for null-state static analysis](/dotnet/csharp/language-reference/attributes/nullable-analysis)
-* [default value expressions (C# reference)](/dotnet/csharp/language-reference/operators/default#default-literal)
 * [! (null-forgiving) operator (C# reference)](/dotnet/csharp/language-reference/operators/null-forgiving)
 
 ## ASP.NET Core Module (ANCM)


### PR DESCRIPTION
@tdykstra @wadepickett @Rick-Anderson ... I'm adding a cross-link to our NRT coverage in the 5.0-6.0 migration topic for ...

https://learn.microsoft.com/dotnet/csharp/language-reference/operators/null-forgiving

... because I have some Blazor implementations that use it. I cross-link to this content for NRT coverage.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/50-to-60.md](https://github.com/dotnet/AspNetCore.Docs/blob/378c2a0ca768dcbf834829a3aae9e48c4a8b83bd/aspnetcore/migration/50-to-60.md) | [Migrate from ASP.NET Core 5.0 to 6.0](https://review.learn.microsoft.com/en-us/aspnet/core/migration/50-to-60?branch=pr-en-us-29990) |

<!-- PREVIEW-TABLE-END -->