### PR TITLE
8.0: gRPC Troubleshoot: Move code snippets to app samples

### DIFF
--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -36,7 +36,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 The .NET Core client must use `https` in the server address to make calls with a secured connection:
 
-[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=StandardHTTPS)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=StandardHTTPS)]
 
 All gRPC client implementations support TLS. gRPC clients from other languages typically require the channel configured with `SslCredentials`. `SslCredentials` specifies the certificate that the client will use, and it must be used instead of insecure credentials. For examples of configuring the different gRPC client implementations to use TLS, see [gRPC Authentication](https://www.grpc.io/docs/guides/auth/).
 
@@ -51,11 +51,11 @@ You may see this error if you are testing your app locally and the ASP.NET Core 
 
 If you are calling a gRPC service on another machine and are unable to trust the certificate then the gRPC client can be configured to ignore the invalid certificate. The following code uses <xref:System.Net.Http.HttpClientHandler.ServerCertificateCustomValidationCallback%2A?displayProperty=nameWithType> to allow calls without a trusted certificate:
 
-[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=IgnoreInvalidCertificate)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=IgnoreInvalidCertificate)]
 
 The [gRPC client factory](xref:grpc/clientfactory) allows calls without a trusted certificate. Use the <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.ConfigurePrimaryHttpMessageHandler%2A> extension method to configure the handler on the client:
 
-[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=IgnoreInvalidCertificateClientFactory)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=IgnoreInvalidCertificateClientFactory)]
 
 > [!WARNING]
 > Untrusted certificates should only be used during app development. Production apps should always use valid certificates.
@@ -135,11 +135,11 @@ The address path is ignored because gRPC has a standardized, prescriptive addres
 
 There are some scenarios when an app needs to include a path with gRPC calls. For example, when an ASP.NET Core gRPC app is hosted in an IIS directory and the directory needs to be included in the request. When a path is required, it can be added to the gRPC call using the custom `SubdirectoryHandler` specified below:
 
-[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=SubdirectoryHandler)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=SubdirectoryHandler)]
 
 `SubdirectoryHandler` is used when the gRPC channel is created.
 
-[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=CallSubdirectoryHandler)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=CallSubdirectoryHandler)]
 
 The preceding code:
 
@@ -155,11 +155,11 @@ The .NET gRPC client supports HTTP/3 with .NET 6 or later. If the server sends a
 
 A <xref:System.Net.Http.DelegatingHandler> can be used to force a gRPC client to use HTTP/3. Forcing HTTP/3 avoids the overhead of upgrading the request. Force HTTP/3 with code similar to the following:
 
-[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=Http3Handler)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=Http3Handler)]
 
 `Http3Handler` is used when the gRPC channel is created. The following code creates a channel configured to use `Http3Handler`.
 
-[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=CallHttp3Handler)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=CallHttp3Handler)]
 
 Alternatively, a client factory can be configured with `Http3Handler` by using <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddHttpMessageHandler%2A>.
 

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -5,7 +5,7 @@ description: Troubleshoot errors when using gRPC on .NET.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: jamesnk
 ms.custom: mvc
-ms.date: 04/26/2023
+ms.date: 08/08/2023
 uid: grpc/troubleshoot
 ---
 
@@ -25,7 +25,7 @@ The gRPC template and samples use [Transport Layer Security (TLS)](https://tools
 
 You can verify the ASP.NET Core gRPC service is using TLS in the logs written on app start. The service will be listening on an HTTPS endpoint:
 
-```text
+```output
 info: Microsoft.Hosting.Lifetime[0]
       Now listening on: https://localhost:5001
 info: Microsoft.Hosting.Lifetime[0]
@@ -36,14 +36,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 The .NET Core client must use `https` in the server address to make calls with a secured connection:
 
-```csharp
-static async Task Main(string[] args)
-{
-    // The port number(5001) must match the port of the gRPC server.
-    var channel = GrpcChannel.ForAddress("https://localhost:5001");
-    var client = new Greet.GreeterClient(channel);
-}
-```
+[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=StandardHTTPS)]
 
 All gRPC client implementations support TLS. gRPC clients from other languages typically require the channel configured with `SslCredentials`. `SslCredentials` specifies the certificate that the client will use, and it must be used instead of insecure credentials. For examples of configuring the different gRPC client implementations to use TLS, see [gRPC Authentication](https://www.grpc.io/docs/guides/auth/).
 
@@ -58,33 +51,11 @@ You may see this error if you are testing your app locally and the ASP.NET Core 
 
 If you are calling a gRPC service on another machine and are unable to trust the certificate then the gRPC client can be configured to ignore the invalid certificate. The following code uses <xref:System.Net.Http.HttpClientHandler.ServerCertificateCustomValidationCallback%2A?displayProperty=nameWithType> to allow calls without a trusted certificate:
 
-```csharp
-var handler = new HttpClientHandler();
-handler.ServerCertificateCustomValidationCallback = 
-    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-
-var channel = GrpcChannel.ForAddress("https://localhost:5001",
-    new GrpcChannelOptions { HttpHandler = handler });
-var client = new Greet.GreeterClient(channel);
-```
+[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=IgnoreInvalidCertificate)]
 
 The [gRPC client factory](xref:grpc/clientfactory) allows calls without a trusted certificate. Use the <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.ConfigurePrimaryHttpMessageHandler%2A> extension method to configure the handler on the client:
 
-```csharp
-builder.Services
-    .AddGrpcClient<Greeter.GreeterClient>(o =>
-    {
-        o.Address = new Uri("https://localhost:5001");
-    })
-    .ConfigurePrimaryHttpMessageHandler(() =>
-    {
-        var handler = new HttpClientHandler();
-        handler.ServerCertificateCustomValidationCallback = 
-            HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
-
-        return handler;
-    });
-```
+[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=IgnoreInvalidCertificateClientFactory)]
 
 > [!WARNING]
 > Untrusted certificates should only be used during app development. Production apps should always use valid certificates.
@@ -96,19 +67,7 @@ The .NET gRPC client can call insecure gRPC services by specifing `http` in the 
 There are some additional requirements to call insecure gRPC services depending on the .NET version an app is using:
 
 * .NET 5 or later requires [Grpc.Net.Client](https://www.nuget.org/packages/Grpc.Net.Client) version 2.32.0 or later.
-* .NET Core 3.x requires additional configuration. The app must set the `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch to `true`:
-
-    ```csharp
-    // This switch must be set before creating the GrpcChannel/HttpClient.
-    AppContext.SetSwitch(
-        "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
-    
-    // The port number(5000) must match the port of the gRPC server.
-    var channel = GrpcChannel.ForAddress("http://localhost:5000");
-    var client = new Greet.GreeterClient(channel);
-    ```
-
-The `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch is only required for .NET Core 3.x. It does nothing in .NET 5 and isn't required.
+* .NET Core 3.x requires additional configuration. The app must set the `System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport` switch to `true`. For more information see [Asp.Net Core 3.x: Call insecure gRPC services with the .NET client](xref:grpc/troubleshoot?view=aspnetcore-3.1#call-insecure-grpc-services-with-net-core-client-2):
 
 > [!IMPORTANT]
 > Insecure gRPC services must be hosted on a HTTP/2-only port. For more information, see [ASP.NET Core protocol negotiation](xref:grpc/aspnetcore#protocol-negotiation).
@@ -119,29 +78,7 @@ Kestrel doesn't support HTTP/2 with TLS on macOS before .NET 8. The ASP.NET Core
 
 > Unable to bind to https://localhost:5001 on the IPv4 loopback interface: 'HTTP/2 over TLS is not supported on macOS due to missing ALPN support.'.
 
-To work around this issue in .NET 7 and earlier, configure Kestrel and the gRPC client to use HTTP/2 *without* TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption.
-
-Kestrel must configure an HTTP/2 endpoint without TLS in `Program.cs`:
-
-```csharp
-var builder = WebApplication.CreateBuilder(args);
-
-builder.WebHost.ConfigureKestrel(options =>
-{
-    // Setup a HTTP/2 endpoint without TLS.
-    options.ListenLocalhost(<5287>, o => o.Protocols =
-        HttpProtocols.Http2);
-});
-```
-
-* In the preceding code, replace the localhost port number `5287` with the `HTTP` (not `HTTPS`) port number specified in `Properties/launchSettings.json` within the gRPC service project.
-
-When an HTTP/2 endpoint is configured without TLS, the endpoint's [ListenOptions.Protocols](xref:fundamentals/servers/kestrel/endpoints#listenoptionsprotocols) must be set to `HttpProtocols.Http2`. `HttpProtocols.Http1AndHttp2` can't be used because TLS is required to negotiate HTTP/2. Without TLS, all connections to the endpoint default to HTTP/1.1, and gRPC calls fail.
-
-The gRPC client must also be configured to not use TLS. For more information, see [Call insecure gRPC services with .NET Core client](#call-insecure-grpc-services-with-net-core-client).
-
-> [!WARNING]
-> HTTP/2 without TLS should only be used during app development. Production apps should always use transport security. For more information, see [Security considerations in gRPC for ASP.NET Core](xref:grpc/security#transport-security).
+To work around this issue in .NET 7 and earlier, configure Kestrel and the gRPC client to use HTTP/2 *without* TLS. You should only do this during development. Not using TLS will result in gRPC messages being sent without encryption. For more information see [Asp.Net Core 7.0: Unable to start ASP.NET Core gRPC app on macOS](xref:grpc/troubleshoot?view=aspnetcore-7.0#unable-to-start-aspnet-core-grpc-app-on-macos).
 
 ## gRPC C# assets are not code generated from `.proto` files
 
@@ -198,44 +135,11 @@ The address path is ignored because gRPC has a standardized, prescriptive addres
 
 There are some scenarios when an app needs to include a path with gRPC calls. For example, when an ASP.NET Core gRPC app is hosted in an IIS directory and the directory needs to be included in the request. When a path is required, it can be added to the gRPC call using the custom `SubdirectoryHandler` specified below:
 
-```csharp
-/// <summary>
-/// A delegating handler that adds a subdirectory to the URI of gRPC requests.
-/// </summary>
-public class SubdirectoryHandler : DelegatingHandler
-{
-    private readonly string _subdirectory;
-
-    public SubdirectoryHandler(HttpMessageHandler innerHandler, string subdirectory)
-        : base(innerHandler)
-    {
-        _subdirectory = subdirectory;
-    }
-
-    protected override Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        var old = request.RequestUri;
-
-        var url = $"{old.Scheme}://{old.Host}:{old.Port}";
-        url += $"{_subdirectory}{request.RequestUri.AbsolutePath}";
-        request.RequestUri = new Uri(url, UriKind.Absolute);
-
-        return base.SendAsync(request, cancellationToken);
-    }
-}
-```
+[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=SubdirectoryHandler)]
 
 `SubdirectoryHandler` is used when the gRPC channel is created.
 
-```csharp
-var handler = new SubdirectoryHandler(new HttpClientHandler(), "/MyApp");
-
-var channel = GrpcChannel.ForAddress("https://localhost:5001", new GrpcChannelOptions { HttpHandler = handler });
-var client = new Greet.GreeterClient(channel);
-
-var reply = await client.SayHelloAsync(new HelloRequest { Name = ".NET" });
-```
+[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=CallSubdirectoryHandler)]
 
 The preceding code:
 
@@ -251,36 +155,11 @@ The .NET gRPC client supports HTTP/3 with .NET 6 or later. If the server sends a
 
 A <xref:System.Net.Http.DelegatingHandler> can be used to force a gRPC client to use HTTP/3. Forcing HTTP/3 avoids the overhead of upgrading the request. Force HTTP/3 with code similar to the following:
 
-```csharp
-/// <summary>
-/// A delegating handler that changes the request HTTP version to HTTP/3.
-/// </summary>
-public class Http3Handler : DelegatingHandler
-{
-    public Http3Handler() { }
-    public Http3Handler(HttpMessageHandler innerHandler) : base(innerHandler) { }
-
-    protected override Task<HttpResponseMessage> SendAsync(
-        HttpRequestMessage request, CancellationToken cancellationToken)
-    {
-        request.Version = HttpVersion.Version30;
-        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
-
-        return base.SendAsync(request, cancellationToken);
-    }
-}
-```
+[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=Http3Handler)]
 
 `Http3Handler` is used when the gRPC channel is created. The following code creates a channel configured to use `Http3Handler`.
 
-```csharp
-var handler = new Http3Handler(new HttpClientHandler());
-
-var channel = GrpcChannel.ForAddress("https://localhost:5001", new GrpcChannelOptions { HttpHandler = handler });
-var client = new Greet.GreeterClient(channel);
-
-var reply = await client.SayHelloAsync(new HelloRequest { Name = ".NET" });
-```
+[!code-csharp[](~/grpc/troubleshoot/samples/8.0/GrpcGreeterClient/Program.cs?name=CallHttp3Handler)]
 
 Alternatively, a client factory can be configured with `Http3Handler` by using <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddHttpMessageHandler%2A>.
 

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -36,7 +36,7 @@ info: Microsoft.Hosting.Lifetime[0]
 
 The .NET Core client must use `https` in the server address to make calls with a secured connection:
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=StandardHTTPS)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_StandardHTTPS)]
 
 All gRPC client implementations support TLS. gRPC clients from other languages typically require the channel configured with `SslCredentials`. `SslCredentials` specifies the certificate that the client will use, and it must be used instead of insecure credentials. For examples of configuring the different gRPC client implementations to use TLS, see [gRPC Authentication](https://www.grpc.io/docs/guides/auth/).
 
@@ -51,11 +51,11 @@ You may see this error if you are testing your app locally and the ASP.NET Core 
 
 If you are calling a gRPC service on another machine and are unable to trust the certificate then the gRPC client can be configured to ignore the invalid certificate. The following code uses <xref:System.Net.Http.HttpClientHandler.ServerCertificateCustomValidationCallback%2A?displayProperty=nameWithType> to allow calls without a trusted certificate:
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=IgnoreInvalidCertificate)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_IgnoreInvalidCertificate)]
 
 The [gRPC client factory](xref:grpc/clientfactory) allows calls without a trusted certificate. Use the <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.ConfigurePrimaryHttpMessageHandler%2A> extension method to configure the handler on the client:
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=IgnoreInvalidCertificateClientFactory)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_IgnoreInvalidCertificateClientFactory)]
 
 > [!WARNING]
 > Untrusted certificates should only be used during app development. Production apps should always use valid certificates.
@@ -135,11 +135,11 @@ The address path is ignored because gRPC has a standardized, prescriptive addres
 
 There are some scenarios when an app needs to include a path with gRPC calls. For example, when an ASP.NET Core gRPC app is hosted in an IIS directory and the directory needs to be included in the request. When a path is required, it can be added to the gRPC call using the custom `SubdirectoryHandler` specified below:
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=SubdirectoryHandler)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_SubdirectoryHandler)]
 
 `SubdirectoryHandler` is used when the gRPC channel is created.
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=CallSubdirectoryHandler)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_CallSubdirectoryHandler)]
 
 The preceding code:
 
@@ -155,11 +155,11 @@ The .NET gRPC client supports HTTP/3 with .NET 6 or later. If the server sends a
 
 A <xref:System.Net.Http.DelegatingHandler> can be used to force a gRPC client to use HTTP/3. Forcing HTTP/3 avoids the overhead of upgrading the request. Force HTTP/3 with code similar to the following:
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=Http3Handler)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_Http3Handler)]
 
 `Http3Handler` is used when the gRPC channel is created. The following code creates a channel configured to use `Http3Handler`.
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=CallHttp3Handler)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_CallHttp3Handler)]
 
 Alternatively, a client factory can be configured with `Http3Handler` by using <xref:Microsoft.Extensions.DependencyInjection.HttpClientBuilderExtensions.AddHttpMessageHandler%2A>.
 

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/GrpcGreeter.csproj
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/GrpcGreeter.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/Program.cs
@@ -1,0 +1,14 @@
+using GrpcGreeter.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddGrpc();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+app.MapGrpcService<GreeterService>();
+app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
+
+app.Run();

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/Protos/greet.proto
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/Protos/greet.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "GrpcGreeter";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings.
+message HelloReply {
+  string message = 1;
+}

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/Services/GreeterService.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/Services/GreeterService.cs
@@ -1,0 +1,22 @@
+using Grpc.Core;
+using GrpcGreeter;
+
+namespace GrpcGreeter.Services
+{
+    public class GreeterService : Greeter.GreeterBase
+    {
+        private readonly ILogger<GreeterService> _logger;
+        public GreeterService(ILogger<GreeterService> logger)
+        {
+            _logger = logger;
+        }
+
+        public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+        {
+            return Task.FromResult(new HelloReply
+            {
+                Message = "Hello " + request.Name
+            });
+        }
+    }
+}

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/appsettings.Development.json
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/appsettings.json
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeter/appsettings.json
@@ -1,0 +1,16 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.Hosting": "Information",
+      "Microsoft.AspNetCore.Routing.EndpointMiddleware": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/GrpcGreeterClient.csproj
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/GrpcGreeterClient.csproj
@@ -1,0 +1,27 @@
+﻿ <Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.23.4" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.55.0" />
+    <PackageReference Include="Grpc.Net.ClientFactory" Version="2.55.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.56.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+  </ItemGroup>
+	<ItemGroup>
+		<Protobuf Include="Protos\greet.proto" GrpcServices="Client" />
+	</ItemGroup>
+	 <ItemGroup>
+		 <RuntimeHostConfigurationOption Include="System.Net.SocketsHttpHandler.Http3Support" Value="true" />
+	 </ItemGroup>
+
+</Project>

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
@@ -1,0 +1,204 @@
+﻿#define StandardHTTPS  // Options: StandardHTTPS | IgnoreInvalidCertificate | IgnoreInvalidCertificateClientFactory | CallInsecureGrpcServices | DotNet3InsecureGrpcServices | SubdirectoryHandler
+
+#if StandardHTTPS
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using GrpcGreeterClient;
+
+// The port number must match the port of the gRPC server.
+#region StandardHTTPS
+using var channel = GrpcChannel.ForAddress("https://localhost:7106");
+var client = new Greeter.GreeterClient(channel);
+#endregion
+var reply = await client.SayHelloAsync(
+                  new HelloRequest { Name = "GreeterClient" });
+Console.WriteLine("Greeting: " + reply.Message);
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();
+#endif
+
+#if IgnoreInvalidCertificate
+// Warning: Untrusted certificates should only be used during app development. 
+// Production apps should always use valid certificates.
+// The following gRPC client factory allows calls without a trusted certificate.
+
+using System.Threading.Tasks;
+using Grpc.Net.Client;
+using GrpcGreeterClient;
+
+#region IgnoreInvalidCertificate
+var handler = new HttpClientHandler();
+handler.ServerCertificateCustomValidationCallback = 
+    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+
+using var channel = GrpcChannel.ForAddress("https://localhost:7106",
+    new GrpcChannelOptions { HttpHandler = handler });
+var client = new Greeter.GreeterClient(channel);
+#endregion
+
+var reply = await client.SayHelloAsync(
+                  new HelloRequest { Name = "GreeterClient" });
+Console.WriteLine("Greeting: " + reply.Message);
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();
+#endif
+
+#if IgnoreInvalidCertificateClientFactory
+// Warning: Untrusted certificates should only be used during app development. 
+// Production apps should always use valid certificates.
+// The following gRPC client factory allows calls without a trusted certificate.
+
+using GrpcGreeterClient;
+using Microsoft.Extensions.DependencyInjection;
+using Grpc.Net.ClientFactory;
+
+#region IgnoreInvalidCertificateClientFactory
+
+var services = new ServiceCollection();
+
+services
+    .AddGrpcClient<Greeter.GreeterClient>(o =>
+    {
+        o.Address = new Uri("https://localhost:5001");
+    })
+    .ConfigurePrimaryHttpMessageHandler(() =>
+    {
+        var handler = new HttpClientHandler();
+        handler.ServerCertificateCustomValidationCallback =
+            HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+
+        return handler;
+    });
+
+#endregion
+#endif
+
+
+#if CallInsecureGrpcServices
+using Grpc.Net.Client;
+using GrpcGreeterClient;
+
+#region CallInsecureGrpcServices
+AppContext.SetSwitch(
+    "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+
+using var channel = GrpcChannel.ForAddress("http://localhost:5186");
+var client = new Greeter.GreeterClient(channel);
+#endregion
+var reply = await client.SayHelloAsync(
+                  new HelloRequest { Name = "GreeterClient" });
+Console.WriteLine("Greeting: " + reply.Message);
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();
+#endif
+
+#if DotNet3InsecureGrpcServices
+// Warning: Untrusted certificates should only be used during app development. 
+// Production apps should always use valid certificates.
+// The following gRPC client factory allows calls without a trusted certificate.
+
+using Grpc.Net.Client;
+using GrpcGreeterClient;
+
+#region DotNet3InsecureGrpcServices
+var handler = new HttpClientHandler();
+handler.ServerCertificateCustomValidationCallback = 
+    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+
+using var channel = GrpcChannel.ForAddress("https://localhost:7106",
+    new GrpcChannelOptions { HttpHandler = handler });
+var client = new Greeter.GreeterClient(channel);
+#endregion
+
+var reply = await client.SayHelloAsync(
+                  new HelloRequest { Name = "GreeterClient" });
+Console.WriteLine("Greeting: " + reply.Message);
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();
+#endif
+
+
+#if SubdirectoryHandler
+using Grpc.Net.Client;
+using GrpcGreeterClient;
+
+#region CallSubdirectoryHandler
+var handler = new SubdirectoryHandler(new HttpClientHandler(), "/MyApp");
+
+using var channel = GrpcChannel.ForAddress("https://localhost:7106", new GrpcChannelOptions { HttpHandler = handler });
+var client = new Greeter.GreeterClient(channel);
+
+var reply = await client.SayHelloAsync(
+                  new HelloRequest { Name = "GreeterClient" });
+Console.WriteLine("Greeting: " + reply.Message);
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();
+#endregion
+
+#region SubdirectoryHandler
+/// <summary>
+/// A delegating handler that adds a subdirectory to the URI of gRPC requests.
+/// </summary>
+public class SubdirectoryHandler : DelegatingHandler
+{
+    private readonly string _subdirectory;
+
+    public SubdirectoryHandler(HttpMessageHandler innerHandler, string subdirectory)
+        : base(innerHandler)
+    {
+        _subdirectory = subdirectory;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var old = request.RequestUri;
+
+        var url = $"{old.Scheme}://{old.Host}:{old.Port}";
+        url += $"{_subdirectory}{request.RequestUri.AbsolutePath}";
+        request.RequestUri = new Uri(url, UriKind.Absolute);
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}
+#endregion
+#endif
+
+#if Http3Handler
+#region Http3Handler
+using Grpc.Net.Client;
+using GrpcGreeterClient;
+using System.Net;
+
+var handler = new Http3Handler(new HttpClientHandler());
+
+var channel = GrpcChannel.ForAddress("https://localhost:7106", new GrpcChannelOptions { HttpHandler = handler });
+var client = new Greeter.GreeterClient(channel);
+
+var reply = await client.SayHelloAsync(
+                  new HelloRequest { Name = "GreeterClient" });
+Console.WriteLine("Greeting: " + reply.Message);
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();
+#endregion
+
+#region Http3Handler
+/// <summary>
+/// A delegating handler that changes the request HTTP version to HTTP/3.
+/// </summary>
+public class Http3Handler : DelegatingHandler
+{
+    public Http3Handler() { }
+    public Http3Handler(HttpMessageHandler innerHandler) : base(innerHandler) { }
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        request.Version = HttpVersion.Version30;
+        request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+
+        return base.SendAsync(request, cancellationToken);
+    }
+}
+#endregion
+#endif

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
@@ -133,10 +133,10 @@ Console.WriteLine("Greeting: " + reply.Message);
 Console.WriteLine("Press any key to exit...");
 Console.ReadKey();
 
-// <snippet_SubdirectoryHandler>
 /// <summary>
 /// A delegating handler that adds a subdirectory to the URI of gRPC requests.
 /// </summary>
+/// // <snippet_SubdirectoryHandler>
 public class SubdirectoryHandler : DelegatingHandler
 {
     private readonly string _subdirectory;
@@ -163,11 +163,11 @@ public class SubdirectoryHandler : DelegatingHandler
 #endif
 
 #if Http3Handler
-// <snippet_CallHttp3Handler>
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 using System.Net;
 
+// <snippet_CallHttp3Handler>
 var handler = new Http3Handler(new HttpClientHandler());
 
 var channel = GrpcChannel.ForAddress("https://localhost:5001", new GrpcChannelOptions { HttpHandler = handler });
@@ -175,15 +175,15 @@ var client = new Greeter.GreeterClient(channel);
 
 var reply = await client.SayHelloAsync(
                   new HelloRequest { Name = "GreeterClient" });
-// </snippet_Http3Handler>
+// </snippet_CallHttp3Handler>
 Console.WriteLine("Greeting: " + reply.Message);
 Console.WriteLine("Press any key to exit...");
 Console.ReadKey();
 
-// <snippet_Http3Handler>
 /// <summary>
 /// A delegating handler that changes the request HTTP version to HTTP/3.
 /// </summary>
+/// // <snippet_Http3Handler>
 public class Http3Handler : DelegatingHandler
 {
     public Http3Handler() { }

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
@@ -1,14 +1,14 @@
-﻿#define StandardHTTPS  // Options: StandardHTTPS | IgnoreInvalidCertificate | IgnoreInvalidCertificateClientFactory | CallInsecureGrpcServices | DotNet3InsecureGrpcServices | SubdirectoryHandler
+﻿#define StandardHTTPS  // Options: StandardHTTPS | IgnoreInvalidCertificate | IgnoreInvalidCertificateClientFactory | CallInsecureGrpcServices | DotNet3InsecureGrpcServices | SubdirectoryHandler | Http3Handler
 
 #if StandardHTTPS
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 
 // The port number must match the port of the gRPC server.
-#region StandardHTTPS
+// <snippet_StandardHTTPS>
 var channel = GrpcChannel.ForAddress("https://localhost:5001");
 var client = new Greeter.GreeterClient(channel);
-#endregion
+// </snippet_StandardHTTPS>
 var reply = await client.SayHelloAsync(
                   new HelloRequest { Name = "GreeterClient" });
 Console.WriteLine("Greeting: " + reply.Message);
@@ -25,7 +25,7 @@ using System.Threading.Tasks;
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 
-#region IgnoreInvalidCertificate
+// <snippet_IgnoreInvalidCertificate>
 var handler = new HttpClientHandler();
 handler.ServerCertificateCustomValidationCallback = 
     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
@@ -33,7 +33,7 @@ handler.ServerCertificateCustomValidationCallback =
 var channel = GrpcChannel.ForAddress("https://localhost:5001",
     new GrpcChannelOptions { HttpHandler = handler });
 var client = new Greeter.GreeterClient(channel);
-#endregion
+// </snippet_IgnoreInvalidCertificate>
 
 var reply = await client.SayHelloAsync(
                   new HelloRequest { Name = "GreeterClient" });
@@ -51,7 +51,7 @@ using GrpcGreeterClient;
 using Microsoft.Extensions.DependencyInjection;
 using Grpc.Net.ClientFactory;
 
-#region IgnoreInvalidCertificateClientFactory
+// <snippet_IgnoreInvalidCertificateClientFactory>
 
 var services = new ServiceCollection();
 
@@ -68,8 +68,7 @@ services
 
         return handler;
     });
-
-#endregion
+// </snippet_IgnoreInvalidCertificateClientFactory>
 #endif
 
 
@@ -77,13 +76,13 @@ services
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 
-#region CallInsecureGrpcServices
+// <snippet_CallInsecureGrpcServices>
 AppContext.SetSwitch(
     "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 
 var channel = GrpcChannel.ForAddress("http://localhost:5000");
 var client = new Greeter.GreeterClient(channel);
-#endregion
+// </snippet_CallInsecureGrpcServices>
 var reply = await client.SayHelloAsync(
                   new HelloRequest { Name = "GreeterClient" });
 Console.WriteLine("Greeting: " + reply.Message);
@@ -99,7 +98,7 @@ Console.ReadKey();
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 
-#region DotNet3InsecureGrpcServices
+// <snippet_DotNet3InsecureGrpcServices>
 var handler = new HttpClientHandler();
 handler.ServerCertificateCustomValidationCallback = 
     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
@@ -107,7 +106,7 @@ handler.ServerCertificateCustomValidationCallback =
 var channel = GrpcChannel.ForAddress("https://localhost:5001",
     new GrpcChannelOptions { HttpHandler = handler });
 var client = new Greeter.GreeterClient(channel);
-#endregion
+// </snippet_DotNet3InsecureGrpcServices>
 
 var reply = await client.SayHelloAsync(
                   new HelloRequest { Name = "GreeterClient" });
@@ -121,7 +120,7 @@ Console.ReadKey();
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 
-#region CallSubdirectoryHandler
+// <snippet_CallSubdirectoryHandler>
 var handler = new SubdirectoryHandler(new HttpClientHandler(), "/MyApp");
 
 var channel = GrpcChannel.ForAddress("https://localhost:5001", new GrpcChannelOptions { HttpHandler = handler });
@@ -129,12 +128,12 @@ var client = new Greeter.GreeterClient(channel);
 
 var reply = await client.SayHelloAsync(
                   new HelloRequest { Name = "GreeterClient" });
+// </snippet_CallSubdirectoryHandler>
 Console.WriteLine("Greeting: " + reply.Message);
 Console.WriteLine("Press any key to exit...");
 Console.ReadKey();
-#endregion
 
-#region SubdirectoryHandler
+// <snippet_SubdirectoryHandler>
 /// <summary>
 /// A delegating handler that adds a subdirectory to the URI of gRPC requests.
 /// </summary>
@@ -160,11 +159,11 @@ public class SubdirectoryHandler : DelegatingHandler
         return base.SendAsync(request, cancellationToken);
     }
 }
-#endregion
+// </snippet_SubdirectoryHandler>
 #endif
 
 #if Http3Handler
-#region Http3Handler
+// <snippet_CallHttp3Handler>
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 using System.Net;
@@ -176,12 +175,12 @@ var client = new Greeter.GreeterClient(channel);
 
 var reply = await client.SayHelloAsync(
                   new HelloRequest { Name = "GreeterClient" });
+// </snippet_Http3Handler>
 Console.WriteLine("Greeting: " + reply.Message);
 Console.WriteLine("Press any key to exit...");
 Console.ReadKey();
-#endregion
 
-#region Http3Handler
+// <snippet_Http3Handler>
 /// <summary>
 /// A delegating handler that changes the request HTTP version to HTTP/3.
 /// </summary>
@@ -199,5 +198,5 @@ public class Http3Handler : DelegatingHandler
         return base.SendAsync(request, cancellationToken);
     }
 }
-#endregion
+// </snippet_Http3Handler>
 #endif

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
@@ -165,11 +165,10 @@ public class SubdirectoryHandler : DelegatingHandler
 #endif
 
 #if Http3Handler
-#region Http3Handler
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 using System.Net;
-
+#region CallHttp3Handler
 var handler = new Http3Handler(new HttpClientHandler());
 
 var channel = GrpcChannel.ForAddress("https://localhost:7106", new GrpcChannelOptions { HttpHandler = handler });

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
@@ -184,7 +184,8 @@ Console.ReadKey();
 /// <summary>
 /// A delegating handler that changes the request HTTP version to HTTP/3.
 /// </summary>
-/// // <snippet_Http3Handler>
+
+// <snippet_Http3Handler>
 public class Http3Handler : DelegatingHandler
 {
     public Http3Handler() { }

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
@@ -136,7 +136,8 @@ Console.ReadKey();
 /// <summary>
 /// A delegating handler that adds a subdirectory to the URI of gRPC requests.
 /// </summary>
-/// // <snippet_SubdirectoryHandler>
+
+// <snippet_SubdirectoryHandler>
 public class SubdirectoryHandler : DelegatingHandler
 {
     private readonly string _subdirectory;

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
@@ -1,13 +1,12 @@
 ﻿#define StandardHTTPS  // Options: StandardHTTPS | IgnoreInvalidCertificate | IgnoreInvalidCertificateClientFactory | CallInsecureGrpcServices | DotNet3InsecureGrpcServices | SubdirectoryHandler
 
 #if StandardHTTPS
-using System.Threading.Tasks;
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 
 // The port number must match the port of the gRPC server.
 #region StandardHTTPS
-using var channel = GrpcChannel.ForAddress("https://localhost:7106");
+var channel = GrpcChannel.ForAddress("https://localhost:5001");
 var client = new Greeter.GreeterClient(channel);
 #endregion
 var reply = await client.SayHelloAsync(
@@ -31,7 +30,7 @@ var handler = new HttpClientHandler();
 handler.ServerCertificateCustomValidationCallback = 
     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
-using var channel = GrpcChannel.ForAddress("https://localhost:7106",
+var channel = GrpcChannel.ForAddress("https://localhost:5001",
     new GrpcChannelOptions { HttpHandler = handler });
 var client = new Greeter.GreeterClient(channel);
 #endregion
@@ -82,7 +81,7 @@ using GrpcGreeterClient;
 AppContext.SetSwitch(
     "System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 
-using var channel = GrpcChannel.ForAddress("http://localhost:5186");
+var channel = GrpcChannel.ForAddress("http://localhost:5000");
 var client = new Greeter.GreeterClient(channel);
 #endregion
 var reply = await client.SayHelloAsync(
@@ -105,7 +104,7 @@ var handler = new HttpClientHandler();
 handler.ServerCertificateCustomValidationCallback = 
     HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
-using var channel = GrpcChannel.ForAddress("https://localhost:7106",
+var channel = GrpcChannel.ForAddress("https://localhost:5001",
     new GrpcChannelOptions { HttpHandler = handler });
 var client = new Greeter.GreeterClient(channel);
 #endregion
@@ -125,7 +124,7 @@ using GrpcGreeterClient;
 #region CallSubdirectoryHandler
 var handler = new SubdirectoryHandler(new HttpClientHandler(), "/MyApp");
 
-using var channel = GrpcChannel.ForAddress("https://localhost:7106", new GrpcChannelOptions { HttpHandler = handler });
+var channel = GrpcChannel.ForAddress("https://localhost:5001", new GrpcChannelOptions { HttpHandler = handler });
 var client = new Greeter.GreeterClient(channel);
 
 var reply = await client.SayHelloAsync(
@@ -165,13 +164,14 @@ public class SubdirectoryHandler : DelegatingHandler
 #endif
 
 #if Http3Handler
+#region Http3Handler
 using Grpc.Net.Client;
 using GrpcGreeterClient;
 using System.Net;
-#region CallHttp3Handler
+
 var handler = new Http3Handler(new HttpClientHandler());
 
-var channel = GrpcChannel.ForAddress("https://localhost:7106", new GrpcChannelOptions { HttpHandler = handler });
+var channel = GrpcChannel.ForAddress("https://localhost:5001", new GrpcChannelOptions { HttpHandler = handler });
 var client = new Greeter.GreeterClient(channel);
 
 var reply = await client.SayHelloAsync(

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Protos/aggregate.proto
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Protos/aggregate.proto
@@ -1,0 +1,24 @@
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+import "greet.proto";
+
+package aggregate;
+
+service Aggregator {
+  rpc AccumulateCount (stream count.CounterRequest) returns (count.CounterReply);
+  rpc SayHellos (greet.HelloRequest) returns (stream greet.HelloReply);
+}

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Protos/greet.proto
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Protos/greet.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "GrpcGreeterClient";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings.
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
Fixes #29224

Moved 8.0 gRPC Troubleshoot topic code snippets to client and server app samples.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/troubleshoot.md](https://github.com/dotnet/AspNetCore.Docs/blob/7ee689d4ee3df03b71ed045499ced05d047c3d68/aspnetcore/grpc/troubleshoot.md) | [Troubleshoot gRPC on .NET](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?branch=pr-en-us-30008) |


<!-- PREVIEW-TABLE-END -->