### PR TITLE
Improve documentation around .NET Framework and gRPC-Web in the client

### DIFF
--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -70,7 +70,7 @@ Requirements and restrictions to using `WinHttpHandler`:
 
 * Windows 11 or later, Windows Server 2022 or later.
   * gRPC client is fully supported on Windows 11 or later.
-  * gRPC client is partially supported on Windows Server 2022 or later. Unary and server streaming methods are supported. Client and bidirectional streaming methods are not supported.
+  * gRPC client is partially supported on Windows Server 2022. Unary and server streaming methods are supported. Client and bidirectional streaming methods are not supported.
 * A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.1 or later.
 * Configure `WinHttpHandler` on the channel using `GrpcChannelOptions.HttpHandler`.
 * .NET Framework 4.6.1 or later.

--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -70,7 +70,7 @@ Requirements and restrictions to using `WinHttpHandler`:
 
 * Windows 11 or later, Windows Server 2022 or later.
   * gRPC client is fully supported on Windows 11 or later.
-  * gRPC client is partially supported on Windows Server 2022. Unary and server streaming methods are supported. Client and bidirectional streaming methods are not supported.
+  * gRPC client is partially supported on Windows Server 2022. Unary and server streaming methods are supported. Client and bidirectional streaming methods are **_not_** supported.
 * A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.1 or later.
 * Configure `WinHttpHandler` on the channel using `GrpcChannelOptions.HttpHandler`.
 * .NET Framework 4.6.1 or later.

--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -69,6 +69,8 @@ For more information, see [Configure gRPC-Web with the .NET gRPC client](xref:gr
 Requirements and restrictions to using `WinHttpHandler`:
 
 * Windows 11 or later, Windows Server 2022 or later.
+  * gRPC client is fully supported on Windows 11 or later.
+  * gRPC client is partially supported on Windows Server 2022 or later. Unary and server streaming methods are supported. Client and bidirectional streaming methods are not supported.
 * A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.1 or later.
 * Configure `WinHttpHandler` on the channel using `GrpcChannelOptions.HttpHandler`.
 * .NET Framework 4.6.1 or later.

--- a/aspnetcore/grpc/supported-platforms.md
+++ b/aspnetcore/grpc/supported-platforms.md
@@ -104,9 +104,12 @@ The following table lists .NET implementations and their gRPC client support:
 | Universal Windows Platform 10.0.16299        | ❌                | ✔️         |
 | Unity 2018.1                                 | ❌                | ✔️         |
 
-&dagger;.NET Framework requires configuration of <xref:System.Net.Http.WinHttpHandler> and Windows 11 or later.
+&dagger;.NET Framework requires configuration of <xref:System.Net.Http.WinHttpHandler> and Windows 11 or later, Windows Server 2022 or later. For more information, see [Make gRPC calls on .NET Framework](xref:grpc/netstandard#net-framework).
 
-Using `Grpc.Net.Client` on .NET Framework or with gRPC-Web requires additional configuration. For more information, see <xref:grpc/netstandard>.
+Using `Grpc.Net.Client` with gRPC-Web requires additional configuration. For more information:
+
+* [Configure gRPC-Web with the .NET gRPC client](xref:grpc/grpcweb#configure-grpc-web-with-the-net-grpc-client)
+* <xref:grpc/netstandard>
 
 > [!IMPORTANT]
 > gRPC-Web requires the client ***and*** server to support it. gRPC-Web can be [quickly configured by an ASP.NET Core gRPC server](xref:grpc/grpcweb#configure-grpc-web-in-aspnet-core). Other gRPC server implementations require a proxy to support gRPC-Web.


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/2197

@jtattermusch Is this what you're looking for?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/netstandard.md](https://github.com/dotnet/AspNetCore.Docs/blob/32e76a58222347e7dd61c9b5f93277275adc9ecd/aspnetcore/grpc/netstandard.md) | [Use gRPC client with .NET Standard 2.0](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/netstandard?branch=pr-en-us-30033) |
| [aspnetcore/grpc/supported-platforms.md](https://github.com/dotnet/AspNetCore.Docs/blob/32e76a58222347e7dd61c9b5f93277275adc9ecd/aspnetcore/grpc/supported-platforms.md) | [gRPC on .NET supported platforms](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/supported-platforms?branch=pr-en-us-30033) |


<!-- PREVIEW-TABLE-END -->