### PR TITLE
update delete handlers in the minimal API tutorial

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/7.0-samples/todo/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/7.0-samples/todo/Program.cs
@@ -111,7 +111,7 @@ app.MapDelete("/todoitems/{id}", async (int id, TodoDb db) =>
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return Results.Ok(todo);
+        return Results.NoContent();
     }
 
     return Results.NotFound();

--- a/aspnetcore/fundamentals/minimal-apis/bindingArrays/7.0-samples/todo/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/bindingArrays/7.0-samples/todo/Program.cs
@@ -49,7 +49,7 @@ app.MapDelete("/todoitems/{id}", async (int id, TodoDb db) =>
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return Results.Ok(todo);
+        return Results.NoContent();
     }
 
     return Results.NotFound();

--- a/aspnetcore/fundamentals/minimal-apis/min-api-filters/7samples/todo/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/min-api-filters/7samples/todo/Program.cs
@@ -136,7 +136,7 @@ app.MapDelete("/todoitems/{id}", async (int id, TodoDb db) =>
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return Results.Ok(todo);
+        return Results.NoContent();
     }
 
     return Results.NotFound();

--- a/aspnetcore/fundamentals/minimal-apis/samples/todo/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/samples/todo/Program.cs
@@ -80,7 +80,7 @@ app.MapDelete("/todoitems/{id}", async (int id, TodoDb db) =>
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return Results.Ok(todo);
+        return Results.NoContent();
     }
 
     return Results.NotFound();

--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -300,7 +300,7 @@ Use the POST endpoint to add data to the app.
 
 * Run the app.
 
-* Select the **Send request** link that is above the `POST` request line.
+* Select the green **run** button to the left of the line that begins with `Post`.
 
   ![.http file window with run link highlighted.](~/tutorials/min-web-api/_static/http-file-run-button.png)
 
@@ -363,7 +363,7 @@ Test the app by calling the `GET` endpoints from a browser or by using **Endpoin
   ###
   ```
 
-* Select the **Send request** link that is above the new `GET` request line.
+* Select the green **run** button to the left of the new `GET` request line.
 
   The GET request is sent to the app and the response is displayed in the **Response** pane.
 
@@ -390,7 +390,7 @@ Test the app by calling the `GET` endpoints from a browser or by using **Endpoin
 
 * Replace `{id}` with `1`.
 
-* Select the **Send request** link that is above the new GET request line.
+* Select the green **run** button to the left of the new GET request line.
 
   The GET request is sent to the app and the response is displayed in the **Response** pane.
 
@@ -496,7 +496,7 @@ Update the to-do item that has Id = 1 and set its name to `"feed fish"`.
 
   The preceding code adds a Content-Type header and a JSON request body.
 
-* Select the **Send request** link that is above the PUT request line.
+* Select the green **run** button to the left of the PUT request line.
 
   The PUT request is sent to the app and the response is displayed in the **Response** pane. The response body is empty, and the status code is 204.
   
@@ -544,7 +544,7 @@ The sample app implements a single DELETE endpoint using `MapDelete`:
   ###
   ```
 
-* Select the **Send request** link for the DELETE request.
+* Select the **run** button for the DELETE request.
 
   The DELETE request is sent to the app and the response is displayed in the **Response** pane. The response body is empty, and the status code is 204.
   

--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -546,7 +546,7 @@ The sample app implements a single DELETE endpoint using `MapDelete`:
 
 * Select the **run** button for the DELETE request.
 
-  The DELETE request is sent to the app and the response is displayed in the **Response** pane. The status code is 200 and the response body contains the deleted `Todo` item.
+  The DELETE request is sent to the app and the response is displayed in the **Response** pane. The response body is empty, and the status code is 204.
   
 # [Visual Studio Code](#tab/visual-studio-code)
 

--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -300,9 +300,9 @@ Use the POST endpoint to add data to the app.
 
 * Run the app.
 
-* Select the green **run** button to the left of the line that begins with `Post`.
+* Select the **Send request** link that is above the `POST` request line.
 
-  ![.http file window with run button highlighted.](~/tutorials/min-web-api/_static/http-file-run-button.png)
+  ![.http file window with run link highlighted.](~/tutorials/min-web-api/_static/http-file-run-button.png)
 
   The POST request is sent to the app and the response is displayed in the **Response** pane.
 
@@ -363,7 +363,7 @@ Test the app by calling the `GET` endpoints from a browser or by using **Endpoin
   ###
   ```
 
-* Select the green **run** button to the left of the new `GET` request line.
+* Select the **Send request** link that is above the new `GET` request line.
 
   The GET request is sent to the app and the response is displayed in the **Response** pane.
 
@@ -390,7 +390,7 @@ Test the app by calling the `GET` endpoints from a browser or by using **Endpoin
 
 * Replace `{id}` with `1`.
 
-* Select the green **run** button to the left of the new GET request line.
+* Select the **Send request** link that is above the new GET request line.
 
   The GET request is sent to the app and the response is displayed in the **Response** pane.
 
@@ -496,7 +496,7 @@ Update the to-do item that has Id = 1 and set its name to `"feed fish"`.
 
   The preceding code adds a Content-Type header and a JSON request body.
 
-* Select the green **run** button to the left of the PUT request line.
+* Select the **Send request** link that is above the PUT request line.
 
   The PUT request is sent to the app and the response is displayed in the **Response** pane. The response body is empty, and the status code is 204.
   
@@ -544,7 +544,7 @@ The sample app implements a single DELETE endpoint using `MapDelete`:
   ###
   ```
 
-* Select the **run** button for the DELETE request.
+* Select the **Send request** link for the DELETE request.
 
   The DELETE request is sent to the app and the response is displayed in the **Response** pane. The response body is empty, and the status code is 204.
   

--- a/aspnetcore/tutorials/min-web-api/samples/6.x/todo/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/6.x/todo/Program.cs
@@ -118,7 +118,7 @@ app.MapDelete("/todoitems/{id}", async (int id, TodoDb db) =>
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return Results.Ok(todo);
+        return Results.NoContent();
     }
 
     return Results.NotFound();

--- a/aspnetcore/tutorials/min-web-api/samples/6.x/todoDTO/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/6.x/todoDTO/Program.cs
@@ -53,7 +53,7 @@ app.MapDelete("/todoitems/{id}", async (int id, TodoDb db) =>
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return Results.Ok(new TodoItemDTO(todo));
+        return Results.NoContent();
     }
 
     return Results.NotFound();

--- a/aspnetcore/tutorials/min-web-api/samples/7.x/todo/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/7.x/todo/Program.cs
@@ -68,7 +68,7 @@ app.MapDelete("/todoitems/{id}", async (int id, TodoDb db) =>
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return Results.Ok(todo);
+        return Results.NoContent();
     }
 
     return Results.NotFound();
@@ -80,7 +80,6 @@ app.Run();
 #elif TYPEDR
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.EntityFrameworkCore;
-using TodoApi;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddDbContext<TodoDb>(opt => opt.UseInMemoryDatabase("TodoList"));

--- a/aspnetcore/tutorials/min-web-api/samples/7.x/todoDTO/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/7.x/todoDTO/Program.cs
@@ -75,10 +75,7 @@ static async Task<IResult> DeleteTodo(int id, TodoDb db)
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-
-        TodoItemDTO todoItemDTO = new TodoItemDTO(todo);
-        
-        return TypedResults.Ok(todoItemDTO);
+        return TypedResults.NoContent();
     }
 
     return TypedResults.NotFound();

--- a/aspnetcore/tutorials/min-web-api/samples/7.x/todoGroup/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/7.x/todoGroup/Program.cs
@@ -49,7 +49,7 @@ todoItems.MapDelete("/{id}", async (int id, TodoDb db) =>
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return Results.Ok(todo);
+        return Results.NoContent();
     }
 
     return Results.NotFound();

--- a/aspnetcore/tutorials/min-web-api/samples/7.x/todoTypedResults/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/7.x/todoTypedResults/Program.cs
@@ -70,7 +70,7 @@ static async Task<IResult> DeleteTodo(int id, TodoDb db)
     {
         db.Todos.Remove(todo);
         await db.SaveChangesAsync();
-        return TypedResults.Ok(todo);
+        return TypedResults.NoContent();
     }
 
     return TypedResults.NotFound();


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #30026

Within the page I also found more delete endpoints/handlers that could be updated.
If this is not desired I can revert these changes.

Side note: I like the new "Examine and test the endpoint" sections for the v8 docs! 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/min-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/0ad32df620cd96fcae710f1a5c3fc18c4fc3aab2/aspnetcore/tutorials/min-web-api.md) | [Tutorial: Create a minimal API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?branch=pr-en-us-30036) |


<!-- PREVIEW-TABLE-END -->