### PR TITLE
First MVC correct new field code link

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/new-field.md
+++ b/aspnetcore/tutorials/first-mvc-app/new-field.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Part 8 of tutorial series on ASP.NET Core MVC.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 04/25/2023
+ms.date: 08/14/2023
 ms.custom: engagement-fy23
 uid: tutorials/first-mvc-app/new-field
 ---
@@ -62,7 +62,7 @@ Update the view templates in order to display, create, and edit the new `Rating`
 
 Edit the `/Views/Movies/Index.cshtml` file and add a `Rating` field:
 
-[!code-cshtml[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Views/Movies/IndexGenreRating.cshtml?highlight=16-18,38-40&range=24-72)]
+[!code-cshtml[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie80/Views/Movies/IndexGenreRating.cshtml?highlight=16-18,38-40&range=24-72)]
 
 Update the `/Views/Movies/Create.cshtml` with a `Rating` field.
 

--- a/aspnetcore/tutorials/first-mvc-app/new-field/includes/new-field7.md
+++ b/aspnetcore/tutorials/first-mvc-app/new-field/includes/new-field7.md
@@ -46,7 +46,7 @@ Update the view templates in order to display, create, and edit the new `Rating`
 
 Edit the `/Views/Movies/Index.cshtml` file and add a `Rating` field:
 
-[!code-cshtml[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie60/Views/Movies/IndexGenreRating.cshtml?highlight=16-18,38-40&range=24-72)]
+[!code-cshtml[](~/tutorials/first-mvc-app/start-mvc/sample/MvcMovie70/Views/Movies/IndexGenreRating.cshtml?highlight=16-18,38-40&range=24-72)]
 
 Update the `/Views/Movies/Create.cshtml` with a `Rating` field.
 


### PR DESCRIPTION
Fixes #29949 

Link to code for adding a new field section was pointing to v6 rather than v8 code for .NET 8 or v7 code for .NET 7 version of the topic.

Issue corrected in both version 7 and 8 of this topic.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mvc-app/new-field.md](https://github.com/dotnet/AspNetCore.Docs/blob/a34a0b2ce400b3a3fcde0c2f12c4992af9b8ba77/aspnetcore/tutorials/first-mvc-app/new-field.md) | [Part 8, add a new field to an ASP.NET Core MVC app](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/new-field?view=aspnetcore-8.0&branch=pr-en-us-30050&tabs=visual-studio#add-a-rating-property-to-the-movie-model) |

<!-- PREVIEW-TABLE-END -->