### PR TITLE
Correct include for .NET 8 VS Mac prereq

### DIFF
--- a/aspnetcore/includes/net-prereqs-mac-8.0.md
+++ b/aspnetcore/includes/net-prereqs-mac-8.0.md
@@ -1,1 +1,2 @@
-* [Visual Studio 2022 for Mac Preview](https://visualstudio.microsoft.com/vs/mac/preview/)
+* [Visual Studio 2022 for Mac (latest version)](https://visualstudio.microsoft.com/vs/mac/)
+  * In Visual Studio 2022 for Mac, select **Tools > Preferences... > Preview Features** and enable **Use the .NET 8 SDK if installed (requires restart)**.

--- a/aspnetcore/includes/net-prereqs-mac-8.0.md
+++ b/aspnetcore/includes/net-prereqs-mac-8.0.md
@@ -1,2 +1,2 @@
 * [Visual Studio 2022 for Mac (latest version)](https://visualstudio.microsoft.com/vs/mac/)
-  * In Visual Studio 2022 for Mac, select **Tools > Preferences... > Preview Features** and enable **Use the .NET 8 SDK if installed (requires restart)**.
+  * In Visual Studio 2022 for Mac, select **Tools** > **Preferences...** > **Preview Features** and enable **Use the .NET 8 SDK if installed (requires restart)**.


### PR DESCRIPTION
Fixes #30063 

Correcting the include for .NET 8 VS Mac prereq to indicate VS for Mac (Latest) and point out the pref setting to allow .NET 8 to be used.  

Previously it indicated VS for Mac Preview, but the VS for Mac Preview does not yet have the option to use .NET 8.