### PR TITLE
Add IMeterFactory best practice to ASP.NET Core metrics

### DIFF
--- a/aspnetcore/log-mon/metrics/metrics.md
+++ b/aspnetcore/log-mon/metrics/metrics.md
@@ -100,7 +100,7 @@ For more information, see [dotnet-counters](/dotnet/core/diagnostics/dotnet-coun
 
 ## Create custom metrics
 
-Metrics are created using APIs in the <xref:System.Diagnostics.Metrics> namespace. See [Create custom metrics](/dotnet/core/diagnostics/metrics-instrumentation#create-custom-metrics) for information on creating custom metrics.
+Metrics are created using APIs in the <xref:System.Diagnostics.Metrics> namespace. See [Create custom metrics](/dotnet/core/diagnostics/metrics-instrumentation#create-a-custom-metric) for information on creating custom metrics.
 
 ### Creating metrics in ASP.NET Core apps with `IMeterFactory`
 

--- a/aspnetcore/log-mon/metrics/metrics.md
+++ b/aspnetcore/log-mon/metrics/metrics.md
@@ -104,11 +104,11 @@ Metrics are created using APIs in the <xref:System.Diagnostics.Metrics> namespac
 
 ### Creating metrics in ASP.NET Core apps with `IMeterFactory`
 
-It's recommended to create `Meter` instances in ASP.NET Core apps with <xref:System.Diagnostics.Metrics.IMeterFactory>.
+We recommended creating `Meter` instances in ASP.NET Core apps with <xref:System.Diagnostics.Metrics.IMeterFactory>.
 
 ASP.NET Core registers <xref:System.Diagnostics.Metrics.IMeterFactory> in dependency injection (DI) by default. The meter factory integrates metrics with DI, making isolating and collecting metrics easy. `IMeterFactory` is especially useful for testing. It allows for multiple tests to run side-by-side and only collecting metrics values that are recorded in a test.
 
-To use `IMeterFactory` in an app, first create a type that uses `IMeterFactory` to create the app's custom metrics:
+To use `IMeterFactory` in an app, create a type that uses `IMeterFactory` to create the app's custom metrics:
 
 ```cs
 public class ContosoMetrics
@@ -136,7 +136,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSingleton<ContosoMetrics>();
 ```
 
-Finally, inject the metrics type and record values where needed. Because the metrics type is registered in DI it can be use with MVC controllers, minimal APIs, or any other type that is created by DI:
+Inject the metrics type and record values where needed. Because the metrics type is registered in DI it can be use with MVC controllers, minimal APIs, or any other type that is created by DI:
 
 ```cs
 app.MapPost("/complete-sale", ([FromBody] SaleModel model, ContosoMetrics metrics) =>


### PR DESCRIPTION
ASP.NET Core has built-in support for `IMeterFactory`. We want to encourage people to write metrics that integrates with DI.

This PR expands the section on writing custom metrics to include a sample of DI-integrated metrics.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/log-mon/metrics/metrics.md](https://github.com/dotnet/AspNetCore.Docs/blob/c71b0eff02f646d9bb86fd38ecb103dfd2f39ce0/aspnetcore/log-mon/metrics/metrics.md) | [ASP.NET Core metrics](https://review.learn.microsoft.com/en-us/aspnet/core/log-mon/metrics/metrics?branch=pr-en-us-30073) |


<!-- PREVIEW-TABLE-END -->