### PR TITLE
Remove IncludeXmlComments instructions for NSwag sample

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -183,11 +183,6 @@ To suppress warnings only for specific members, enclose the code in [#pragma war
 
 :::code language="csharp" source="web-api-help-pages-using-swagger/samples/7.x/NSwagSample/Models/TodoContext.cs" id="snippet_PragmaWarningDisable" highlight="3,10":::
 
-Configure Swagger to use the XML file that's generated with the preceding instructions.
-
-> [!TIP]
-> For Linux or non-Windows operating systems, file names and paths can be case-sensitive. For example, a `TodoApi.XML` file is valid on Windows but not CentOS.
-
 ### Data annotations
 
 Mark the model with attributes, found in the <xref:System.ComponentModel.DataAnnotations?displayProperty=fullName> namespace, to help drive the Swagger UI components.


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #30072

This was an accidental copy-paste of the swashbuckle instructions that I added with #29993
These can be removed because NSwag renders these comments by default, without additional configuration.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/getting-started-with-NSwag.md](https://github.com/dotnet/AspNetCore.Docs/blob/40a098d737cbd1e8e7b9814617c14176503d57c6/aspnetcore/tutorials/getting-started-with-NSwag.md) | [Get started with NSwag and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-NSwag?branch=pr-en-us-30085) |

<!-- PREVIEW-TABLE-END -->