### PR TITLE
Add note about processing of anti-forgery tokens in header and form

### DIFF
--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -263,6 +263,9 @@ The following example uses JavaScript to make an AJAX request to obtain the toke
 
 <a name="antimin7"></a>
 
+> [!NOTE]
+> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header will be validated.
+
 ### Antiforgery with Minimal APIs
 
 `Minimal APIs` do not support the usage of the included filters (`ValidateAntiForgeryToken`, `AutoValidateAntiforgeryToken`, `IgnoreAntiforgeryToken`), however, <xref:Microsoft.AspNetCore.Antiforgery.IAntiforgery> provides the required APIs to validate a request.
@@ -535,6 +538,9 @@ The following example uses JavaScript to make an AJAX request to obtain the toke
 :::code language="javascript" source="anti-request-forgery/samples/6.x/AntiRequestForgerySample/Snippets/Index.js" highlight="1,15":::
 
 <a name="antimin7"></a>
+
+> [!NOTE]
+> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header will be validated.
 
 ### Antiforgery with Minimal APIs
 
@@ -1212,6 +1218,9 @@ public void ConfigureServices(IServiceCollection services)
     services.AddAntiforgery(options => options.HeaderName = "X-XSRF-TOKEN");
 }
 ```
+
+> [!NOTE]
+> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header will be validated.
 
 ## Windows authentication and antiforgery cookies
 

--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -1220,7 +1220,7 @@ public void ConfigureServices(IServiceCollection services)
 ```
 
 > [!NOTE]
-> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header will be validated.
+> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header is validated.
 
 ## Windows authentication and antiforgery cookies
 

--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -540,7 +540,7 @@ The following example uses JavaScript to make an AJAX request to obtain the toke
 <a name="antimin7"></a>
 
 > [!NOTE]
-> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header will be validated.
+> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header is validated.
 
 ### Antiforgery with Minimal APIs
 

--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -264,7 +264,7 @@ The following example uses JavaScript to make an AJAX request to obtain the toke
 <a name="antimin7"></a>
 
 > [!NOTE]
-> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header will be validated.
+> When the antiforgery token is provided in both the request header and in the form payload, only the token in the header is validated.
 
 ### Antiforgery with Minimal APIs
 


### PR DESCRIPTION
Clarifying the behavior of antiforgery validation when a token is provided in both the header and form payload.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/anti-request-forgery.md](https://github.com/dotnet/AspNetCore.Docs/blob/730cbc5a1a9f8da0e3c54b7072414510b8e6b32d/aspnetcore/security/anti-request-forgery.md) | [Prevent Cross-Site Request Forgery (XSRF/CSRF) attacks in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?branch=pr-en-us-30090) |


<!-- PREVIEW-TABLE-END -->