### PR TITLE
Root-level cascading values 8.0

### DIFF
--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -63,7 +63,7 @@ The following `Daleks` component displays the cascaded values.
 
 <ul>
     <li>Dalek Units: @Daleks?.Units</li>
-    <li>Alpha Group Dalek Units: @NamedDaleks?.Units</li>
+    <li>Alpha Group Dalek Units: @AlphaGroupDaleks?.Units</li>
 </ul>
 
 <p>
@@ -76,7 +76,7 @@ The following `Daleks` component displays the cascaded values.
     public Daleks? Daleks { get; set; }
 
     [CascadingParameter(Name = "AlphaGroup")]
-    public Daleks? NamedDaleks { get; set; }
+    public Daleks? AlphaGroupDaleks { get; set; }
 }
 ```
 

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -35,12 +35,7 @@ The following classes are used in this section's examples.
     "Doctor Who" ©BBC https://www.bbc.co.uk/programmes/b006q2x0
 */
 
-public class Daleks1
-{
-    public int Units { get; set; }
-}
-
-public class Daleks2
+public class Daleks
 {
     public int Units { get; set; }
 }
@@ -48,27 +43,16 @@ public class Daleks2
 
 The following registrations are made in the app's `Program` file.
 
-In the following example, `Daleks1` is registered with a property value as a fixed cascading value:
+In the following example, `Daleks` is registered with a property value as a fixed cascading value:
 
 ```csharp
-builder.Services.AddCascadingValue(sp => new Daleks1 { Units = 123 });
+builder.Services.AddCascadingValue(sp => new Daleks { Units = 123 });
 ```
 
-In the following example, `Daleks1` is registered with the name "`AlphaGroup`" as a fixed cascading value by name:
+In the following example, `Daleks` is registered with the name "`AlphaGroup`" as a fixed cascading value by name:
 
 ```csharp
-builder.Services.AddCascadingValue("AlphaGroup", sp => new Daleks1 { Units = 456 });
-```
-
-In the following example, `Daleks2` is registered as a cascading value using `CascadingValueSource<T>`, where `<T>` is the type. The `isFixed` flag indicates whether the value is fixed. If false, all receipients are subscribed for update notifications, which are issued by calling `NotifyChangedAsync`. Subscriptions create overhead and reduce performance, so set `isFixed` to `true` if the value doesn't change.
-
-```csharp
-builder.Services.AddCascadingValue(sp =>
-{
-    var daleks = new Daleks2 { Units = 789 };
-    var source = new CascadingValueSource<Daleks2>(daleks, isFixed: false);
-    return source;
-});
+builder.Services.AddCascadingValue("AlphaGroup", sp => new Daleks { Units = 456 });
 ```
 
 The following `Daleks` component displays the cascaded values. The value of `Daleks2.Units` is updated for this component and all subscribers when `UpdateUnits` is called.
@@ -76,7 +60,39 @@ The following `Daleks` component displays the cascaded values. The value of `Dal
 `Daleks.razor`:
 
 ```razor
+@page "/daleks"
+@attribute [RenderModeServer]
 
+<h1>Root-level cascading value registration example</h1>
+
+<ul>
+    <li>@Daleks?.Units</li>
+    <li>@NamedDaleks?.Units</li>
+</ul>
+
+<p>
+    Dalek ©<a href="https://www.imdb.com/name/nm0622334/">Terry Nation</a><br>
+    Doctor Who ©<a href="https://www.bbc.co.uk/programmes/b006q2x0">BBC</a>
+</p>
+
+@code {
+    [CascadingParameter]
+    public Daleks? Daleks { get; set; }
+
+    [CascadingParameter(Name = "AlphaGroup")]
+    public Daleks? NamedDaleks { get; set; }
+}
+```
+
+In the following example, `Daleks` is registered as a cascading value using `CascadingValueSource<T>`, where `<T>` is the type. The `isFixed` flag indicates whether the value is fixed. If false, all receipients are subscribed for update notifications, which are issued by calling `NotifyChangedAsync`. Subscriptions create overhead and reduce performance, so set `isFixed` to `true` if the value doesn't change.
+
+```csharp
+builder.Services.AddCascadingValue(sp =>
+{
+    var daleks = new Daleks { Units = 789 };
+    var source = new CascadingValueSource<Daleks>(daleks, isFixed: false);
+    return source;
+});
 ```
 
 :::moniker-end

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -19,6 +19,68 @@ This article explains how to flow data from an ancestor Razor component to desce
 > [!NOTE]
 > The code examples in this article adopt [nullable reference types (NRTs) and .NET compiler null-state static analysis](xref:migration/50-to-60#nullable-reference-types-nrts-and-net-compiler-null-state-static-analysis), which are supported in ASP.NET Core 6.0 or later. When targeting ASP.NET Core 5.0 or earlier, remove the null type designation (`?`) from the `CascadingType?`, `@ActiveTab?`, `RenderFragment?`, `ITab?`, `TabSet?`, and `string?` types in the article's examples.
 
+:::moniker range=">= aspnetcore-8.0"
+
+## Root-level cascading values
+
+Root-level cascading values can be registered for the entire component hierarchy. Named cascading values and subscriptions for update notifications are supported.
+
+The following classes are used in this section's examples.
+
+`Daleks.cs`:
+
+```csharp
+/*
+    "Dalek" ©Terry Nation https://www.imdb.com/name/nm0622334/
+    "Doctor Who" ©BBC https://www.bbc.co.uk/programmes/b006q2x0
+*/
+
+public class Daleks1
+{
+    public int Units { get; set; }
+}
+
+public class Daleks2
+{
+    public int Units { get; set; }
+}
+```
+
+The following registrations are made in the app's `Program` file.
+
+In the following example, `Daleks1` is registered with a property value as a fixed cascading value:
+
+```csharp
+builder.Services.AddCascadingValue(sp => new Daleks1 { Units = 123 });
+```
+
+In the following example, `Daleks1` is registered with the name "`AlphaGroup`" as a fixed cascading value by name:
+
+```csharp
+builder.Services.AddCascadingValue("AlphaGroup", sp => new Daleks1 { Units = 456 });
+```
+
+In the following example, `Daleks2` is registered as a cascading value using `CascadingValueSource<T>`, where `<T>` is the type. The `isFixed` flag indicates whether the value is fixed. If false, all receipients are subscribed for update notifications, which are issued by calling `NotifyChangedAsync`. Subscriptions create overhead and reduce performance, so set `isFixed` to `true` if the value doesn't change.
+
+```csharp
+builder.Services.AddCascadingValue(sp =>
+{
+    var daleks = new Daleks2 { Units = 789 };
+    var source = new CascadingValueSource<Daleks2>(daleks, isFixed: false);
+    return source;
+});
+```
+
+The following `Daleks` component displays the cascaded values. The value of `Daleks2.Units` is updated for this component and all subscribers when `UpdateUnits` is called.
+
+`Daleks.razor`:
+
+```razor
+
+```
+
+:::moniker-end
+
 ## `CascadingValue` component
 
 An ancestor component provides a cascading value using the Blazor framework's [`CascadingValue`](xref:Microsoft.AspNetCore.Components.CascadingValue%601) component, which wraps a subtree of a component hierarchy and supplies a single value to all of the components within its subtree.

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -62,8 +62,8 @@ The following `Daleks` component displays the cascaded values.
 <h1>Root-level cascading value registration example</h1>
 
 <ul>
-    <li>@Daleks?.Units</li>
-    <li>@NamedDaleks?.Units</li>
+    <li>Dalek Units: @Daleks?.Units</li>
+    <li>Alpha Group Dalek Units: @NamedDaleks?.Units</li>
 </ul>
 
 <p>

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -30,10 +30,8 @@ The following class is used in this section's examples.
 `Daleks.cs`:
 
 ```csharp
-/*
-    "Dalek" ©Terry Nation https://www.imdb.com/name/nm0622334/
-    "Doctor Who" ©BBC https://www.bbc.co.uk/programmes/b006q2x0
-*/
+// "Dalek" ©Terry Nation https://www.imdb.com/name/nm0622334/
+// "Doctor Who" ©BBC https://www.bbc.co.uk/programmes/b006q2x0
 
 public class Daleks
 {

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -25,7 +25,7 @@ This article explains how to flow data from an ancestor Razor component to desce
 
 Root-level cascading values can be registered for the entire component hierarchy. Named cascading values and subscriptions for update notifications are supported.
 
-The following classes are used in this section's examples.
+The following class is used in this section's examples.
 
 `Daleks.cs`:
 
@@ -41,21 +41,17 @@ public class Daleks
 }
 ```
 
-The following registrations are made in the app's `Program` file.
+The following registrations are made in the app's `Program` file:
 
-In the following example, `Daleks` is registered with a property value as a fixed cascading value:
+* `Daleks` with a property value for `Units` is registered as a fixed cascading value.
+* A second `Daleks` registration with a different property value for `Units` is named "`AlphaGroup`".
 
 ```csharp
 builder.Services.AddCascadingValue(sp => new Daleks { Units = 123 });
-```
-
-In the following example, `Daleks` is registered with the name "`AlphaGroup`" as a fixed cascading value by name:
-
-```csharp
 builder.Services.AddCascadingValue("AlphaGroup", sp => new Daleks { Units = 456 });
 ```
 
-The following `Daleks` component displays the cascaded values. The value of `Daleks2.Units` is updated for this component and all subscribers when `UpdateUnits` is called.
+The following `Daleks` component displays the cascaded values.
 
 `Daleks.razor`:
 


### PR DESCRIPTION
Fixes #30093

***Steve***, for ...

> something like a global “weather forecast” service that is defined in Program.cs, has some way of getting state changes from an external source of information, and exposes the current forecast as a cascaded value (which may change over time).

Do you want me to draft up something like that now, table it for later (like 24Q1), or not place coverage for that at all?

If you want me to take a 🔪 at it, I'll need some info on triggering `NotifyChangedAsync` from a service because the tests at ...

https://github.com/dotnet/aspnetcore/blob/f902a5b27cf2d89e555a1cf67ae796d11dab039e/src/Components/Components/test/CascadingParameterTest.cs#L571-L635

... new up the `CascadingValueSource` in the method. How is `NotifyChangedAsync` called in a service? What am I registering/injecting to call it because it apparently isn't directly related to the cascading parameter.

Also ...

> to expose some information from the original HttpContext to components

Do you have an example cross-link? What I have here is fun, but I could tack on a quick ***real world*** example.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/cascading-values-and-parameters.md](https://github.com/dotnet/AspNetCore.Docs/blob/6b5741456f3426f03dca024f25524bb2d244a443/aspnetcore/blazor/components/cascading-values-and-parameters.md) | [ASP.NET Core Blazor cascading values and parameters](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/cascading-values-and-parameters?branch=pr-en-us-30095) |


<!-- PREVIEW-TABLE-END -->