### PR TITLE
Add a note about restricting access to certificate files

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/endpoints/includes/endpoints5-7.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints/includes/endpoints5-7.md
@@ -108,7 +108,7 @@ Configure Kestrel to use HTTPS.
 
 In production, HTTPS must be explicitly configured. At a minimum, a default certificate must be provided.
 
-If certificates are being read from disk, as opposed to a [Windows Certificate Store](https://learn.microsoft.com/windows-hardware/drivers/install/certificate-stores), the containing directory must have appropriate permissions to prevent unauthorized access.
+If certificates are being read from disk, as opposed to a [Windows Certificate Store](/windows-hardware/drivers/install/certificate-stores), the containing directory must have appropriate permissions to prevent unauthorized access.
 
 Supported configurations described next:
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints/includes/endpoints5-7.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints/includes/endpoints5-7.md
@@ -108,7 +108,7 @@ Configure Kestrel to use HTTPS.
 
 In production, HTTPS must be explicitly configured. At a minimum, a default certificate must be provided.
 
-If certificates are being read from disk (as opposed to a [Windows Certificate Store](https://learn.microsoft.com/windows-hardware/drivers/install/certificate-stores)), the containing directory must have appropriate permissions to prevent unauthorized access.
+If certificates are being read from disk, as opposed to a [Windows Certificate Store](https://learn.microsoft.com/windows-hardware/drivers/install/certificate-stores), the containing directory must have appropriate permissions to prevent unauthorized access.
 
 Supported configurations described next:
 

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints/includes/endpoints5-7.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints/includes/endpoints5-7.md
@@ -108,6 +108,8 @@ Configure Kestrel to use HTTPS.
 
 In production, HTTPS must be explicitly configured. At a minimum, a default certificate must be provided.
 
+If certificates are being read from disk (as opposed to a [Windows Certificate Store](https://learn.microsoft.com/windows-hardware/drivers/install/certificate-stores)), the containng directory must have appropriate permissions to prevent unauthorized access.
+
 Supported configurations described next:
 
 * No configuration

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints/includes/endpoints5-7.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints/includes/endpoints5-7.md
@@ -108,7 +108,7 @@ Configure Kestrel to use HTTPS.
 
 In production, HTTPS must be explicitly configured. At a minimum, a default certificate must be provided.
 
-If certificates are being read from disk (as opposed to a [Windows Certificate Store](https://learn.microsoft.com/windows-hardware/drivers/install/certificate-stores)), the containng directory must have appropriate permissions to prevent unauthorized access.
+If certificates are being read from disk (as opposed to a [Windows Certificate Store](https://learn.microsoft.com/windows-hardware/drivers/install/certificate-stores)), the containing directory must have appropriate permissions to prevent unauthorized access.
 
 Supported configurations described next:
 


### PR DESCRIPTION
This information is not version specific - certificates should always be protected.