### PR TITLE
HTTP/3 not enabled by default

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -528,7 +528,7 @@ TLS is required to support more than one HTTP version. The TLS [Application-Laye
 | `Http1AndHttp2` | HTTP/1.1 and HTTP/2. HTTP/2 requires the client to select HTTP/2 in the TLS [Application-Layer Protocol Negotiation (ALPN)](https://tools.ietf.org/html/rfc7301#section-3) handshake; otherwise, the connection defaults to HTTP/1.1. |
 | `Http1AndHttp2AndHttp3` | HTTP/1.1, HTTP/2 and HTTP/3. The first client request normally uses HTTP/1.1 or HTTP/2, and the [`alt-svc` response header](xref:fundamentals/servers/kestrel/http3#alt-svc) prompts the client to upgrade to HTTP/3. HTTP/2 and HTTP/3 requires TLS; otherwise, the connection defaults to HTTP/1.1. |
 
-The default protocol value for an endpoint is `HttpProtocols.Http1AndHttp2AndHttp3`.
+The default protocol value for an endpoint is `HttpProtocols.Http1AndHttp2`.
 
 TLS restrictions for HTTP/2:
 

--- a/aspnetcore/fundamentals/servers/kestrel/http3.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http3.md
@@ -5,7 +5,7 @@ description: Learn about using HTTP/3 with Kestrel, the cross-platform web serve
 monikerRange: '>= aspnetcore-6.0'
 ms.author: wigodbe
 ms.custom: mvc
-ms.date: 04/04/2023
+ms.date: 08/24/2023
 uid: fundamentals/servers/kestrel/http3
 ---
 
@@ -46,9 +46,18 @@ HTTP/3 isn't currently supported on macOS and may be available in a future relea
 
 ## Getting started
 
-HTTP/3 is enabled by default. Because not all routers, firewalls, and proxies properly support HTTP/3, by default HTTP/3 is configured together with HTTP/1.1 and HTTP/2.
+HTTP/3 is not enabled by default. Add configuration to `Program.cs` to enable HTTP/3.
 
-For more information, see <xref:fundamentals/servers/kestrel/endpoints#listenoptionsprotocols>.
+:::code language="csharp" source="samples/6.x/KestrelSample/Snippets/Program.cs" id="snippet_Http3" highlight="7-8":::
+
+The preceding code configures port 5001 to:
+
+* Use HTTP/3 alongside HTTP/1.1 and HTTP/2 by specifying `HttpProtocols.Http1AndHttp2AndHttp3`.
+* Enable HTTPS with `UseHttps`. HTTP/3 requires HTTPS.
+
+Because not all routers, firewalls, and proxies properly support HTTP/3, HTTP/3 should be configured together with HTTP/1.1 and HTTP/2. This can be done by specifying [`HttpProtocols.Http1AndHttp2AndHttp3`](xref:Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1AndHttp2AndHttp3) as an endpoint's supported protocols.
+
+For more information, see <xref:fundamentals/servers/kestrel/endpoints>.
 
 ## Alt-svc
 

--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -151,7 +151,7 @@ Alternatively, a client factory can be configured with `SubdirectoryHandler` by 
 
 ## Configure gRPC client to use HTTP/3
 
-The .NET gRPC client supports HTTP/3 with .NET 6 or later. If the server sends an `alt-svc` response header to the client that indicates the server supports HTTP/3, the client will automatically upgrade its connection to HTTP/3. The Kestrel server supports HTTP/3 by default. For more information, see <xref:fundamentals/servers/kestrel/http3>.
+The .NET gRPC client supports HTTP/3 with .NET 6 or later. If the server sends an `alt-svc` response header to the client that indicates the server supports HTTP/3, the client will automatically upgrade its connection to HTTP/3. For more information, see <xref:fundamentals/servers/kestrel/http3>.
 
 A <xref:System.Net.Http.DelegatingHandler> can be used to force a gRPC client to use HTTP/3. Forcing HTTP/3 avoids the overhead of upgrading the request. Force HTTP/3 with code similar to the following:
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -345,17 +345,6 @@ Time to create 100,000 connections:
 * Before : 5.916 seconds
 * After &nbsp; : 2.374 seconds
 
-
-### HTTP/3 enabled by default in Kestrel
-
-HTTP/3 is a new internet technology that was standardized in June 2022. HTTP/3 offers several advantages over older HTTP protocols, including:
-
-* Faster connection setup.
-* No head-of-line blocking.
-* Better transitions between networks.
-
-.NET 7 added support for HTTP/3 to ASP.NET Core and Kestrel. ASP.NET Core apps could choose to turn it on. In .NET 8, HTTP/3 is enabled by default for Kestrel, alongside HTTP/1.1 and HTTP/2. For more information about HTTP/3 and its requirements, see <xref:fundamentals/servers/kestrel/http3>.
-
 ### HTTP/2 over TLS (HTTPS) support on macOS in Kestrel
 
 .NET 8 adds support for Application-Layer Protocol Negotiation (ALPN) to macOS. ALPN is a TLS feature used to negotiate which HTTP protocol a connection will use. For example, ALPN allows browsers and other HTTP clients to request an HTTP/2 connection. This feature is especially useful for gRPC apps, which require HTTP/2. For more information, see <xref:fundamentals/servers/kestrel/http2>.


### PR DESCRIPTION
Fixes #30114 
Reverts #29368 
Partially reverts #28876

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/kestrel/endpoints.md](https://github.com/dotnet/AspNetCore.Docs/blob/fcc3e267f7f0c510b4d59c8dd83fff027e93a2ec/aspnetcore/fundamentals/servers/kestrel/endpoints.md) | [Configure endpoints for the ASP.NET Core Kestrel web server](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?branch=pr-en-us-30146) |
| [aspnetcore/fundamentals/servers/kestrel/http3.md](https://github.com/dotnet/AspNetCore.Docs/blob/fcc3e267f7f0c510b4d59c8dd83fff027e93a2ec/aspnetcore/fundamentals/servers/kestrel/http3.md) | [Use HTTP/3 with the ASP.NET Core Kestrel web server](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/http3?branch=pr-en-us-30146) |
| [aspnetcore/grpc/troubleshoot.md](https://github.com/dotnet/AspNetCore.Docs/blob/fcc3e267f7f0c510b4d59c8dd83fff027e93a2ec/aspnetcore/grpc/troubleshoot.md) | [Troubleshoot gRPC on .NET](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?branch=pr-en-us-30146) |
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/fcc3e267f7f0c510b4d59c8dd83fff027e93a2ec/aspnetcore/release-notes/aspnetcore-8.0.md) | [aspnetcore/release-notes/aspnetcore-8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-30146) |

<!-- PREVIEW-TABLE-END -->