### PR TITLE
add external link to Vue

### DIFF
--- a/aspnetcore/introduction-to-aspnet-core.md
+++ b/aspnetcore/introduction-to-aspnet-core.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Get an overview of ASP.NET Core, a cross-platform, high-performance, open-source framework for building modern, cloud-enabled, Internet-connected apps.
 ms.author: riande
 ms.custom: mvc
-ms.date: 03/02/2022
+ms.date: 3/2/2022
 uid: index
 ---
 # Overview of ASP.NET Core

--- a/aspnetcore/introduction-to-aspnet-core.md
+++ b/aspnetcore/introduction-to-aspnet-core.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Get an overview of ASP.NET Core, a cross-platform, high-performance, open-source framework for building modern, cloud-enabled, Internet-connected apps.
 ms.author: riande
 ms.custom: mvc
-ms.date: 3/2/2022
+ms.date: 03/02/2022
 uid: index
 ---
 # Overview of ASP.NET Core

--- a/aspnetcore/migration/proper-to-2x/mvc2.md
+++ b/aspnetcore/migration/proper-to-2x/mvc2.md
@@ -66,7 +66,7 @@ ASP.NET Core uses a similar approach, but doesn't rely on OWIN to handle the ent
 
 `Startup` must include a `Configure` method. In `Configure`, add the necessary middleware to the pipeline. In the following example (from the default web site template), several extension methods are used to configure the pipeline with support for:
 
-* [BrowserLink](https://vswebessentials.com/features/browserlink)
+* BrowserLink
 * Error pages
 * Static files
 * ASP.NET Core MVC

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -599,6 +599,8 @@ items:
                 uid: spa/react
               - name: JavaScript Services
                 uid: client-side/spa-services
+              - name: ASP.NET Core app with Vue >>
+                href: /visualstudio/javascript/tutorial-asp-net-core-with-vue
           - name: LibMan
             items:
               - name: Overview

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -599,7 +599,7 @@ items:
                 uid: spa/react
               - name: JavaScript Services
                 uid: client-side/spa-services
-              - name: ASP.NET Core app with Vue >>
+              - name: Vue with Visual Studio >>
                 href: /visualstudio/javascript/tutorial-asp-net-core-with-vue
           - name: LibMan
             items:


### PR DESCRIPTION
Fixes #30161
See [New Visual Studio templates](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-7/#new-visual-studio-templates)

[Internal review URL](https://review.learn.microsoft.com/en-us/aspnet/core/client-side/spa-services?view=aspnetcore-8.0&branch=pr-en-us-30162)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/proper-to-2x/mvc2.md](https://github.com/dotnet/AspNetCore.Docs/blob/eaec76c15c26e6e156e09bbf7fcc308d1545c584/aspnetcore/migration/proper-to-2x/mvc2.md) | [Migrate from ASP.NET to ASP.NET Core 2.0](https://review.learn.microsoft.com/en-us/aspnet/core/migration/proper-to-2x/mvc2?branch=pr-en-us-30162) |


<!-- PREVIEW-TABLE-END -->