### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,13 @@ You need a basic understanding of [Git and GitHub.com](https://guides.github.com
 
 For an example where this process led to publication of a new article, see [Issue 1477](https://github.com/dotnet/docs/issues/1477) and [Pull Request 18955](https://github.com/dotnet/docs/pull/18955) in the .NET Docs repository. The new article is [Use code coverage for unit testing](https://learn.microsoft.com/dotnet/core/testing/unit-testing-code-coverage).
 
-## Docs Authoring Pack extension in Visual Studio Code
+## Learn Authoring Pack extension in Visual Studio Code
 
-If you use Visual Studio Code to contribute to the ASP.NET documentation, you can boost your productivity by installing the [Docs Authoring Pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack) extension. The extension provides a variety of tools that helps with Markdown linting, code spell checking, and article templates.
+If you use Visual Studio Code to contribute to the ASP.NET documentation, you can boost your productivity by installing the [Learn Authoring Pack](https://marketplace.visualstudio.com/items?itemName=docsmsft.docs-authoring-pack) extension. The extension provides a variety of tools that helps with Markdown linting, code spell checking, and article templates.
 
 ## Markdown syntax
 
-Articles are written in [DocFx-flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html), which is a superset of [GitHub-flavored Markdown (GFM)](https://guides.github.com/features/mastering-markdown/). For examples of DFM syntax for UI features commonly used in the ASP.NET documentation, see [Metadata and Markdown Template](https://github.com/dotnet/docs/blob/main/styleguide/template.md) in the .NET Docs repo style guide. 
+Articles are written in [DocFx-flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html), which is a superset of [GitHub-flavored Markdown (GFM)](https://guides.github.com/features/mastering-markdown/). For examples of DFM syntax for UI features commonly used in the ASP.NET documentation, see [Metadata and Markdown Template](https://learn.microsoft.com/en-us/contribute/content/dotnet/dotnet-style-guide) in the .NET Docs repo style guide. 
 
 ## Folder structure conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you use Visual Studio Code to contribute to the ASP.NET documentation, you ca
 
 ## Markdown syntax
 
-Articles are written in [DocFx-flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html), which is a superset of [GitHub-flavored Markdown (GFM)](https://guides.github.com/features/mastering-markdown/). For examples of DFM syntax for UI features commonly used in the ASP.NET documentation, see [Metadata and Markdown template](https://learn.microsoft.com/en-us/contribute/content/dotnet/dotnet-style-guide). 
+Articles are written in [DocFx-flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html), which is a superset of [GitHub-flavored Markdown (GFM)](https://guides.github.com/features/mastering-markdown/). For examples of DFM syntax for UI features commonly used in the ASP.NET documentation, see [Metadata and Markdown template](/contribute/content/dotnet/dotnet-style-guide). 
 
 ## Folder structure conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you use Visual Studio Code to contribute to the ASP.NET documentation, you ca
 
 ## Markdown syntax
 
-Articles are written in [DocFx-flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html), which is a superset of [GitHub-flavored Markdown (GFM)](https://guides.github.com/features/mastering-markdown/). For examples of DFM syntax for UI features commonly used in the ASP.NET documentation, see [Metadata and Markdown Template](https://learn.microsoft.com/en-us/contribute/content/dotnet/dotnet-style-guide) in the .NET Docs repo style guide. 
+Articles are written in [DocFx-flavored Markdown](https://dotnet.github.io/docfx/spec/docfx_flavored_markdown.html), which is a superset of [GitHub-flavored Markdown (GFM)](https://guides.github.com/features/mastering-markdown/). For examples of DFM syntax for UI features commonly used in the ASP.NET documentation, see [Metadata and Markdown template](https://learn.microsoft.com/en-us/contribute/content/dotnet/dotnet-style-guide). 
 
 ## Folder structure conventions
 


### PR DESCRIPTION
Minor updates:
* Use the current name of the authoring pack (Learn instead of Docs)
* Link to Metadata and Markdown template (the old one led to a redirect page)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [CONTRIBUTING.md](https://github.com/dotnet/AspNetCore.Docs/blob/1b923e32b8e7859538f64e6225bd79f60461a969/CONTRIBUTING.md) | [Contribute to the ASP.NET Core documentation](https://review.learn.microsoft.com/en-us/aspnet/core/CONTRIBUTING?branch=pr-en-us-30167) |


<!-- PREVIEW-TABLE-END -->