### PR TITLE
Fix client side files position

### DIFF
--- a/aspnetcore/includes/signalr-typescript-webpack/npm-run-release.md
+++ b/aspnetcore/includes/signalr-typescript-webpack/npm-run-release.md
@@ -12,4 +12,4 @@ Webpack completed the following tasks:
 * Copied the processed JavaScript, CSS, and HTML files from `src` to the `wwwroot` directory.
 * Injected the following elements into the `wwwroot/index.html` file:
   * A `<link>` tag, referencing the `wwwroot/main.<hash>.css` file. This tag is placed immediately before the closing `</head>` tag.
-  * A `<script>` tag, referencing the minified `wwwroot/main.<hash>.js` file. This tag is placed immediately before the closing `</body>` tag.
+  * A `<script>` tag, referencing the minified `wwwroot/main.<hash>.js` file. This tag is placed immediately after the closing `</title>` tag.

--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -175,7 +175,7 @@ In this section, you create a [Node.js](https://nodejs.org/) project to convert 
 
 1. Create a new directory named `src` in the project root, `SignalRWebpack/`, for the client code.
    
-1. Copy the `src` directory from the [sample project](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/tutorials/signalr-typescript-webpack/samples/8.x/SignalRWebpack/src/) into the `src`. The `src` directory contains the following files:
+1. Copy the `src` directory and its contents from the [sample project](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/tutorials/signalr-typescript-webpack/samples/8.x/SignalRWebpack/) into the project root. The `src` directory contains the following files:
 
    * `index.html`, which defines the homepage's boilerplate markup:
 

--- a/aspnetcore/tutorials/signalr-typescript-webpack.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack.md
@@ -173,7 +173,9 @@ In this section, you create a [Node.js](https://nodejs.org/) project to convert 
    * The `output` property overrides the default value of `dist`. The bundle is instead emitted in the `wwwroot` directory.
    * The `resolve.extensions` array includes `.js` to import the SignalR client JavaScript.
 
-1. Copy the `src` directory from the [sample project](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/tutorials/signalr-typescript-webpack/samples/8.x/SignalRWebpack/src/) into the project root. The `src` directory contains the following files:
+1. Create a new directory named `src` in the project root, `SignalRWebpack/`, for the client code.
+   
+1. Copy the `src` directory from the [sample project](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/tutorials/signalr-typescript-webpack/samples/8.x/SignalRWebpack/src/) into the `src`. The `src` directory contains the following files:
 
    * `index.html`, which defines the homepage's boilerplate markup:
 

--- a/aspnetcore/tutorials/signalr-typescript-webpack/includes/signalr-typescript-webpack6.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack/includes/signalr-typescript-webpack6.md
@@ -150,7 +150,7 @@ In this section, you create a [Node.js](https://nodejs.org/) project to convert 
    * The `output` property overrides the default value of `dist`. The bundle is instead emitted in the `wwwroot` directory.
    * The `resolve.extensions` array includes `.js` to import the SignalR client JavaScript.
 
-1. Copy the `src` directory from the [sample project](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/tutorials/signalr-typescript-webpack/samples/6.x/SignalRWebpack/src/) into the project root. The `src` directory contains the following files:
+1. Copy the `src` directory and its contents from the [sample project](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/tutorials/signalr-typescript-webpack/samples/6.x/SignalRWebpack/) into the project root. The `src` directory contains the following files:
 
    * `index.html`, which defines the homepage's boilerplate markup:
 

--- a/aspnetcore/tutorials/signalr-typescript-webpack/includes/signalr-typescript-webpack7.md
+++ b/aspnetcore/tutorials/signalr-typescript-webpack/includes/signalr-typescript-webpack7.md
@@ -156,7 +156,7 @@ In this section, you create a [Node.js](https://nodejs.org/) project to convert 
    * The `output` property overrides the default value of `dist`. The bundle is instead emitted in the `wwwroot` directory.
    * The `resolve.extensions` array includes `.js` to import the SignalR client JavaScript.
 
-1. Copy the `src` directory from the [sample project](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/tutorials/signalr-typescript-webpack/samples/7.x/SignalRWebpack/src/) into the project root. The `src` directory contains the following files:
+1. Copy the `src` directory and its contents from the [sample project](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/tutorials/signalr-typescript-webpack/samples/7.x/SignalRWebpack/) into the project root. The `src` directory contains the following files:
 
    * `index.html`, which defines the homepage's boilerplate markup:
 


### PR DESCRIPTION
There is a little error in the sample: if you follow the tutorial, the `npm run release` fails because it looks for html/css/ts files in the src folder but the tutorial says to create these files in the project root.

My favourite solution is to create the _src_ folder and then put these files into this folder. I modified the tutorial to follow this solution.

Thanks!

Samuele



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/signalr-typescript-webpack.md](https://github.com/dotnet/AspNetCore.Docs/blob/7adf0ef7219ac7d78e49d5a9d553a119a9fb3827/aspnetcore/tutorials/signalr-typescript-webpack.md) | [Tutorial: Get started with ASP.NET Core SignalR using TypeScript and Webpack](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/signalr-typescript-webpack?branch=pr-en-us-30173) |


<!-- PREVIEW-TABLE-END -->