### PR TITLE
Change Blazor WASM compression flag

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -164,18 +164,18 @@ Blazor relies on the host to serve the appropriate compressed files. When using 
 
     For more information on loading boot resources, see <xref:blazor/fundamentals/startup#load-boot-resources>.
 
-To disable compression, add the `BlazorEnableCompression` MSBuild property to the app's project file and set the value to `false`:
+To disable compression, add the `CompressionEnabled` MSBuild property to the app's project file and set the value to `false`:
 
 ```xml
 <PropertyGroup>
-  <BlazorEnableCompression>false</BlazorEnableCompression>
+  <CompressionEnabled>false</CompressionEnabled>
 </PropertyGroup>
 ```
 
-The `BlazorEnableCompression` property can be passed to the [`dotnet publish`](/dotnet/core/tools/dotnet-publish) command with the following syntax in a command shell:
+The `CompressionEnabled` property can be passed to the [`dotnet publish`](/dotnet/core/tools/dotnet-publish) command with the following syntax in a command shell:
 
 ```dotnetcli
-dotnet publish -p:BlazorEnableCompression=false
+dotnet publish -p:CompressionEnabled=false
 ```
 
 ## Rewrite URLs for correct routing

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -164,6 +164,9 @@ Blazor relies on the host to serve the appropriate compressed files. When using 
 
     For more information on loading boot resources, see <xref:blazor/fundamentals/startup#load-boot-resources>.
 
+
+:::moniker range=">= aspnetcore-8.0"
+
 To disable compression, add the `CompressionEnabled` MSBuild property to the app's project file and set the value to `false`:
 
 ```xml
@@ -177,6 +180,26 @@ The `CompressionEnabled` property can be passed to the [`dotnet publish`](/dotne
 ```dotnetcli
 dotnet publish -p:CompressionEnabled=false
 ```
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
+To disable compression, add the `BlazorEnableCompression` MSBuild property to the app's project file and set the value to `false`:
+
+```xml
+<PropertyGroup>
+  <BlazorEnableCompression>false</BlazorEnableCompression>
+</PropertyGroup>
+```
+
+The `BlazorEnableCompression` property can be passed to the [`dotnet publish`](/dotnet/core/tools/dotnet-publish) command with the following syntax in a command shell:
+
+```dotnetcli
+dotnet publish -p:BlazorEnableCompression=false
+```
+
+:::moniker-end
 
 ## Rewrite URLs for correct routing
 


### PR DESCRIPTION
Corrected documentation to reflect the compression flag name change from BlazorEnableCompression to CompressionEnabled as described here https://github.com/dotnet/aspnetcore/issues/50451#issuecomment-1702809005

Fixes #30213


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/6011ee846f30c6f135c6b6c07c0e8d37647d7c98/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-30214) |


<!-- PREVIEW-TABLE-END -->