### PR TITLE
MVC Get Started - Add Model - Link Fix

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/adding-model/includes/adding-model3.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model/includes/adding-model3.md
@@ -388,7 +388,7 @@ Because the `Model` object is strongly typed (as an `IEnumerable<Movie>` object)
 * [Globalization and localization](xref:fundamentals/localization)
 
 > [!div class="step-by-step"]
-> [Previous Adding a View]((~/tutorials/first-mvc-app/adding-view.md)
-> [Next Working with SQL]((~/tutorials/first-mvc-app/working-with-sql.md)
+> [Previous Adding a View](~/tutorials/first-mvc-app/adding-view.md)
+> [Next Working with SQL](~/tutorials/first-mvc-app/working-with-sql.md)
 
 :::moniker-end

--- a/aspnetcore/tutorials/first-mvc-app/adding-model/includes/adding-model5.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model/includes/adding-model5.md
@@ -435,7 +435,7 @@ Because the `Model` object is strongly typed as an `IEnumerable<Movie>` object, 
 * [Globalization and localization](xref:fundamentals/localization)
 
 > [!div class="step-by-step"]
-> [Previous Adding a View]((~/tutorials/first-mvc-app/adding-view.md)
-> [Next Working with SQL]((~/tutorials/first-mvc-app/working-with-sql.md)
+> [Previous Adding a View](~/tutorials/first-mvc-app/adding-view.md)
+> [Next Working with SQL](~/tutorials/first-mvc-app/working-with-sql.md)
 
 :::moniker-end

--- a/aspnetcore/tutorials/first-mvc-app/adding-model/includes/adding-model6.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model/includes/adding-model6.md
@@ -467,7 +467,7 @@ Because the `Model` object is strongly typed as an `IEnumerable<Movie>` object, 
 * [Globalization and localization](xref:fundamentals/localization)
 
 > [!div class="step-by-step"]
-> [Previous Adding a View]((~/tutorials/first-mvc-app/adding-view.md)
-> [Next Working with SQL]((~/tutorials/first-mvc-app/working-with-sql.md)
+> [Previous Adding a View](~/tutorials/first-mvc-app/adding-view.md)
+> [Next Working with SQL](~/tutorials/first-mvc-app/working-with-sql.md)
 
 :::moniker-end


### PR DESCRIPTION
Fixes @30266

Next and previous page links for versions 3-5 had an extra bracket, removed it.

[Internal review](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-6.0&branch=pr-en-us-30267&tabs=visual-studio#additional-resources)