### PR TITLE
Hosting models/render modes & What's New 8.0

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -135,7 +135,7 @@ In the preceding example, the `{ROUTE}` placeholder is the route template.
 Applying a render mode to a component definition is commonly used when applying a render mode to a specific page. Routable pages by default use the same render mode as the router component that rendered the page.
 
 > [!NOTE]
-> Component authors should avoid coupling a component's implementation to a specific render mode. Instead, component authors should typically design components to support any render mode or hosting model. A component's implementation should avoid assumptions on where it's running (server or client) and should degrade gracefully when rendered statically. Specifying the render mode in the component definition might be needed if the component isn't instantiated directly (such as with a routable page component) or to specify a render mode for all component instances.
+> Component authors should avoid coupling a component's implementation to a specific render mode. Instead, component authors should typically design components to support any render mode or hosting model. A component's implementation should avoid assumptions on where it's running (server or client) and should degrade gracefully when rendered statically. Specifying the render mode in the component definition may be needed if the component isn't instantiated directly (such as with a routable page component) or to specify a render mode for all component instances.
 
 > [!NOTE]
 > During .NET 8 *Release Candidate 1*, use the following attributes:
@@ -378,7 +378,7 @@ You also typically must set the same interactive render mode on the `HeadOutlet`
 ```
 
 > [!NOTE]
-> Making a root component interactive, such as the `App` component, isn't supported because the Blazor script might be evaluated multiple times.
+> Making a root component interactive, such as the `App` component, isn't supported because the Blazor script may be evaluated multiple times.
 
 > [!NOTE]
 > In an upcoming preview release, a template option for the Blazor Web App template to create the app with root-level interactivity.

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -348,10 +348,10 @@ In the following example, the `SharedMessage` component is interactive over a Si
 
 ### Child components with different render modes
 
-In the following example:
+In the following example, both `SharedMessage` components are prerendered (by default) and appear when the page is displayed in the browser.
 
-* The first `SharedMessage` child component is interactive with Server rendering. The component immediately appears and is interactive when the page is displayed in the browser.
-* The second `SharedMessage` child component is interactive with WebAssembly rendering. The component is rendered and interactive *after* the Blazor app bundle is downloaded and the .NET runtime is active on the client.
+* The first `SharedMessage` component with Server rendering is interactive after the SignalR circuit is established.
+* The second `SharedMessage` component with WebAssembly rendering is interactive *after* the Blazor app bundle is downloaded and the .NET runtime is active on the client.
 
 `RenderMode7.razor`:
 

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -388,7 +388,7 @@ Non-serializable component parameters, such as child content or a render fragmen
 
 <span aria-hidden="true">❌</span> **Error**:
 
-:::no-loc text="System.InvalidOperationException: Cannot pass the parameter 'ChildContent' to component 'SharedMessage' with rendermode 'ServerRenderMode'. This is because the parameter is of the delegate type 'Microsoft.AspNetCore.Components.RenderFragment', which is arbitrary code and cannot be serialized.":::
+> :::no-loc text="System.InvalidOperationException: Cannot pass the parameter 'ChildContent' to component 'SharedMessage' with rendermode 'ServerRenderMode'. This is because the parameter is of the delegate type 'Microsoft.AspNetCore.Components.RenderFragment', which is arbitrary code and cannot be serialized.":::
 
 To circumvent the preceding limitation, wrap the child component in another component that doesn't have the parameter. This is the approach taken in the Blazor Web App project template with the `Routes` component (`Components/Routes.razor`) to wrap the Blazor router.
 
@@ -417,7 +417,7 @@ In the preceding example:
 
 Don't try to apply a different interactive render mode to a child component than its parent's render mode.
 
-The following component results in a runtime error when the `RenderMode9` component is rendered:
+The following component results in a runtime error when the component is rendered:
 
 `RenderMode11.razor`:
 

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -106,8 +106,6 @@ To apply a render mode to a component instance use the [`@rendermode` Razor dire
 
 In the following example, the Server render mode is applied to the `Dialog` component instance:
 
-<!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
-
 ```razor
 <Dialog @rendermode="@RenderMode.Server" />
 ```
@@ -151,8 +149,6 @@ Applying a render mode to a component definition is commonly used when applying 
 > The preceding syntax will be simplified in an upcoming preview release.
 
 ## Prerendering
-
-<!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
 
 Prerendering is enabled by default for interactive components.
 
@@ -437,8 +433,6 @@ The following component results in a runtime error when the `RenderMode9` compon
 > :::no-loc text="Cannot create a component of type 'BlazorSample.Components.SharedMessage' because its render mode 'Microsoft.AspNetCore.Components.Web.WebAssemblyRenderMode' is not supported by interactive server-side rendering.":::
 
 ## Set the render mode for the entire app
-
-<!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
 
 To set the render mode for the entire app, indicate the render mode at the highest-level component in the app's component hierarchy that isn't a root component (root components can't be interactive). Typically, this is where the `Routes` component is used in the `App` component (`Components/App.razor`) for apps based on the Blazor Web App project template:
 

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -98,6 +98,8 @@ app.MapRazorComponents<App>()
     .AddWebAssemblyRenderMode();
 ```
 
+Blazor uses the Blazor WebAssembly hosting model to download and execute components that use the WebAssembly render mode. A separate client project is required to set up Blazor WebAssembly hosting for these components. The client project contains the startup code for the Blazor WebAssembly host and sets up the .NET runtime for running in a browser. The Blazor Web App template adds this client project for you when you select the option to enable WebAssembly interactivity. Any components using the WebAssembly render mode should be built from the client project, so they get included in the downloaded app bundle.
+
 ## Apply a render mode to a component instance
 
 To apply a render mode to a component instance use the [`@rendermode` Razor directive attribute](xref:mvc/views/razor#attribute) where the component is used.
@@ -107,7 +109,7 @@ In the following example, the Server render mode is applied to the `Dialog` comp
 <!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
 
 ```razor
-<Dialog @rendermode="new ServerRenderMode()" />
+<Dialog @rendermode="@RenderMode.Server" />
 ```
 
 > [!NOTE]
@@ -115,9 +117,9 @@ In the following example, the Server render mode is applied to the `Dialog` comp
 >
 > Render mode | Value
 > ----------- | -----
-> Server      | `new ServerRenderMode()`
-> WebAssembly | `new WebAssemblyRenderMode()`
-> Auto        | `new AutoRenderMode()`
+> Server      | `@RenderMode.Server`
+> WebAssembly | `@RenderMode.WebAssembly`
+> Auto        | `@RenderMode.Auto`
 >
 > The preceding syntax will be simplified in an upcoming preview release.
 
@@ -159,7 +161,7 @@ To disable prerendering, pass the `prerender` flag with a value of `false`.
 For a component instance:
 
 ```razor
-<Dialog @rendermode="new ServerRenderMode(prerender: false)" />
+<Dialog @rendermode="@(new ServerRenderMode(prerender: false))" />
 ```
 
 From the component definition:
@@ -176,9 +178,9 @@ In the preceding example, the `{ROUTE}` placeholder is the route template.
 >
 > Render mode | Value
 > ----------- | -----
-> Server      | `new ServerRenderMode(prerender: false)`
-> WebAssembly | `new WebAssemblyRenderMode(prerender: false)`
-> Auto        | `new AutoRenderMode(prerender: false)`
+> Server      | `@(new ServerRenderMode(prerender: false))`
+> WebAssembly | `@(new WebAssemblyRenderMode(prerender: false))`
+> Auto        | `@(new AutoRenderMode(prerender: false))`
 >
 > The preceding syntax will be simplified in an upcoming preview release.
 
@@ -235,7 +237,7 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ## WebAssembly render mode
 
-The WebAssembly render mode renders the component interactively on the client using Blazor WebAssembly. The .NET runtime and app bundle are downloaded and cached when the WebAssembly component is initially rendered.
+The WebAssembly render mode renders the component interactively on the client using Blazor WebAssembly. The .NET runtime and app bundle are downloaded and cached when the WebAssembly component is initially rendered. Components using the WebAssembly render mode must be built from a separate client project that sets up the Blazor WebAssembly host.
 
 In the following example, the render mode is set to WebAssembly with `@attribute [RenderModeWebAssembly]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI.
 
@@ -261,7 +263,7 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ## Auto render mode
 
-The Auto render mode determines how to render the component at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. The .NET runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits.
+The Auto render mode determines how to render the component at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. The .NET runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits. Components using the Auto render mode must be built from a separate client project that sets up the Blazor WebAssembly host.
 
 In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI. Initially, the component is rendered interactively from the server, but on subsequent visits it's rendered from the client after the .NET runtime and app bundle are downloaded and cached.
 
@@ -360,10 +362,10 @@ In the following example, the `SharedMessage` component is interactive over a Si
 
 <!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
 
-To set the render mode for the entire app, indicate the render mode at the highest level component in the app's component hierarchy, typically the `Routes` component (`Components/App.razor`) for apps based on the Blazor Web App project template:
+To set the render mode for the entire app, indicate the render mode at the highest-level component in the app's component hierarchy that isn't a root component (root components can't be interactive). Typically, this is where the `Routes` component is used in the `App` component (`Components/App.razor`) for apps based on the Blazor Web App project template:
 
 ```razor
-<Routes @rendermode="new ServerRenderMode()" />
+<Routes @rendermode="@RenderMode.Server" />
 ```
 
 > [!NOTE]
@@ -374,7 +376,7 @@ The Blazor router propagates its render mode to the pages it routes. The pages a
 You also typically must set the same interactive render mode on the `HeadOutlet` component, which is also found in the `App` component of a Blazor Web App generated from the project template:
 
 ```
-<HeadOutlet @rendermode="new ServerRenderMode()" />
+<HeadOutlet @rendermode="@RenderMode.Server" />
 ```
 
 > [!NOTE]

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -60,7 +60,7 @@ Endpoint convention builder extensions:
 > [!NOTE]
 > For orientation on the placement of the API in the following examples, inspect the `Program` file of an app generated from the Blazor Web App project template. For guidance on how to create a Blazor Web App, see <xref:blazor/tooling>.
 
-Example 1: The following `Program` file API adds services and a render mode for Razor components with only server-side rendering support:
+Example 1: The following `Program` file API adds services and configuration for enabling the Server render mode:
 
 ```csharp
 builder.Services.AddRazorComponents()
@@ -72,7 +72,7 @@ app.MapRazorComponents<App>()
     .AddServerRenderMode();
 ```
 
-Example 2: The following `Program` file API adds services and a render mode for Razor components with only client-side rendering support:
+Example 2: The following `Program` file API adds services and configuration for enabling the WebAssembly render mode:
 
 ```csharp
 builder.Services.AddRazorComponents()
@@ -84,7 +84,7 @@ app.MapRazorComponents<App>()
     .AddWebAssemblyRenderMode();
 ```
 
-Example 3: The following `Program` file API adds services and render modes for Razor components with both server-side and client-side rendering support:
+Example 3: The following `Program` file API adds services and configuration for enabling the Server, WebAssembly, and Auto render modes:
 
 ```csharp
 builder.Services.AddRazorComponents()
@@ -101,9 +101,6 @@ app.MapRazorComponents<App>()
 ## Apply a render mode to a component instance
 
 To apply a render mode to a component instance use the [`@rendermode` Razor directive attribute](xref:mvc/views/razor#attribute) where the component is used.
-
-> [!NOTE]
-> Component authors should typically design components to support any render mode or hosting model. Components should avoid assumptions on where they are running (server or client) and should degrade gracefully when rendered statically.
 
 In the following example, the Server render mode is applied to the `Dialog` component instance:
 
@@ -133,12 +130,23 @@ To specify the render mode for a component as part of its definition, use the [`
 @attribute [RenderModeServer]
 ```
 
+In the preceding example, the `{ROUTE}` placeholder is the route template.
+
 Applying a render mode to a component definition is commonly used when applying a render mode to a specific page. Routable pages by default use the same render mode as the router component that rendered the page.
 
 > [!NOTE]
-> Component authors should typically design components to support any render mode or hosting model. Components should avoid assumptions on where they are running (server or client) and should degrade gracefully when rendered statically.
+> Component authors should avoid coupling a component's implementation to a specific render mode. Instead, component authors should typically design components to support any render mode or hosting model. A component's implementation should avoid assumptions on where it's running (server or client) and should degrade gracefully when rendered statically. Specifying the render mode in the component definition might be needed if the component isn't instantiated directly (such as with a routable page component) or to specify a render mode for all component instances.
 
-In the preceding example, the `{ROUTE}` placeholder is the route template.
+> [!NOTE]
+> During .NET 8 *Release Candidate 1*, use the following attributes:
+>
+> Render mode | Value
+> ----------- | -----
+> Server      | `[RenderModeServer`
+> WebAssembly | `[RenderModeWebAssembly]`
+> Auto        | `[RenderModeAuto]`
+>
+> The preceding syntax will be simplified in an upcoming preview release.
 
 ## Prerendering
 
@@ -148,7 +156,13 @@ Prerendering is enabled by default for interactive components.
 
 To disable prerendering, pass the `prerender` flag with a value of `false`.
 
-For a routable page:
+For a component instance:
+
+```razor
+<Dialog @rendermode="new ServerRenderMode(prerender: false)" />
+```
+
+From the component definition:
 
 ```razor
 @page "{ROUTE}"
@@ -156,12 +170,6 @@ For a routable page:
 ```
 
 In the preceding example, the `{ROUTE}` placeholder is the route template.
-
-For a non-routable, non-page component:
-
-```razor
-<Dialog @rendermode="new ServerRenderMode(prerender: false)" />
-```
 
 > [!NOTE]
 > During .NET 8 *Release Candidate 1*, use the following values:
@@ -176,7 +184,7 @@ For a non-routable, non-page component:
 
 ## Static render mode
 
-By default components use the Static render mode. The component renders to the response stream and interactivity isn't enabled.
+By default, components use the Static render mode. The component renders to the response stream and interactivity isn't enabled.
 
 In the following example, there's no designation for the component's render mode, and the component inherits the default render mode from its parent. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't rerendered in response to UI events.
 
@@ -225,11 +233,11 @@ In the following example, the render mode is set to Server by adding `@attribute
 
 If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
 
-## Client render mode
+## WebAssembly render mode
 
-The Client render mode renders the component interactively on the client using Blazor WebAssembly. The .NET runtime and app bundle are downloaded when the WebAssembly component is initially rendered and is cached for future use.
+The WebAssembly render mode renders the component interactively on the client using Blazor WebAssembly. The .NET runtime and app bundle are downloaded and cached when the WebAssembly component is initially rendered.
 
-In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI.
+In the following example, the render mode is set to WebAssembly with `@attribute [RenderModeWebAssembly]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI.
 
 `RenderMode3.razor`:
 

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -6,7 +6,7 @@ monikerRange: '>= aspnetcore-8.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 09/08/2023
-uid: blazor/fundamentals/render-modes
+uid: blazor/components/render-modes
 ---
 # ASP.NET Core Blazor render modes
 
@@ -288,6 +288,8 @@ Rules for applying render modes:
 * You can't switch to a different interactive render mode in a child component. For example, a Server component can't be a child of a WebAssembly component.
 * Parameters passed to an interactive child component from a Static parent must be JSON serializable. This means that you can't pass render fragments or child content from a Static parent component to an interactive child component.
 
+### Render mode inheritance
+
 Consider the following non-routable, non-page `SharedMessage` component for use in other components. The render mode agnostic `SharedMessage` component doesn't apply a render mode with an [`@attribute` directive](xref:mvc/views/razor#attribute).
 
 `SharedMessage.razor`:
@@ -327,6 +329,23 @@ In the following example, the `SharedMessage` component is interactive over a Si
 
 <SharedMessage />
 ```
+
+### A parent component with two child sibling component that use different render modes
+
+
+
+### A negative case of a child component that tries to use a different interactive render mode than its parent, which results in an error
+
+
+
+### A parent component with an interactive child component that takes a parameter that is serializable (works)
+
+
+
+### A negative case of an interactive child component that has a non-serializable component parameter, like child content or a render fragment, which results in an error.
+
+-----> Show that you can sometimes work around this by wrapping the child component in another component that doesn't have the parameter. This is what we do in the Blazor Web App template with the Routes component to wrap the Blazor Router.
+
 
 
 ## Set the render mode for the entire app

--- a/aspnetcore/blazor/fundamentals/index.md
+++ b/aspnetcore/blazor/fundamentals/index.md
@@ -38,9 +38,33 @@ The following is an example counter component and part of an app created from a 
 
 `Counter.razor`:
 
-<!-- UPDATE 8.0 Probably switch over to the BWA example when the BWA snippet sample goes up -->
+:::moniker range=">= aspnetcore-8.0"
 
-:::moniker range=">= aspnetcore-7.0"
+```razor
+@page "/counter"
+@attribute [RenderModeServer]
+
+<PageTitle>Counter</PageTitle>
+
+<h1>Counter</h1>
+
+<p role="status">Current count: @currentCount</p>
+
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}
+```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
 
 :::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Pages/Counter.razor":::
 
@@ -66,10 +90,24 @@ The following is an example counter component and part of an app created from a 
 
 The preceding `Counter` component:
 
+:::moniker range=">= aspnetcore-8.0"
+
+* Sets its route with the `@page` directive in the first line.
+* Sets the component's render mode to the [Blazor Server hosting model](xref:blazor/hosting-models#blazor-server) with `@attribute [RenderModeServer]`. Render modes are fully explained and demonstrated in the next article, <xref:blazor/fundamentals/render-modes>.
+* Sets its page title and heading.
+* Renders the current count with `@currentCount`. `currentCount` is an integer variable defined in the C# code of the `@code` block.
+* Displays a button to trigger the `IncrementCount` method, which is also found in the `@code` block and increases the value of the `currentCount` variable.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
 * Sets its route with the `@page` directive in the first line.
 * Sets its page title and heading.
 * Renders the current count with `@currentCount`. `currentCount` is an integer variable defined in the C# code of the `@code` block.
 * Displays a button to trigger the `IncrementCount` method, which is also found in the `@code` block and increases the value of the `currentCount` variable.
+
+:::moniker-end
 
 ## Document Object Model (DOM)
 

--- a/aspnetcore/blazor/fundamentals/index.md
+++ b/aspnetcore/blazor/fundamentals/index.md
@@ -38,33 +38,7 @@ The following is an example counter component and part of an app created from a 
 
 `Counter.razor`:
 
-:::moniker range=">= aspnetcore-8.0"
-
-```razor
-@page "/counter"
-@attribute [RenderModeServer]
-
-<PageTitle>Counter</PageTitle>
-
-<h1>Counter</h1>
-
-<p role="status">Current count: @currentCount</p>
-
-<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
-
-@code {
-    private int currentCount = 0;
-
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-```
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
+:::moniker range=">= aspnetcore-7.0"
 
 :::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Pages/Counter.razor":::
 
@@ -90,24 +64,10 @@ The following is an example counter component and part of an app created from a 
 
 The preceding `Counter` component:
 
-:::moniker range=">= aspnetcore-8.0"
-
-* Sets its route with the `@page` directive in the first line.
-* Sets the component's render mode to the [Blazor Server hosting model](xref:blazor/hosting-models#blazor-server) with `@attribute [RenderModeServer]`. Render modes are fully explained and demonstrated in the next article, <xref:blazor/fundamentals/render-modes>.
-* Sets its page title and heading.
-* Renders the current count with `@currentCount`. `currentCount` is an integer variable defined in the C# code of the `@code` block.
-* Displays a button to trigger the `IncrementCount` method, which is also found in the `@code` block and increases the value of the `currentCount` variable.
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-8.0"
-
 * Sets its route with the `@page` directive in the first line.
 * Sets its page title and heading.
 * Renders the current count with `@currentCount`. `currentCount` is an integer variable defined in the C# code of the `@code` block.
 * Displays a button to trigger the `IncrementCount` method, which is also found in the `@code` block and increases the value of the `currentCount` variable.
-
-:::moniker-end
 
 ## Document Object Model (DOM)
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -157,7 +157,7 @@ Render modes propagate down the component hierarchy. Consider the following `Sha
 }
 ```
 
-If the `SharedMessage` component is placed in a statically-rendered parent component, the `SharedMessage` component is also rendered statically and isn't interactive. The button doesn't call `Update Message`, and the message isn't updated.
+If the `SharedMessage` component is placed in a statically-rendered parent component, the `SharedMessage` component is also rendered statically and isn't interactive. The button doesn't call `UpdateMessage`, and the message isn't updated.
 
 `PassedRenderMode1.razor`:
 
@@ -167,7 +167,7 @@ If the `SharedMessage` component is placed in a statically-rendered parent compo
 <SharedMessage />
 ```
 
-If the `SharedMessage` component is placed in a server-side rendered (SSR) component, it adopts SSR. The `SharedMessage` component is interactive over a SignalR connection to the client. The button calls `Update Message`, and the message is updated.
+If the `SharedMessage` component is placed in a server-side rendered (SSR) component, it adopts SSR. The `SharedMessage` component is interactive over a SignalR connection to the client. The button calls `UpdateMessage`, and the message is updated.
 
 `PassedRenderMode2.razor`:
 
@@ -178,7 +178,7 @@ If the `SharedMessage` component is placed in a server-side rendered (SSR) compo
 <SharedMessage />
 ```
 
-If the `SharedMessage` component is placed in a client-side rendered (CSR) component, it adopts CSR. The `SharedMessage` component is interactive on the client with the .NET WebAssembly-based runtime. The button calls `Update Message`, and the message is updated.
+If the `SharedMessage` component is placed in a client-side rendered (CSR) component, it adopts CSR. The `SharedMessage` component is interactive on the client with the .NET WebAssembly-based runtime. The button calls `UpdateMessage`, and the message is updated.
 
 `PassedRenderMode3.razor`:
 
@@ -189,7 +189,7 @@ If the `SharedMessage` component is placed in a client-side rendered (CSR) compo
 <SharedMessage />
 ```
 
-If the `SharedMessage` component is placed in a dynamically-rendered component, where the render mode is determined at runtime, it adopts SSR initially, then CSR after the component and Blazor bundle are downloaded and the .NET runtime activates on the client. The component is interactive. The button calls `Update Message`, and the message is updated.
+If the `SharedMessage` component is placed in a dynamically-rendered component, where the render mode is determined at runtime, it adopts SSR initially, then CSR after the component and Blazor bundle are downloaded and the .NET runtime activates on the client. The component is interactive. The button calls `UpdateMessage`, and the message is updated.
 
 `PassedRenderMode4.razor`:
 
@@ -284,7 +284,6 @@ Example 3: The following `Program` file API adds services and render modes for R
 builder.Services.AddRazorComponents()
     .AddServerComponents()
     .AddWebAssemblyComponents();
-#endif
 
 ...
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -38,8 +38,6 @@ To test the render mode behaviors locally, you can place the following component
 
 In the following example, there's no designation for the component's render mode. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't re-rendered.
 
-If using the following component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-1` in the browser's address bar.
-
 `RenderMode1.razor`:
 
 ```razor
@@ -57,6 +55,8 @@ If using the following component locally in a Blazor Web App, place the componen
 }
 ```
 
+If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-1` in the browser's address bar.
+
 > [!NOTE]
 > The anatomy of a basic Razor component is fully explained in the <xref:blazor/fundamentals/index> article. Project structure for apps created by a Blazor template are described in the <xref:blazor/project-structure> article. Detailed components coverage is found in the *Components* articles later in the documentation.
 
@@ -64,9 +64,7 @@ If using the following component locally in a Blazor Web App, place the componen
 
 Server render mode results in rendering a component on the server with user interactivity.
 
-In the following example, the render mode is set to use the Blazor Server hosting model with `@attribute [RenderModeServer]`. Therefore, the component is rendered server-side with server-side interactivity over a SignalR connection. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
-
-If using the following component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
+In the following example, the render mode is set to use the Blazor Server hosting model with `@attribute [RenderModeServer]`. Therefore, the component is rendered server-side with interactivity over a SignalR connection. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
 
 `RenderMode2.razor`:
 
@@ -86,13 +84,13 @@ If using the following component locally in a Blazor Web App, place the componen
 }
 ```
 
+If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
+
 ### Client render mode
 
 Client render mode results in rendering a component on the client with user interactivity.
 
 In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. Therefore, the component is rendered client-side with interactivity. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
-
-If using the following component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-3` in the browser's address bar.
 
 `RenderMode3.razor`:
 
@@ -112,13 +110,13 @@ If using the following component locally in a Blazor Web App, place the componen
 }
 ```
 
+If using the preceding component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-3` in the browser's address bar.
+
 ### Render mode determined at runtime
 
 The render mode can be determined at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. After the Blazor bundle is downloaded to the client and the .NET client-side runtime activates, the component adopts the Blazor WebAssembly hosting model for client-side rendering and interactivity.
 
 In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered, either server-side or client-side, to update the message in the UI.
-
-If using the following component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-4` in the browser's address bar.
 
 `RenderMode4.razor`:
 
@@ -137,6 +135,8 @@ If using the following component locally in a Blazor Web App, place the componen
     }
 }
 ```
+
+If using the preceding component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-4` in the browser's address bar.
 
 ## Render mode propagation
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -100,22 +100,30 @@ app.MapRazorComponents<App>()
 
 ## Apply a render mode
 
-### Routable page components
+### Apply a render mode to a component definition
 
-To specify the render mode for an entire page, use the [`@attribute` Razor directive](xref:mvc/views/razor#attribute) and the corresponding render mode attribute. But since pages are typically defined by app developers, not library authors, it's still the app developer that is in control of the render mode.
+To specify the render mode for a component as part of its definition, use the [`@attribute` Razor directive](xref:mvc/views/razor#attribute) and the corresponding render mode attribute.
 
 ```razor
 @page "{ROUTE}"
 @attribute [RenderModeServer]
 ```
 
+Applying a render mode to a component definition is commonly used when applying a render mode to a specific page. Routable pages by default use the same render mode as the router component that rendered the page.
+
+> [!NOTE]
+> Component authors should typically design components to support any render mode or hosting model. Components should avoid assumptions on where they are running (server or client) and should degrade gracefully when rendered statically.
+
 In the preceding example, the `{ROUTE}` placeholder is the route template.
 
-### Non-routable, non-page components
+### Apply a render mode to a component instance
 
-Typically, non-routable, non-page components don't apply a render mode with an [`@attribute` directive](xref:mvc/views/razor#attribute), which means that they're created render mode agnostic. The developer usually applies the render mode using the [`@rendermode` Razor directive](xref:mvc/views/razor#attribute) where the component is used.
+To apply a render mode to a component instance use the [`@rendermode` Razor directive attribute](xref:mvc/views/razor#attribute) where the component is used.
 
-In the following example, the `Dialog` component doesn't specify a render mode. The render mode is applied where the `Dialog` component is used:
+> [!NOTE]
+> Component authors should typically design components to support any render mode or hosting model. Components should avoid assumptions on where they are running (server or client) and should degrade gracefully when rendered statically.
+
+In the following example, the Server render mode is applied to the `Dialog` component instance:
 
 <!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -178,7 +178,7 @@ For a non-routable, non-page component:
 
 By default components use the Static render mode. The component renders to the response stream and interactivity isn't enabled.
 
-In the following example, there's no designation for the component's render mode. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't rerendered in response to UI events.
+In the following example, there's no designation for the component's render mode, and the component inherits the default render mode from its parent. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't rerendered in response to UI events.
 
 `RenderMode1.razor`:
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -199,9 +199,6 @@ In the following example, there's no designation for the component's render mode
 
 If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-1` in the browser's address bar.
 
-> [!NOTE]
-> The anatomy of a basic Razor component is fully explained in the <xref:blazor/fundamentals/index> article. Project structure for apps created by a Blazor template are described in the <xref:blazor/project-structure> article. Detailed components coverage is found in the *Components* articles later in the documentation.
-
 ## Server render mode
 
 The Server render mode renders the component interactively from the server using Blazor Server. User interactions are handled over a SignalR connection.

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -10,11 +10,11 @@ uid: blazor/fundamentals/render-modes
 ---
 # ASP.NET Core Blazor render modes
 
-This article explains how to establish hosting models for rendered Razor components in Blazor Web Apps, either at compile time or runtime.
+This article explains control of Razor component rendering in Blazor Web Apps, either at compile time or runtime.
 
 ## Render modes
 
-Every component in a Blazor Web App adopts a *render mode* to determine the hosting model that it uses, where it's rendered, and whether or not it's interactive with C# code.
+Every component in a Blazor Web App adopts a *render mode* to determine the hosting model that it uses, where it's rendered, and whether or not it's interactive.
 
 The following table shows the four potential render mode scenarios for rendering Razor components in a Blazor Web App. The render mode attributes in the *Render mode attribute* column are applied to components with the [`@attribute` Razor directive](xref:mvc/views/razor#attribute). Later in this article, examples are shown for each render mode scenario.
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -18,12 +18,12 @@ Every component in a Blazor Web App adopts a *render mode* to determine the host
 
 The following table shows the four potential render mode scenarios for rendering Razor components in a Blazor Web App. The render mode attributes in the *Render mode attribute* column are applied to components with the [`@attribute` Razor directive](xref:mvc/views/razor#attribute). Later in this article, examples are shown for each render mode scenario.
 
-Scenario                      | Render mode attribute     | Hosting model                             | Render location     | Interactive
------------------------------ | :-----------------------: | :---------------------------------------: | :-----------------: | :---------:
-Statically-rendered           | None                      | None                                      | Server              | ❌
-*Server-side rendering (SSR)* | `[RenderModeServer]`      | Blazor Server                             | Server              | ✔️
-*Client-side rendering (CSR)* | `[RenderModeWebAssembly]` | Blazor WebAssembly                        | Client              | ✔️
-Determined at runtime         | `[RenderModeAuto]`        | Blazor Server,<br>then Blazor WebAssembly | Server, then client | ✔️
+Scenario              | Render mode attribute     | Hosting model                             | Render location     | Interactive
+--------------------- | :-----------------------: | :---------------------------------------: | :-----------------: | :---------:
+Statically-rendered   | None                      | None                                      | Server              | ❌
+Server render mode    | `[RenderModeServer]`      | Blazor Server                             | Server              | ✔️
+Client render mode    | `[RenderModeWebAssembly]` | Blazor WebAssembly                        | Client              | ✔️
+Determined at runtime | `[RenderModeAuto]`        | Blazor Server,<br>then Blazor WebAssembly | Server, then client | ✔️
 
 <!-- HOLD for final commit - We'll use accessible markup for the ❌ and ✔️:
 <span aria-hidden="true">❌</span><span class="visually-hidden">No</span>
@@ -60,9 +60,9 @@ If using the following component locally in a Blazor Web App, place the componen
 > [!NOTE]
 > The anatomy of a basic Razor component is fully explained in the <xref:blazor/fundamentals/index> article. Project structure for apps created by a Blazor template are described in the <xref:blazor/project-structure> article. Detailed components coverage is found in the *Components* articles later in the documentation.
 
-### Server-side rendering (SSR)
+### Server render mode
 
-Server-side rendering (SSR) results in rendering a component on the server with user interactivity.
+Server render mode results in rendering a component on the server with user interactivity.
 
 In the following example, the render mode is set to use the Blazor Server hosting model with `@attribute [RenderModeServer]`. Therefore, the component is rendered server-side with server-side interactivity over a SignalR connection. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
 
@@ -86,9 +86,9 @@ If using the following component locally in a Blazor Web App, place the componen
 }
 ```
 
-### Client-side rendering (CSR)
+### Client render mode
 
-Client-side rendering (CSR) results in rendering a component on the client with user interactivity.
+Client render mode results in rendering a component on the client with user interactivity.
 
 In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. Therefore, the component is rendered client-side with interactivity. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
 
@@ -114,7 +114,7 @@ If using the following component locally in a Blazor Web App, place the componen
 
 ### Render mode determined at runtime
 
-The render mode can be determined at runtime. The component is initially rendered server-side with interactivity (SSR) using the Blazor Server hosting model. After the Blazor bundle is downloaded to the client and the .NET client-side runtime activates, the component adopts the Blazor WebAssembly hosting model for client-side rendering and interactivity (CSR).
+The render mode can be determined at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. After the Blazor bundle is downloaded to the client and the .NET client-side runtime activates, the component adopts the Blazor WebAssembly hosting model for client-side rendering and interactivity.
 
 In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered, either server-side or client-side, to update the message in the UI.
 
@@ -167,7 +167,7 @@ If the `SharedMessage` component is placed in a statically-rendered parent compo
 <SharedMessage />
 ```
 
-If the `SharedMessage` component is placed in a server-side rendered (SSR) component, it adopts SSR. The `SharedMessage` component is interactive over a SignalR connection to the client. The button calls `UpdateMessage`, and the message is updated.
+If the `SharedMessage` component is placed in a server-rendered component, it adopts server-side rendering. The `SharedMessage` component is interactive over a SignalR connection to the client. The button calls `UpdateMessage`, and the message is updated.
 
 `PassedRenderMode2.razor`:
 
@@ -178,7 +178,7 @@ If the `SharedMessage` component is placed in a server-side rendered (SSR) compo
 <SharedMessage />
 ```
 
-If the `SharedMessage` component is placed in a client-side rendered (CSR) component, it adopts CSR. The `SharedMessage` component is interactive on the client with the .NET WebAssembly-based runtime. The button calls `UpdateMessage`, and the message is updated.
+If the `SharedMessage` component is placed in a client-rendered component, it adopts client-side rendering. The `SharedMessage` component is interactive on the client with the .NET WebAssembly-based runtime. The button calls `UpdateMessage`, and the message is updated.
 
 `PassedRenderMode3.razor`:
 
@@ -189,7 +189,7 @@ If the `SharedMessage` component is placed in a client-side rendered (CSR) compo
 <SharedMessage />
 ```
 
-If the `SharedMessage` component is placed in a dynamically-rendered component, where the render mode is determined at runtime, it adopts SSR initially, then CSR after the component and Blazor bundle are downloaded and the .NET runtime activates on the client. The component is interactive. The button calls `UpdateMessage`, and the message is updated.
+If the `SharedMessage` component is placed in a dynamically-rendered component, where the render mode is determined at runtime, it adopts server-side rendering initially, then client-side rendering after the component and Blazor bundle are downloaded and the .NET runtime activates on the client. The component is interactive. The button calls `UpdateMessage`, and the message is updated.
 
 `PassedRenderMode4.razor`:
 
@@ -243,7 +243,7 @@ Endpoint convention builder extensions:
     <xref:Microsoft.AspNetCore.Builder.WebAssemblyRazorComponentsEndpointConventionBuilderExtensions.AddWebAssemblyRenderMode%2A>
 -->
 
-Example 1: The following `Program` file API adds services and a render mode for Razor components with only server-side rendering (SSR) support:
+Example 1: The following `Program` file API adds services and a render mode for Razor components with only server-side rendering support:
 
 ```csharp
 ...
@@ -260,7 +260,7 @@ app.MapRazorComponents<App>()
 ...
 ```
 
-Example 2: The following `Program` file API adds services and a render mode for Razor components with only client-side rendering (CSR) support:
+Example 2: The following `Program` file API adds services and a render mode for Razor components with only client-side rendering support:
 
 ```csharp
 ...
@@ -276,7 +276,7 @@ app.MapRazorComponents<App>()
 ...
 ```
 
-Example 3: The following `Program` file API adds services and render modes for Razor components with both SSR and CSR support:
+Example 3: The following `Program` file API adds services and render modes for Razor components with both server-side and client-side rendering support:
 
 ```csharp
 ...

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -226,14 +226,22 @@ Services for Razor components are added by calling <xref:Microsoft.Extensions.De
 Component builder extensions:
 
 * <xref:Microsoft.Extensions.DependencyInjection.RazorComponentsBuilderExtensions.AddServerComponents%2A> adds services to support rendering interactive server components.
-* <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyRazorComponentsBuilderExtensions.AddWebAssemblyComponents%2A> adds services to support rendering interactive WebAssembly components.
+* `AddWebAssemblyComponents` adds services to support rendering interactive WebAssembly components.
+
+<!-- UPDATE 8.0 HOLD
+     <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyRazorComponentsBuilderExtensions.AddWebAssemblyComponents%2A>
+-->
 
 <xref:Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions.MapRazorComponents%2A> discovers available components and specifies the root component for the app, which by default is the `App` component (`App.razor`).
 
 Endpoint convention builder extensions:
 
 * <xref:Microsoft.AspNetCore.Builder.RazorComponentEndpointConventionBuilder.AddServerRenderMode%2A> configures the Server render mode for the app.
-* <xref:Microsoft.AspNetCore.Builder.WebAssemblyRazorComponentsEndpointConventionBuilderExtensions.AddWebAssemblyRenderMode%2A> configures the WebAssembly render mode for the app.
+* `AddWebAssemblyRenderMode` configures the WebAssembly render mode for the app.
+
+<!-- UPDATE 8.0 HOLD
+    <xref:Microsoft.AspNetCore.Builder.WebAssemblyRazorComponentsEndpointConventionBuilderExtensions.AddWebAssemblyRenderMode%2A>
+-->
 
 Example 1: The following `Program` file API adds services and a render mode for Razor components with only server-side rendering (SSR) support:
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -16,208 +16,18 @@ This article explains control of Razor component rendering in Blazor Web Apps, e
 
 Every component in a Blazor Web App adopts a *render mode* to determine the hosting model that it uses, where it's rendered, and whether or not it's interactive.
 
-The following table shows the available render modes for rendering Razor components in a Blazor Web App. To apply a render mode to a component use the `@rendermode` directive on the component instance or use the [`@attribute` Razor directive](xref:mvc/views/razor#attribute) with the corresponding render mode attribute on the component type. Later in this article, examples are shown for each render mode scenario.
+The following table shows the available render modes for rendering Razor components in a Blazor Web App. To apply a render mode to a component use the `@rendermode` directive on the component instance or use the [`@attribute` Razor directive](xref:mvc/views/razor#attribute) with the corresponding render mode attribute in the component's Razor markup. Later in this article, examples are shown for each render mode scenario.
 
-Name | Description  |  Render location     | Interactive
---------------------- | :-----------------------: | :---------------------------------------: | :-----------------: | :---------:
-Static  | Static server rendering |  Server  | ❌
-Server    | Interactive server rendering using Blazor Server | Server  | ✔️
-WebAssembly | Interactive client rendering using Blazor WebAssembly | Client  | ✔️
-Auto | Interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits once download | Server, then client | ✔️
-
-<!-- HOLD for final commit - We'll use accessible markup for the ❌ and ✔️:
-<span aria-hidden="true">❌</span><span class="visually-hidden">No</span>
-<span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
--->
+Name | Description | Render location | Interactive
+---- | ----------- | :-------------: | :---------:
+Static | Static server rendering |  Server  | <span aria-hidden="true">❌</span><span class="visually-hidden">No</span>
+Server | Interactive server rendering using Blazor Server | Server | <span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
+WebAssembly | Interactive client rendering using Blazor WebAssembly | Client | <span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
+Auto | Interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits once download | Server, then client | <span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
 
 The following examples demonstrate setting the component's render mode with a few basic Razor component features.
 
 To test the render mode behaviors locally, you can place the following components in an app created from the *Blazor Web App* project template. When you create the app, select the checkboxes (Visual Studio) or apply the CLI options (.NET CLI) to enable both server-side and client-side interactivity. For guidance on how to create a Blazor Web App, see <xref:blazor/tooling>.
-
-### Static render mode
-
-By default components use the Static render mode. The component renders to the response stream and interactivity isn't enabled.
-
-In the following example, there's no designation for the component's render mode. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't re-rendered in response to UI events.
-
-`RenderMode1.razor`:
-
-```razor
-@page "/render-mode-1"
-
-<button @onclick="UpdateMessage">Click me</button> @message
-
-@code {
-    private string message = "Not clicked yet.";
-
-    private void UpdateMessage()
-    {
-        message = "Somebody clicked me!";
-    }
-}
-```
-
-If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-1` in the browser's address bar.
-
-> [!NOTE]
-> The anatomy of a basic Razor component is fully explained in the <xref:blazor/fundamentals/index> article. Project structure for apps created by a Blazor template are described in the <xref:blazor/project-structure> article. Detailed components coverage is found in the *Components* articles later in the documentation.
-
-### Server render mode
-
-The Server render mode renders the component interactively from the server using Blazor Server. User interactions are handled over a SignalR connection.
-
-In the following example, the render mode is set to Server by adding `@attribute [RenderModeServer]` to the component definition. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
-
-`RenderMode2.razor`:
-
-```razor
-@page "/render-mode-2"
-@attribute [RenderModeServer]
-
-<button @onclick="UpdateMessage">Click me</button> @message
-
-@code {
-    private string message = "Not clicked yet.";
-
-    private void UpdateMessage()
-    {
-        message = "Somebody clicked me!";
-    }
-}
-```
-
-If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
-
-### Client render mode
-
-The Client render mode renders the component interactively on the client using Blazor WebAssembly.
-
-In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
-
-`RenderMode3.razor`:
-
-```razor
-@page "/render-mode-3"
-@attribute [RenderModeWebAssembly]
-
-<button @onclick="UpdateMessage">Click me</button> @message
-
-@code {
-    private string message = "Not clicked yet.";
-
-    private void UpdateMessage()
-    {
-        message = "Somebody clicked me!";
-    }
-}
-```
-
-If using the preceding component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-3` in the browser's address bar.
-
-### Auto render mode
-
-The Auto render mode determines how to render the component at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. The Blazor WebAssembly runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits.
-
-In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI. Initially, the component is rendered interactively from the server, but on subsequent visits it's rendered from the client after the Blazor WebAssembly runtime and app bundle are downloaded and cached.
-
-`RenderMode4.razor`:
-
-```razor
-@page "/render-mode-4"
-@attribute [RenderModeAuto]
-
-<button @onclick="UpdateMessage">Click me</button> @message
-
-@code {
-    private string message = "Not clicked yet.";
-
-    private void UpdateMessage()
-    {
-        message = "Somebody clicked me!";
-    }
-}
-```
-
-If using the preceding component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-4` in the browser's address bar.
-
-## Render mode propagation
-
-Render modes propagate down the component hierarchy. Consider the following `SharedMessage` component for use in other components that doesn't indicate a render mode.
-
-`SharedMessage.razor`:
-
-```razor
-<button @onclick="UpdateMessage">Click me</button> @message
-
-@code {
-    private string message = "Not clicked yet.";
-
-    private void UpdateMessage()
-    {
-        message = "Somebody clicked me!";
-    }
-}
-```
-
-If the `SharedMessage` component is placed in a statically-rendered parent component, the `SharedMessage` component is also rendered statically and isn't interactive. The button doesn't call `UpdateMessage`, and the message isn't updated.
-
-`PassedRenderMode1.razor`:
-
-```razor
-@page "/passed-render-mode-1"
-
-<SharedMessage />
-```
-
-If the `SharedMessage` component is placed in a server-rendered component, it adopts server-side rendering. The `SharedMessage` component is interactive over a SignalR connection to the client. The button calls `UpdateMessage`, and the message is updated.
-
-`PassedRenderMode2.razor`:
-
-```razor
-@page "/passed-render-mode-2"
-@attribute [RenderModeServer]
-
-<SharedMessage />
-```
-
-If the `SharedMessage` component is placed in a client-rendered component, it adopts client-side rendering. The `SharedMessage` component is interactive on the client with the .NET WebAssembly-based runtime. The button calls `UpdateMessage`, and the message is updated.
-
-`PassedRenderMode3.razor`:
-
-```razor
-@page "/passed-render-mode-3"
-@attribute [RenderModeWebAssembly]
-
-<SharedMessage />
-```
-
-If the `SharedMessage` component is placed in a component using the Auto render mode, it adopts the Auto render mode as well. The component adopts server-side rendering initially, then the component uses client-side rendering after the component and Blazor bundle are downloaded and the .NET runtime activates on the client. The component is interactive. The button calls `UpdateMessage`, and the message is updated.
-
-`PassedRenderMode4.razor`:
-
-```razor
-@page "/passed-render-mode-4"
-@attribute [RenderModeAuto]
-
-<SharedMessage />
-```
-
-## Set the render mode for the entire app
-
-To set the render mode for the entire app, indicate the render mode at the highest level component in the app's component hierarchy, typically the `Routes` component (`Components/Routes.razor`) for apps based on the Blazor Web App project template:
-
-```razor
-@attribute {RENDER MODE}
-
-<Router AppAssembly="@typeof(App).Assembly" ...>
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)" />
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-    </Found>
-</Router>
-```
-
-In the preceding example, the `{RENDER MODE}` placeholder is the render mode (`[RenderModeServer]`, `[RenderModeWebAssembly]`, or `[RenderModeAuto]`). The render mode propagates down the component hierarchy to all of the components in the app.
 
 ## Enable support for interactive render modes
 
@@ -295,3 +105,213 @@ app.MapRazorComponents<App>()
 
 ...
 ```
+
+## Apply a render mode
+
+### Routable page components
+
+To specify the render mode for an entire page you need to use the @attribute directive and the corresponding render mode attribute. But since pages are typically defined by app developers, not library authors, it's still the app developer that is in control of the render mode.
+
+```razor
+@page "{ROUTE}"
+@attribute [RenderModeServer]
+```
+
+In the preceding example, the `{ROUTE}` placeholder is the route template.
+
+### Non-routable, non-page components
+
+Typically, non-routable, non-page components are created render mode agnostic. The developer usually applies a render mode to a given component using the `@rendermode` directive on the component instance.
+
+In the following example, the `Dialog` component doesn't specify a render mode. The render mode is applied where the `Dialog` component is used:
+
+<!-- UPDATE 8.0 RC2: Remove preview remark update code -->
+
+```razor
+<Dialog @rendermode="new ServerRenderMode()" />
+```
+
+> [!NOTE]
+> The preceding syntax will be simplified in an upcoming preview release.
+
+### Static render mode
+
+By default components use the Static render mode. The component renders to the response stream and interactivity isn't enabled.
+
+In the following example, there's no designation for the component's render mode. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't rerendered in response to UI events.
+
+`RenderMode1.razor`:
+
+```razor
+@page "/render-mode-1"
+
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-1` in the browser's address bar.
+
+> [!NOTE]
+> The anatomy of a basic Razor component is fully explained in the <xref:blazor/fundamentals/index> article. Project structure for apps created by a Blazor template are described in the <xref:blazor/project-structure> article. Detailed components coverage is found in the *Components* articles later in the documentation.
+
+### Server render mode
+
+The Server render mode renders the component interactively from the server using Blazor Server. User interactions are handled over a SignalR connection.
+
+In the following example, the render mode is set to Server by adding `@attribute [RenderModeServer]` to the component definition. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI.
+
+`RenderMode2.razor`:
+
+```razor
+@page "/render-mode-2"
+@attribute [RenderModeServer]
+
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
+
+### Client render mode
+
+The Client render mode renders the component interactively on the client using Blazor WebAssembly.
+
+In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI.
+
+`RenderMode3.razor`:
+
+```razor
+@page "/render-mode-3"
+@attribute [RenderModeWebAssembly]
+
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+If using the preceding component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-3` in the browser's address bar.
+
+### Auto render mode
+
+The Auto render mode determines how to render the component at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. The Blazor WebAssembly runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits.
+
+In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI. Initially, the component is rendered interactively from the server, but on subsequent visits it's rendered from the client after the Blazor WebAssembly runtime and app bundle are downloaded and cached.
+
+`RenderMode4.razor`:
+
+```razor
+@page "/render-mode-4"
+@attribute [RenderModeAuto]
+
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+If using the preceding component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-4` in the browser's address bar.
+
+## Render mode propagation
+
+Render modes propagate down the component hierarchy. Consider the following `SharedMessage` component for use in other components that doesn't indicate a render mode.
+
+`SharedMessage.razor`:
+
+```razor
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+If the `SharedMessage` component is placed in a statically-rendered parent component, the `SharedMessage` component is also rendered statically and isn't interactive. The button doesn't call `UpdateMessage`, and the message isn't updated.
+
+`PassedRenderMode.razor`:
+
+```razor
+@page "/passed-render-mode"
+
+<SharedMessage />
+```
+
+If the `SharedMessage` component is placed in a component that defines the render mode, it inherits the applied render mode.
+
+In the following example, the `SharedMessage` component is interactive over a SignalR connection to the client. The button calls `UpdateMessage`, and the message is updated.
+
+`PassedRenderMode2.razor`:
+
+```razor
+@page "/passed-render-mode-2"
+@attribute [RenderModeServer]
+
+<SharedMessage />
+```
+
+Additional rules for applying render modes:
+
+* You can't switch to a different interactive render mode in a child component. For example, a Server component can't be a child of a WebAssembly component.
+* Parameters passed to an interactive child component from a Static parent must be JSON serializable. This means that you can't pass render fragments or child content from a Static parent component to an interactive child component.
+
+## Set the render mode for the entire app
+
+<!-- UPDATE 8.0 RC2: Remove preview remark update code -->
+
+To set the render mode for the entire app, indicate the render mode at the highest level component in the app's component hierarchy, typically the `Routes` component (`Components/App.razor`) for apps based on the Blazor Web App project template:
+
+```razor
+<Routes @rendermode="new ServerRenderMode()" />
+```
+
+> [!NOTE]
+> The preceding syntax will be simplified in an upcoming preview release.
+
+The Blazor router propagates its render mode to the pages it routes. The pages aren't technically child components of the router, but when the routes are discovered at runtime for the router, they inherit the router's render mode.
+
+You also typically need to set the same interactive render mode on the `HeadOutlet` component, also in the `App` component:
+
+```
+<HeadOutlet @rendermode="new ServerRenderMode()" />
+```
+
+> [!NOTE]
+> Making a root component interactive, such as the `App` component, isn't supported because the Blazor script might be evaluated multiple times.
+
+> [!NOTE]
+> In an upcoming preview release, a template option for the Blazor Web App template to create the app with root-level interactivity.
+
+<!-- UPDATE 8.0 The preceding is tracked by https://github.com/dotnet/aspnetcore/issues/50433 -->

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -1,0 +1,288 @@
+---
+title: ASP.NET Core Blazor render modes
+author: guardrex
+description: Learn about Blazor render modes and how to apply them in Blazor Web Apps.
+monikerRange: '>= aspnetcore-8.0'
+ms.author: riande
+ms.custom: mvc
+ms.date: 09/08/2023
+uid: blazor/fundamentals/render-modes
+---
+# ASP.NET Core Blazor render modes
+
+This article explains how to establish hosting models for rendered Razor components in Blazor Web Apps, either at compile time or runtime.
+
+## Render modes
+
+Every component in a Blazor Web App adopts a *render mode* to determine the hosting model that it uses, where it's rendered, and whether or not it's interactive with C# code.
+
+The following table shows the four potential render mode scenarios for rendering Razor components in a Blazor Web App. The render mode attributes in the *Render mode attribute* column are applied to components with the [`@attribute` Razor directive](xref:mvc/views/razor#attribute). Later in this article, examples are shown for each render mode scenario.
+
+Scenario                      | Render mode attribute     | Hosting model                             | Render location     | Interactive
+----------------------------- | :-----------------------: | :---------------------------------------: | :-----------------: | :---------:
+Statically-rendered           | None                      | None                                      | Server              | ❌
+*Server-side rendering (SSR)* | `[RenderModeServer]`      | Blazor Server                             | Server              | ✔️
+*Client-side rendering (CSR)* | `[RenderModeWebAssembly]` | Blazor WebAssembly                        | Client              | ✔️
+Determined at runtime         | `[RenderModeAuto]`        | Blazor Server,<br>then Blazor WebAssembly | Server, then client | ✔️
+
+<!-- HOLD for final commit - We'll use accessible markup for the ❌ and ✔️:
+<span aria-hidden="true">❌</span><span class="visually-hidden">No</span>
+<span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
+-->
+
+The following examples demonstrate setting the component's render mode with a few basic Razor component features.
+
+To test the render mode behaviors locally, you can place the following components in an app created from the *Blazor Web App* project template. When you create the app, select the checkboxes (Visual Studio) or apply the CLI options (.NET CLI) to enable both server-side and client-side interactivity. For guidance on how to create a Blazor Web App, see <xref:blazor/tooling>.
+
+### Statically-rendered on the server without user interactivity
+
+In the following example, there's no designation for the component's render mode. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't re-rendered.
+
+If using the following component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-1` in the browser's address bar.
+
+`RenderMode1.razor`:
+
+```razor
+@page "/render-mode-1"
+
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+> [!NOTE]
+> The anatomy of a basic Razor component is fully explained in the <xref:blazor/fundamentals/index> article. Project structure for apps created by a Blazor template are described in the <xref:blazor/project-structure> article. Detailed components coverage is found in the *Components* articles later in the documentation.
+
+### Server-side rendering (SSR)
+
+Server-side rendering (SSR) results in rendering a component on the server with user interactivity.
+
+In the following example, the render mode is set to use the Blazor Server hosting model with `@attribute [RenderModeServer]`. Therefore, the component is rendered server-side with server-side interactivity over a SignalR connection. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
+
+If using the following component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
+
+`RenderMode2.razor`:
+
+```razor
+@page "/render-mode-2"
+@attribute [RenderModeServer]
+
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+### Client-side rendering (CSR)
+
+Client-side rendering (CSR) results in rendering a component on the client with user interactivity.
+
+In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. Therefore, the component is rendered client-side with interactivity. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
+
+If using the following component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-3` in the browser's address bar.
+
+`RenderMode3.razor`:
+
+```razor
+@page "/render-mode-3"
+@attribute [RenderModeWebAssembly]
+
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+### Render mode determined at runtime
+
+The render mode can be determined at runtime. The component is initially rendered server-side with interactivity (SSR) using the Blazor Server hosting model. After the Blazor bundle is downloaded to the client and the .NET client-side runtime activates, the component adopts the Blazor WebAssembly hosting model for client-side rendering and interactivity (CSR).
+
+In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered, either server-side or client-side, to update the message in the UI.
+
+If using the following component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-4` in the browser's address bar.
+
+`RenderMode4.razor`:
+
+```razor
+@page "/render-mode-4"
+@attribute [RenderModeAuto]
+
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+## Render mode propagation
+
+Render modes propagate down the component hierarchy. Consider the following `SharedMessage` component for use in other components that doesn't indicate a render mode.
+
+`SharedMessage.razor`:
+
+```razor
+<button @onclick="UpdateMessage">Click me</button> @message
+
+@code {
+    private string message = "Not clicked yet.";
+
+    private void UpdateMessage()
+    {
+        message = "Somebody clicked me!";
+    }
+}
+```
+
+If the `SharedMessage` component is placed in a statically-rendered parent component, the `SharedMessage` component is also rendered statically and isn't interactive. The button doesn't call `Update Message`, and the message isn't updated.
+
+`PassedRenderMode1.razor`:
+
+```razor
+@page "/passed-render-mode-1"
+
+<SharedMessage />
+```
+
+If the `SharedMessage` component is placed in a server-side rendered (SSR) component, it adopts SSR. The `SharedMessage` component is interactive over a SignalR connection to the client. The button calls `Update Message`, and the message is updated.
+
+`PassedRenderMode2.razor`:
+
+```razor
+@page "/passed-render-mode-2"
+@attribute [RenderModeServer]
+
+<SharedMessage />
+```
+
+If the `SharedMessage` component is placed in a client-side rendered (CSR) component, it adopts CSR. The `SharedMessage` component is interactive on the client with the .NET WebAssembly-based runtime. The button calls `Update Message`, and the message is updated.
+
+`PassedRenderMode3.razor`:
+
+```razor
+@page "/passed-render-mode-3"
+@attribute [RenderModeWebAssembly]
+
+<SharedMessage />
+```
+
+If the `SharedMessage` component is placed in a dynamically-rendered component, where the render mode is determined at runtime, it adopts SSR initially, then CSR after the component and Blazor bundle are downloaded and the .NET runtime activates on the client. The component is interactive. The button calls `Update Message`, and the message is updated.
+
+`PassedRenderMode4.razor`:
+
+```razor
+@page "/passed-render-mode-4"
+@attribute [RenderModeAuto]
+
+<SharedMessage />
+```
+
+## Set the render mode for the entire app
+
+To set the render mode for the entire app, indicate the render mode at the highest level component in the app's component hierarchy, typically the `Routes` component (`Components/Routes.razor`) for apps based on the Blazor Web App project template:
+
+```razor
+@attribute {RENDER MODE}
+
+<Router AppAssembly="@typeof(App).Assembly" ...>
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(Layout.MainLayout)" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+    </Found>
+</Router>
+```
+
+In the preceding example, the `{RENDER MODE}` placeholder is the render mode (`[RenderModeServer]`, `[RenderModeWebAssembly]`, or `[RenderModeAuto]`). The render mode propagates down the component hierarchy to all of the components in the app.
+
+## API extensions that support components in Blazor Web Apps
+
+The following extensions are automatically applied to apps created from the [*Blazor Web App* project template](xref:blazor/tooling) when either or both of server-side component interactivity and client-side component interactivity are enabled during app creation. Individual components are still required to declare their render mode per the [*Render modes*](#render-modes) section after the component services and endpoints are configured in the app's `Program` file.
+
+Services for Razor components are added by calling <xref:Microsoft.Extensions.DependencyInjection.RazorComponentsServiceCollectionExtensions.AddRazorComponents%2A>.
+
+Component builder extensions:
+
+* <xref:Microsoft.Extensions.DependencyInjection.RazorComponentsBuilderExtensions.AddServerComponents%2A> adds services to support rendering interactive server components.
+* <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyRazorComponentsBuilderExtensions.AddWebAssemblyComponents%2A> adds services to support rendering interactive WebAssembly components.
+
+<xref:Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions.MapRazorComponents%2A> discovers available components and specifies the root component for the app, which by default is the `App` component (`App.razor`).
+
+Endpoint convention builder extensions:
+
+* <xref:Microsoft.AspNetCore.Builder.RazorComponentEndpointConventionBuilder.AddServerRenderMode%2A> configures the Server render mode for the app.
+* <xref:Microsoft.AspNetCore.Builder.WebAssemblyRazorComponentsEndpointConventionBuilderExtensions.AddWebAssemblyRenderMode%2A> configures the WebAssembly render mode for the app.
+
+Example 1: The following `Program` file API adds services and a render mode for Razor components with only server-side rendering (SSR) support:
+
+```csharp
+...
+
+builder.Services.AddRazorComponents()
+    .AddServerComponents();
+    
+
+...
+
+app.MapRazorComponents<App>()
+    .AddServerRenderMode();
+
+...
+```
+
+Example 2: The following `Program` file API adds services and a render mode for Razor components with only client-side rendering (CSR) support:
+
+```csharp
+...
+
+builder.Services.AddRazorComponents()
+    .AddWebAssemblyComponents();
+
+...
+
+app.MapRazorComponents<App>()
+    .AddWebAssemblyRenderMode();
+
+...
+```
+
+Example 3: The following `Program` file API adds services and render modes for Razor components with both SSR and CSR support:
+
+```csharp
+...
+
+builder.Services.AddRazorComponents()
+    .AddServerComponents()
+    .AddWebAssemblyComponents();
+#endif
+
+...
+
+app.MapRazorComponents<App>()
+    .AddServerRenderMode()
+    .AddWebAssemblyRenderMode();
+
+...
+```

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -98,25 +98,7 @@ app.MapRazorComponents<App>()
     .AddWebAssemblyRenderMode();
 ```
 
-## Apply a render mode
-
-### Apply a render mode to a component definition
-
-To specify the render mode for a component as part of its definition, use the [`@attribute` Razor directive](xref:mvc/views/razor#attribute) and the corresponding render mode attribute.
-
-```razor
-@page "{ROUTE}"
-@attribute [RenderModeServer]
-```
-
-Applying a render mode to a component definition is commonly used when applying a render mode to a specific page. Routable pages by default use the same render mode as the router component that rendered the page.
-
-> [!NOTE]
-> Component authors should typically design components to support any render mode or hosting model. Components should avoid assumptions on where they are running (server or client) and should degrade gracefully when rendered statically.
-
-In the preceding example, the `{ROUTE}` placeholder is the route template.
-
-### Apply a render mode to a component instance
+## Apply a render mode to a component instance
 
 To apply a render mode to a component instance use the [`@rendermode` Razor directive attribute](xref:mvc/views/razor#attribute) where the component is used.
 
@@ -142,7 +124,23 @@ In the following example, the Server render mode is applied to the `Dialog` comp
 >
 > The preceding syntax will be simplified in an upcoming preview release.
 
-### Prerendering
+## Apply a render mode to a component definition
+
+To specify the render mode for a component as part of its definition, use the [`@attribute` Razor directive](xref:mvc/views/razor#attribute) and the corresponding render mode attribute.
+
+```razor
+@page "{ROUTE}"
+@attribute [RenderModeServer]
+```
+
+Applying a render mode to a component definition is commonly used when applying a render mode to a specific page. Routable pages by default use the same render mode as the router component that rendered the page.
+
+> [!NOTE]
+> Component authors should typically design components to support any render mode or hosting model. Components should avoid assumptions on where they are running (server or client) and should degrade gracefully when rendered statically.
+
+In the preceding example, the `{ROUTE}` placeholder is the route template.
+
+## Prerendering
 
 <!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
 
@@ -176,7 +174,7 @@ For a non-routable, non-page component:
 >
 > The preceding syntax will be simplified in an upcoming preview release.
 
-### Static render mode
+## Static render mode
 
 By default components use the Static render mode. The component renders to the response stream and interactivity isn't enabled.
 
@@ -204,7 +202,7 @@ If using the preceding component locally in a Blazor Web App, place the componen
 > [!NOTE]
 > The anatomy of a basic Razor component is fully explained in the <xref:blazor/fundamentals/index> article. Project structure for apps created by a Blazor template are described in the <xref:blazor/project-structure> article. Detailed components coverage is found in the *Components* articles later in the documentation.
 
-### Server render mode
+## Server render mode
 
 The Server render mode renders the component interactively from the server using Blazor Server. User interactions are handled over a SignalR connection.
 
@@ -230,7 +228,7 @@ In the following example, the render mode is set to Server by adding `@attribute
 
 If using the preceding component locally in a Blazor Web App, place the component in the server-side project's `Components/Pages` folder. The server-side project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
 
-### Client render mode
+## Client render mode
 
 The Client render mode renders the component interactively on the client using Blazor WebAssembly.
 
@@ -256,7 +254,7 @@ In the following example, the render mode is set to use the Blazor WebAssembly h
 
 If using the preceding component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-3` in the browser's address bar.
 
-### Auto render mode
+## Auto render mode
 
 The Auto render mode determines how to render the component at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. The Blazor WebAssembly runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits.
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -62,9 +62,9 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ### Server render mode
 
-Server render mode results in rendering a component on the server with user interactivity.
+Server render mode results in rendering a component on the server with interactivity over a SignalR connection.
 
-In the following example, the render mode is set to use the Blazor Server hosting model with `@attribute [RenderModeServer]`. Therefore, the component is rendered server-side with interactivity over a SignalR connection. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
+In the following example, the render mode is set to use the Blazor Server hosting model with `@attribute [RenderModeServer]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
 
 `RenderMode2.razor`:
 
@@ -88,9 +88,9 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ### Client render mode
 
-Client render mode results in rendering a component on the client with user interactivity.
+Client render mode results in rendering a component on the client with interactivity.
 
-In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. Therefore, the component is rendered client-side with interactivity. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
+In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
 
 `RenderMode3.razor`:
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -33,7 +33,7 @@ To test the render mode behaviors locally, you can place the following component
 
 ## Enable support for interactive render modes
 
-A Blazor Web App must be configured to support interactive render modes. The following extensions are automatically applied to apps created from the [*Blazor Web App* project template](xref:blazor/tooling) when either or both of server-side component interactivity and client-side component interactivity are enabled during app creation. Individual components are still required to declare their render mode per the [*Render modes*](#render-modes) section after the component services and endpoints are configured in the app's `Program` file.
+A Blazor Web App must be configured to support interactive render modes. The following extensions are automatically applied to apps created from the *Blazor Web App* project template during app creation. Individual components are still required to declare their render mode per the [*Render modes*](#render-modes) section after the component services and endpoints are configured in the app's `Program` file.
 
 Services for Razor components are added by calling <xref:Microsoft.Extensions.DependencyInjection.RazorComponentsServiceCollectionExtensions.AddRazorComponents%2A>.
 
@@ -57,55 +57,45 @@ Endpoint convention builder extensions:
     <xref:Microsoft.AspNetCore.Builder.WebAssemblyRazorComponentsEndpointConventionBuilderExtensions.AddWebAssemblyRenderMode%2A>
 -->
 
+> [!NOTE]
+> For orientation on the placement of the API in the following examples, inspect the `Program` file of an app generated from the Blazor Web App project template. For guidance on how to create a Blazor Web App, see <xref:blazor/tooling>.
+
 Example 1: The following `Program` file API adds services and a render mode for Razor components with only server-side rendering support:
 
 ```csharp
-...
-
 builder.Services.AddRazorComponents()
     .AddServerComponents();
-    
+```
 
-...
-
+```csharp
 app.MapRazorComponents<App>()
     .AddServerRenderMode();
-
-...
 ```
 
 Example 2: The following `Program` file API adds services and a render mode for Razor components with only client-side rendering support:
 
 ```csharp
-...
-
 builder.Services.AddRazorComponents()
     .AddWebAssemblyComponents();
+```
 
-...
-
+```csharp
 app.MapRazorComponents<App>()
     .AddWebAssemblyRenderMode();
-
-...
 ```
 
 Example 3: The following `Program` file API adds services and render modes for Razor components with both server-side and client-side rendering support:
 
 ```csharp
-...
-
 builder.Services.AddRazorComponents()
     .AddServerComponents()
     .AddWebAssemblyComponents();
+```
 
-...
-
+```csharp
 app.MapRazorComponents<App>()
     .AddServerRenderMode()
     .AddWebAssemblyRenderMode();
-
-...
 ```
 
 ## Apply a render mode

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -253,9 +253,9 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ## Auto render mode
 
-The Auto render mode determines how to render the component at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. The Blazor WebAssembly runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits.
+The Auto render mode determines how to render the component at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. The .NET runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits.
 
-In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI. Initially, the component is rendered interactively from the server, but on subsequent visits it's rendered from the client after the Blazor WebAssembly runtime and app bundle are downloaded and cached.
+In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI. Initially, the component is rendered interactively from the server, but on subsequent visits it's rendered from the client after the .NET runtime and app bundle are downloaded and cached.
 
 `RenderMode4.razor`:
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -201,7 +201,7 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ## Server render mode
 
-The Server render mode renders the component interactively from the server using Blazor Server. User interactions are handled over a SignalR connection.
+The Server render mode renders the component interactively from the server using Blazor Server. User interactions are handled over a real-time connection with the browser. The circuit connection is established when the Server component is rendered.
 
 In the following example, the render mode is set to Server by adding `@attribute [RenderModeServer]` to the component definition. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI.
 
@@ -227,7 +227,7 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ## Client render mode
 
-The Client render mode renders the component interactively on the client using Blazor WebAssembly.
+The Client render mode renders the component interactively on the client using Blazor WebAssembly. The .NET runtime and app bundle are downloaded when the WebAssembly component is initially rendered and is cached for future use.
 
 In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is rerendered to update the message in the UI.
 
@@ -279,7 +279,16 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ## Render mode propagation
 
-Render modes propagate down the component hierarchy. Consider the following non-routable, non-page `SharedMessage` component for use in other components. The render mode agnostic `SharedMessage` component doesn't apply a render mode with an [`@attribute` directive](xref:mvc/views/razor#attribute).
+Render modes propagate down the component hierarchy.
+
+Rules for applying render modes:
+
+* The default render mode is Static. 
+* The interactive Server, WebAssembly, and Auto render modes can be used from a Static component, including using different render modes for sibling components. 
+* You can't switch to a different interactive render mode in a child component. For example, a Server component can't be a child of a WebAssembly component.
+* Parameters passed to an interactive child component from a Static parent must be JSON serializable. This means that you can't pass render fragments or child content from a Static parent component to an interactive child component.
+
+Consider the following non-routable, non-page `SharedMessage` component for use in other components. The render mode agnostic `SharedMessage` component doesn't apply a render mode with an [`@attribute` directive](xref:mvc/views/razor#attribute).
 
 `SharedMessage.razor`:
 
@@ -319,10 +328,6 @@ In the following example, the `SharedMessage` component is interactive over a Si
 <SharedMessage />
 ```
 
-Additional rules for applying render modes:
-
-* You can't switch to a different interactive render mode in a child component. For example, a Server component can't be a child of a WebAssembly component.
-* Parameters passed to an interactive child component from a Static parent must be JSON serializable. This means that you can't pass render fragments or child content from a Static parent component to an interactive child component.
 
 ## Set the render mode for the entire app
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -286,7 +286,7 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ## Render mode propagation
 
-Render modes propagate down the component hierarchy. Consider the following `SharedMessage` component for use in other components that doesn't indicate a render mode.
+Render modes propagate down the component hierarchy. Consider the following non-routable, non-page `SharedMessage` component for use in other components that doesn't indicate a render mode.
 
 `SharedMessage.razor`:
 
@@ -305,10 +305,10 @@ Render modes propagate down the component hierarchy. Consider the following `Sha
 
 If the `SharedMessage` component is placed in a statically-rendered parent component, the `SharedMessage` component is also rendered statically and isn't interactive. The button doesn't call `UpdateMessage`, and the message isn't updated.
 
-`PassedRenderMode.razor`:
+`PassedRenderMode1.razor`:
 
 ```razor
-@page "/passed-render-mode"
+@page "/passed-render-mode-1"
 
 <SharedMessage />
 ```
@@ -346,7 +346,7 @@ To set the render mode for the entire app, indicate the render mode at the highe
 
 The Blazor router propagates its render mode to the pages it routes. The pages aren't technically child components of the router, but when the routes are discovered at runtime for the router, they inherit the router's render mode.
 
-You also typically need to set the same interactive render mode on the `HeadOutlet` component, also in the `App` component:
+You also typically must set the same interactive render mode on the `HeadOutlet` component, which is also found in the `App` component of a Blazor Web App generated from the project template:
 
 ```
 <HeadOutlet @rendermode="new ServerRenderMode()" />

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -113,7 +113,7 @@ In the preceding example, the `{ROUTE}` placeholder is the route template.
 
 ### Non-routable, non-page components
 
-Typically, non-routable, non-page components are created render mode agnostic. The developer usually applies a render mode to a given component using the [`@rendermode` Razor directive](xref:mvc/views/razor#attribute) on the component instance.
+Typically, non-routable, non-page components don't apply a render mode with an [`@attribute` directive](xref:mvc/views/razor#attribute), which means that they're created render mode agnostic. The developer usually applies the render mode using the [`@rendermode` Razor directive](xref:mvc/views/razor#attribute) where the component is used.
 
 In the following example, the `Dialog` component doesn't specify a render mode. The render mode is applied where the `Dialog` component is used:
 
@@ -276,7 +276,7 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ## Render mode propagation
 
-Render modes propagate down the component hierarchy. Consider the following non-routable, non-page `SharedMessage` component for use in other components that doesn't indicate a render mode.
+Render modes propagate down the component hierarchy. Consider the following non-routable, non-page `SharedMessage` component for use in other components. The render mode agnostic `SharedMessage` component doesn't apply a render mode with an [`@attribute` directive](xref:mvc/views/razor#attribute).
 
 `SharedMessage.razor`:
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -23,7 +23,9 @@ Name | Description | Render location | Interactive
 Static | Static server rendering |  Server  | <span aria-hidden="true">❌</span><span class="visually-hidden">No</span>
 Server | Interactive server rendering using Blazor Server | Server | <span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
 WebAssembly | Interactive client rendering using Blazor WebAssembly | Client | <span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
-Auto | Interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits once download | Server, then client | <span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
+Auto | Interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits after the Blazor bundle is downloaded | Server, then client | <span aria-hidden="true">✔️</span><span class="visually-hidden">Yes</span>
+
+Prerendering is enabled by default for interactive components. Guidance on controlling prerendering is provided later in this article. 
 
 The following examples demonstrate setting the component's render mode with a few basic Razor component features.
 
@@ -110,7 +112,7 @@ app.MapRazorComponents<App>()
 
 ### Routable page components
 
-To specify the render mode for an entire page you need to use the @attribute directive and the corresponding render mode attribute. But since pages are typically defined by app developers, not library authors, it's still the app developer that is in control of the render mode.
+To specify the render mode for an entire page, use the [`@attribute` Razor directive](xref:mvc/views/razor#attribute) and the corresponding render mode attribute. But since pages are typically defined by app developers, not library authors, it's still the app developer that is in control of the render mode.
 
 ```razor
 @page "{ROUTE}"
@@ -121,17 +123,59 @@ In the preceding example, the `{ROUTE}` placeholder is the route template.
 
 ### Non-routable, non-page components
 
-Typically, non-routable, non-page components are created render mode agnostic. The developer usually applies a render mode to a given component using the `@rendermode` directive on the component instance.
+Typically, non-routable, non-page components are created render mode agnostic. The developer usually applies a render mode to a given component using the [`@rendermode` Razor directive](xref:mvc/views/razor#attribute) on the component instance.
 
 In the following example, the `Dialog` component doesn't specify a render mode. The render mode is applied where the `Dialog` component is used:
 
-<!-- UPDATE 8.0 RC2: Remove preview remark update code -->
+<!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
 
 ```razor
 <Dialog @rendermode="new ServerRenderMode()" />
 ```
 
 > [!NOTE]
+> During .NET 8 *Release Candidate 1*, use the following values:
+>
+> Render mode | Value
+> ----------- | -----
+> Server      | `new ServerRenderMode()`
+> WebAssembly | `new WebAssemblyRenderMode()`
+> Auto        | `new AutoRenderMode()`
+>
+> The preceding syntax will be simplified in an upcoming preview release.
+
+### Prerendering
+
+<!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
+
+Prerendering is enabled by default for interactive components.
+
+To disable prerendering, pass the `prerender` flag with a value of `false`.
+
+For a routable page:
+
+```razor
+@page "{ROUTE}"
+@attribute [RenderModeServer(prerender: false)]
+```
+
+In the preceding example, the `{ROUTE}` placeholder is the route template.
+
+For a non-routable, non-page component:
+
+```razor
+<Dialog @rendermode="new ServerRenderMode(prerender: false)" />
+```
+
+> [!NOTE]
+> During .NET 8 *Release Candidate 1*, use the following values:
+>
+> Render mode | Value
+> ----------- | -----
+> Server      | `new ServerRenderMode(prerender: false)`
+> WebAssembly | `new WebAssemblyRenderMode(prerender: false)`
+> Auto        | `new AutoRenderMode(prerender: false)`
+>
 > The preceding syntax will be simplified in an upcoming preview release.
 
 ### Static render mode
@@ -289,7 +333,7 @@ Additional rules for applying render modes:
 
 ## Set the render mode for the entire app
 
-<!-- UPDATE 8.0 RC2: Remove preview remark update code -->
+<!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
 
 To set the render mode for the entire app, indicate the render mode at the highest level component in the app's component hierarchy, typically the `Routes` component (`Components/App.razor`) for apps based on the Blazor Web App project template:
 

--- a/aspnetcore/blazor/fundamentals/render-modes.md
+++ b/aspnetcore/blazor/fundamentals/render-modes.md
@@ -16,14 +16,14 @@ This article explains control of Razor component rendering in Blazor Web Apps, e
 
 Every component in a Blazor Web App adopts a *render mode* to determine the hosting model that it uses, where it's rendered, and whether or not it's interactive.
 
-The following table shows the four potential render mode scenarios for rendering Razor components in a Blazor Web App. The render mode attributes in the *Render mode attribute* column are applied to components with the [`@attribute` Razor directive](xref:mvc/views/razor#attribute). Later in this article, examples are shown for each render mode scenario.
+The following table shows the available render modes for rendering Razor components in a Blazor Web App. To apply a render mode to a component use the `@rendermode` directive on the component instance or use the [`@attribute` Razor directive](xref:mvc/views/razor#attribute) with the corresponding render mode attribute on the component type. Later in this article, examples are shown for each render mode scenario.
 
-Scenario              | Render mode attribute     | Hosting model                             | Render location     | Interactive
+Name | Description  |  Render location     | Interactive
 --------------------- | :-----------------------: | :---------------------------------------: | :-----------------: | :---------:
-Statically-rendered   | None                      | None                                      | Server              | ❌
-Server render mode    | `[RenderModeServer]`      | Blazor Server                             | Server              | ✔️
-Client render mode    | `[RenderModeWebAssembly]` | Blazor WebAssembly                        | Client              | ✔️
-Determined at runtime | `[RenderModeAuto]`        | Blazor Server,<br>then Blazor WebAssembly | Server, then client | ✔️
+Static  | Static server rendering |  Server  | ❌
+Server    | Interactive server rendering using Blazor Server | Server  | ✔️
+WebAssembly | Interactive client rendering using Blazor WebAssembly | Client  | ✔️
+Auto | Interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits once download | Server, then client | ✔️
 
 <!-- HOLD for final commit - We'll use accessible markup for the ❌ and ✔️:
 <span aria-hidden="true">❌</span><span class="visually-hidden">No</span>
@@ -34,9 +34,11 @@ The following examples demonstrate setting the component's render mode with a fe
 
 To test the render mode behaviors locally, you can place the following components in an app created from the *Blazor Web App* project template. When you create the app, select the checkboxes (Visual Studio) or apply the CLI options (.NET CLI) to enable both server-side and client-side interactivity. For guidance on how to create a Blazor Web App, see <xref:blazor/tooling>.
 
-### Statically-rendered on the server without user interactivity
+### Static render mode
 
-In the following example, there's no designation for the component's render mode. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't re-rendered.
+By default components use the Static render mode. The component renders to the response stream and interactivity isn't enabled.
+
+In the following example, there's no designation for the component's render mode. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't re-rendered in response to UI events.
 
 `RenderMode1.razor`:
 
@@ -62,9 +64,9 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ### Server render mode
 
-Server render mode results in rendering a component on the server with interactivity over a SignalR connection.
+The Server render mode renders the component interactively from the server using Blazor Server. User interactions are handled over a SignalR connection.
 
-In the following example, the render mode is set to use the Blazor Server hosting model with `@attribute [RenderModeServer]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
+In the following example, the render mode is set to Server by adding `@attribute [RenderModeServer]` to the component definition. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
 
 `RenderMode2.razor`:
 
@@ -88,7 +90,7 @@ If using the preceding component locally in a Blazor Web App, place the componen
 
 ### Client render mode
 
-Client render mode results in rendering a component on the client with interactivity.
+The Client render mode renders the component interactively on the client using Blazor WebAssembly.
 
 In the following example, the render mode is set to use the Blazor WebAssembly hosting model with `@attribute [RenderModeWebAssembly]`. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI.
 
@@ -112,11 +114,11 @@ In the following example, the render mode is set to use the Blazor WebAssembly h
 
 If using the preceding component locally in a Blazor Web App, place the component in the client-side project's `Pages` folder. The client-side project is the solution's project with a name that ends in `.Client`. When the app is running, navigate to `/render-mode-3` in the browser's address bar.
 
-### Render mode determined at runtime
+### Auto render mode
 
-The render mode can be determined at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. After the Blazor bundle is downloaded to the client and the .NET client-side runtime activates, the component adopts the Blazor WebAssembly hosting model for client-side rendering and interactivity.
+The Auto render mode determines how to render the component at runtime. The component is initially rendered server-side with interactivity using the Blazor Server hosting model. The Blazor WebAssembly runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits.
 
-In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered, either server-side or client-side, to update the message in the UI.
+In the following example, the component is interactive throughout the process. The button calls the `UpdateMessage` method when selected. The value of `message` changes, and the component is re-rendered to update the message in the UI. Initially, the component is rendered interactively from the server, but on subsequent visits it's rendered from the client after the Blazor WebAssembly runtime and app bundle are downloaded and cached.
 
 `RenderMode4.razor`:
 
@@ -189,7 +191,7 @@ If the `SharedMessage` component is placed in a client-rendered component, it ad
 <SharedMessage />
 ```
 
-If the `SharedMessage` component is placed in a dynamically-rendered component, where the render mode is determined at runtime, it adopts server-side rendering initially, then client-side rendering after the component and Blazor bundle are downloaded and the .NET runtime activates on the client. The component is interactive. The button calls `UpdateMessage`, and the message is updated.
+If the `SharedMessage` component is placed in a component using the Auto render mode, it adopts the Auto render mode as well. The component adopts server-side rendering initially, then the component uses client-side rendering after the component and Blazor bundle are downloaded and the .NET runtime activates on the client. The component is interactive. The button calls `UpdateMessage`, and the message is updated.
 
 `PassedRenderMode4.razor`:
 
@@ -217,9 +219,9 @@ To set the render mode for the entire app, indicate the render mode at the highe
 
 In the preceding example, the `{RENDER MODE}` placeholder is the render mode (`[RenderModeServer]`, `[RenderModeWebAssembly]`, or `[RenderModeAuto]`). The render mode propagates down the component hierarchy to all of the components in the app.
 
-## API extensions that support components in Blazor Web Apps
+## Enable support for interactive render modes
 
-The following extensions are automatically applied to apps created from the [*Blazor Web App* project template](xref:blazor/tooling) when either or both of server-side component interactivity and client-side component interactivity are enabled during app creation. Individual components are still required to declare their render mode per the [*Render modes*](#render-modes) section after the component services and endpoints are configured in the app's `Program` file.
+A Blazor Web App must be configured to support interactive render modes. The following extensions are automatically applied to apps created from the [*Blazor Web App* project template](xref:blazor/tooling) when either or both of server-side component interactivity and client-side component interactivity are enabled during app creation. Individual components are still required to declare their render mode per the [*Render modes*](#render-modes) section after the component services and endpoints are configured in the app's `Program` file.
 
 Services for Razor components are added by calling <xref:Microsoft.Extensions.DependencyInjection.RazorComponentsServiceCollectionExtensions.AddRazorComponents%2A>.
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -39,7 +39,7 @@ Blazor is a web framework for building web UI components ([Razor components](xre
 * Determined at runtime, starting with server-side (*Blazor Server*) and switching over to client-side (*Blazor WebAssembly*) after the components, their dependencies, and the .NET runtime are downloaded to the browser.
 
 > [!NOTE]
-> For web-based Blazor apps, a component's hosting model is set by its *render mode*, which is described with examples in the next article, <xref:blazor-render-modes>.
+> For web-based Blazor apps, a component's hosting model is set by its *render mode*, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it, as it relies on an understanding of broader Blazor concepts.
 
 You can also host Razor components in native mobile and desktop apps that render to an embedded Web View control (*Blazor Hybrid*). Regardless of the hosting model, the way you build Razor components *is the same*. The same Razor components can be used with any of the hosting models unchanged.
 
@@ -94,7 +94,7 @@ Blazor WebAssembly (WASM) runs client-side in the browser on a WebAssembly-based
 
 When an app is created that exclusively runs on the Blazor WebAssembly hosting model without server-side rendering and interactivity, the app is called a *standalone* or *static* Blazor WebAssembly app.
 
-An app created with WebAssembly-hosted components in addition to server-hosted components is a *Blazor Web App* with client-side interactivity. More information on setting *render modes* to determine which hosting model is selected by Blazor is provided in the next article, <xref:blazor-render-modes>.
+An app created with WebAssembly-hosted components in addition to server-hosted components is a *Blazor Web App* with client-side interactivity. Guidance on setting the *render mode* to determine a component's hosting model is provided in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it, as it relies on an understanding of broader Blazor concepts.
 
 :::moniker-end
 
@@ -190,7 +190,7 @@ For more information on Microsoft native client frameworks, see the following re
 
 :::moniker range=">= aspnetcore-8.0"
 
-A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in the next article, <xref:blazor-render-modes>. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For static Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
+A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it, as it relies on an understanding of broader Blazor concepts. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For static Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
 
 :::moniker-end
 
@@ -451,6 +451,8 @@ To set a component's hosting model to Blazor Server or Blazor WebAssembly at com
 * <xref:signalr/introduction>
 * <xref:blazor/fundamentals/signalr>
 * <xref:blazor/tutorials/signalr-blazor>
+
+:::moniker-end
 
 :::moniker range="< aspnetcore-6.0"
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -185,7 +185,7 @@ For more information on Microsoft native client frameworks, see the following re
 
 :::moniker range=">= aspnetcore-8.0"
 
-A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/fundamentals/render-modes>. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For standalone Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
+A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/components/render-modes>. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For standalone Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
 
 :::moniker-end
 
@@ -428,7 +428,7 @@ Blazor Hybrid apps are native client apps that typically require an installer an
 
 ## Setting a component's hosting model
 
-To set a component's hosting model to Blazor Server or Blazor WebAssembly at compile-time or dynamically at runtime, you set its *render mode*. Render modes are fully explained and demonstrated in the <xref:blazor/fundamentals/render-modes> article. We don't recommend that you jump from this article directly to the *Render modes* article without reading the content in the articles between these two articles. For example, render modes are more easily understood by looking at Razor component examples, but basic Razor component structure and function isn't covered until the <xref:blazor/fundamentals/index> article is reached. It's also helpful to learn about Blazor's project templates and tooling before working with the component examples in the *Render modes* article.
+To set a component's hosting model to Blazor Server or Blazor WebAssembly at compile-time or dynamically at runtime, you set its *render mode*. Render modes are fully explained and demonstrated in the <xref:blazor/components/render-modes> article. We don't recommend that you jump from this article directly to the *Render modes* article without reading the content in the articles between these two articles. For example, render modes are more easily understood by looking at Razor component examples, but basic Razor component structure and function isn't covered until the <xref:blazor/fundamentals/index> article is reached. It's also helpful to learn about Blazor's project templates and tooling before working with the component examples in the *Render modes* article.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -36,9 +36,9 @@ Blazor is a web framework for building web UI components ([Razor components](xre
 
 * Server-side in ASP.NET Core (*Blazor Server* or statically rendered).
 * Client-side in the browser on a [WebAssembly](https://webassembly.org/)-based .NET runtime (*Blazor WebAssembly*).
-* Blazor Hybrid to build native client apps.
+* Client-side in a native mobile or desktop app that renders components to an embedded Web View control (*Blazor Hybrid*).
 
-You can also host Razor components in native mobile and desktop apps that render to an embedded Web View control (*Blazor Hybrid*). Regardless of the hosting model, the way you build Razor components *is the same*. The same Razor components can be used with any of the hosting models unchanged.
+Regardless of the hosting model, the way you build Razor components *is the same*. The same Razor components can be used with any of the hosting models unchanged.
 
 :::moniker-end
 
@@ -134,9 +134,9 @@ The .NET [Intermediate Language (IL)](/dotnet/standard/glossary#il) interpreter 
 
 :::moniker range=">= aspnetcore-6.0"
 
-Static Blazor WebAssembly apps support ahead-of-time (AOT) compilation, where you can compile your .NET code directly into WebAssembly. AOT compilation results in runtime performance improvements at the expense of a larger app size. For more information, see <xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation>. 
+Blazor supports ahead-of-time (AOT) compilation, where you can compile your .NET code directly into WebAssembly. AOT compilation results in runtime performance improvements at the expense of a larger app size. For more information, see <xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation>. 
 
-The same [.NET WebAssembly build tools](xref:blazor/tooling#net-webassembly-build-tools) used for AOT compilation also [relink the .NET WebAssembly runtime](xref:blazor/host-and-deploy/webassembly#runtime-relinking) to trim unused runtime code. Static Blazor also trims unused code from .NET Core framework libraries. The .NET compiler further precompresses a static Blazor WebAssembly app for a smaller app payload.
+The same [.NET WebAssembly build tools](xref:blazor/tooling#net-webassembly-build-tools) used for AOT compilation also [relink the .NET WebAssembly runtime](xref:blazor/host-and-deploy/webassembly#runtime-relinking) to trim unused runtime code. Blazor also trims unused code from .NET framework libraries. The .NET compiler further precompresses a static Blazor WebAssembly app for a smaller app payload.
 
 WebAssembly-rendered Razor components can use [native dependencies](xref:blazor/webassembly-native-dependencies) built to run on WebAssembly.
 
@@ -245,7 +245,7 @@ To create a Blazor Hybrid app, see the articles under <xref:blazor/hybrid/tutori
 
 :::moniker range=">= aspnetcore-8.0"
 
-Components rendered for the Blazor Server hosting model and Blazor Hybrid apps have complete .NET API compatibility, while components rendered for the Blazor WebAssembly hosting model and static Blazor WebAssembly apps are limited to a subset of .NET APIs. When an app's specification requires one or more .NET APIs that are unavailable to WebAssembly-rendered components, then choose to render components for Blazor Server or use Blazor Hybrid.
+Components rendered for the Blazor Server hosting model and Blazor Hybrid apps have complete .NET API compatibility, while components rendered for Blazor WebAssembly are limited to a subset of .NET APIs. When an app's specification requires one or more .NET APIs that are unavailable to WebAssembly-rendered components, then choose to render components for Blazor Server or use Blazor Hybrid.
 
 :::moniker-end
 
@@ -300,7 +300,7 @@ To avoid server-based APIs for Blazor WebAssembly apps, adopt Blazor Server, whi
 
 :::moniker range=">= aspnetcore-8.0"
 
-Components rendered for the Blazor Server hosting model have relatively small payload sizes with faster initial load times. When a fast initial load time is desired, use the Blazor Server hosting model.
+Rendering components from the server reduces the app payload size and improves initial load times. When a fast initial load time is desired, use the Blazor Server hosting model or consider static server rendering.
 
 :::moniker-end
 
@@ -316,7 +316,7 @@ Blazor Server apps have relatively small payload sizes with faster initial load 
 
 Blazor Hybrid apps run using the .NET runtime natively on the target platform, which offers the best possible speed.
 
-Components rendered for the Blazor WebAssembly hosting model, including Progressive Web Apps (PWAs), and standalone Blazor WebAssembly apps run using the .NET runtime for WebAssembly, which is slower than running directly on the platform, even for standalone apps that are [ahead-of-time (AOT) compiled](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) for WebAssembly in the browser.
+Components rendered for the Blazor WebAssembly hosting model, including Progressive Web Apps (PWAs), and standalone Blazor WebAssembly apps run using the .NET runtime for WebAssembly, which is slower than running directly on the platform. Consider using [ahead-of-time (AOT) compiled](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) to improve runtime performance when using Blazor WebAssembly.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -97,9 +97,9 @@ Blazor web apps can use the Blazor WebAssembly hosting model to enable client-si
 
 When the Blazor WebAssembly app is created for deployment without a backend ASP.NET Core app to serve its files, the app is called a *standalone* Blazor WebAssembly app.
 
-When a standalone Blazor WebAssembly app uses a backend ASP.NET Core app to serve its files, the app is called a *hosted* Blazor WebAssembly app. Using hosted Blazor WebAssembly, you get a full-stack web development experience with .NET, including the ability to share code between the client and server apps, support for prerendering, and integration with MVC and Razor Pages. A hosted client app can interact with its backend server app over the network using a variety of messaging frameworks and protocols, such as [web API](xref:web-api/index), [gRPC-web](xref:grpc/index), and [SignalR](xref:signalr/introduction) (<xref:blazor/tutorials/signalr-blazor>).
-
 :::moniker-end
+
+When a standalone Blazor WebAssembly app uses a backend ASP.NET Core app to serve its files, the app is called a *hosted* Blazor WebAssembly app. Using hosted Blazor WebAssembly, you get a full-stack web development experience with .NET, including the ability to share code between the client and server apps, support for prerendering, and integration with MVC and Razor Pages. A hosted client app can interact with its backend server app over the network using a variety of messaging frameworks and protocols, such as [web API](xref:web-api/index), [gRPC-web](xref:grpc/index), and [SignalR](xref:signalr/introduction) (<xref:blazor/tutorials/signalr-blazor>).
 
 :::moniker range=">= aspnetcore-6.0"
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -65,7 +65,7 @@ In a traditional server-rendered app, opening the same app in multiple browser s
 
 ![The browser interacts with Blazor (hosted inside of an ASP.NET Core app) on the server over a SignalR connection.](~/blazor/hosting-models/_static/blazor-server.png)
 
-On the client, the Blazor JavaScript script establishes the SignalR connection with the server. The script is served from an embedded resource in the ASP.NET Core shared framework.
+On the client, the Blazor script establishes the SignalR connection with the server. The script is served from an embedded resource in the ASP.NET Core shared framework.
 
 The Blazor Server hosting model offers several benefits:
 
@@ -94,13 +94,13 @@ Blazor WebAssembly (WASM) runs client-side in the browser on a WebAssembly-based
 
 When an app is created that exclusively runs on the Blazor WebAssembly hosting model without server-side rendering and interactivity, the app is called a *standalone* or *static* Blazor WebAssembly app.
 
-An app created with WebAssembly-hosted components in addition to server-hosted components is a *Blazor Web App* with client-side interactivity. Guidance on setting the *render mode* to determine a component's hosting model is provided in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it, as it relies on an understanding of broader Blazor concepts.
+An app created with WebAssembly-hosted components in addition to server-hosted components is a *Blazor Web App* with client-side interactivity. Guidance on setting the *render mode* to determine a component's hosting model is provided in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it.
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-8.0"
 
-When the Blazor WebAssembly app is created for deployment without a backend ASP.NET Core app to serve its files, the app is called a *standalone* Blazor WebAssembly app.
+When the Blazor WebAssembly app is created for deployment without a backend ASP.NET Core app to serve its files, the app is called a *standalone* or *static* Blazor WebAssembly app.
 
 When the app is created for deployment with a backend app to serve its files, the app is called a *hosted* Blazor WebAssembly app. Using hosted Blazor WebAssembly, you get a full-stack web development experience with .NET, including the ability to share code between the client and server apps, support for prerendering, and integration with MVC and Razor Pages. A hosted client app can interact with its backend server app over the network using a variety of messaging frameworks and protocols, such as [web API](xref:web-api/index), [gRPC-web](xref:grpc/index), and [SignalR](xref:signalr/introduction) (<xref:blazor/tutorials/signalr-blazor>).
 
@@ -112,7 +112,7 @@ A Blazor WebAssembly app built as a [Progressive Web App (PWA)](xref:blazor/prog
 
 :::moniker-end
 
-The Blazor JavaScript script handles:
+The Blazor script handles:
 
 * Downloading the .NET runtime, Razor components, and the component's dependencies.
 * Initialization of the runtime.
@@ -190,7 +190,7 @@ For more information on Microsoft native client frameworks, see the following re
 
 :::moniker range=">= aspnetcore-8.0"
 
-A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it, as it relies on an understanding of broader Blazor concepts. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For static Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
+A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For static Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
 
 :::moniker-end
 
@@ -437,7 +437,7 @@ Blazor Hybrid apps are native client apps that typically require an installer an
 
 ## Setting a component's hosting model
 
-To set a component's hosting model to Blazor Server or Blazor WebAssembly at compile-time or dynamically at runtime, you set its *render mode*. Render modes are fully explained and demonstrated in the <xref:blazor/fundamentals/render-modes> article. We don't recommend that you jump from this article directly to the *Render modes* article without reading the content in the articles between these two articles. For example, render modes are more easily understood using Razor component examples, but basic Razor component anatomy and functioning isn't covered until the <xref:blazor/fundamentals/index> article is reached. It's also helpful to learn about Blazor's project templates and their structure before working with the component examples in the *Render modes* article.
+To set a component's hosting model to Blazor Server or Blazor WebAssembly at compile-time or dynamically at runtime, you set its *render mode*. Render modes are fully explained and demonstrated in the <xref:blazor/fundamentals/render-modes> article. We don't recommend that you jump from this article directly to the *Render modes* article without reading the content in the articles between these two articles. For example, render modes are more easily understood by looking at Razor component examples, but basic Razor component structure and function isn't covered until the <xref:blazor/fundamentals/index> article is reached. It's also helpful to learn about Blazor's project templates and tooling before working with the component examples in the *Render modes* article.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -314,17 +314,13 @@ Blazor Server apps have relatively small payload sizes with faster initial load 
 
 :::moniker range=">= aspnetcore-8.0"
 
-Components rendered for the Blazor Server hosting model generally execute on the server quickly. However, the components are usually slower than other types of apps that execute code natively on the client.
-
 Blazor Hybrid apps run using the .NET runtime natively on the target platform, which offers the best possible speed.
 
-Components rendered for the Blazor WebAssembly hosting model, including Progressive Web Apps (PWAs), and static Blazor WebAssembly apps run using the .NET runtime for WebAssembly, which is slower than running directly on the platform, even for static apps that are [ahead-of-time (AOT) compiled](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) for WebAssembly in the browser.
+Components rendered for the Blazor WebAssembly hosting model, including Progressive Web Apps (PWAs), and standalone Blazor WebAssembly apps run using the .NET runtime for WebAssembly, which is slower than running directly on the platform, even for standalone apps that are [ahead-of-time (AOT) compiled](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) for WebAssembly in the browser.
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
-
-Blazor Server apps generally execute on the server quickly. However, Blazor Server apps are usually slower than other types of apps that execute natively on the client.
 
 Blazor Hybrid apps run using the .NET runtime natively on the target platform, which offers the best possible speed.
 
@@ -334,7 +330,7 @@ Blazor WebAssembly, including Progressive Web Apps (PWAs), apps run using the .N
 
 :::moniker range="< aspnetcore-6.0"
 
-Blazor Server apps generally execute on the server quickly. However, Blazor Server apps are usually slower than other types of apps that execute natively on the client.
+Blazor Server apps generally execute on the server quickly.
 
 Blazor WebAssembly apps run using the .NET runtime for WebAssembly, which is slower than running directly on the platform.
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -36,7 +36,7 @@ Blazor is a web framework for building web UI components ([Razor components](xre
 
 * Server-side in ASP.NET Core (*Blazor Server* or statically rendered).
 * Client-side in the browser on a [WebAssembly](https://webassembly.org/)-based .NET runtime (*Blazor WebAssembly*).
-* Determined at runtime, starting with server-side (*Blazor Server*) and switching over to client-side (*Blazor WebAssembly*) after the components, their dependencies, and the .NET runtime are downloaded to the browser.
+* Blazor Hybrid to build native client apps.
 
 > [!NOTE]
 > For web-based Blazor apps, a component's hosting model is set by its *render mode*, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it, as it relies on an understanding of broader Blazor concepts.

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -18,9 +18,34 @@ NOTE: Daggered lines under the table (&dagger;, &Dagger;) use a double-space at 
 
 -->
 
-This article explains the different Blazor hosting models and how to choose which one to use.
+:::moniker range=">= aspnetcore-8.0"
 
-:::moniker range=">= aspnetcore-6.0"
+This article explains Blazor hosting models, which can be applied in different parts of a Blazor app at either compile time or runtime.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
+This article explains Blazor hosting models and how to choose which one to use.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
+
+Blazor is a web framework for building web UI components ([Razor components](xref:blazor/components/index)) that can be hosted in different ways:
+
+* Server-side in ASP.NET Core (*Blazor Server*).
+* Client-side in the browser on a [WebAssembly](https://webassembly.org/)-based .NET runtime (*Blazor WebAssembly*, *Blazor WASM*).
+* Determined at runtime, starting with server-side (*Blazor Server*) and switching over to client-side (*Blazor WebAssembly*) after the components, their dependencies, and the .NET runtime are downloaded to the browser.
+
+> [!NOTE]
+> For web-based Blazor apps, a component's hosting model is set by its *render mode*, which is described with examples in the next article, <xref:blazor-render-modes>.
+
+You can also host Razor components in native mobile and desktop apps that render to an embedded Web View control (*Blazor Hybrid*). Regardless of the hosting model, the way you build Razor components *is the same*. The same Razor components can be used with any of the hosting models unchanged.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
 Blazor is a web framework for building web UI components ([Razor components](xref:blazor/components/index)) that can be hosted in different ways. Razor components can run server-side in ASP.NET Core (*Blazor Server*) versus client-side in the browser on a [WebAssembly](https://webassembly.org/)-based .NET runtime (*Blazor WebAssembly*, *Blazor WASM*). You can also host Razor components in native mobile and desktop apps that render to an embedded Web View control (*Blazor Hybrid*). Regardless of the hosting model, the way you build Razor components *is the same*. The same Razor components can be used with any of the hosting models unchanged.
 
@@ -34,38 +59,52 @@ Blazor is a web framework for building web UI components ([Razor components](xre
 
 ## Blazor Server
 
-With the Blazor Server hosting model, the app is executed on the server from within an ASP.NET Core app. UI updates, event handling, and JavaScript calls are handled over a [SignalR](xref:signalr/introduction) connection using the [WebSockets protocol](xref:fundamentals/websockets). The state on the server associated with each connected client is called a *circuit*. Circuits aren't tied to a specific network connection and can tolerate temporary network interruptions and attempts by the client to reconnect to the server when the connection is lost.
+With the Blazor Server hosting model, components are executed on the server from within an ASP.NET Core app. UI updates, event handling, and JavaScript calls are handled over a [SignalR](xref:signalr/introduction) connection using the [WebSockets protocol](xref:fundamentals/websockets). The state on the server associated with each connected client is called a *circuit*. Circuits aren't tied to a specific network connection and can tolerate temporary network interruptions and attempts by the client to reconnect to the server when the connection is lost.
 
-In a traditional server-rendered app, opening the same app in multiple browser screens (tabs or `iframes`) typically doesn't translate into additional resource demands on the server. In a Blazor Server app, each browser screen requires a separate circuit and separate instances of server-managed component state. Blazor considers closing a browser tab or navigating to an external URL a *graceful* termination. In the event of a graceful termination, the circuit and associated resources are immediately released. A client may also disconnect non-gracefully, for instance due to a network interruption. Blazor Server stores disconnected circuits for a configurable interval to allow the client to reconnect.
+In a traditional server-rendered app, opening the same app in multiple browser screens (tabs or `iframes`) typically doesn't translate into additional resource demands on the server. For the Blazor Server hosting model, each browser screen requires a separate circuit and separate instances of server-managed component state. Blazor considers closing a browser tab or navigating to an external URL a *graceful* termination. In the event of a graceful termination, the circuit and associated resources are immediately released. A client may also disconnect non-gracefully, for instance due to a network interruption. Blazor Server stores disconnected circuits for a configurable interval to allow the client to reconnect.
 
-![The browser interacts with the app (hosted inside of an ASP.NET Core app) on the server over a SignalR connection.](~/blazor/hosting-models/_static/blazor-server.png)
+![The browser interacts with Blazor (hosted inside of an ASP.NET Core app) on the server over a SignalR connection.](~/blazor/hosting-models/_static/blazor-server.png)
 
-On the client, the Blazor script (`blazor.server.js`) establishes the SignalR connection with the server. The script is served to the client-side app from an embedded resource in the ASP.NET Core shared framework. The client-side app is responsible for persisting and restoring app state as required. 
+On the client, the Blazor JavaScript script establishes the SignalR connection with the server. The script is served from an embedded resource in the ASP.NET Core shared framework.
 
 The Blazor Server hosting model offers several benefits:
 
-* Download size is significantly smaller than a Blazor WebAssembly app, and the app loads much faster.
+* Download size is significantly smaller than when the Blazor WebAssembly hosting model is used, and the app loads much faster.
 * The app takes full advantage of server capabilities, including the use of .NET Core APIs.
 * .NET Core on the server is used to run the app, so existing .NET tooling, such as debugging, works as expected.
-* Thin clients are supported. For example, Blazor Server apps work with browsers that don't support WebAssembly and on resource-constrained devices.
+* Thin clients are supported. For example, Blazor Server works with browsers that don't support WebAssembly and on resource-constrained devices.
 * The app's .NET/C# code base, including the app's component code, isn't served to clients.
 
 The Blazor Server hosting model has the following limitations:
 
 * Higher latency usually exists. Every user interaction involves a network hop.
-* There's no offline support. If the client connection fails, the app stops working.
+* There's no offline support. If the client connection fails, interactivity fails.
 * Scaling apps with many users requires server resources to handle multiple client connections and client state.
 * An ASP.NET Core server is required to serve the app. Serverless deployment scenarios aren't possible, such as serving the app from a Content Delivery Network (CDN).
 
-We recommend using the [Azure SignalR Service](/azure/azure-signalr) for Blazor Server apps. The service allows for scaling up a Blazor Server app to a large number of concurrent SignalR connections.
+We recommend using the [Azure SignalR Service](/azure/azure-signalr) for apps that adopt the Blazor Server hosting model. The service allows for scaling up a Blazor Server app to a large number of concurrent SignalR connections.
 
 ## Blazor WebAssembly
 
-Blazor WebAssembly (WASM) apps run client-side in the browser on a WebAssembly-based .NET runtime. The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser. The app is executed directly on the browser UI thread. UI updates and event handling occur within the same process. The app's assets are deployed as static files to a web server or service capable of serving static content to clients.
+Blazor WebAssembly (WASM) runs client-side in the browser on a WebAssembly-based .NET runtime. Razor components, their dependencies, and the .NET runtime are downloaded to the browser. Components are executed directly on the browser UI thread. UI updates and event handling occur within the same process. Assets are deployed as static files to a web server or service capable of serving static content to clients.
 
-![Blazor WebAssembly: The Blazor app runs on a UI thread inside the browser.](~/blazor/hosting-models/_static/blazor-webassembly.png)
+![Blazor WebAssembly: Blazor runs on a UI thread inside the browser.](~/blazor/hosting-models/_static/blazor-webassembly.png)
 
-When the Blazor WebAssembly app is created for deployment without a backend ASP.NET Core app to serve its files, the app is called a *standalone* Blazor WebAssembly app. When the app is created for deployment with a backend app to serve its files, the app is called a *hosted* Blazor WebAssembly app.
+:::moniker range=">= aspnetcore-8.0"
+
+When an app is created that exclusively runs on the Blazor WebAssembly hosting model without server-side rendering and interactivity, the app is called a *standalone* or *static* Blazor WebAssembly app.
+
+An app created with WebAssembly-hosted components in addition to server-hosted components is a *Blazor Web App* with client-side interactivity. More information on setting *render modes* to determine which hosting model is selected by Blazor is provided in the next article, <xref:blazor-render-modes>.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
+When the Blazor WebAssembly app is created for deployment without a backend ASP.NET Core app to serve its files, the app is called a *standalone* Blazor WebAssembly app.
+
+When the app is created for deployment with a backend app to serve its files, the app is called a *hosted* Blazor WebAssembly app. Using hosted Blazor WebAssembly, you get a full-stack web development experience with .NET, including the ability to share code between the client and server apps, support for prerendering, and integration with MVC and Razor Pages. A hosted client app can interact with its backend server app over the network using a variety of messaging frameworks and protocols, such as [web API](xref:web-api/index), [gRPC-web](xref:grpc/index), and [SignalR](xref:signalr/introduction) (<xref:blazor/tutorials/signalr-blazor>).
+
+:::moniker-end
 
 :::moniker range=">= aspnetcore-6.0"
 
@@ -73,26 +112,24 @@ A Blazor WebAssembly app built as a [Progressive Web App (PWA)](xref:blazor/prog
 
 :::moniker-end
 
-Using hosted Blazor WebAssembly, you get a full-stack web development experience with .NET, including the ability to share code between the client and server apps, support for prerendering, and integration with MVC and Razor Pages. A hosted client app can interact with its backend server app over the network using a variety of messaging frameworks and protocols, such as [web API](xref:web-api/index), [gRPC-web](xref:grpc/index), and [SignalR](xref:signalr/introduction) (<xref:blazor/tutorials/signalr-blazor>).
+The Blazor JavaScript script handles:
 
-The `blazor.webassembly.js` script is provided by the framework and handles:
+* Downloading the .NET runtime, Razor components, and the component's dependencies.
+* Initialization of the runtime.
 
-* Downloading the .NET runtime, the app, and the app's dependencies.
-* Initialization of the runtime to run the app.
+The Blazor WebAssembly hosting model offers several benefits:
 
-The Blazor WebAssembly (WASM) hosting model offers several benefits:
-
-* There's no .NET server-side dependency after the app is downloaded from the server, so the app remains functional if the server goes offline.
+* For static Blazor WebAssembly apps, there's no .NET server-side dependency after the app is downloaded from the server, so the app remains functional if the server goes offline.
 * Client resources and capabilities are fully leveraged.
 * Work is offloaded from the server to the client.
-* An ASP.NET Core web server isn't required to host the app. Serverless deployment scenarios are possible, such as serving the app from a Content Delivery Network (CDN).
+* For static Blazor WebAssembly apps, an ASP.NET Core web server isn't required to host the app. Serverless deployment scenarios are possible, such as serving the app from a Content Delivery Network (CDN).
 
 The Blazor WebAssembly hosting model has the following limitations:
 
-* The app is restricted to the capabilities of the browser.
+* Razor components are restricted to the capabilities of the browser.
 * Capable client hardware and software (for example, WebAssembly support) is required.
-* Download size is larger, and apps take longer to load.
-* The app's code can't be protected from inspection and tampering by users.
+* Download size is larger, and components take longer to load.
+* Code sent to the client can't be protected from inspection and tampering by users.
 
 :::moniker range=">= aspnetcore-8.0"
 
@@ -102,13 +139,11 @@ The .NET [Intermediate Language (IL)](/dotnet/standard/glossary#il) interpreter 
 
 :::moniker range=">= aspnetcore-6.0"
 
-Blazor WebAssembly supports ahead-of-time (AOT) compilation, where you can compile your .NET code directly into WebAssembly. AOT compilation results in runtime performance improvements at the expense of a larger app size. For more information, see <xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation>. 
+Static Blazor WebAssembly apps support ahead-of-time (AOT) compilation, where you can compile your .NET code directly into WebAssembly. AOT compilation results in runtime performance improvements at the expense of a larger app size. For more information, see <xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation>. 
 
-The same [.NET WebAssembly build tools](xref:blazor/tooling#net-webassembly-build-tools) used for AOT compilation also [relink the .NET WebAssembly runtime](xref:blazor/host-and-deploy/webassembly#runtime-relinking) to trim unused runtime code.
+The same [.NET WebAssembly build tools](xref:blazor/tooling#net-webassembly-build-tools) used for AOT compilation also [relink the .NET WebAssembly runtime](xref:blazor/host-and-deploy/webassembly#runtime-relinking) to trim unused runtime code. Static Blazor also trims unused code from .NET Core framework libraries. The .NET compiler further precompresses a static Blazor WebAssembly app for a smaller app payload.
 
-Blazor WebAssembly includes support for trimming unused code from .NET Core framework libraries. For more information, see <xref:blazor/globalization-localization>. The .NET compiler further precompresses a Blazor WebAssembly app for a smaller app payload.
-
-Blazor WebAssembly apps can use [native dependencies](xref:blazor/webassembly-native-dependencies) built to run on WebAssembly.
+WebAssembly-rendered Razor components can use [native dependencies](xref:blazor/webassembly-native-dependencies) built to run on WebAssembly.
 
 :::moniker-end
 
@@ -153,7 +188,17 @@ For more information on Microsoft native client frameworks, see the following re
 
 ## Which Blazor hosting model should I choose?
 
+:::moniker range=">= aspnetcore-8.0"
+
+A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in the next article, <xref:blazor-render-modes>. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For static Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
 Select the Blazor hosting model based on the app's feature requirements. The following table shows the primary considerations for selecting the hosting model.
+
+:::moniker-end
 
 :::moniker range=">= aspnetcore-6.0" 
 
@@ -203,7 +248,13 @@ To create a Blazor Hybrid app, see the articles under <xref:blazor/hybrid/tutori
 
 ### Complete .NET API compatibility
 
-:::moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-8.0"
+
+Components rendered for the Blazor Server hosting model and Blazor Hybrid apps have complete .NET API compatibility, while components rendered for the Blazor WebAssembly hosting model and static Blazor WebAssembly apps are limited to a subset of .NET APIs. When an app's specification requires one or more .NET APIs that are unavailable to WebAssembly-rendered components, then choose to render components for Blazor Server or use Blazor Hybrid.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
 Blazor Server and Blazor Hybrid apps have complete .NET API compatibility, while Blazor WebAssembly apps are limited to a subset of .NET APIs. When an app's specification requires one or more .NET APIs that are unavailable to Blazor WebAssembly apps, then choose Blazor Server or Blazor Hybrid.
 
@@ -217,7 +268,18 @@ Blazor Server apps have complete .NET API compatibility, while Blazor WebAssembl
 
 ### Direct access to server and network resources
 
-:::moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-8.0"
+
+Components rendered for the Blazor Server hosting model have direct access to server and network resources where the app is executing. Because components rendered for the Blazor WebAssembly hosting model, static Blazor WebAssembly apps, and Blazor Hybrid apps execute on a client, they don't have direct access to server and network resources. Components can access server and network resources *indirectly* via protected server-based APIs. Server-based APIs might be available via third-party libraries, packages, and services. Take into account the following considerations:
+
+* Third-party libraries, packages, and services might be costly to implement and maintain, weakly supported, or introduce security risks.
+* If one or more server-based APIs are developed internally by your organization, additional resources are required to build and maintain them.
+
+To avoid server-based APIs for the Blazor WebAssembly hosting model or Blazor Hybrid apps, render components for the Blazor Server hosting model, which can access server and network resources directly.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
 Blazor Server apps have direct access to server and network resources where the app is executing. Because Blazor WebAssembly and Blazor Hybrid apps execute on a client, they don't have direct access to server and network resources. Blazor WebAssembly and Blazor Hybrid apps can access server and network resources *indirectly* via protected server-based APIs. Server-based APIs might be available via third-party libraries, packages, and services. Take into account the following considerations:
 
@@ -241,13 +303,33 @@ To avoid server-based APIs for Blazor WebAssembly apps, adopt Blazor Server, whi
 
 ### Small payload size with fast initial load time
 
+:::moniker range=">= aspnetcore-8.0"
+
+Components rendered for the Blazor Server hosting model have relatively small payload sizes with faster initial load times. When a fast initial load time is desired, adopt rendering for the Blazor Server hosting model.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
 Blazor Server apps have relatively small payload sizes with faster initial load times. When a fast initial load time is desired, adopt Blazor Server.
+
+:::moniker-end
 
 ### Near native execution speed
 
-Blazor Server apps generally execute on the server quickly. However, Blazor Server apps are usually slower than other types of apps that execute natively on the client.
+:::moniker range=">= aspnetcore-8.0"
 
-:::moniker range=">= aspnetcore-6.0"
+Components rendered for the Blazor Server hosting model generally execute on the server quickly. However, the components are usually slower than other types of apps that execute code natively on the client.
+
+Blazor Hybrid apps run using the .NET runtime natively on the target platform, which offers the best possible speed.
+
+Components rendered for the Blazor WebAssembly hosting model, including Progressive Web Apps (PWAs), and static Blazor WebAssembly apps run using the .NET runtime for WebAssembly, which is slower than running directly on the platform, even for static apps that are [ahead-of-time (AOT) compiled](xref:blazor/host-and-deploy/webassembly#ahead-of-time-aot-compilation) for WebAssembly in the browser.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
+
+Blazor Server apps generally execute on the server quickly. However, Blazor Server apps are usually slower than other types of apps that execute natively on the client.
 
 Blazor Hybrid apps run using the .NET runtime natively on the target platform, which offers the best possible speed.
 
@@ -257,13 +339,21 @@ Blazor WebAssembly, including Progressive Web Apps (PWAs), apps run using the .N
 
 :::moniker range="< aspnetcore-6.0"
 
+Blazor Server apps generally execute on the server quickly. However, Blazor Server apps are usually slower than other types of apps that execute natively on the client.
+
 Blazor WebAssembly apps run using the .NET runtime for WebAssembly, which is slower than running directly on the platform.
 
 :::moniker-end
 
 ### App code secure and private on the server
 
-:::moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-8.0"
+
+Maintaining app code securely and privately on the server is a built-in feature of components rendered for the Blazor Server hosting model. Components rendered for the Blazor WebAssembly hosting model, static Blazor WebAssembly apps, and Blazor Hybrid apps can use server-based APIs to access functionality that must be kept private and secure. The considerations for developing and maintaining server-based APIs described in the [Direct access to server and network resources](#direct-access-to-server-and-network-resources) section apply. If the development and maintenance of server-based APIs isn't desirable for maintaining secure and private app code, render components for the Blazor Server hosting model.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
 Maintaining app code securely and privately on the server is a built-in feature of Blazor Server. Blazor WebAssembly and Blazor Hybrid apps can use server-based APIs to access functionality that must be kept private and secure. The considerations for developing and maintaining server-based APIs described in the [Direct access to server and network resources](#direct-access-to-server-and-network-resources) section apply. If the development and maintenance of server-based APIs isn't desirable for maintaining secure and private app code, adopt the Blazor Server hosting model.
 
@@ -277,7 +367,13 @@ Maintaining app code securely and privately on the server is a built-in feature 
 
 ### Run apps offline once downloaded
 
-:::moniker range=">= aspnetcore-6.0"
+:::moniker range=">= aspnetcore-8.0"
+
+Static Blazor WebAssembly apps built as Progressive Web Apps (PWAs) and Blazor Hybrid apps can run offline, which is particularly useful when clients aren't able to connect to the Internet. Components rendered for the Blazor Server hosting model fail to run when the connection to the server is lost. If an app must run offline, static Blazor WebAssembly and Blazor Hybrid are the best choices.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
 Blazor WebAssembly apps built as Progressive Web Apps (PWAs) and Blazor Hybrid apps can run offline, which is particularly useful when clients aren't able to connect to the Internet. Blazor Server apps fail to run when the connection to the server is lost. If an app must run offline, Blazor WebAssembly and Blazor Hybrid are the best choices.
 
@@ -291,15 +387,21 @@ Blazor WebAssembly apps can run offline, which is particularly useful when clien
 
 ### Static site hosting
 
-Static site hosting is possible with Blazor WebAssembly apps because they're downloaded to clients as a set of static files. Blazor WebAssembly apps don't require a server to execute server-side code in order to download and run. Blazor WebAssembly apps can be delivered via a [Content Delivery Network (CDN)](https://developer.mozilla.org/docs/Glossary/CDN) (for example, [Azure CDN](https://azure.microsoft.com/services/cdn/)).
+Static site hosting is possible with static Blazor WebAssembly apps because they're downloaded to clients as a set of static files. Static Blazor WebAssembly apps don't require a server to execute server-side code in order to download and run and can be delivered via a [Content Delivery Network (CDN)](https://developer.mozilla.org/docs/Glossary/CDN) (for example, [Azure CDN](https://azure.microsoft.com/services/cdn/)).
 
 :::moniker range=">= aspnetcore-6.0"
 
-Although Blazor Hybrid apps are compiled into one or more self-contained deployment assets, the assets are usually provided to clients through a third-party app store. If static hosting is an app requirement, select Blazor WebAssembly.
+Although Blazor Hybrid apps are compiled into one or more self-contained deployment assets, the assets are usually provided to clients through a third-party app store. If static hosting is an app requirement, select static Blazor WebAssembly.
 
 :::moniker-end
 
 ### Offloads processing to clients
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
+
+Components rendered for the Blazor WebAssembly hosting model, static Blazor WebAssembly apps, and Blazor Hybrid apps execute on clients and thus offload processing to clients. Components rendered for the Blazor Server hosting model execute on a server, so server resource demand typically increases with the number of users and the amount of processing required per user. When it's possible to offload most or all of an app's processing to clients and the app processes a significant amount of data, Blazor WebAssembly or Blazor Hybrid is the best choice.
+
+:::moniker-end
 
 :::moniker range=">= aspnetcore-6.0"
 
@@ -323,11 +425,19 @@ Blazor Hybrid apps have full access to native client API capabilities via .NET n
 
 ### Web-based deployment
 
-Blazor Server and Blazor WebAssembly are deployed as web apps that are updated on the next app refresh.
+Apps that use either the Blazor Server or Blazor WebAssembly hosting model are deployed as web apps that are updated on the next app refresh.
 
 :::moniker range=">= aspnetcore-6.0"
 
 Blazor Hybrid apps are native client apps that typically require an installer and platform-specific deployment mechanism.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
+
+## Setting a component's hosting model
+
+To set a component's hosting model to Blazor Server or Blazor WebAssembly at compile-time or dynamically at runtime, you set its *render mode*. Render modes are fully explained and demonstrated in the <xref:blazor/fundamentals/render-modes> article. We don't recommend that you jump from this article directly to the *Render modes* article without reading the content in the articles between these two articles. For example, render modes are more easily understood using Razor component examples, but basic Razor component anatomy and functioning isn't covered until the <xref:blazor/fundamentals/index> article is reached. It's also helpful to learn about Blazor's project templates and their structure before working with the component examples in the *Render modes* article.
 
 :::moniker-end
 
@@ -341,8 +451,6 @@ Blazor Hybrid apps are native client apps that typically require an installer an
 * <xref:signalr/introduction>
 * <xref:blazor/fundamentals/signalr>
 * <xref:blazor/tutorials/signalr-blazor>
-
-:::moniker-end
 
 :::moniker range="< aspnetcore-6.0"
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -38,9 +38,6 @@ Blazor is a web framework for building web UI components ([Razor components](xre
 * Client-side in the browser on a [WebAssembly](https://webassembly.org/)-based .NET runtime (*Blazor WebAssembly*).
 * Blazor Hybrid to build native client apps.
 
-> [!NOTE]
-> For web-based Blazor apps, a component's hosting model is set by its *render mode*, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it, as it relies on an understanding of broader Blazor concepts.
-
 You can also host Razor components in native mobile and desktop apps that render to an embedded Web View control (*Blazor Hybrid*). Regardless of the hosting model, the way you build Razor components *is the same*. The same Razor components can be used with any of the hosting models unchanged.
 
 :::moniker-end
@@ -92,7 +89,7 @@ The Blazor WebAssembly hosting model runs components client-side in the browser 
 
 :::moniker range=">= aspnetcore-8.0"
 
-Blazor web apps can use the Blazor WebAssembly hosting model to enable client-side interactivity. When an app is created that exclusively runs on the Blazor WebAssembly hosting model without server-side rendering and interactivity, the app is called a *standalone* Blazor WebAssembly app. Guidance on setting the *render mode* to determine a component's hosting model is provided in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it.
+Blazor web apps can use the Blazor WebAssembly hosting model to enable client-side interactivity. When an app is created that exclusively runs on the Blazor WebAssembly hosting model without server-side rendering and interactivity, the app is called a *standalone* Blazor WebAssembly app.
 
 :::moniker-end
 
@@ -188,7 +185,7 @@ For more information on Microsoft native client frameworks, see the following re
 
 :::moniker range=">= aspnetcore-8.0"
 
-A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For standalone Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
+A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/fundamentals/render-modes>. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For standalone Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
 
 :::moniker-end
 
@@ -347,7 +344,7 @@ Blazor WebAssembly apps run using the .NET runtime for WebAssembly, which is slo
 
 :::moniker range=">= aspnetcore-8.0"
 
-Maintaining app code securely and privately on the server is a built-in feature of components rendered for the Blazor Server hosting model. Components rendered for the Blazor WebAssembly hosting model, static Blazor WebAssembly apps, and Blazor Hybrid apps can use server-based APIs to access functionality that must be kept private and secure. The considerations for developing and maintaining server-based APIs described in the [Direct access to server and network resources](#direct-access-to-server-and-network-resources) section apply. If the development and maintenance of server-based APIs isn't desirable for maintaining secure and private app code, render components for the Blazor Server hosting model.
+Maintaining app code securely and privately on the server is a built-in feature of components rendered for the Blazor Server hosting model. Components rendered using the Blazor WebAssembly or Blazor Hybrid hosting models can use server-based APIs to access functionality that must be kept private and secure. The considerations for developing and maintaining server-based APIs described in the [Direct access to server and network resources](#direct-access-to-server-and-network-resources) section apply. If the development and maintenance of server-based APIs isn't desirable for maintaining secure and private app code, render components for the Blazor Server hosting model.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -34,8 +34,8 @@ This article explains Blazor hosting models and how to choose which one to use.
 
 Blazor is a web framework for building web UI components ([Razor components](xref:blazor/components/index)) that can be hosted in different ways:
 
-* Server-side in ASP.NET Core (*Blazor Server*).
-* Client-side in the browser on a [WebAssembly](https://webassembly.org/)-based .NET runtime (*Blazor WebAssembly*, *Blazor WASM*).
+* Server-side in ASP.NET Core (*Blazor Server* or statically rendered).
+* Client-side in the browser on a [WebAssembly](https://webassembly.org/)-based .NET runtime (*Blazor WebAssembly*).
 * Determined at runtime, starting with server-side (*Blazor Server*) and switching over to client-side (*Blazor WebAssembly*) after the components, their dependencies, and the .NET runtime are downloaded to the browser.
 
 > [!NOTE]
@@ -86,7 +86,7 @@ We recommend using the [Azure SignalR Service](/azure/azure-signalr) for apps th
 
 ## Blazor WebAssembly
 
-Blazor WebAssembly (WASM) runs client-side in the browser on a WebAssembly-based .NET runtime. Razor components, their dependencies, and the .NET runtime are downloaded to the browser. Components are executed directly on the browser UI thread. UI updates and event handling occur within the same process. Assets are deployed as static files to a web server or service capable of serving static content to clients.
+The Blazor WebAssembly hosting model runs components client-side in the browser on a WebAssembly-based .NET runtime. Razor components, their dependencies, and the .NET runtime are downloaded to the browser. Components are executed directly on the browser UI thread. UI updates and event handling occur within the same process. Assets are deployed as static files to a web server or service capable of serving static content to clients.
 
 ![Blazor WebAssembly: Blazor runs on a UI thread inside the browser.](~/blazor/hosting-models/_static/blazor-webassembly.png)
 

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -92,17 +92,15 @@ The Blazor WebAssembly hosting model runs components client-side in the browser 
 
 :::moniker range=">= aspnetcore-8.0"
 
-When an app is created that exclusively runs on the Blazor WebAssembly hosting model without server-side rendering and interactivity, the app is called a *standalone* or *static* Blazor WebAssembly app.
-
-An app created with WebAssembly-hosted components in addition to server-hosted components is a *Blazor Web App* with client-side interactivity. Guidance on setting the *render mode* to determine a component's hosting model is provided in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it.
+Blazor web apps can use the Blazor WebAssembly hosting model to enable client-side interactivity. When an app is created that exclusively runs on the Blazor WebAssembly hosting model without server-side rendering and interactivity, the app is called a *standalone* Blazor WebAssembly app. Guidance on setting the *render mode* to determine a component's hosting model is provided in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it.
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-8.0"
 
-When the Blazor WebAssembly app is created for deployment without a backend ASP.NET Core app to serve its files, the app is called a *standalone* or *static* Blazor WebAssembly app.
+When the Blazor WebAssembly app is created for deployment without a backend ASP.NET Core app to serve its files, the app is called a *standalone* Blazor WebAssembly app.
 
-When the app is created for deployment with a backend app to serve its files, the app is called a *hosted* Blazor WebAssembly app. Using hosted Blazor WebAssembly, you get a full-stack web development experience with .NET, including the ability to share code between the client and server apps, support for prerendering, and integration with MVC and Razor Pages. A hosted client app can interact with its backend server app over the network using a variety of messaging frameworks and protocols, such as [web API](xref:web-api/index), [gRPC-web](xref:grpc/index), and [SignalR](xref:signalr/introduction) (<xref:blazor/tutorials/signalr-blazor>).
+When a standalone Blazor WebAssembly app uses a backend ASP.NET Core app to serve its files, the app is called a *hosted* Blazor WebAssembly app. Using hosted Blazor WebAssembly, you get a full-stack web development experience with .NET, including the ability to share code between the client and server apps, support for prerendering, and integration with MVC and Razor Pages. A hosted client app can interact with its backend server app over the network using a variety of messaging frameworks and protocols, such as [web API](xref:web-api/index), [gRPC-web](xref:grpc/index), and [SignalR](xref:signalr/introduction) (<xref:blazor/tutorials/signalr-blazor>).
 
 :::moniker-end
 
@@ -119,10 +117,10 @@ The Blazor script handles:
 
 The Blazor WebAssembly hosting model offers several benefits:
 
-* For static Blazor WebAssembly apps, there's no .NET server-side dependency after the app is downloaded from the server, so the app remains functional if the server goes offline.
+* For standalone Blazor WebAssembly apps, there's no .NET server-side dependency after the app is downloaded from the server, so the app remains functional if the server goes offline.
 * Client resources and capabilities are fully leveraged.
 * Work is offloaded from the server to the client.
-* For static Blazor WebAssembly apps, an ASP.NET Core web server isn't required to host the app. Serverless deployment scenarios are possible, such as serving the app from a Content Delivery Network (CDN).
+* For standalone Blazor WebAssembly apps, an ASP.NET Core web server isn't required to host the app. Serverless deployment scenarios are possible, such as serving the app from a Content Delivery Network (CDN).
 
 The Blazor WebAssembly hosting model has the following limitations:
 
@@ -190,7 +188,7 @@ For more information on Microsoft native client frameworks, see the following re
 
 :::moniker range=">= aspnetcore-8.0"
 
-A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For static Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
+A component's hosting model is set by its *render mode*, either at compile time or runtime, which is described with examples in <xref:blazor/fundamentals/render-modes>. We recommend waiting to read the *Render modes* article until after you've read the articles leading up to it. The following table shows the primary considerations for setting the render mode to determine a component's hosting model. For standalone Blazor WebAssembly apps, all of the app's components are rendered on the client with the Blazor WebAssembly hosting model.
 
 :::moniker-end
 
@@ -270,12 +268,12 @@ Blazor Server apps have complete .NET API compatibility, while Blazor WebAssembl
 
 :::moniker range=">= aspnetcore-8.0"
 
-Components rendered for the Blazor Server hosting model have direct access to server and network resources where the app is executing. Because components rendered for the Blazor WebAssembly hosting model, static Blazor WebAssembly apps, and Blazor Hybrid apps execute on a client, they don't have direct access to server and network resources. Components can access server and network resources *indirectly* via protected server-based APIs. Server-based APIs might be available via third-party libraries, packages, and services. Take into account the following considerations:
+Components rendered for the Blazor Server hosting model have direct access to server and network resources where the app is executing. Because components hosted using Blazor WebAssembly or Blazor Hybrid execute on a client, they don't have direct access to server and network resources. Components can access server and network resources *indirectly* via protected server-based APIs. Server-based APIs might be available via third-party libraries, packages, and services. Take into account the following considerations:
 
 * Third-party libraries, packages, and services might be costly to implement and maintain, weakly supported, or introduce security risks.
 * If one or more server-based APIs are developed internally by your organization, additional resources are required to build and maintain them.
 
-To avoid server-based APIs for the Blazor WebAssembly hosting model or Blazor Hybrid apps, render components for the Blazor Server hosting model, which can access server and network resources directly.
+Use the Blazor Server hosting model to avoid the need to expose APIs from the server environment.
 
 :::moniker-end
 
@@ -305,7 +303,7 @@ To avoid server-based APIs for Blazor WebAssembly apps, adopt Blazor Server, whi
 
 :::moniker range=">= aspnetcore-8.0"
 
-Components rendered for the Blazor Server hosting model have relatively small payload sizes with faster initial load times. When a fast initial load time is desired, adopt rendering for the Blazor Server hosting model.
+Components rendered for the Blazor Server hosting model have relatively small payload sizes with faster initial load times. When a fast initial load time is desired, use the Blazor Server hosting model.
 
 :::moniker-end
 
@@ -369,7 +367,7 @@ Maintaining app code securely and privately on the server is a built-in feature 
 
 :::moniker range=">= aspnetcore-8.0"
 
-Static Blazor WebAssembly apps built as Progressive Web Apps (PWAs) and Blazor Hybrid apps can run offline, which is particularly useful when clients aren't able to connect to the Internet. Components rendered for the Blazor Server hosting model fail to run when the connection to the server is lost. If an app must run offline, static Blazor WebAssembly and Blazor Hybrid are the best choices.
+Standalone Blazor WebAssembly apps built as Progressive Web Apps (PWAs) and Blazor Hybrid apps can run offline, which is particularly useful when clients aren't able to connect to the Internet. Components rendered for the Blazor Server hosting model fail to run when the connection to the server is lost. If an app must run offline, static Blazor WebAssembly and Blazor Hybrid are the best choices.
 
 :::moniker-end
 
@@ -387,11 +385,11 @@ Blazor WebAssembly apps can run offline, which is particularly useful when clien
 
 ### Static site hosting
 
-Static site hosting is possible with static Blazor WebAssembly apps because they're downloaded to clients as a set of static files. Static Blazor WebAssembly apps don't require a server to execute server-side code in order to download and run and can be delivered via a [Content Delivery Network (CDN)](https://developer.mozilla.org/docs/Glossary/CDN) (for example, [Azure CDN](https://azure.microsoft.com/services/cdn/)).
+Static site hosting is possible with standalone Blazor WebAssembly apps because they're downloaded to clients as a set of static files. Standalone Blazor WebAssembly apps don't require a server to execute server-side code in order to download and run and can be delivered via a [Content Delivery Network (CDN)](https://developer.mozilla.org/docs/Glossary/CDN) (for example, [Azure CDN](https://azure.microsoft.com/services/cdn/)).
 
 :::moniker range=">= aspnetcore-6.0"
 
-Although Blazor Hybrid apps are compiled into one or more self-contained deployment assets, the assets are usually provided to clients through a third-party app store. If static hosting is an app requirement, select static Blazor WebAssembly.
+Although Blazor Hybrid apps are compiled into one or more self-contained deployment assets, the assets are usually provided to clients through a third-party app store. If static hosting is an app requirement, select standalone Blazor WebAssembly.
 
 :::moniker-end
 
@@ -399,7 +397,7 @@ Although Blazor Hybrid apps are compiled into one or more self-contained deploym
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
-Components rendered for the Blazor WebAssembly hosting model, static Blazor WebAssembly apps, and Blazor Hybrid apps execute on clients and thus offload processing to clients. Components rendered for the Blazor Server hosting model execute on a server, so server resource demand typically increases with the number of users and the amount of processing required per user. When it's possible to offload most or all of an app's processing to clients and the app processes a significant amount of data, Blazor WebAssembly or Blazor Hybrid is the best choice.
+Components rendered using the Blazor WebAssembly or Blazor Hybrid hosting models execute on clients and thus offload processing to clients. Components rendered for the Blazor Server hosting model execute on a server, so server resource demand typically increases with the number of users and the amount of processing required per user. When it's possible to offload most or all of an app's processing to clients and the app processes a significant amount of data, Blazor WebAssembly or Blazor Hybrid is the best choice.
 
 :::moniker-end
 
@@ -425,7 +423,7 @@ Blazor Hybrid apps have full access to native client API capabilities via .NET n
 
 ### Web-based deployment
 
-Apps that use either the Blazor Server or Blazor WebAssembly hosting model are deployed as web apps that are updated on the next app refresh.
+Blazor web apps are updated on the next app refresh from the browser.
 
 :::moniker range=">= aspnetcore-6.0"
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -738,9 +738,11 @@ When set to `false` (default), whitespace in the rendered markup from Razor comp
 
 Sets the render mode of a Razor component:
 
-* `Server`: Interactive server rendering using Blazor Server.
-* `WebAssembly`: Interactive client rendering using Blazor WebAssembly.
-* `Auto`: Interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits after the Blazor bundle is downloaded.
+* `Server`: Applies interactive server rendering using Blazor Server.
+* `WebAssembly`: Applies interactive client rendering using Blazor WebAssembly.
+* `Auto`: Initially applies interactive client rendering using Blazor Server, and then applies interactive client rendering using WebAssembly on subsequent visits after the Blazor bundle is downloaded.
+
+The following example sets the Server render mode to a `Dialog` component:
 
 ```razor
 <Dialog @rendermode="new ServerRenderMode()" />

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -745,13 +745,13 @@ Sets the render mode of a Razor component:
 The following example sets the Server render mode to a `Dialog` component:
 
 ```razor
-<Dialog @rendermode="new ServerRenderMode()" />
+<Dialog @rendermode="@RenderMode.Server" />
 ```
 
 To disable prerendering, pass the `prerender` flag with a value of `false`:
 
 ```razor
-<Dialog @rendermode="new ServerRenderMode(prerender: false)" />
+<Dialog @rendermode="@(new ServerRenderMode(prerender: false))" />
 ```
 
 > [!NOTE]
@@ -759,9 +759,9 @@ To disable prerendering, pass the `prerender` flag with a value of `false`:
 >
 > Render mode | Value
 > ----------- | -----
-> Server      | `new ServerRenderMode()` or `new ServerRenderMode(prerender: false)`
-> WebAssembly | `new WebAssemblyRenderMode()` or `new WebAssemblyRenderMode(prerender: false)`
-> Auto        | `new AutoRenderMode()` or `new AutoRenderMode(prerender: false)`
+> Server      | `@RenderMode.Server` or `@(new ServerRenderMode(prerender: false))`
+> WebAssembly | `@RenderMode.WebAssembly` or `@(new WebAssemblyRenderMode(prerender: false))`
+> Auto        | `@RenderMode.Auto` or `@(new AutoRenderMode(prerender: false))`
 >
 > The preceding syntax will be simplified in an upcoming preview release.
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -728,6 +728,45 @@ When set to `false` (default), whitespace in the rendered markup from Razor comp
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-8.0"
+
+### `@rendermode`
+
+*This scenario only applies to Razor components (`.razor`).*
+
+<!-- UPDATE 8.0 RC2: Remove preview remark and update code -->
+
+Sets the render mode of a Razor component:
+
+* `Server`: Interactive server rendering using Blazor Server.
+* `WebAssembly`: Interactive client rendering using Blazor WebAssembly.
+* `Auto`: Interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits after the Blazor bundle is downloaded.
+
+```razor
+<Dialog @rendermode="new ServerRenderMode()" />
+```
+
+To disable prerendering, pass the `prerender` flag with a value of `false`:
+
+```razor
+<Dialog @rendermode="new ServerRenderMode(prerender: false)" />
+```
+
+> [!NOTE]
+> During .NET 8 *Release Candidate 1*, use the following values:
+>
+> Render mode | Value
+> ----------- | -----
+> Server      | `new ServerRenderMode()` or `new ServerRenderMode(prerender: false)`
+> WebAssembly | `new WebAssemblyRenderMode()` or `new WebAssemblyRenderMode(prerender: false)`
+> Auto        | `new AutoRenderMode()` or `new AutoRenderMode(prerender: false)`
+>
+> The preceding syntax will be simplified in an upcoming preview release.
+
+For more information, see <xref:blazor/fundamentals/render-modes>.
+
+:::moniker-end
+
 ### `@section`
 
 *This scenario only applies to MVC views and Razor Pages (`.cshtml`).*

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -765,7 +765,7 @@ To disable prerendering, pass the `prerender` flag with a value of `false`:
 >
 > The preceding syntax will be simplified in an upcoming preview release.
 
-For more information, see <xref:blazor/fundamentals/render-modes>.
+For more information, see <xref:blazor/components/render-modes>.
 
 :::moniker-end
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -60,7 +60,15 @@ For more information on the new Blazor Web App template, see the following artic
 
 ### Enhanced navigation and form handling
 
-Static server rendering typically performs a full page refresh whenever the user navigates to a new page or submits a form. In .NET 8, Blazor can enhance page navigations and form handling by intercepting the request and performing a fetch request instead. Blazor then handles the rendered response content by patching it into the browser DOM. Enhanced navigation and form handling avoids the need for a full page refresh and preserves more of the page state, so pages load faster and more smoothly. Enhanced navigation and form handling are enabled by default for static server rendered pages when the Blazor script (`blazor.web.js`) is loaded.
+Static server rendering typically performs a full page refresh whenever the user navigates to a new page or submits a form. In .NET 8, Blazor can enhance page navigation and form handling by intercepting the request and performing a fetch request instead. Blazor then handles the rendered response content by patching it into the browser DOM. Enhanced navigation and form handling avoids the need for a full page refresh and preserves more of the page state, so pages load faster and more smoothly. Enhanced navigation and form handling are enabled by default for static server rendered pages when the Blazor script (`blazor.web.js`) is loaded.
+
+### Support for multiple forms and antiforgery
+
+With new form handling features for multiple forms on a page, a request is handled by the form with the matching form handler name with per-form model binding and form validation. Also in this release, standard HTML forms based on a plain HTML `<form>` element with server-side rendering is supported without using an `EditForm`.
+
+New antiforgery support is included in .NET 8. A new `AntiforgeryToken` component renders an antiforgery token as a hidden field, and the new `[RequireAntiforgeryToken]` attribute enables antiforgery protection. If an antiforgery check fails, a 400 (Bad Request) response is returned without form processing. The new antiforgery features are enabled by default for forms based on `Editform` and can be applied manually to standard HTML forms.
+
+For more information, see <xref:blazor/forms-and-input-components?view=aspnetcore-8.0&preserve-view=true>.
 
 ### Streaming rendering
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -136,7 +136,7 @@ The *Jiterpreter* is a new runtime feature in .NET 8 that enables partial Just-i
 For more information, see the following:
 
 * [Improved Blazor WebAssembly performance with the Jiterpreter (.NET Blog)](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-2/#improved-blazor-webassembly-performance-with-the-jiterpreter)
-* <xref:/blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#ahead-of-time-aot-compilation>
+* <xref:blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#ahead-of-time-aot-compilation>
 
 ### Ahead-of-time (AOT) SIMD and exception handling
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -72,7 +72,7 @@ Static server rendering typically performs a full page refresh whenever the user
 
 ### Streaming rendering
 
-You can now stream content updates on the response stream when using server-side rendering with Blazor. Streaming rendering can improve the user experience for pages that perform long-running asynchronous tasks in order to fully render.
+You can now stream content updates on the response stream when using static server rendering with Blazor. Streaming rendering can improve the user experience for pages that perform long-running asynchronous tasks in order to fully render by rendering content as soon as it's available.
 
 For example, to render a page you might need to make a long running database query or an API call. Normally, asynchronous tasks executed as part of rendering a page must complete before the rendered response is sent, which can delay loading the page. Streaming rendering initially renders the entire page with placeholder content while asynchronous operations execute. After the asynchronous operations are complete, the updated content is sent to the client on the same response connection and patched by into the DOM. The benefit of this approach is that the main layout of the app renders as quickly as possible and the page is updated as soon as the content is ready.
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -58,10 +58,6 @@ For more information on the new Blazor Web App template, see the following artic
 * <xref:blazor/tooling?view=aspnetcore-8.0&pivots=windows&preserve-view=true>
 * <xref:blazor/project-structure?view=aspnetcore-8.0&preserve-view=true>
 
-### Enhanced navigation and form handling
-
-Static server rendering typically performs a full page refresh whenever the user navigates to a new page or submits a form. In .NET 8, Blazor can enhance page navigation and form handling by intercepting the request and performing a fetch request instead. Blazor then handles the rendered response content by patching it into the browser DOM. Enhanced navigation and form handling avoids the need for a full page refresh and preserves more of the page state, so pages load faster and more smoothly. Enhanced navigation is enabled by default when the Blazor script (`blazor.web.js`) is loaded. Enhanced form handling can be optionally enabled for specific forms.
-
 ### Form handling and model binding
 
 Blazor components can now handle submitted form requests, including model binding and validating the request data. Components can implement forms with separate form handlers using the standard HTML `<form>` tag or using the existing `EditForm` component.
@@ -69,6 +65,10 @@ Blazor components can now handle submitted form requests, including model bindin
 New antiforgery support is included in .NET 8. A new `AntiforgeryToken` component renders an antiforgery token as a hidden field, and the new `[RequireAntiforgeryToken]` attribute enables antiforgery protection. If an antiforgery check fails, a 400 (Bad Request) response is returned without form processing. The new antiforgery features are enabled by default for forms based on `Editform` and can be applied manually to standard HTML forms.
 
 For more information, see <xref:blazor/forms-and-input-components?view=aspnetcore-8.0&preserve-view=true>.
+
+### Enhanced navigation and form handling
+
+Static server rendering typically performs a full page refresh whenever the user navigates to a new page or submits a form. In .NET 8, Blazor can enhance page navigation and form handling by intercepting the request and performing a fetch request instead. Blazor then handles the rendered response content by patching it into the browser DOM. Enhanced navigation and form handling avoids the need for a full page refresh and preserves more of the page state, so pages load faster and more smoothly. Enhanced navigation is enabled by default when the Blazor script (`blazor.web.js`) is loaded. Enhanced form handling can be optionally enabled for specific forms.
 
 ### Streaming rendering
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -35,7 +35,7 @@ This article is under development and not complete. More information may be foun
 
 With the release of .NET 8, Blazor is a full-stack web UI framework for developing apps that render content at either the component or page level with:
 
-* Static server-side rendering to generate static HTML.
+* Static server rendering to generate static HTML.
 * Interactive server rendering using the Blazor Server hosting model.
 * Interactive client rendering using the Blazor WebAssembly hosting model.
 * Automatic interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits after the Blazor bundle is downloaded and the .NET WebAssembly runtime activates. Automatic rendering usually provides the fastest app startup experience.
@@ -46,12 +46,12 @@ For more information, see <xref:blazor/components/render-modes?view=aspnetcore-8
 
 ### New Blazor Web App template
 
-We've introduced a new Blazor project template: the *Blazor Web App* template. The new template provides a single starting point for using Blazor components to build any style of web UI. The template combines the strengths of the existing Blazor Server and Blazor WebAssembly hosting models with the new Blazor capabilities added in .NET 8: server-side rendering, streaming rendering, enhanced navigation and form handling, and the ability to add interactivity using either Blazor Server or Blazor WebAssembly on a per-component basis.
+We've introduced a new Blazor project template: the *Blazor Web App* template. The new template provides a single starting point for using Blazor components to build any style of web UI. The template combines the strengths of the existing Blazor Server and Blazor WebAssembly hosting models with the new Blazor capabilities added in .NET 8: static server rendering, streaming rendering, enhanced navigation and form handling, and the ability to add interactivity using either Blazor Server or Blazor WebAssembly on a per-component basis.
 
 As part of unifying the various Blazor hosting models into a single model in .NET 8, we're also consolidating the number of Blazor project templates. We removed the Blazor Server template, and the ASP.NET Core Hosted option has been removed from the Blazor WebAssembly template. Both of these scenarios are represented by options when using the Blazor Web App template.
 
 > [!NOTE]
-> Hosted Blazor WebAssembly remains supported in .NET 8 or later, and existing hosted Blazor WebAssembly apps can be upgraded to use .NET 8 or later API and features.
+> Existing Blazor Server and Blazor WebAssembly apps remain supported in .NET 8. Optionally, these apps can be  updated to use the new full-stack web UI Blazor features.
 
 For more information on the new Blazor Web App template, see the following articles:
 
@@ -60,11 +60,7 @@ For more information on the new Blazor Web App template, see the following artic
 
 ### Enhanced navigation and form handling
 
-With new form handling features for multiple forms on a page, a request is handled by the form with the matching form handler name with per-form model binding and form validation. Also in this release, standard HTML forms based on a plain HTML `<form>` element with server-side rendering is supported without using an `EditForm`.
-
-New antiforgery support is included in .NET 8. A new `AntiforgeryToken` component renders an antiforgery token as a hidden field, and the new `[RequireAntiforgeryToken]` attribute enables antiforgery protection. If an antiforgery check fails, a 400 (Bad Request) response is returned without form processing. The new antiforgery features are enabled by default for forms based on `Editform` and can be applied manually to standard HTML forms.
-
-For more information, see <xref:blazor/forms-and-input-components?view=aspnetcore-8.0&preserve-view=true>.
+Static server rendering typically performs a full page refresh whenever the user navigates to a new page or submits a form. In .NET 8, Blazor can enhance page navigations and form handling by intercepting the request and performing a fetch request instead. Blazor then handles the rendered response content by patching it into the browser DOM. Enhanced navigation and form handling avoids the need for a full page refresh and preserves more of the page state, so pages load faster and more smoothly. Enhanced navigation and form handling are enabled by default for static server rendered pages when the Blazor script (`blazor.web.js`) is loaded.
 
 ### Streaming rendering
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -23,6 +23,8 @@ This article is under development and not complete. More information may be foun
 * [What's new in .NET 8 Preview 7](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-7/)
 <!--
 * [What's new in .NET 8 Release Candidate 1](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-rc-1/)
+* [What's new in .NET 8 Release Candidate 2](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-rc-2/)
+* [Announcing ASP.NET Core in .NET 8](https://devblogs.microsoft.com/dotnet/announcing-asp-net-core-in-dotnet-8/)
 -->
 
 [!INCLUDE [](~/includes/preview-notice.md)]
@@ -31,22 +33,25 @@ This article is under development and not complete. More information may be foun
 
 ### Full-stack web UI
 
-<!-- TODO ... I'll write this up on Monday morning -->
+With the release of .NET 8, Blazor is a full-stack web UI framework for developing apps that render content at either the component or page level with:
 
-* Server-side rendering (SSR) and client-side rendering (CSR) with interactivity per component or page
-* Auto-switch between Server and WebAssembly execution for fast startup
-* Generate static HTML with components
+* Static server-side rendering to generate static HTML.
+* Interactive server rendering using the Blazor Server hosting model.
+* Interactive client rendering using the Blazor WebAssembly hosting model.
+* Automatic interactive client rendering using Blazor Server initially and then WebAssembly on subsequent visits after the Blazor bundle is downloaded and the .NET WebAssembly runtime activates. Automatic rendering usually provides the fastest app startup experience.
+
+Interactive render modes also prerender content by default.
 
 For more information, see <xref:blazor/components/render-modes?view=aspnetcore-8.0&preserve-view=true>.
 
 ### New Blazor Web App template
 
-We've introduced a new Blazor project template: the *Blazor Web App* template. This new template provides a single starting point for using Blazor components to build any style of web UI, both server-side rendered and client-side rendered. It combines the strengths of the existing Blazor Server and Blazor WebAssembly hosting models with the new Blazor capabilities added in .NET 8: server-side rendering, streaming rendering, enhanced navigation and form handling, and the ability to add interactivity using either Blazor Server or Blazor WebAssembly on a per-component basis.
+We've introduced a new Blazor project template: the *Blazor Web App* template. The new template provides a single starting point for using Blazor components to build any style of web UI. The template combines the strengths of the existing Blazor Server and Blazor WebAssembly hosting models with the new Blazor capabilities added in .NET 8: server-side rendering, streaming rendering, enhanced navigation and form handling, and the ability to add interactivity using either Blazor Server or Blazor WebAssembly on a per-component basis.
 
-As part of unifying the various Blazor hosting models into a single model in .NET 8, we're also consolidating the number of Blazor project templates. We've removed the Blazor Server template, and the ASP.NET Core Hosted option has been removed from the Blazor WebAssembly template. Both of these scenarios are represented by options when using the new Blazor Web App template.
+As part of unifying the various Blazor hosting models into a single model in .NET 8, we're also consolidating the number of Blazor project templates. We removed the Blazor Server template, and the ASP.NET Core Hosted option has been removed from the Blazor WebAssembly template. Both of these scenarios are represented by options when using the Blazor Web App template.
 
 > [!NOTE]
-> Hosted Blazor WebAssembly is still supported in .NET 8 or later, and existing hosted Blazor WebAssembly apps can be upgraded to use .NET 8 or later API, features, and runtimes.
+> Hosted Blazor WebAssembly remains supported in .NET 8 or later, and existing hosted Blazor WebAssembly apps can be upgraded to use .NET 8 or later API and features.
 
 For more information on the new Blazor Web App template, see the following articles:
 
@@ -55,21 +60,34 @@ For more information on the new Blazor Web App template, see the following artic
 
 ### Enhanced navigation and form handling
 
-With new form handling features for multiple forms on a page, a request is handled by the form with the matching form handler name with per-form model binding and form validation.
+With new form handling features for multiple forms on a page, a request is handled by the form with the matching form handler name with per-form model binding and form validation. Also in this release, standard HTML forms based on a plain HTML `<form>` element with server-side rendering is supported without using an `EditForm`.
+
+New antiforgery support is included in .NET 8. A new `AntiforgeryToken` component renders an antiforgery token as a hidden field, and the new `[RequireAntiforgeryToken]` attribute enables antiforgery protection. If an antiforgery check fails, a 400 (Bad Request) response is returned without form processing. The new antiforgery features are enabled by default for forms based on `Editform` and can be applied manually to standard HTML forms.
 
 For more information, see <xref:blazor/forms-and-input-components?view=aspnetcore-8.0&preserve-view=true>.
 
 ### Streaming rendering
 
-You can now stream content updates on the response stream when using server-side rendering (SSR) with Blazor in .NET 8. Streaming rendering can improve the user experience for server-side rendered pages that need to perform long-running async tasks in order to render fully.
+You can now stream content updates on the response stream when using server-side rendering with Blazor. Streaming rendering can improve the user experience for pages that perform long-running asynchronous tasks in order to fully render.
 
-For example, to render a page you might need to make a long running database query or an API call. Normally all async tasks executed as part of rendering a page must complete before the rendered response can be sent, which can delay loading the page. Streaming rendering initially renders the entire page with placeholder content while async operations execute. Once the async operations completes, the updated content is sent to the client on the same response connection and then patched by Blazor into the DOM. The benefit of this approach is that the main layout of the app renders as quickly as possible and the page is updated as soon as the content is ready.
+For example, to render a page you might need to make a long running database query or an API call. Normally, asynchronous tasks executed as part of rendering a page must complete before the rendered response is sent, which can delay loading the page. Streaming rendering initially renders the entire page with placeholder content while asynchronous operations execute. After the asynchronous operations are complete, the updated content is sent to the client on the same response connection and patched by into the DOM. The benefit of this approach is that the main layout of the app renders as quickly as possible and the page is updated as soon as the content is ready.
 
 For more information, see <xref:blazor/components/rendering?view=aspnetcore-8.0&preserve-view=true#streaming-rendering>.
 
+<!-- UPDATE 8.0
+
+RC2
+
+### Blazor interactive server rendering APIs for accessing `HttpContext`
+
+Issue: https://github.com/dotnet/aspnetcore/issues/48769
+PR: https://github.com/dotnet/aspnetcore/pull/50253
+
+-->
+
 ### Render Razor components outside of ASP.NET Core
 
-A convenient side-effect of the work to enable server-side rendering with Razor components is that you can now render Razor components outside the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for a generated email, or even for generating static site content.
+A convenient side-effect of the work to enable server-side rendering is that you can now render Razor components outside the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for a generating email or static site content.
 
 For more information, see <xref:blazor/components/render-outside-of-aspnetcore?view=aspnetcore-8.0&preserve-view=true>.
 
@@ -89,25 +107,42 @@ For more information, see <xref:blazor/components/quickgrid?view=aspnetcore-8.0&
 
 ### Route to named elements
 
-Blazor now supports using client-side routing to navigate to a specific HTML element on a page using standard URL fragments. If you specify an identifier for an HTML element using the standard id attribute, Blazor correctly scrolls to that element when the URL fragment matches the element identifier.
+Blazor now supports using client-side routing to navigate to a specific HTML element on a page using standard URL fragments. If you specify an identifier for an HTML element using the standard `id` attribute, Blazor correctly scrolls to that element when the URL fragment matches the element identifier.
 
 For more information, see <xref:blazor/fundamentals/routing?view=aspnetcore-8.0&preserve-view=true#hashed-routing-to-named-elements>.
 
-### Monitor Blazor Server circuit activity
+### Root-level cascading values
 
-You can now monitor inbound circuit activity in Blazor Server apps using the new `CreateInboundActivityHandler` method on `CircuitHandler`. Inbound circuit activity is any activity sent from the browser to the server, such as UI events or JavaScript-to-.NET interop calls.
+Root-level cascading values can be registered for the entire component hierarchy. Named cascading values and subscriptions for update notifications are supported.
+
+For more information, see <xref:blazor/components/cascading-values-and-parameters?view=aspnetcore-8.0&preserve-view=true#root-level-cascading-values>.
+
+### Virtualize empty content
+
+Use the new `EmptyContent` parameter to supply content when the component has loaded and either `Items` is empty or `ItemsProviderResult<T>.TotalItemCount` is zero.
+
+For more information, see <xref:blazor/components/virtualization?view=aspnetcore-8.0&preserve-view=true#empty-content>.
+
+### Monitor SignalR circuit activity
+
+You can now monitor inbound circuit activity in server-side apps using the new `CreateInboundActivityHandler` method on `CircuitHandler`. Inbound circuit activity is any activity sent from the browser to the server, such as UI events or JavaScript-to-.NET interop calls.
 
 For more information, see <xref:blazor/fundamentals/signalr?view=aspnetcore-8.0&preserve-view=true#monitor-server-side-circuit-activity>.
 
 ### Faster runtime performance with the Jiterpreter
 
-The Jiterpreter is a new runtime feature in .NET 8 that enables partial JIT support in the .NET IL interpreter to achieve improved runtime performance.
+The *Jiterpreter* is a new runtime feature in .NET 8 that enables partial Just-in-Time (JIT) support in the .NET Intermediate Language (IL) interpreter to achieve improved runtime performance.
 
-For more information, see [Improved Blazor WebAssembly performance with the jiterpreter (.NET Blog)](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-2/#improved-blazor-webassembly-performance-with-the-jiterpreter).
+For more information, see the following:
+
+* [Improved Blazor WebAssembly performance with the Jiterpreter (.NET Blog)](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-2/#improved-blazor-webassembly-performance-with-the-jiterpreter)
+* <xref:/blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#ahead-of-time-aot-compilation>
 
 ### Ahead-of-time (AOT) SIMD and exception handling
 
-WebAssembly Single Instruction, Multiple Data (SIMD) can improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction. SIMD is enabled by default for all major browsers. AOT exception handling is also enabled by default.
+WebAssembly Single Instruction, Multiple Data (SIMD) can improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction. SIMD is enabled by default for all major browsers.
+
+New AOT exception handling is also enabled by default.
 
 For more information, see the following:
 
@@ -116,13 +151,13 @@ For more information, see the following:
 
 ### Web-friendly Webcil packaging
 
-Webcil is web-friendly packaging of .NET assemblies that removes any content specific to native Windows execution to avoid issues when deploying to environments that block the download or use of `.dll` files. Webcil is enabled by default for Blazor WebAssembly apps.
+Webcil is web-friendly packaging of .NET assemblies that removes content specific to native Windows execution to avoid issues when deploying to environments that block the download or use of `.dll` files. Webcil is enabled by default for Blazor WebAssembly apps.
 
 For more information, see <xref:blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#webcil-packaging-format-for-net-assemblies>.
 
 ### Blazor WebAssembly debugging
 
-When debugging .NET on WebAssembly, the debugger will now download symbol data from symbol locations that are configured in Visual Studio preferences. This improves the debugging experience for apps that use NuGet packages.
+When debugging .NET on WebAssembly, the debugger now downloads symbol data from symbol locations that are configured in Visual Studio preferences. This improves the debugging experience for apps that use NuGet packages.
 
 You can now debug Blazor WebAssembly apps using Firefox. Debugging Blazor WebAssembly apps requires configuring the browser for remote debugging and then connecting to the browser using the browser developer tools through the .NET WebAssembly debugging proxy. Debugging Firefox from Visual Studio isn't supported at this time.
 
@@ -133,6 +168,56 @@ For more information, see <xref:blazor/debug?view=aspnetcore-8.0&preserve-view=t
 Blazor WebAssembly no longer requires enabling the `unsafe-eval` script source when specifying a Content Security Policy (CSP).
 
 For more information, see <xref:blazor/security/content-security-policy?view=aspnetcore-8.0&preserve-view=true>.
+
+### Handle caught exceptions outside of a Razor component's lifecycle
+
+Use `ComponentBase.DispatchExceptionAsync` in a Razor component to process exceptions thrown outside of the component's lifecycle call stack. This permits the component's code to treat exceptions as though they're lifecycle method exceptions. Thereafter, Blazor's error handling mechanisms, such as error boundaries, can process exceptions.
+
+For more information, see <xref:blazor/fundamentals/handle-errors?view=aspnetcore-8.0&preserve-view=true#handle-caught-exceptions-outside-of-a-razor-components-lifecycle>.
+
+<!-- UPDATE 8.0
+
+RC1
+
+### API for enhanced page refresh
+
+Coverage TBD
+
+* Issue: https://github.com/dotnet/aspnetcore/issues/49414
+* PR: https://github.com/dotnet/aspnetcore/issues/50014
+
+For more information, see <xref:>.
+
+-->
+
+<!-- UPDATE 8.0
+
+RC1
+
+### Configure .NET WebAssembly runtime
+
+Coverage TBD
+
+* Issue: https://github.com/dotnet/aspnetcore/issues/49264
+* PR: https://github.com/dotnet/aspnetcore/pull/49420
+
+For more information, see <xref:>.
+
+-->
+
+### Configuration of connection timeouts in `HubConnectionBuilder`
+
+Prior workarounds for configuring hub connection timeouts can be replaced with formal SignalR hub connection builder timeout configuration.
+
+For more information, see the following:
+
+* <xref:blazor/fundamentals/signalr?view=aspnetcore-8.0&preserve-view=true#configure-signalr-timeouts-and-keep-alive-on-the-client>
+* <xref:blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#global-deployment-and-connection-failures>
+* <xref:blazor/host-and-deploy/server?view=aspnetcore-8.0&preserve-view=true#global-deployment-and-connection-failures>
+
+### Project templates shed Open Iconic
+
+[Open Iconic](https://github.com/iconic/open-iconic) on GitHub has been abandoned by its maintainers, so project templates for .NET 8 or later adopt Bootstrap for app icons.
 
 ## SignalR
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn about the new features in ASP.NET Core 8.0.
 ms.author: riande
 ms.custom: mvc
-ms.date: 9/8/2023
+ms.date: 9/10/2023
 uid: aspnetcore-8
 ---
 # What's new in ASP.NET Core 8.0
@@ -20,15 +20,119 @@ This article is under development and not complete. More information may be foun
 * [What's new in .NET 8 Preview 4](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-4/)
 * [What's new in .NET 8 Preview 5](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-5/)
 * [What's new in .NET 8 Preview 6](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-6/)
-<!--
 * [What's new in .NET 8 Preview 7](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-7/)
+<!--
+* [What's new in .NET 8 Release Candidate 1](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-rc-1/)
 -->
 
 [!INCLUDE [](~/includes/preview-notice.md)]
 
-<!--
 ## Blazor
--->
+
+### Full-stack web UI
+
+<!-- TODO ... I'll write this up on Monday morning -->
+
+* Server-side rendering (SSR) and client-side rendering (CSR) with interactivity per component or page
+* Auto-switch between Server and WebAssembly execution for fast startup
+* Generate static HTML with components
+
+For more information, see <xref:blazor/components/render-modes?view=aspnetcore-8.0&preserve-view=true>.
+
+### New Blazor Web App template
+
+We've introduced a new Blazor project template: the *Blazor Web App* template. This new template provides a single starting point for using Blazor components to build any style of web UI, both server-side rendered and client-side rendered. It combines the strengths of the existing Blazor Server and Blazor WebAssembly hosting models with the new Blazor capabilities added in .NET 8: server-side rendering, streaming rendering, enhanced navigation and form handling, and the ability to add interactivity using either Blazor Server or Blazor WebAssembly on a per-component basis.
+
+As part of unifying the various Blazor hosting models into a single model in .NET 8, we're also consolidating the number of Blazor project templates. We've removed the Blazor Server template, and the ASP.NET Core Hosted option has been removed from the Blazor WebAssembly template. Both of these scenarios are represented by options when using the new Blazor Web App template.
+
+> [!NOTE]
+> Hosted Blazor WebAssembly is still supported in .NET 8 or later, and existing hosted Blazor WebAssembly apps can be upgraded to use .NET 8 or later API, features, and runtimes.
+
+For more information on the new Blazor Web App template, see the following articles:
+
+* <xref:blazor/tooling?view=aspnetcore-8.0&pivots=windows&preserve-view=true>
+* <xref:blazor/project-structure?view=aspnetcore-8.0&preserve-view=true>
+
+### Enhanced navigation and form handling
+
+With new form handling features for multiple forms on a page, a request is handled by the form with the matching form handler name with per-form model binding and form validation.
+
+For more information, see <xref:blazor/forms-and-input-components?view=aspnetcore-8.0&preserve-view=true>.
+
+### Streaming rendering
+
+You can now stream content updates on the response stream when using server-side rendering (SSR) with Blazor in .NET 8. Streaming rendering can improve the user experience for server-side rendered pages that need to perform long-running async tasks in order to render fully.
+
+For example, to render a page you might need to make a long running database query or an API call. Normally all async tasks executed as part of rendering a page must complete before the rendered response can be sent, which can delay loading the page. Streaming rendering initially renders the entire page with placeholder content while async operations execute. Once the async operations completes, the updated content is sent to the client on the same response connection and then patched by Blazor into the DOM. The benefit of this approach is that the main layout of the app renders as quickly as possible and the page is updated as soon as the content is ready.
+
+For more information, see <xref:blazor/components/rendering?view=aspnetcore-8.0&preserve-view=true#streaming-rendering>.
+
+### Render Razor components outside of ASP.NET Core
+
+A convenient side-effect of the work to enable server-side rendering with Razor components is that you can now render Razor components outside the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for a generated email, or even for generating static site content.
+
+For more information, see <xref:blazor/components/render-outside-of-aspnetcore?view=aspnetcore-8.0&preserve-view=true>.
+
+### Sections support
+
+The new `SectionOutlet` and `SectionContent` components in Blazor add support for specifying outlets for content that can be filled in later. Sections are often used to define placeholders in layouts that are then filled in by specific pages. Sections are referenced either by a unique name or using a unique object ID.
+
+For more information, see <xref:blazor/components/sections?view=aspnetcore-8.0&preserve-view=true>.
+
+### QuickGrid
+
+The Blazor QuickGrid component is no longer experimental and is now part of the Blazor framework in .NET 8.
+
+QuickGrid is a high performance grid component for displaying data in tabular form. QuickGrid is built to be a simple and convenient way to display your data, while still providing powerful features, such as sorting, filtering, paging, and virtualization.
+
+For more information, see <xref:blazor/components/quickgrid?view=aspnetcore-8.0&preserve-view=true>.
+
+### Route to named elements
+
+Blazor now supports using client-side routing to navigate to a specific HTML element on a page using standard URL fragments. If you specify an identifier for an HTML element using the standard id attribute, Blazor correctly scrolls to that element when the URL fragment matches the element identifier.
+
+For more information, see <xref:https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-8.0&preserve-view=true#hashed-routing-to-named-elements>.
+
+### Monitor Blazor Server circuit activity
+
+You can now monitor inbound circuit activity in Blazor Server apps using the new `CreateInboundActivityHandler` method on `CircuitHandler`. Inbound circuit activity is any activity sent from the browser to the server, such as UI events or JavaScript-to-.NET interop calls.
+
+For more information, see <xref:https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/signalr?view=aspnetcore-8.0&preserve-view=true#monitor-server-side-circuit-activity>.
+
+### Faster runtime performance with the Jiterpreter
+
+The Jiterpreter is a new runtime feature in .NET 8 that enables partial JIT support in the .NET IL interpreter to achieve improved runtime performance.
+
+For more information, see [Improved Blazor WebAssembly performance with the jiterpreter (.NET Blog)](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-2/#improved-blazor-webassembly-performance-with-the-jiterpreter).
+
+### Ahead-of-time (AOT) SIMD and exception handling
+
+WebAssembly Single Instruction, Multiple Data (SIMD) can improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction. SIMD is enabled by default for all major browsers. AOT exception handling is also enabled by default.
+
+For more information, see the following:
+
+[AOT: Single Instruction, Multiple Data (SIMD)](xref:blazor/tooling?view=aspnetcore-8.0&pivots=windows&preserve-view=true#single-instruction-multiple-data-simd)
+[AOT: Exception handling](<xref:blazor/tooling?view=aspnetcore-8.0&pivots=windows&preserve-view=true#exception-handling)
+
+### Web-friendly Webcil packaging
+
+Webcil is web-friendly packaging of .NET assemblies that removes any content specific to native Windows execution to avoid issues when deploying to environments that block the download or use of `.dll` files. Webcil is enabled by default for Blazor WebAssembly apps.
+
+For more information, see <xref:blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#webcil-packaging-format-for-net-assemblies>.
+
+### Blazor WebAssembly debugging
+
+When debugging .NET on WebAssembly, the debugger will now download symbol data from symbol locations that are configured in Visual Studio preferences. This improves the debugging experience for apps that use NuGet packages.
+
+You can now debug Blazor WebAssembly apps using Firefox. Debugging Blazor WebAssembly apps requires configuring the browser for remote debugging and then connecting to the browser using the browser developer tools through the .NET WebAssembly debugging proxy. Debugging Firefox from Visual Studio isn't supported at this time.
+
+For more information, see <xref:blazor/debug?view=aspnetcore-8.0&preserve-view=true#debug-with-firefox>.
+
+### Content Security Policy (CSP) compatibility
+
+Blazor WebAssembly no longer requires enabling the `unsafe-eval` script source when specifying a Content Security Policy (CSP).
+
+For more information, see <xref:blazor/security/content-security-policy?view=aspnetcore-8.0&preserve-view=true>.
 
 ## SignalR
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -91,13 +91,13 @@ For more information, see <xref:blazor/components/quickgrid?view=aspnetcore-8.0&
 
 Blazor now supports using client-side routing to navigate to a specific HTML element on a page using standard URL fragments. If you specify an identifier for an HTML element using the standard id attribute, Blazor correctly scrolls to that element when the URL fragment matches the element identifier.
 
-For more information, see <xref:https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?view=aspnetcore-8.0&preserve-view=true#hashed-routing-to-named-elements>.
+For more information, see <xref:blazor/fundamentals/routing?view=aspnetcore-8.0&preserve-view=true#hashed-routing-to-named-elements>.
 
 ### Monitor Blazor Server circuit activity
 
 You can now monitor inbound circuit activity in Blazor Server apps using the new `CreateInboundActivityHandler` method on `CircuitHandler`. Inbound circuit activity is any activity sent from the browser to the server, such as UI events or JavaScript-to-.NET interop calls.
 
-For more information, see <xref:https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/signalr?view=aspnetcore-8.0&preserve-view=true#monitor-server-side-circuit-activity>.
+For more information, see <xref:blazor/fundamentals/signalr?view=aspnetcore-8.0&preserve-view=true#monitor-server-side-circuit-activity>.
 
 ### Faster runtime performance with the Jiterpreter
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -91,7 +91,7 @@ PR: https://github.com/dotnet/aspnetcore/pull/50253
 
 ### Render Razor components outside of ASP.NET Core
 
-A convenient side-effect of the work to enable server-side rendering is that you can now render Razor components outside the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for a generating email or static site content.
+You can now render Razor components outside the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for a generating email or static site content.
 
 For more information, see <xref:blazor/components/render-outside-of-aspnetcore?view=aspnetcore-8.0&preserve-view=true>.
 
@@ -123,7 +123,7 @@ For more information, see <xref:blazor/components/cascading-values-and-parameter
 
 ### Virtualize empty content
 
-Use the new `EmptyContent` parameter to supply content when the component has loaded and either `Items` is empty or `ItemsProviderResult<T>.TotalItemCount` is zero.
+Use the new `EmptyContent` parameter on the `Virtualize` component to supply content when the component has loaded and either `Items` is empty or `ItemsProviderResult<T>.TotalItemCount` is zero.
 
 For more information, see <xref:blazor/components/virtualization?view=aspnetcore-8.0&preserve-view=true#empty-content>.
 
@@ -135,23 +135,17 @@ For more information, see <xref:blazor/fundamentals/signalr?view=aspnetcore-8.0&
 
 ### Faster runtime performance with the Jiterpreter
 
-The *Jiterpreter* is a new runtime feature in .NET 8 that enables partial Just-in-Time (JIT) support in the .NET Intermediate Language (IL) interpreter to achieve improved runtime performance.
+The *Jiterpreter* is a new runtime feature in .NET 8 that enables partial Just-in-Time (JIT) compilation support when running on WebAssembly to achieve improved runtime performance.
 
-For more information, see the following:
-
-* [Improved Blazor WebAssembly performance with the Jiterpreter (.NET Blog)](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-2/#improved-blazor-webassembly-performance-with-the-jiterpreter)
-* <xref:blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#ahead-of-time-aot-compilation>
-
+For more information, see <xref:blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#ahead-of-time-aot-compilation>.
 ### Ahead-of-time (AOT) SIMD and exception handling
 
-WebAssembly Single Instruction, Multiple Data (SIMD) can improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction. SIMD is enabled by default for all major browsers.
-
-New AOT exception handling is also enabled by default.
+Blazor WebAssembly ahead-of-time (AOT) compilation now uses [WebAssembly Fixed-width SIMD](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) and [WebAssembly Exception handling](https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md) by default to improve runtime performance.
 
 For more information, see the following:
 
 [AOT: Single Instruction, Multiple Data (SIMD)](xref:blazor/tooling?view=aspnetcore-8.0&pivots=windows&preserve-view=true#single-instruction-multiple-data-simd)
-[AOT: Exception handling](<xref:blazor/tooling?view=aspnetcore-8.0&pivots=windows&preserve-view=true#exception-handling)
+[AOT: Exception handling](xref:blazor/tooling?view=aspnetcore-8.0&pivots=windows&preserve-view=true#exception-handling)
 
 ### Web-friendly Webcil packaging
 
@@ -159,7 +153,7 @@ Webcil is web-friendly packaging of .NET assemblies that removes content specifi
 
 For more information, see <xref:blazor/host-and-deploy/webassembly?view=aspnetcore-8.0&preserve-view=true#webcil-packaging-format-for-net-assemblies>.
 
-### Blazor WebAssembly debugging
+### Blazor WebAssembly debugging improvements
 
 When debugging .NET on WebAssembly, the debugger now downloads symbol data from symbol locations that are configured in Visual Studio preferences. This improves the debugging experience for apps that use NuGet packages.
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -62,9 +62,9 @@ For more information on the new Blazor Web App template, see the following artic
 
 Static server rendering typically performs a full page refresh whenever the user navigates to a new page or submits a form. In .NET 8, Blazor can enhance page navigation and form handling by intercepting the request and performing a fetch request instead. Blazor then handles the rendered response content by patching it into the browser DOM. Enhanced navigation and form handling avoids the need for a full page refresh and preserves more of the page state, so pages load faster and more smoothly. Enhanced navigation is enabled by default when the Blazor script (`blazor.web.js`) is loaded. Enhanced form handling can be optionally enabled for specific forms.
 
-### Support for multiple forms and antiforgery
+### Form handling and model binding
 
-With new form handling features for multiple forms on a page, a request is handled by the form with the matching form handler name with per-form model binding and form validation. Also in this release, standard HTML forms based on a plain HTML `<form>` element with server-side rendering is supported without using an `EditForm`.
+Blazor components can now handle submitted form requests, including model binding and validating the request data. Components can implement forms with separate form handlers using the standard HTML `<form>` tag or using the existing `EditForm` component.
 
 New antiforgery support is included in .NET 8. A new `AntiforgeryToken` component renders an antiforgery token as a hidden field, and the new `[RequireAntiforgeryToken]` attribute enables antiforgery protection. If an antiforgery check fails, a 400 (Bad Request) response is returned without form processing. The new antiforgery features are enabled by default for forms based on `Editform` and can be applied manually to standard HTML forms.
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -60,7 +60,7 @@ For more information on the new Blazor Web App template, see the following artic
 
 ### Enhanced navigation and form handling
 
-Static server rendering typically performs a full page refresh whenever the user navigates to a new page or submits a form. In .NET 8, Blazor can enhance page navigation and form handling by intercepting the request and performing a fetch request instead. Blazor then handles the rendered response content by patching it into the browser DOM. Enhanced navigation and form handling avoids the need for a full page refresh and preserves more of the page state, so pages load faster and more smoothly. Enhanced navigation and form handling are enabled by default for static server rendered pages when the Blazor script (`blazor.web.js`) is loaded.
+Static server rendering typically performs a full page refresh whenever the user navigates to a new page or submits a form. In .NET 8, Blazor can enhance page navigation and form handling by intercepting the request and performing a fetch request instead. Blazor then handles the rendered response content by patching it into the browser DOM. Enhanced navigation and form handling avoids the need for a full page refresh and preserves more of the page state, so pages load faster and more smoothly. Enhanced navigation is enabled by default when the Blazor script (`blazor.web.js`) is loaded. Enhanced form handling can be optionally enabled for specific forms.
 
 ### Support for multiple forms and antiforgery
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -425,6 +425,8 @@ items:
             items:
               - name: Overview
                 uid: blazor/fundamentals/index
+              - name: Render modes
+                uid: blazor/fundamentals/render-modes
               - name: Routing and navigation
                 uid: blazor/fundamentals/routing
               - name: Configuration

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -425,8 +425,6 @@ items:
             items:
               - name: Overview
                 uid: blazor/fundamentals/index
-              - name: Render modes
-                uid: blazor/fundamentals/render-modes
               - name: Routing and navigation
                 uid: blazor/fundamentals/routing
               - name: Configuration
@@ -449,6 +447,8 @@ items:
             items:
               - name: Overview
                 uid: blazor/components/index
+              - name: Render modes
+                uid: blazor/components/render-modes
               - name: Generic type support
                 uid: blazor/components/generic-type-support
               - name: Synchronization context


### PR DESCRIPTION
Fixes #29861
Fixes #30270
Addresses #28161

## Notes

* This has a *brain dump* 🧠💩 feeling cranking it out so quickly. *Future passes can polish up this turd!* 😆 
* Because I don't have RC1 yet, I had to guess on a few behaviors/scenarios.
* I recommend accessing the *Hosting Models* updates first. New content for render modes flows from it.
* I placed the *Render modes* article in the *Fundamentals* node immediately under the overview because ...
  * Render modes makes the most sense with examples, but we don't even show a component or explain anything about them until the *Fundamentals* node overview is reached. **UPDATE**: I meant beyond the example in the landing page. The first place we get into a fuller explanation is in the *Fundamentals* overview.
  * Render modes activate at the component level with gestures in the component (or hierarchy). It makes sense to present them after the overarching tooling-level and app-level concepts.
  * It could be placed after the *Fundamentals* node and before the *Components* node, but that would mean that render modes wouldn't make sense for any other article in the *Fundamentals* node, where there are a handful of examples that set the render mode.
* I place a cut-'n-paste, fully-working example for ***each*** Render mode scenario. That's a bit easier on the reader than having a single component and modifying it each time because in the WASM and Auto case, the component has to also be moved to the `.Client` project's `Pages` folder. It could go either way, but this fine and perfectly clear. In fact, devs can do the SxS MSBuild talk-style study of looking at what's loading in dev tools in a single app run this way.
* I thought it made sense to leave Blazor Hybrid in the table. I don't detect a problem with it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/30ebc415053f34d119d4bc4d56e075c0d9c729b8/aspnetcore/blazor/components/render-modes.md) | [aspnetcore/blazor/components/render-modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-30279) |
| [aspnetcore/blazor/fundamentals/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/30ebc415053f34d119d4bc4d56e075c0d9c729b8/aspnetcore/blazor/fundamentals/index.md) | [ASP.NET Core Blazor fundamentals](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/index?branch=pr-en-us-30279) |
| [aspnetcore/blazor/hosting-models.md](https://github.com/dotnet/AspNetCore.Docs/blob/30ebc415053f34d119d4bc4d56e075c0d9c729b8/aspnetcore/blazor/hosting-models.md) | [ASP.NET Core Blazor hosting models](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hosting-models?branch=pr-en-us-30279) |
| [aspnetcore/mvc/views/razor.md](https://github.com/dotnet/AspNetCore.Docs/blob/30ebc415053f34d119d4bc4d56e075c0d9c729b8/aspnetcore/mvc/views/razor.md) | [Razor syntax reference for ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/views/razor?branch=pr-en-us-30279) |
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/30ebc415053f34d119d4bc4d56e075c0d9c729b8/aspnetcore/release-notes/aspnetcore-8.0.md) | [aspnetcore/release-notes/aspnetcore-8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-30279) |


<!-- PREVIEW-TABLE-END -->