### PR TITLE
Clarify expected behavior of validation for non-nullable props/params in nullable contexts

### DIFF
--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -101,7 +101,7 @@ public class Person
 }
 ```
 
-If the app was built with `<Nullable>enable</Nullable>`, a missing value for `Name` in a JSON or form post results in a validation error. Use a nullable reference type to allow null or missing values to be specified for the `Name` property:
+If the app was built with `<Nullable>enable</Nullable>`, a missing value for `Name` in a JSON or form post results in a validation error. This may seem contradictory since the `[Required(AllowEmptyStrings = true)]` attribute is implied, but this is expected behavior because [empty strings are converted to null by default](xref:System.ComponentModel.DataAnnotations.DisplayFormatAttribute.ConvertEmptyStringToNull%2A). Use a nullable reference type to allow null or missing values to be specified for the `Name` property:
 
 ```csharp
 public class Person


### PR DESCRIPTION
I [misinterpreted expected behavior](https://github.com/dotnet/AspNetCore.Docs/pull/29000#issuecomment-1712026290) from the docs. Added a sentence to hopefully help clarify the expected behavior.

Also, I can't tell if the xref link will resolve correctly since the preview doesn't generate the link. Copied the xref from [here](https://github.com/dotnet/dotnet-api-docs/blob/6eadf345b36fbfd7b6b3ddd30f7ab717c8239382/xml/System.ComponentModel.DataAnnotations/DisplayFormatAttribute.xml#L225C73-L225C73).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/models/validation.md](https://github.com/dotnet/AspNetCore.Docs/blob/3fd066b609903e1709784a6746f4796f04c309e8/aspnetcore/mvc/models/validation.md) | [Model validation in ASP.NET Core MVC and Razor Pages](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/models/validation?branch=pr-en-us-30286) |

<!-- PREVIEW-TABLE-END -->