### PR TITLE
Clarify that the Blazor templates don't depend on Bootstrap icons

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -215,7 +215,7 @@ For more information, see the following:
 
 ### Project templates shed Open Iconic
 
-[Open Iconic](https://github.com/iconic/open-iconic) on GitHub has been abandoned by its maintainers, so project templates for .NET 8 or later adopt Bootstrap for app icons.
+The Blazor project templates no longer depend on [Open Iconic](https://github.com/iconic/open-iconic) for icons.
 
 ## SignalR
 


### PR DESCRIPTION
We removed Open Iconic from the Blazor templates and initially used the Bootstrap icons, but we've switched to using custom SVG instead.

@guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/4a3152cc5a5c036ab4fc2fee492a0c2069fd558a/aspnetcore/release-notes/aspnetcore-8.0.md) | [What's new in ASP.NET Core 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-30308) |


<!-- PREVIEW-TABLE-END -->