### PR TITLE
Fix broken Create.cshtml.cs page model reference

### DIFF
--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -123,7 +123,7 @@ The `Pages/Customers/Create.cshtml` view file:
 
 The `Pages/Customers/Create.cshtml.cs` page model:
 
-[!code-csharp[](~/razor-pages/index/6.0sample/RazorPagesContacts/Pages/Customers/Create.cshtml.cs?name=snippet)]
+[!code-csharp[](~/razor-pages/index/6.0sample/RazorPagesContacts/Pages/Customers/Create.cshtml.cs?name=snippet_PageModel)]
 
 By convention, the `PageModel` class is called `<PageName>Model` and is in the same namespace as the page.
 


### PR DESCRIPTION
This PR fixes the Create.cshtml.cs page model code snippet which is currently broken on https://learn.microsoft.com/en-us/aspnet/core/razor-pages/?view=aspnetcore-6.0&tabs=visual-studio&source=docs:

<img width="682" alt="image" src="https://github.com/dotnet/AspNetCore.Docs/assets/314326/83072a7f-9382-4d76-a761-81a7983538da">


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/razor-pages/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/06729221460d7fa5a51659e938600b1cccad9f0b/aspnetcore/razor-pages/index.md) | [Introduction to Razor Pages in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/razor-pages/index?branch=pr-en-us-30316) |

<!-- PREVIEW-TABLE-END -->