### PR TITLE
Configure the Blazor WASM runtime

### DIFF
--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -458,6 +458,29 @@ In `wwwroot/index.html`, remove the default SVG round indicator in `<div id="app
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-8.0"
+
+## Configure the .NET WebAssembly runtime
+
+To configure the .NET WebAssembly runtime, use the `configureRuntime` property with the `dotnet` runtime host builder.
+
+The following example sets an environment variable, `CONFIGURE_RUNTIME`, to `true`:
+
+```html
+<script src="{BLAZOR SCRIPT}" autostart="false"></script>
+<script>
+  Blazor.start({
+    configureRuntime: dotnet => {
+      dotnet.withEnvironmentVariable("CONFIGURE_RUNTIME", "true");
+    }
+  });
+</script>
+```
+
+In the preceding example, the `{BLAZOR SCRIPT}` placeholder is the Blazor script path and file name.
+
+:::moniker-end
+
 ## Additional resources
 
 * [Environments: Set the app's environment](xref:blazor/fundamentals/environments)

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -188,20 +188,11 @@ For more information, see <xref:>.
 
 -->
 
-<!-- UPDATE 8.0
+### Configure the .NET WebAssembly runtime
 
-RC1
+The .NET WebAssembly runtime can now be configured for Blazor startup.
 
-### Configure .NET WebAssembly runtime
-
-Coverage TBD
-
-* Issue: https://github.com/dotnet/aspnetcore/issues/49264
-* PR: https://github.com/dotnet/aspnetcore/pull/49420
-
-For more information, see <xref:>.
-
--->
+For more information, see <xref:blazor/fundamentals/startup?view=aspnetcore-8.0&preserve-view=true#configure-the-net-webAssembly-runtime>.
 
 ### Configuration of connection timeouts in `HubConnectionBuilder`
 


### PR DESCRIPTION
Fixes  #30320

Confirm what I called these in case I'm making up my own 🦖 Blazor framework .... ***again!*** 😆

> To configure the .NET WebAssembly runtime, use the `configureRuntime` property with the `dotnet` runtime host builder.

* `configureRuntime` ... a "***property***"?
* `dotnet` ... the "***runtime host builder***"?

@maraf ... I took your test example for the doc coverage. If either you or Pavel have something better for the example, I'm 👂.

Finally, this is used to configure quite a few runtime-y things. I see what looks like an incomplete list at ...

https://github.com/dotnet/aspnetcore/issues/49264#issuecomment-1628483544

What do we want to say about that (or cross-link for it)?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/startup.md](https://github.com/dotnet/AspNetCore.Docs/blob/d6e30fb4244a5cbd6f629e9e7701beb22ed4bb68/aspnetcore/blazor/fundamentals/startup.md) | [ASP.NET Core Blazor startup](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/startup?branch=pr-en-us-30321) |
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/d6e30fb4244a5cbd6f629e9e7701beb22ed4bb68/aspnetcore/release-notes/aspnetcore-8.0.md) | [What's new in ASP.NET Core 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-30321) |


<!-- PREVIEW-TABLE-END -->