### PR TITLE
Update hubcontext.md

### DIFF
--- a/aspnetcore/signalr/hubcontext.md
+++ b/aspnetcore/signalr/hubcontext.md
@@ -21,9 +21,6 @@ The SignalR hub is the core abstraction for sending messages to clients connecte
 
 In ASP.NET Core SignalR, you can access an instance of `IHubContext` via dependency injection. You can inject an instance of `IHubContext` into a controller, middleware, or other DI service. Use the instance to send messages to clients.
 
-> [!NOTE]
-> This differs from ASP.NET 4.x SignalR which used GlobalHost to provide access to the `IHubContext`. ASP.NET Core has a dependency injection framework that removes the need for this global singleton.
-
 ### Inject an instance of `IHubContext` in a controller
 
 You can inject an instance of `IHubContext` into a controller by adding it to your constructor:


### PR DESCRIPTION
History lessons should be in a history doc, not in the primary doc. You can move this to a topic that compares classic SignalR to Core. I'm sure the list is extensive.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/signalr/hubcontext.md](https://github.com/dotnet/AspNetCore.Docs/blob/4da5370a1ba4ce971fe4a5ace8895c54ffdca023/aspnetcore/signalr/hubcontext.md) | [Send messages from outside a hub](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/hubcontext?branch=pr-en-us-30347) |

<!-- PREVIEW-TABLE-END -->