### PR TITLE
Note VS for Mac EOL

### DIFF
--- a/aspnetcore/includes/net-prereqs-mac-6.0.md
+++ b/aspnetcore/includes/net-prereqs-mac-6.0.md
@@ -1,1 +1,3 @@
 * [Visual Studio 2022 for Mac latest preview](https://visualstudio.microsoft.com/vs/mac/preview/)
+
+  [!INCLUDE[](~/includes/vs-mac-eol.md)]

--- a/aspnetcore/includes/net-prereqs-mac-7.0.md
+++ b/aspnetcore/includes/net-prereqs-mac-7.0.md
@@ -1,1 +1,3 @@
 * [Visual Studio 2022 for Mac](https://visualstudio.microsoft.com/vs/mac/)
+
+  [!INCLUDE[](~/includes/vs-mac-eol.md)]

--- a/aspnetcore/includes/net-prereqs-mac-8.0.md
+++ b/aspnetcore/includes/net-prereqs-mac-8.0.md
@@ -1,2 +1,4 @@
 * [Visual Studio 2022 for Mac (latest version)](https://visualstudio.microsoft.com/vs/mac/)
   * In Visual Studio 2022 for Mac, select **Tools** > **Preferences...** > **Preview Features** and enable **Use the .NET 8 SDK if installed (requires restart)**.
+
+[!INCLUDE [](~/includes/vs-mac-eol.md)]

--- a/aspnetcore/includes/net-prereqs-mac-8.0.md
+++ b/aspnetcore/includes/net-prereqs-mac-8.0.md
@@ -1,2 +1,5 @@
 * [Visual Studio 2022 for Mac (latest version)](https://visualstudio.microsoft.com/vs/mac/)
   * In Visual Studio 2022 for Mac, select **Tools** > **Preferences...** > **Preview Features** and enable **Use the .NET 8 SDK if installed (requires restart)**.
+
+  [!INCLUDE[](~/includes/vs-mac-eol.md)]
+

--- a/aspnetcore/includes/net-prereqs-mac-8.0.md
+++ b/aspnetcore/includes/net-prereqs-mac-8.0.md
@@ -1,4 +1,2 @@
 * [Visual Studio 2022 for Mac (latest version)](https://visualstudio.microsoft.com/vs/mac/)
   * In Visual Studio 2022 for Mac, select **Tools** > **Preferences...** > **Preview Features** and enable **Use the .NET 8 SDK if installed (requires restart)**.
-
-[!INCLUDE [](~/includes/vs-mac-eol.md)]

--- a/aspnetcore/includes/vs-mac-eol.md
+++ b/aspnetcore/includes/vs-mac-eol.md
@@ -1,0 +1,14 @@
+---
+author: tdykstra
+ms.author: tdykstra
+ms.date: 09/15/2023
+ms.topic: include
+---
+> [!IMPORTANT]
+> Microsoft has announced the retirement of Visual Studio for Mac. Visual Studio for Mac will no longer be supported starting August 31, 2024. Alternatives include:
+>
+> * Visual Studio Code with the [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) and related extensions, such as [.NET MAUI](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-maui) and [Unity](https://marketplace.visualstudio.com/items?itemName=visualstudiotoolsforunity.vstuc).
+> * Visual Studio IDE running on Windows in a VM on Mac.
+> * Visual Studio IDE running on Windows in a [VM in the Cloud](https://aka.ms/devbox).
+>
+> For more information, see [Visual Studio for Mac retirement announcement](https://devblogs.microsoft.com/visualstudio/visual-studio-for-mac-retirement-announcement).

--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -595,7 +595,7 @@ The preceding commands solve most browser trust issues. If the browser is still 
 
 * Delete the *C:\Users\{USER}\AppData\Roaming\ASP.NET\Https* folder.
 * Clean the solution. Delete the *bin* and *obj* folders.
-* Restart the development tool. For example, Visual Studio, Visual Studio Code, or Visual Studio for Mac.
+* Restart the development tool. For example, Visual Studio or Visual Studio Code.
 
 ### Windows - certificate not trusted
 

--- a/aspnetcore/test/razor-pages-tests.md
+++ b/aspnetcore/test/razor-pages-tests.md
@@ -176,7 +176,7 @@ In the `Assert` step, the actual messages (`actualMessages`) are assigned from t
 
 [!code-csharp[](razor-pages-tests/samples/3.x/tests/RazorPagesTestSample.Tests/UnitTests/IndexPageTests.cs?name=snippet3)]
 
-Other tests in this group create page model objects that include the <xref:Microsoft.AspNetCore.Http.DefaultHttpContext>, the <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary>, an <xref:Microsoft.AspNetCore.Mvc.ActionContext> to establish the `PageContext`, a `ViewDataDictionary`, and a `PageContext`. These are useful in conducting tests. For example, the message app establishes a `ModelState` error with <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary.AddModelError*> to check that a valid <xref:Microsoft.AspNetCore.Mvc.RazorPages.PageResult> is returned when `OnPostAddMessageAsync` is executed:
+Other tests in this group create page model objects that include the <xref:Microsoft.AspNetCore.Http.DefaultHttpContext>, the <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary>, an <xref:Microsoft.AspNetCore.Mvc.ActionContext> to establish the `PageContext`, a `ViewDataDictionary`, and a `PageContext`. These are useful in conducting tests. For example, the message app establishes a `ModelState` error with <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary.AddModelError%2A> to check that a valid <xref:Microsoft.AspNetCore.Mvc.RazorPages.PageResult> is returned when `OnPostAddMessageAsync` is executed:
 
 [!code-csharp[](razor-pages-tests/samples/3.x/tests/RazorPagesTestSample.Tests/UnitTests/IndexPageTests.cs?name=snippet4&highlight=11,26,29,32)]
 
@@ -217,7 +217,7 @@ The sample project is composed of two apps:
 | Message app | *src/RazorPagesTestSample*         | Allows a user to add a message, delete one message, delete all messages, and analyze messages (find the average number of words per message). |
 | Test app    | *tests/RazorPagesTestSample.Tests* | Used to unit test the DAL and Index page model of the message app. |
 
-The tests can be run using the built-in test features of an IDE such as [Visual Studio](/visualstudio/test/unit-test-your-code). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesTestSample.Tests* folder:
+The tests can be run using the built-in test features of an IDE, such as [Visual Studio](/visualstudio/test/unit-test-your-code). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesTestSample.Tests* folder:
 
 ```dotnetcli
 dotnet test
@@ -359,7 +359,7 @@ In the `Assert` step, the actual messages (`actualMessages`) are assigned from t
 
 [!code-csharp[](razor-pages-tests/samples/2.x/tests/RazorPagesTestSample.Tests/UnitTests/IndexPageTests.cs?name=snippet3)]
 
-Other tests in this group create page model objects that include the <xref:Microsoft.AspNetCore.Http.DefaultHttpContext>, the <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary>, an <xref:Microsoft.AspNetCore.Mvc.ActionContext> to establish the `PageContext`, a `ViewDataDictionary`, and a `PageContext`. These are useful in conducting tests. For example, the message app establishes a `ModelState` error with <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary.AddModelError*> to check that a valid <xref:Microsoft.AspNetCore.Mvc.RazorPages.PageResult> is returned when `OnPostAddMessageAsync` is executed:
+Other tests in this group create page model objects that include the <xref:Microsoft.AspNetCore.Http.DefaultHttpContext>, the <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary>, an <xref:Microsoft.AspNetCore.Mvc.ActionContext> to establish the `PageContext`, a `ViewDataDictionary`, and a `PageContext`. These are useful in conducting tests. For example, the message app establishes a `ModelState` error with <xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary.AddModelError%2A> to check that a valid <xref:Microsoft.AspNetCore.Mvc.RazorPages.PageResult> is returned when `OnPostAddMessageAsync` is executed:
 
 [!code-csharp[](razor-pages-tests/samples/2.x/tests/RazorPagesTestSample.Tests/UnitTests/IndexPageTests.cs?name=snippet4&highlight=11,26,29,32)]
 

--- a/aspnetcore/test/razor-pages-tests.md
+++ b/aspnetcore/test/razor-pages-tests.md
@@ -34,7 +34,7 @@ The sample project is composed of two apps:
 | Message app | *src/RazorPagesTestSample*         | Allows a user to add a message, delete one message, delete all messages, and analyze messages (find the average number of words per message). |
 | Test app    | *tests/RazorPagesTestSample.Tests* | Used to unit test the DAL and Index page model of the message app. |
 
-The tests can be run using the built-in test features of an IDE, such as [Visual Studio](/visualstudio/test/unit-test-your-code) or [Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesTestSample.Tests* folder:
+The tests can be run using the built-in test features of an IDE, such as [Visual Studio](/visualstudio/test/unit-test-your-code). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesTestSample.Tests* folder:
 
 ```dotnetcli
 dotnet test
@@ -187,7 +187,6 @@ Other tests in this group create page model objects that include the <xref:Micro
 * [Unit Test Your Code](/visualstudio/test/unit-test-your-code) (Visual Studio)
 * <xref:test/integration-tests>
 * [xUnit.net](https://github.com/xunit/xunit)
-* [Building a complete .NET Core solution on macOS using Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution)
 * [Getting started with xUnit.net: Using .NET Core with the .NET SDK command line](https://xunit.net/docs/getting-started/netcore/cmdline)
 * [Moq](https://github.com/moq/moq4)
 * [Moq Quickstart](https://github.com/Moq/moq4/wiki/Quickstart)
@@ -218,7 +217,7 @@ The sample project is composed of two apps:
 | Message app | *src/RazorPagesTestSample*         | Allows a user to add a message, delete one message, delete all messages, and analyze messages (find the average number of words per message). |
 | Test app    | *tests/RazorPagesTestSample.Tests* | Used to unit test the DAL and Index page model of the message app. |
 
-The tests can be run using the built-in test features of an IDE, such as [Visual Studio](/visualstudio/test/unit-test-your-code) or [Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesTestSample.Tests* folder:
+The tests can be run using the built-in test features of an IDE such as [Visual Studio](/visualstudio/test/unit-test-your-code). If using [Visual Studio Code](https://code.visualstudio.com/) or the command line, execute the following command at a command prompt in the *tests/RazorPagesTestSample.Tests* folder:
 
 ```dotnetcli
 dotnet test
@@ -371,7 +370,6 @@ Other tests in this group create page model objects that include the <xref:Micro
 * [Unit Test Your Code](/visualstudio/test/unit-test-your-code) (Visual Studio)
 * <xref:test/integration-tests>
 * [xUnit.net](https://github.com/xunit/xunit)
-* [Building a complete .NET Core solution on macOS using Visual Studio for Mac](/dotnet/core/tutorials/using-on-mac-vs-full-solution)
 * [Getting started with xUnit.net: Using .NET Core with the .NET SDK command line](https://xunit.net/docs/getting-started/netcore/cmdline)
 * [Moq](https://github.com/moq/moq4)
 * [Moq Quickstart](https://github.com/Moq/moq4/wiki/Quickstart)

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to build a web API with ASP.NET Core.
 ms.author: wpickett
 ms.custom: mvc, engagement-fy24
-ms.date: 09/15/2023
+ms.date: 08/17/2023
 uid: tutorials/first-web-api
 ---
 
@@ -47,8 +47,6 @@ The following diagram shows the design of the app.
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
 [!INCLUDE[](~/includes/net-prereqs-mac-8.0.md)]
-
-[!INCLUDE[](~/includes/vs-mac-eol.md)]
 
 ---
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -47,7 +47,8 @@ The following diagram shows the design of the app.
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
 [!INCLUDE[](~/includes/net-prereqs-mac-8.0.md)]
-[!INCLUDE [](~/includes/vs-mac-eol.md)]
+
+[!INCLUDE[](~/includes/vs-mac-eol.md)]
 
 ---
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -47,6 +47,7 @@ The following diagram shows the design of the app.
 # [Visual Studio for Mac](#tab/visual-studio-mac)
 
 [!INCLUDE[](~/includes/net-prereqs-mac-8.0.md)]
+[!INCLUDE [](~/includes/vs-mac-eol.md)]
 
 ---
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to build a web API with ASP.NET Core.
 ms.author: wpickett
 ms.custom: mvc, engagement-fy24
-ms.date: 08/17/2023
+ms.date: 09/15/2023
 uid: tutorials/first-web-api
 ---
 

--- a/aspnetcore/tutorials/publish-to-azure-webapp-using-vs.md
+++ b/aspnetcore/tutorials/publish-to-azure-webapp-using-vs.md
@@ -12,8 +12,6 @@ uid: tutorials/publish-to-azure-webapp-using-vs
 
 [!INCLUDE [Azure App Service Preview Notice](../includes/azure-apps-preview-notice.md)]
 
-If you're working on macOS, see [Publish a Web app to Azure App Service using Visual Studio for Mac](/visualstudio/mac/publish-app-svc).
-
 To troubleshoot an App Service deployment issue, see <xref:test/troubleshoot-azure-iis>.
 
 ## Set up

--- a/aspnetcore/tutorials/publish-to-iis.md
+++ b/aspnetcore/tutorials/publish-to-iis.md
@@ -132,7 +132,6 @@ To learn more about hosting ASP.NET Core apps on IIS, see the IIS Overview artic
 * <xref:tutorials/publish-to-azure-webapp-using-vs>
 * <xref:tutorials/publish-to-azure-webapp-using-vscode>
 * <xref:host-and-deploy/visual-studio-publish-profiles>
-* [Publish a Web app to a folder using Visual Studio for Mac](/visualstudio/mac/publish-folder)
 
 ### Articles on IIS HTTPS configuration
 


### PR DESCRIPTION
Fixes #30217 

This is mainly about getting the notice into tutorials, which it does by adding an include to the VS Mac prerequisites includes.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/enforcing-ssl.md](https://github.com/dotnet/AspNetCore.Docs/blob/b81dfafa9726c785159ca0758ff3be7e341b11a7/aspnetcore/security/enforcing-ssl.md) | [Enforce HTTPS in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?branch=pr-en-us-30382) |
| [aspnetcore/test/razor-pages-tests.md](https://github.com/dotnet/AspNetCore.Docs/blob/b81dfafa9726c785159ca0758ff3be7e341b11a7/aspnetcore/test/razor-pages-tests.md) | [Razor Pages unit tests in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/test/razor-pages-tests?branch=pr-en-us-30382) |
| [aspnetcore/tutorials/publish-to-azure-webapp-using-vs.md](https://github.com/dotnet/AspNetCore.Docs/blob/b81dfafa9726c785159ca0758ff3be7e341b11a7/aspnetcore/tutorials/publish-to-azure-webapp-using-vs.md) | [Publish an ASP.NET Core app to Azure with Visual Studio](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/publish-to-azure-webapp-using-vs?branch=pr-en-us-30382) |
| [aspnetcore/tutorials/publish-to-iis.md](https://github.com/dotnet/AspNetCore.Docs/blob/b81dfafa9726c785159ca0758ff3be7e341b11a7/aspnetcore/tutorials/publish-to-iis.md) | [[Visual Studio](#tab/visual-studio)](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/publish-to-iis?branch=pr-en-us-30382) |


<!-- PREVIEW-TABLE-END -->