### PR TITLE
Add note to C-core migration about non-ASP.NET Core SDKs

### DIFF
--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -260,6 +260,7 @@ You can add a gRPC server to non-ASP.NET Core projects with the following projec
 
 The preceding project file:
 
+* Uses a non-ASP.NET Core SDK.
 * Adds a framework reference to `Microsoft.AspNetCore.App`.
   * The framework reference allows non-ASP.NET Core apps, such as Windows Services, WPF apps, or WinForms apps to use ASP.NET Core APIs.
   * The app can now use ASP.NET Core APIs to start an ASP.NET Core server.
@@ -268,6 +269,7 @@ The preceding project file:
   * `.proto` file.
 
 For more information about using the `Microsoft.AspNetCore.App` framework reference, see [Use the ASP.NET Core shared framework](xref:fundamentals/target-aspnetcore#use-the-aspnet-core-shared-framework).
+
 ## Integration with ASP.NET Core APIs
 
 gRPC services have full access to the ASP.NET Core features such as [Dependency Injection](xref:fundamentals/dependency-injection) (DI) and [Logging](xref:fundamentals/logging/index). For example, the service implementation can resolve a logger service from the DI container via the constructor:

--- a/aspnetcore/grpc/aspnetcore.md
+++ b/aspnetcore/grpc/aspnetcore.md
@@ -260,7 +260,7 @@ You can add a gRPC server to non-ASP.NET Core projects with the following projec
 
 The preceding project file:
 
-* Uses a non-ASP.NET Core SDK.
+* Doesn't use `Microsoft.NET.SDK.Web` as the SDK.
 * Adds a framework reference to `Microsoft.AspNetCore.App`.
   * The framework reference allows non-ASP.NET Core apps, such as Windows Services, WPF apps, or WinForms apps to use ASP.NET Core APIs.
   * The app can now use ASP.NET Core APIs to start an ASP.NET Core server.

--- a/aspnetcore/grpc/migrate/Server-web.csproj
+++ b/aspnetcore/grpc/migrate/Server-web.csproj
@@ -1,8 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
-
-  <ItemGroup>
-    <PackageReference Include="Grpc.AspNetCore" Version="2.47.0" />
-    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
-  </ItemGroup>
-
-</Project>

--- a/aspnetcore/grpc/migrate/Server-web.csproj
+++ b/aspnetcore/grpc/migrate/Server-web.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.47.0" />
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/grpc/migration.md
+++ b/aspnetcore/grpc/migration.md
@@ -115,7 +115,7 @@ For more information on how these features compare to each other, see [gRPC Inte
 
 ## Host gRPC in non-ASP.NET Core projects
 
-C-core-based server can be added to any project type. Meanwhile, an ASP.NET Core gRPC server is usually created from the gRPC template. The project file created by the template uses `Microsoft.NET.SDK.Web` as the SDK:
+A C-core-based server can be added to any project type. Meanwhile, an ASP.NET Core gRPC server is usually created from the gRPC template. The project file created by the template uses `Microsoft.NET.SDK.Web` as the SDK:
 
 [!code-xml[](~/grpc/aspnetcore/Server-web.csproj?highlight=1)]
 

--- a/aspnetcore/grpc/migration.md
+++ b/aspnetcore/grpc/migration.md
@@ -115,13 +115,11 @@ For more information on how these features compare to each other, see [gRPC Inte
 
 ## Host gRPC in non-ASP.NET Core projects
 
-A C-core-based server can be added to any project type. Meanwhile, an ASP.NET Core gRPC server is usually created from the gRPC template. The project file created by the template uses `Microsoft.NET.SDK.Web` as the SDK:
+A C-core-based server can be added to any project type. Meanwhile, a gRPC for .NET server requires ASP.NET Core. ASP.NET Core is usually available because a project file uses `Microsoft.NET.SDK.Web` as the SDK.
 
-[!code-xml[](~/grpc/aspnetcore/Server-web.csproj?highlight=1)]
+You can host a gRPC server to non-ASP.NET Core projects by adding `<FrameworkReference Include="Microsoft.AspNetCore.App" />` to a project. The framework reference makes ASP.NET Core APIs available and they can be used to start an ASP.NET Core server.
 
-The `Microsoft.NET.SDK.Web` SDK value automatically adds a reference to the ASP.NET Core framework. The reference allows the app to use ASP.NET Core types required to host a server.
-
-It's also possible to add an ASP.NET Core gRPC server to existing non-ASP.NET Core projects, such as Windows Services, WPF apps, or WinForms apps. See [Host gRPC in non-ASP.NET Core projects](xref:grpc/aspnetcore#host-grpc-in-non-aspnet-core-projects) for more information.
+For more information, see [Host gRPC in non-ASP.NET Core projects](xref:grpc/aspnetcore#host-grpc-in-non-aspnet-core-projects).
 
 ## Additional resources
 

--- a/aspnetcore/grpc/migration.md
+++ b/aspnetcore/grpc/migration.md
@@ -115,9 +115,9 @@ For more information on how these features compare to each other, see [gRPC Inte
 
 ## Host gRPC in non-ASP.NET Core projects
 
-A C-core-based server can be added to any project type. Meanwhile, a gRPC for .NET server requires ASP.NET Core. ASP.NET Core is usually available because a project file uses `Microsoft.NET.SDK.Web` as the SDK.
+A C-core-based server can be added to any project type. gRPC for .NET server requires ASP.NET Core. ASP.NET Core is usually available because the project file specifies `Microsoft.NET.SDK.Web` as the SDK.
 
-You can host a gRPC server to non-ASP.NET Core projects by adding `<FrameworkReference Include="Microsoft.AspNetCore.App" />` to a project. The framework reference makes ASP.NET Core APIs available and they can be used to start an ASP.NET Core server.
+A gRPC server can be hosted to non-ASP.NET Core projects by adding `<FrameworkReference Include="Microsoft.AspNetCore.App" />` to a project. The framework reference makes ASP.NET Core APIs available and they can be used to start an ASP.NET Core server.
 
 For more information, see [Host gRPC in non-ASP.NET Core projects](xref:grpc/aspnetcore#host-grpc-in-non-aspnet-core-projects).
 

--- a/aspnetcore/grpc/migration.md
+++ b/aspnetcore/grpc/migration.md
@@ -113,6 +113,16 @@ ASP.NET Core [middleware](xref:fundamentals/middleware/index) offers similar fun
 
 For more information on how these features compare to each other, see [gRPC Interceptors versus Middleware](xref:grpc/interceptors#grpc-interceptors-versus-middleware).
 
+## Host gRPC in non-ASP.NET Core projects
+
+C-core-based server can be added to any project type. Meanwhile, an ASP.NET Core gRPC server is usually created from the gRPC template. The project file created by the template uses `Microsoft.NET.SDK.Web` as the SDK:
+
+[!code-xml[](~/grpc/aspnetcore/Server-web.csproj?highlight=1)]
+
+The `Microsoft.NET.SDK.Web` SDK value automatically adds a reference to the ASP.NET Core framework. The reference allows the app to use ASP.NET Core types required to host a server.
+
+It's also possible to add an ASP.NET Core gRPC server to existing non-ASP.NET Core projects, such as Windows Services, WPF apps, or WinForms apps. See [Host gRPC in non-ASP.NET Core projects](xref:grpc/aspnetcore#host-grpc-in-non-aspnet-core-projects) for more information.
+
 ## Additional resources
 
 * <xref:grpc/index>


### PR DESCRIPTION
This is useful information for the migration page.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/aspnetcore.md](https://github.com/dotnet/AspNetCore.Docs/blob/6024cd7f84c8e477b613b5cf4eb3d27916f571fc/aspnetcore/grpc/aspnetcore.md) | [gRPC services with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/aspnetcore?branch=pr-en-us-30415) |
| [aspnetcore/grpc/migration.md](https://github.com/dotnet/AspNetCore.Docs/blob/6024cd7f84c8e477b613b5cf4eb3d27916f571fc/aspnetcore/grpc/migration.md) | [Migrate gRPC from C-core to gRPC for .NET](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/migration?branch=pr-en-us-30415) |


<!-- PREVIEW-TABLE-END -->