### PR TITLE
Add "Unit Testing" page to .NET Core Incremental Migration

### DIFF
--- a/aspnetcore/migration/inc/samples/unit-testing/Program.cs
+++ b/aspnetcore/migration/inc/samples/unit-testing/Program.cs
@@ -61,4 +61,4 @@ namespace TestProject1
         }
     }
 }
-// <snippet_UnitTestingFixture>
+// </snippet_UnitTestingFixture>

--- a/aspnetcore/migration/inc/samples/unit-testing/Program.cs
+++ b/aspnetcore/migration/inc/samples/unit-testing/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using System.Web;
 using System.Web.Hosting;
 
+// <snippet_UnitTestingFixture>
 namespace TestProject1
 {
     /// <summary>
@@ -60,3 +61,4 @@ namespace TestProject1
         }
     }
 }
+// <snippet_UnitTestingFixture>

--- a/aspnetcore/migration/inc/samples/unit-testing/Program.cs
+++ b/aspnetcore/migration/inc/samples/unit-testing/Program.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SystemWebAdapters;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Web;
+using System.Web.Hosting;
+
+namespace TestProject1
+{
+    /// <summary>
+    /// This is an xUnit concept that allows us to ensure all tests in classes marked with this collection are run sequentially
+    /// </summary>
+    [CollectionDefinition(nameof(SystemWebAdatpersHostedTests), DisableParallelization = true)]
+    public class SystemWebAdatpersHostedTests
+    {
+    }
+
+    [Collection(nameof(SystemWebAdatpersHostedTests))]
+    public class RuntimeTests
+    {
+        /// <summary>
+        /// This starts up a host in the background that allows us to initialize <see cref="HttpRuntime"/> and <see cref="HostingEnvironment"/>
+        /// with values we want for testing with the <paramref name="configure"/> option.
+        /// </summary>
+        /// <param name="configure">Configuration for the hosting and runtime options.</param>
+        public static async Task<IDisposable> EnableRuntimeAsync(Action<SystemWebAdaptersOptions>? configure = null, CancellationToken token = default)
+            => await new HostBuilder()
+               .ConfigureWebHost(webBuilder =>
+               {
+                   webBuilder
+                       .UseTestServer()
+                       .ConfigureServices(services =>
+                       {
+                           services.AddSystemWebAdapters();
+
+                           if (configure is not null)
+                           {
+                               services.AddOptions<SystemWebAdaptersOptions>()
+                                .Configure(configure);
+                           }
+                       })
+                       .Configure(app =>
+                       {
+                           // No need to configure pipeline for tests
+                       });
+               })
+               .StartAsync(token);
+
+        [Fact]
+        public async Task RuntimeEnabled()
+        {
+            using (await EnableRuntimeAsync(options => options.AppDomainAppPath = "path"))
+            {
+                Assert.True(HostingEnvironment.IsHosted);
+                Assert.Equal("path", HttpRuntime.AppDomainAppPath);
+            }
+
+            Assert.False(HostingEnvironment.IsHosted);
+        }
+    }
+}

--- a/aspnetcore/migration/inc/unit-testing.md
+++ b/aspnetcore/migration/inc/unit-testing.md
@@ -1,0 +1,19 @@
+---
+title: Unit Testing
+description: Unit Testing 
+author: afshinm
+ms.author: amehrabani
+monikerRange: '>= aspnetcore-6.0'
+ms.date: 02/10/2023
+ms.topic: article
+ms.prod: aspnet-core
+uid: migration/inc/unit-testing
+---
+
+# Unit Testing
+
+In most cases, there is no need to set up additional components for running tests, but if the subject under test makes use of `HttpRuntime`, you may need to start up the `SystemWebAdapters` service as outlined below:
+
+:::code language="csharp" source="~/migration/inc/samples/unit-testing/Program.cs" id="snippet_UnitTestingFixture" :::
+
+It's important to emphasize that the tests must be executed in a sequential manner. In the above example, we've illustrated how you can achieve this by configuring the [XUnit's `DisableParallelization` option](https://xunit.net/docs/running-tests-in-parallel#parallelism-in-test-frameworks), setting it to `true`. This particular setting is designed to disable parallel execution for a specific test collection, ensuring that the tests within that collection run one after the other, without concurrency.


### PR DESCRIPTION
As discussed in this issue https://github.com/dotnet/systemweb-adapters/issues/401, there are some additional steps that must be followed if the subject under test make use of `HttpRuntime`. 

This PR adds a new subpage **Unit Testing** to [ASP.NET to ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/migration/proper-to-2x/?view=aspnetcore-7.0) and explains how that particular issue can be resolved.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/inc/unit-testing.md](https://github.com/dotnet/AspNetCore.Docs/blob/15be33f0cf3e51aa66fd68df5b20f33205a568b9/aspnetcore/migration/inc/unit-testing.md) | [aspnetcore/migration/inc/unit-testing](https://review.learn.microsoft.com/en-us/aspnet/core/migration/inc/unit-testing?branch=pr-en-us-30537) |


<!-- PREVIEW-TABLE-END -->