### PR TITLE
GitHub page hosting without WasmStripILAfterAOT

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -703,6 +703,18 @@ To handle URL rewrites, add a `wwwroot/404.html` file with a script that handles
 
 When using a project site instead of an organization site, update the `<base>` tag in `wwwroot/index.html`. Set the `href` attribute value to the GitHub repository name with a trailing slash (for example, `/my-repository/`). In the [SteveSandersonMS/BlazorOnGitHubPages GitHub repository](https://github.com/SteveSandersonMS/BlazorOnGitHubPages), the base `href` is updated at publish by the [`.github/workflows/main.yml` configuration file](https://github.com/SteveSandersonMS/BlazorOnGitHubPages/blob/master/.github/workflows/main.yml).
 
+:::moniker range=">= aspnetcore-8.0"
+
+Removing the .NET Intermediate Language (IL) for compiled methods after performing AOT compilation to WebAssembly (MSBuild property: `WasmStripILAfterAOT`) is ***not*** supported for GitHub Page hosting. Either remove the property or set its value to `false` in the project file:
+
+```xml
+<WasmStripILAfterAOT>false</WasmStripILAfterAOT>
+```
+
+For more information, see <xref:blazor/host-and-deploy/webassembly#trim-net-il-after-ahead-of-time-aot-compilation>.
+
+:::moniker-end
+
 > [!NOTE]
 > The [SteveSandersonMS/BlazorOnGitHubPages GitHub repository](https://github.com/SteveSandersonMS/BlazorOnGitHubPages) isn't owned, maintained, or supported by the .NET Foundation or Microsoft.
 


### PR DESCRIPTION
Fixes #30535

Thanks @AceHack! :rocket:

BTW ... I still need to know on the other issue that you opened if the original (published) code was still working under .NET 7.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/9039d501212759b82f736890d0195b92ee7cfd0d/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-30542) |

<!-- PREVIEW-TABLE-END -->