### PR TITLE
fix: grammar mistake in rate limiting documentation

### DIFF
--- a/aspnetcore/performance/rate-limit.md
+++ b/aspnetcore/performance/rate-limit.md
@@ -126,7 +126,7 @@ When <xref:System.Threading.RateLimiting.TokenBucketRateLimiterOptions.AutoReple
 
 ### Concurrency limiter
 
-The concurrency limiter limits the number concurrent requests. Each request reduces the concurrency limit by one. When a request completes, the limit is increased by one. Unlike the other requests limiters that limit the total number of requests for a specified period, the concurrency limiter limits only the number of concurrent requests and doesn't cap the number of requests in a time period.
+The concurrency limiter limits the number of concurrent requests. Each request reduces the concurrency limit by one. When a request completes, the limit is increased by one. Unlike the other requests limiters that limit the total number of requests for a specified period, the concurrency limiter limits only the number of concurrent requests and doesn't cap the number of requests in a time period.
 
 The following code uses the concurrency limiter:
 


### PR DESCRIPTION
Fixed grammar mistake in rate limiting documentation



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/rate-limit.md](https://github.com/dotnet/AspNetCore.Docs/blob/752e39f42f7bd150bbc3fbb3dfbbf2c62504992b/aspnetcore/performance/rate-limit.md) | [Rate limiting middleware in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/rate-limit?branch=pr-en-us-30548) |

<!-- PREVIEW-TABLE-END -->