### PR TITLE
AAD rename - gRPC node topics

### DIFF
--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -207,7 +207,7 @@ public Ticketer.TicketerClient CreateClientWithCert(
 
 Many ASP.NET Core supported authentication mechanisms work with gRPC:
 
-* Azure Active Directory
+* Microsoft Entra (ME-ID)
 * Client Certificate
 * IdentityServer
 * JWT Token
@@ -476,7 +476,7 @@ public Ticketer.TicketerClient CreateClientWithCert(
 
 Many ASP.NET Core supported authentication mechanisms work with gRPC:
 
-* Azure Active Directory
+* Microsoft Entra (ME-ID)
 * Client Certificate
 * IdentityServer
 * JWT Token

--- a/aspnetcore/grpc/authn-and-authz.md
+++ b/aspnetcore/grpc/authn-and-authz.md
@@ -207,7 +207,7 @@ public Ticketer.TicketerClient CreateClientWithCert(
 
 Many ASP.NET Core supported authentication mechanisms work with gRPC:
 
-* Microsoft Entra (ME-ID)
+* Microsoft Entra ID
 * Client Certificate
 * IdentityServer
 * JWT Token
@@ -476,7 +476,7 @@ public Ticketer.TicketerClient CreateClientWithCert(
 
 Many ASP.NET Core supported authentication mechanisms work with gRPC:
 
-* Microsoft Entra (ME-ID)
+* Microsoft Entra ID
 * Client Certificate
 * IdentityServer
 * JWT Token


### PR DESCRIPTION
Fixes #30590

Azure Active Directory rename update for all gRPC topics in the gRPC node.
Criteria: replace "Azure Active Directory," "Azure AD," and "AAD" and looked for any links to docs with those names in the filename or title.

There was just one topic that needed an update in that gRPC node:  authn-and-authz.md

See related issues #30591 and #30592

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/authn-and-authz.md](https://github.com/dotnet/AspNetCore.Docs/blob/210f27d2f27e488dea2452b55084f0da4e8e2556/aspnetcore/grpc/authn-and-authz.md) | [Authentication and authorization in gRPC for ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/authn-and-authz?branch=pr-en-us-30593) |


<!-- PREVIEW-TABLE-END -->