### PR TITLE
AAD rename for all content owned by wp

### DIFF
--- a/aspnetcore/includes/DuendeIdentityServer.md
+++ b/aspnetcore/includes/DuendeIdentityServer.md
@@ -1,7 +1,7 @@
 ASP.NET Core Identity adds user interface (UI) login functionality to ASP.NET Core web apps. To secure web APIs and SPAs, use one of the following:
 
 * [Microsoft Entra ID](/azure/api-management/api-management-howto-protect-backend-with-aad)
-* [Microsoft Entra ID B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw)
+* [Azure Active Directory B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw) (Azure AD B2C)
 * [Duende Identity Server](https://docs.duendesoftware.com)
 
 Duende Identity Server is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core. Duende Identity Server enables the following security features:

--- a/aspnetcore/includes/DuendeIdentityServer.md
+++ b/aspnetcore/includes/DuendeIdentityServer.md
@@ -1,7 +1,7 @@
 ASP.NET Core Identity adds user interface (UI) login functionality to ASP.NET Core web apps. To secure web APIs and SPAs, use one of the following:
 
-* [Azure Active Directory](/azure/api-management/api-management-howto-protect-backend-with-aad)
-* [Azure Active Directory B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw) (Azure AD B2C)
+* [Microsoft Entra ID](/azure/api-management/api-management-howto-protect-backend-with-aad)
+* [Microsoft Entra ID B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw)
 * [Duende Identity Server](https://docs.duendesoftware.com)
 
 Duende Identity Server is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core. Duende Identity Server enables the following security features:

--- a/aspnetcore/includes/IdentityServer4.md
+++ b/aspnetcore/includes/IdentityServer4.md
@@ -1,7 +1,7 @@
 ASP.NET Core Identity adds user interface (UI) login functionality to ASP.NET Core web apps. To secure web APIs and SPAs, use one of the following:
 
 * [Microsoft Entra ID](/azure/api-management/api-management-howto-protect-backend-with-aad)
-* [Microsoft Entra ID B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw)
+* [Azure Active Directory B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw) (Azure AD B2C)
 * [Duende IdentityServer](https://docs.duendesoftware.com/identityserver/v6/overview/). Duende IdentityServer is 3rd party product.
 
 Duende IdentityServer is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core. Duende IdentityServer enables the following security features:

--- a/aspnetcore/includes/IdentityServer4.md
+++ b/aspnetcore/includes/IdentityServer4.md
@@ -1,7 +1,7 @@
 ASP.NET Core Identity adds user interface (UI) login functionality to ASP.NET Core web apps. To secure web APIs and SPAs, use one of the following:
 
-* [Azure Active Directory](/azure/api-management/api-management-howto-protect-backend-with-aad)
-* [Azure Active Directory B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw) (Azure AD B2C)
+* [Microsoft Entra ID](/azure/api-management/api-management-howto-protect-backend-with-aad)
+* [Microsoft Entra ID B2C](/azure/active-directory-b2c/active-directory-b2c-custom-rest-api-netfw)
 * [Duende IdentityServer](https://docs.duendesoftware.com/identityserver/v6/overview/). Duende IdentityServer is 3rd party product.
 
 Duende IdentityServer is an OpenID Connect and OAuth 2.0 framework for ASP.NET Core. Duende IdentityServer enables the following security features:


### PR DESCRIPTION
Fixes #30592

Searched through entire aspnetcore\tutorials node and for anything in aspnetcore/ that has wadepickett in the metadata.

Topics were clean (beyond the gRPC and SignalR nodes which are taken care of in other PR's)
However, I had topics that used includes that needed renaming, so that is what I am updating in this PR.

Found and fixed AAD references here:
aspnetcore/includes/DuendeldentityServer.md  (used in the MongoDB tutorial for example).
aspnetcore/includes/IdentityServer4.md

Checked for:
"Azure Active"
"Azure AD"
"Azure-active"
"Azure-ad"
"AAD" (which brings up 20 random doc ID's that had "aad" in the sequence but no legit AAD hits).

