### PR TITLE
Add websocket support to generic nginx docs

### DIFF
--- a/aspnetcore/host-and-deploy/linux-nginx.md
+++ b/aspnetcore/host-and-deploy/linux-nginx.md
@@ -160,28 +160,35 @@ Open `/etc/nginx/sites-available/default` in a text editor, and replace the cont
 
 # [Red Hat Enterprise Linux](#tab/linux-rhel)
 
-To configure Nginx as a reverse proxy to forward HTTP requests to an ASP.NET Core app, modify `/etc/nginx.conf`. Replace the `server{}` code block with the following snippet:
+To configure Nginx as a reverse proxy to forward HTTP requests to an ASP.NET Core app, modify `/etc/nginx.conf`. Update the `http{}` code block with the following snippet:
 
 # [SUSE Linux Enterprise Server](#tab/linux-sles)
 
-To configure Nginx as a reverse proxy to forward HTTP requests to an ASP.NET Core app, modify `/etc/nginx.conf`. Replace the `server{}` code block with the following snippet:
+To configure Nginx as a reverse proxy to forward HTTP requests to an ASP.NET Core app, modify `/etc/nginx.conf`. Update the `http{}` code block with the following snippet:
 
 ---
 
 ```text
-server {
+http {
+  map $http_connection $connection_upgrade {
+    "~*Upgrade" $http_connection;
+    default keep-alive;
+  }
+
+  server {
     listen        80;
     server_name   example.com *.example.com;
     location / {
         proxy_pass         http://127.0.0.1:5000;
         proxy_http_version 1.1;
         proxy_set_header   Upgrade $http_upgrade;
-        proxy_set_header   Connection keep-alive;
+        proxy_set_header   Connection $connection_upgrade;
         proxy_set_header   Host $host;
         proxy_cache_bypass $http_upgrade;
         proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header   X-Forwarded-Proto $scheme;
     }
+  }
 }
 ```
 


### PR DESCRIPTION
Part of https://github.com/dotnet/aspnetcore/issues/45522, users aren't necessarily noticing/following the SignalR link after the nginx snippet. So we should just add the small bit needed to support websockets to the main snippet.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/linux-nginx.md](https://github.com/dotnet/AspNetCore.Docs/blob/1b7bdb8dae7d2be0e3e6a78d9503a5705088a337/aspnetcore/host-and-deploy/linux-nginx.md) | [Host ASP.NET Core on Linux with Nginx](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/linux-nginx?branch=pr-en-us-30605) |

<!-- PREVIEW-TABLE-END -->