### PR TITLE
Fix index.md code snippet

### DIFF
--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -187,7 +187,7 @@ In the previous code, posting the form:
 
 The `Customer` property uses [`[BindProperty]`](xref:Microsoft.AspNetCore.Mvc.BindPropertyAttribute) attribute to opt in to model binding:
 
-[!code-csharp[](~/razor-pages/index/6.0sample/RazorPagesContacts/Pages/Customers/Create.cshtml.cs?name=snippet&highlight=15-16)]
+[!code-csharp[](~/razor-pages/index/6.0sample/RazorPagesContacts/Pages/Customers/Create.cshtml.cs?name=snippet_OnPostAsync&highlight=1-2)]
 
 `[BindProperty]` should **not** be used on models containing properties that should not be changed by the client. For more information, see [Overposting](xref:data/ef-rp/crud#overposting).
 


### PR DESCRIPTION
Code snippet wasn't showing any code, also highlighting the wrong part of the code.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/razor-pages/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/e85110d6a0720095a7eea6ccac8ed8b2dcc8a96d/aspnetcore/razor-pages/index.md) | [Introduction to Razor Pages in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/razor-pages/index?branch=pr-en-us-30606) |

<!-- PREVIEW-TABLE-END -->