### PR TITLE
Link to Blazor docs in IIS sub-application section

### DIFF
--- a/aspnetcore/host-and-deploy/iis/advanced.md
+++ b/aspnetcore/host-and-deploy/iis/advanced.md
@@ -171,7 +171,9 @@ Enable the **IIS Management Console** and **World Wide Web Services**.
 
 An ASP.NET Core app can be hosted as an [IIS sub-application (sub-app)](/iis/get-started/planning-your-iis-architecture/understanding-sites-applications-and-virtual-directories-on-iis#applications). The sub-app's path becomes part of the root app's URL.
 
-Static asset links within the sub-app should use tilde-slash (`~/`) notation. Tilde-slash notation triggers a [Tag Helper](xref:mvc/views/tag-helpers/intro) to prepend the sub-app's pathbase to the rendered relative link. For a sub-app at `/subapp_path`, an image linked with `src="~/image.png"` is rendered as `src="/subapp_path/image.png"`. The root app's Static File Middleware doesn't process the static file request. The request is processed by the sub-app's Static File Middleware.
+Static asset links within the sub-app should use tilde-slash (`~/`) notation in MVC and Razor Pages. Tilde-slash notation triggers a [Tag Helper](xref:mvc/views/tag-helpers/intro) to prepend the sub-app's pathbase to the rendered relative link. For a sub-app at `/subapp_path`, an image linked with `src="~/image.png"` is rendered as `src="/subapp_path/image.png"`. The root app's Static File Middleware doesn't process the static file request. The request is processed by the sub-app's Static File Middleware.
+
+> [!NOTE] Blazor apps should not use the tilde-slash notation. [Blazor app base path documentation.](xref:blazor/host-and-deploy#app-base-path)
 
 If a static asset's `src` attribute is set to an absolute path (for example, `src="/image.png"`), the link is rendered without the sub-app's pathbase. The root app's Static File Middleware attempts to serve the asset from the root app's [web root](xref:fundamentals/index#web-root), which results in a *404 - Not Found* response unless the static asset is available from the root app.
 

--- a/aspnetcore/host-and-deploy/iis/advanced.md
+++ b/aspnetcore/host-and-deploy/iis/advanced.md
@@ -174,7 +174,7 @@ An ASP.NET Core app can be hosted as an [IIS sub-application (sub-app)](/iis/get
 Static asset links within the sub-app should use tilde-slash (`~/`) notation in MVC and Razor Pages. Tilde-slash notation triggers a [Tag Helper](xref:mvc/views/tag-helpers/intro) to prepend the sub-app's pathbase to the rendered relative link. For a sub-app at `/subapp_path`, an image linked with `src="~/image.png"` is rendered as `src="/subapp_path/image.png"`. The root app's Static File Middleware doesn't process the static file request. The request is processed by the sub-app's Static File Middleware.
 
 > [!NOTE]
-> `*.razor` components should not use the tilde-slash notation. [Blazor app base path documentation.](xref:blazor/host-and-deploy/index#app-base-path)
+> Razor components (`.razor`) shouldn't use tilde-slash notation. For more information, see the [Blazor app base path documentation](xref:blazor/host-and-deploy/index#app-base-path).
 
 If a static asset's `src` attribute is set to an absolute path (for example, `src="/image.png"`), the link is rendered without the sub-app's pathbase. The root app's Static File Middleware attempts to serve the asset from the root app's [web root](xref:fundamentals/index#web-root), which results in a *404 - Not Found* response unless the static asset is available from the root app.
 

--- a/aspnetcore/host-and-deploy/iis/advanced.md
+++ b/aspnetcore/host-and-deploy/iis/advanced.md
@@ -173,7 +173,8 @@ An ASP.NET Core app can be hosted as an [IIS sub-application (sub-app)](/iis/get
 
 Static asset links within the sub-app should use tilde-slash (`~/`) notation in MVC and Razor Pages. Tilde-slash notation triggers a [Tag Helper](xref:mvc/views/tag-helpers/intro) to prepend the sub-app's pathbase to the rendered relative link. For a sub-app at `/subapp_path`, an image linked with `src="~/image.png"` is rendered as `src="/subapp_path/image.png"`. The root app's Static File Middleware doesn't process the static file request. The request is processed by the sub-app's Static File Middleware.
 
-> [!NOTE] Blazor apps should not use the tilde-slash notation. [Blazor app base path documentation.](xref:blazor/host-and-deploy#app-base-path)
+> [!NOTE]
+> `*.razor` components should not use the tilde-slash notation. [Blazor app base path documentation.](xref:blazor/host-and-deploy/index#app-base-path)
 
 If a static asset's `src` attribute is set to an absolute path (for example, `src="/image.png"`), the link is rendered without the sub-app's pathbase. The root app's Static File Middleware attempts to serve the asset from the root app's [web root](xref:fundamentals/index#web-root), which results in a *404 - Not Found* response unless the static asset is available from the root app.
 


### PR DESCRIPTION
The old docs were confusing because they seemed to indicate that `~/` should work with just Blazor. See https://github.com/dotnet/aspnetcore/issues/51027.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/iis/advanced.md](https://github.com/dotnet/AspNetCore.Docs/blob/44cbb6c3109f4363d1ea205782445e6ce53c674e/aspnetcore/host-and-deploy/iis/advanced.md) | [Advanced configuration of the ASP.NET Core Module and IIS](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/advanced?branch=pr-en-us-30632) |


<!-- PREVIEW-TABLE-END -->