### PR TITLE
Http methods in route-handlers.md are Pascal-cased

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/route-handlers.md
+++ b/aspnetcore/fundamentals/minimal-apis/route-handlers.md
@@ -10,7 +10,7 @@ uid: fundamentals/minimal-apis/route-handlers
 
 # Route Handlers in Minimal API apps
 
-A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapMethods%2A> where `{Verb}` is a camel-cased HTTP method like `Get`, `Post`, `Put` or `Delete`:
+A configured `WebApplication` supports `Map{Verb}` and <xref:Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapMethods%2A> where `{Verb}` is a Pascal-cased HTTP method like `Get`, `Post`, `Put` or `Delete`:
 
 [!code-csharp[](7.0-samples/WebMinAPIs/Program.cs?name=snippet_r1)]
 


### PR DESCRIPTION
According the usual naming convention within .NET `MapGet`, etc. is Pascal-cased, so the term camel-cased is most likely a typo.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/route-handlers.md](https://github.com/dotnet/AspNetCore.Docs/blob/f841052db92cc801f858fb7b1970c8df80f1a468/aspnetcore/fundamentals/minimal-apis/route-handlers.md) | [Route Handlers in Minimal API apps](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/route-handlers?branch=pr-en-us-30649) |

<!-- PREVIEW-TABLE-END -->