### PR TITLE
Versioning repair

### DIFF
--- a/aspnetcore/blazor/forms-and-input-components.md
+++ b/aspnetcore/blazor/forms-and-input-components.md
@@ -1202,7 +1202,7 @@ In the following example, the user must select at least two starship classificat
 
 :::moniker-end
 
-:::moniker range="< aspnetcore-8.0"
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
 ```razor
 @page "/starship-7"


### PR DESCRIPTION
An example is showing outside of the rest of this section's >=6.0-only content in <6.0 content 😈.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms-and-input-components.md](https://github.com/dotnet/AspNetCore.Docs/blob/d36174811eca12773245dcb7fc66bd665b8c4292/aspnetcore/blazor/forms-and-input-components.md) | [ASP.NET Core Blazor forms and input components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms-and-input-components?branch=pr-en-us-30650) |

<!-- PREVIEW-TABLE-END -->