### PR TITLE
Cross-link updates

### DIFF
--- a/aspnetcore/log-mon/metrics/metrics.md
+++ b/aspnetcore/log-mon/metrics/metrics.md
@@ -226,14 +226,14 @@ Alternatively, enter counter category such as `kestrel` in the **Expression** in
 
 ## Test metrics in ASP.NET Core apps
 
-It's possible to test metrics in ASP.NET Core apps. One way to do that is collect and assert metrics values in [ASP.NET Core integration tests](xref:test/integration-tests) using <!--<xref:Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector%601>--> [MetricCollector](https://learn.microsoft.com/dotnet/api/microsoft.extensions.telemetry.testing.metering.metriccollector-1?view=dotnet-plat-ext-8.0).
+It's possible to test metrics in ASP.NET Core apps. One way to do that is collect and assert metrics values in [ASP.NET Core integration tests](xref:test/integration-tests) using <!--<xref:Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector%601>/[MetricCollector](/dotnet/api/microsoft.extensions.telemetry.testing.metering.metriccollector-1?view=dotnet-plat-ext-8.0)-->`Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector`.
 
 :::code language="csharp" source="~/log-mon/metrics/metrics/samples/metric-tests/BasicTests.cs" id="snippet_TestClass":::
 
 The proceeding test:
 
 * Bootstraps a web app in memory with <xref:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory%601>. `Program` in the factory's generic argument specifies the web app.
-* Collects metrics values with <!--<xref:Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector%601>--> [MetricCollector](https://learn.microsoft.com/dotnet/api/microsoft.extensions.telemetry.testing.metering.metriccollector-1?view=dotnet-plat-ext-8.0).
+* Collects metrics values with <!--<xref:Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector%601>/[MetricCollector](https://learn.microsoft.com/dotnet/api/microsoft.extensions.telemetry.testing.metering.metriccollector-1?view=dotnet-plat-ext-8.0)-->`Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector`.
 
   * Requires a package reference to `Microsoft.Extensions.Telemetry.Testing`.
   * The `MetricCollector<T>` is created using the web app's <xref:System.Diagnostics.Metrics.IMeterFactory>. This allows the collector to only report metrics values recorded by test.

--- a/aspnetcore/log-mon/metrics/metrics.md
+++ b/aspnetcore/log-mon/metrics/metrics.md
@@ -233,7 +233,7 @@ It's possible to test metrics in ASP.NET Core apps. One way to do that is collec
 The proceeding test:
 
 * Bootstraps a web app in memory with <xref:Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory%601>. `Program` in the factory's generic argument specifies the web app.
-* Collects metrics values with <!--<xref:Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector%601>/[MetricCollector](https://learn.microsoft.com/dotnet/api/microsoft.extensions.telemetry.testing.metering.metriccollector-1?view=dotnet-plat-ext-8.0)-->`Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector`.
+* Collects metrics values with <!--<xref:Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector%601>/[MetricCollector](/dotnet/api/microsoft.extensions.telemetry.testing.metering.metriccollector-1?view=dotnet-plat-ext-8.0)-->`Microsoft.Extensions.Telemetry.Testing.Metering.MetricCollector`.
 
   * Requires a package reference to `Microsoft.Extensions.Telemetry.Testing`.
   * The `MetricCollector<T>` is created using the web app's <xref:System.Diagnostics.Metrics.IMeterFactory>. This allows the collector to only report metrics values recorded by test.

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -22,8 +22,8 @@ This article is under development and not complete. More information may be foun
 * [What's new in .NET 8 Preview 6](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-6/)
 * [What's new in .NET 8 Preview 7](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-7/)
 * [What's new in .NET 8 Release Candidate 1](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-rc-1/)
-<!--
 * [What's new in .NET 8 Release Candidate 2](https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-rc-2/)
+<!--
 * [Announcing ASP.NET Core in .NET 8](https://devblogs.microsoft.com/dotnet/announcing-asp-net-core-in-dotnet-8/)
 -->
 
@@ -109,6 +109,8 @@ public HttpContext? HttpContext { get; set; }
 ```
 
 Accessing the <xref:Microsoft.AspNetCore.Http.HttpContext> from a static server component may be useful for inspecting and modifying headers or other properties.
+
+For an example that passes <xref:Microsoft.AspNetCore.Http.HttpContext> state, access and refresh tokens, to components, see <xref:blazor/security/server/additional-scenarios?view=aspnetcore-8.0&preserve-view=true#pass-tokens-to-a-server-side-blazor-app>.
 
 ### Render Razor components outside of ASP.NET Core
 


### PR DESCRIPTION
Addresses #28161

@Rick-Anderson ... In the Metrics article, the absolute links where throwing. Even when I tried to visit them in the browser they 404'ed on me 💥. Therefore, I'm just code-fencing the API in the doc to clear the build. I left the XREF and the absolute links in the article commented out.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/log-mon/metrics/metrics.md](https://github.com/dotnet/AspNetCore.Docs/blob/e0557a093b7d7ba73d8fb4a64f5a5c7224f6cd46/aspnetcore/log-mon/metrics/metrics.md) | [ASP.NET Core metrics](https://review.learn.microsoft.com/en-us/aspnet/core/log-mon/metrics/metrics?branch=pr-en-us-30668) |
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/e0557a093b7d7ba73d8fb4a64f5a5c7224f6cd46/aspnetcore/release-notes/aspnetcore-8.0.md) | [What's new in ASP.NET Core 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-30668) |


<!-- PREVIEW-TABLE-END -->