### PR TITLE
Clarity heading of Tag Helper list

### DIFF
--- a/aspnetcore/includes/built-in-TH.md
+++ b/aspnetcore/includes/built-in-TH.md
@@ -1,4 +1,4 @@
-## Built-in ASP.NET Cores
+## Built-in ASP.NET Core Tag Helpers
 
 **[Anchor](xref:mvc/views/tag-helpers/builtin-th/anchor-tag-helper)**
 


### PR DESCRIPTION
The listing of built-in tag helpers (included in e.g. https://learn.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/intro?view=aspnetcore-7.0#built-in-aspnet-cores) is using the heading "Built-in ASP.NET Cores", which doesn't make sense. This PR updates that heading to "Built-in ASP.NET Core Tag Helpers"