### PR TITLE
Update 70-80.md

### DIFF
--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -60,10 +60,10 @@ In the project file, update each [Microsoft.AspNetCore.*](https://www.nuget.org/
 
 ```diff
 <ItemGroup>
--   <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.0" />
--   <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0" />
--   <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
--   <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
+-   <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="7.0.12" />
+-   <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.12" />
+-   <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
+-   <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
 +   <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="8.0.0" />
 +   <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.0">
 +   <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />


### PR DESCRIPTION
Updated the package reference diff to use the latest v7 packages for the before state as they were incorrectly using 8.0.0.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/70-80.md](https://github.com/dotnet/AspNetCore.Docs/blob/f20f52d057e85f6cb8cebd95f433b8646ce27e14/aspnetcore/migration/70-80.md) | [Migrate from ASP.NET Core 7.0 to 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/migration/70-80?branch=pr-en-us-30693) |


<!-- PREVIEW-TABLE-END -->