### PR TITLE
Fix code snip for unit test HttpContext

### DIFF
--- a/aspnetcore/grpc/test-services.md
+++ b/aspnetcore/grpc/test-services.md
@@ -62,7 +62,7 @@ To configure a `HttpContext` during test setup, create a new instance and add it
 var httpContext = new DefaultHttpContext();
 
 var serverCallContext = TestServerCallContext.Create();
-serviceCallContext.UserState["__HttpContext"] = httpContext;
+serverCallContext.UserState["__HttpContext"] = httpContext;
 ```
 
 Execute service methods with this call context to use the configured `HttpContext` instance.


### PR DESCRIPTION
Use correct variable to access UserState collection in code snip



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/test-services.md](https://github.com/dotnet/AspNetCore.Docs/blob/8649deeff6cf278b3bf082f09c4c6b4f7b305c19/aspnetcore/grpc/test-services.md) | [Test gRPC services in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/test-services?branch=pr-en-us-30705) |


<!-- PREVIEW-TABLE-END -->