### PR TITLE
Restore keyed services section

### DIFF
--- a/aspnetcore/fundamentals/dependency-injection.md
+++ b/aspnetcore/fundamentals/dependency-injection.md
@@ -143,6 +143,11 @@ public class MyService
     }
 }
 ```
+### Keyed services
+
+*Keyed services* refers to a mechanism for registering and retrieving Dependency Injection (DI) services using keys. A service is associated with a key by calling <xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddKeyedSingleton%2A> (or `AddKeyedScoped` or `AddKeyedTransient`) to register it. Access a registered service by specifying the key with the [`[FromKeyedServices]`](xref:Microsoft.Extensions.DependencyInjection.FromKeyedServicesAttribute) attribute. The following code shows how to use keyed services:
+
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/samples/KeyedServices/Program.cs" highlight="6,7,12-14,39,47":::
 
 ## Constructor injection behavior
 


### PR DESCRIPTION
Fixes #30741
Restore the keyed services section only for .NET 8.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/dependency-injection.md](https://github.com/dotnet/AspNetCore.Docs/blob/bab007a3325efb1748bed6ae7c2fb55d8889eb1e/aspnetcore/fundamentals/dependency-injection.md) | [Dependency injection in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?branch=pr-en-us-30743) |

<!-- PREVIEW-TABLE-END -->