### PR TITLE
Fix typo in ObjectPool.md

### DIFF
--- a/aspnetcore/performance/ObjectPool.md
+++ b/aspnetcore/performance/ObjectPool.md
@@ -49,7 +49,7 @@ NOTE: After the pool is disposed:
 Important `ObjectPool` types and interfaces:
 
 * <xref:Microsoft.Extensions.ObjectPool.ObjectPool`1> : The basic object pool abstraction. Used to get and return objects.
-* <xref:Microsoft.Extensions.ObjectPool.PooledObjectPolicy%601> : Implement this to customize how an object is created and how it is reset when returned to the pool. This can be passed into an object pool that is constructed directly, or
+* <xref:Microsoft.Extensions.ObjectPool.PooledObjectPolicy%601> : Implement this to customize how an object is created and how it's reset when returned to the pool. This can be passed into an object pool that's constructed directly.
 * <xref:Microsoft.Extensions.ObjectPool.IResettable> : Automatically resets the object when returned to an object pool.
 
 The ObjectPool can be used in an app in multiple ways:

--- a/aspnetcore/performance/ObjectPool.md
+++ b/aspnetcore/performance/ObjectPool.md
@@ -49,7 +49,7 @@ NOTE: After the pool is disposed:
 Important `ObjectPool` types and interfaces:
 
 * <xref:Microsoft.Extensions.ObjectPool.ObjectPool`1> : The basic object pool abstraction. Used to get and return objects.
-* <xref:Microsoft.Extensions.ObjectPool.PooledObjectPolicy%601> : Implement this to customize how an object is created and how it is reset when returned to the pool. This can be passed into an object pool that is construct directly, or
+* <xref:Microsoft.Extensions.ObjectPool.PooledObjectPolicy%601> : Implement this to customize how an object is created and how it is reset when returned to the pool. This can be passed into an object pool that is constructed directly, or
 * <xref:Microsoft.Extensions.ObjectPool.IResettable> : Automatically resets the object when returned to an object pool.
 
 The ObjectPool can be used in an app in multiple ways:


### PR DESCRIPTION
The sentence:

> an object pool that is **construct** directly

Should read:

> an object pool that is **constructed** directly



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/ObjectPool.md](https://github.com/dotnet/AspNetCore.Docs/blob/966706ec02bbbbf1b215cb15c5287e3c5df204d2/aspnetcore/performance/ObjectPool.md) | [Object reuse with ObjectPool in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/ObjectPool?branch=pr-en-us-30754) |


<!-- PREVIEW-TABLE-END -->