### PR TITLE
8.0: Update What's New: SignalR stateful reconnect

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -428,8 +428,6 @@ To opt-in to stateful reconnect for a .NET client:
   });
   ```
 
-For more information on the progress of the SignalR stateful reconnect feature for ASP.NET Core 8.0, see [dotnet/aspnetcore #46691](https://github.com/dotnet/aspnetcore/issues/46691).
-
 ## Minimal APIs
 
 This section describes new features for minimal APIs. See also [the section on native AOT](#native-aot) for more information relevant to minimal APIs.

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -398,7 +398,7 @@ To opt-in to stateful reconnect for a JavaScript or Typescript client:
   const connection = builder.build();
   ```
 
-* The server also needs to enable support on the endpoint being accessed by the client:
+* Update the server hub endpoint configuration to enable the `AllowStatefulReconnects` option:
 
   ```csharp
   app.MapHub<MyHub>("/hubName", options =>
@@ -422,7 +422,10 @@ To opt-in to stateful reconnect for a .NET client:
 * Update the server hub endpoint configuration to enable the `AllowStatefulReconnects` option:
 
   ```csharp
-  app.MapHub<AppHub>("/default", o => o.AllowStatefulReconnects = true);
+  app.MapHub<MyHub>("/hubName", options =>
+  {
+      options.AllowStatefulReconnects = true;
+  });
   ```
 
 For more information on the progress of the SignalR stateful reconnect feature for ASP.NET Core 8.0, see [dotnet/aspnetcore #46691](https://github.com/dotnet/aspnetcore/issues/46691).

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -412,14 +412,11 @@ To opt-in to stateful reconnect for a .NET client:
 * Update the .NET client code to enable the `UseStatefulReconnect` option:
 
   ```csharp
-  var hubConnection = new HubConnectionBuilder()
-      .WithUrl("<hub url>",
-               options =>
-               {
-                  options.UseStatefulReconnect = true;
-                  options.StatefulReconnectBufferSize = 1000;  // Optional, defaults to 100,000
-               })
-      .Build();
+    var builder = new HubConnectionBuilder()
+        .WithUrl("<hub url>")
+        .WithStatefulReconnect();
+    builder.Services.Configure<HubConnectionOptions>(o => o.StatefulReconnectBufferSize = 1000);
+    var hubConnection = builder.Build();
   ```
 
 * Update the server hub endpoint configuration to enable the `AllowStatefulReconnects` option:

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -387,14 +387,14 @@ Stateful reconnect achieves this by:
 * Acknowledging messages received (ACK-ing) by both the server and client.
 * Recognizing when a connection is returning and replaying messages that may have been sent while the connection was down.
 
-To opt-in to seamless reconnect:
+To opt-in to stateful reconnect for a JavaScript or Typescript client:
 
 * Update the JavaScript or TypeScript client code to enable the `withStatefulReconnect` option:
 
   ```JavaScript
   const builder = new signalR.HubConnectionBuilder()
     .withUrl("/hubname")
-    .withStatefulReconnect({ bufferSize: 1000 }); // optional options, defaults to 100,000
+    .withStatefulReconnect({ bufferSize: 1000 });  // Optional, defaults to 100,000
   const connection = builder.build();
   ```
 
@@ -405,6 +405,27 @@ To opt-in to seamless reconnect:
   {
       options.AllowStatefulReconnects = true;
   });
+  ```
+
+To opt-in to stateful reconnect for a .NET client:
+
+* Update the .NET client code to enable the `UseStatefulReconnect` option:
+
+  ```csharp
+  var hubConnection = new HubConnectionBuilder()
+      .WithUrl("<hub url>",
+               options =>
+               {
+                  options.UseStatefulReconnect = true;
+                  options.StatefulReconnectBufferSize = 1000;  // Optional, defaults to 100,000
+               })
+      .Build();
+  ```
+
+* Update the server hub endpoint configuration to enable the `AllowStatefulReconnects` option:
+
+  ```csharp
+  app.MapHub<AppHub>("/default", o => o.AllowStatefulReconnects = true);
   ```
 
 For more information on the progress of the SignalR stateful reconnect feature for ASP.NET Core 8.0, see [dotnet/aspnetcore #46691](https://github.com/dotnet/aspnetcore/issues/46691).

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -377,11 +377,11 @@ builder.On<string, string>("ReceiveMessage", (user, message) => ...
 await builder.StartAsync();
 ```
 
-### SignalR seamless reconnect
+### SignalR stateful reconnect
 
-SignalR seamless reconnect reduces the perceived downtime of clients that have a temporary disconnect in their network connection, such as when switching network connections or a short temporary loss in access.
+SignalR stateful reconnect reduces the perceived downtime of clients that have a temporary disconnect in their network connection, such as when switching network connections or a short temporary loss in access.
 
-Seamless reconnect achieves this by:
+Stateful reconnect achieves this by:
 
 * Temporarily buffering data on the server and client.
 * Acknowledging messages received (ACK-ing) by both the server and client.
@@ -389,25 +389,25 @@ Seamless reconnect achieves this by:
 
 To opt-in to seamless reconnect:
 
-* Update the .NET client code to enable the `UseAcks` option:
+* Update the JavaScript or TypeScript client code to enable the `withStatefulReconnect` option:
 
-  ```csharp
-  var hubConnection = new HubConnectionBuilder()
-      .WithUrl("<hub url>",
-               options =>
-               {
-                  options.UseAcks = true;
-               })
-      .Build();
+  ```JavaScript
+  const builder = new signalR.HubConnectionBuilder()
+    .withUrl("/hubname")
+    .withStatefulReconnect({ bufferSize: 1000 }); // optional options, defaults to 100,000
+  const connection = builder.build();
   ```
 
-* Update the server hub endpoint configuration to enable the `AllowAcks` option:
+* The server also needs to enable support on the endpoint being accessed by the client:
 
   ```csharp
-  app.MapHub<AppHub>("/default", o => o.AllowAcks = true);
+  app.MapHub<MyHub>("/hubName", options =>
+  {
+      options.AllowStatefulReconnects = true;
+  });
   ```
 
-For more information on the progress of the seamless reconnect feature for ASP.NET Core 8.0, see [dotnet/aspnetcore #46691](https://github.com/dotnet/aspnetcore/issues/46691).
+For more information on the progress of the SignalR stateful reconnect feature for ASP.NET Core 8.0, see [dotnet/aspnetcore #46691](https://github.com/dotnet/aspnetcore/issues/46691).
 
 ## Minimal APIs
 


### PR DESCRIPTION
Fixes #30675 

Updates the SignalR stateful reconnect section of the What's New for 8.0.

- SignalR seamless reconnect is renamed to _SignalR stateful reconnect_.
- Code example updated.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/fe9ee39273a92a44a8c44ec0c622e690d9f7640b/aspnetcore/release-notes/aspnetcore-8.0.md) | [What's new in ASP.NET Core 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-30804) |


<!-- PREVIEW-TABLE-END -->