### PR TITLE
Content structure updates

### DIFF
--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -119,7 +119,7 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
    > [!NOTE]
    > In the following example, the project's namespace is `BlazorServerApp`. Adjust the namespace to match your project.
 
-   Remove the following lines from the top of the file and replace them with a line that injects an <xref:Microsoft.Extensions.Hosting.IHostEnvironment> instance:
+   Remove the following lines from the top of the file:
 
    ```diff
    - @page "/"
@@ -127,6 +127,8 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
    - @namespace BlazorServerApp.Pages
    - @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
    ```
+
+   Replace the preceding lines with a line that injects an <xref:Microsoft.Extensions.Hosting.IHostEnvironment> instance:
 
    ```razor
    @inject IHostEnvironment Env
@@ -139,21 +141,29 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
    + <base href="/" />
    ```
 
-   Remove the Component Tag Helper for the `HeadOutlet` component and replace it with the `HeadOutlet` component:
+   Remove the Component Tag Helper for the `HeadOutlet` component and replace it with the `HeadOutlet` component.
+
+   Remove:
 
    ```diff
    - <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
    ```
 
+   Replace the preceding line with the following line:
+
    ```razor
    <HeadOutlet @rendermode="InteractiveServer" />
    ```
 
-   Remove the Component Tag Helper for the `App` component and replace it with the `Routes` component:
+   Remove the Component Tag Helper for the `App` component and replace it with the `Routes` component.
+
+   Remove:
 
    ```diff
    - <component type="typeof(App)" render-mode="ServerPrerendered" />
    ```
+
+   Replace the preceding line with the following line:
 
    ```razor
    <Routes @rendermode="InteractiveServer" />
@@ -162,7 +172,9 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
    > [!NOTE]
    > The preceding configuration assumes that the app's components adopt interactive server rendering. For more information, including how to adopt static server rendering, see <xref:blazor/components/render-modes>.
 
-   Remove the Environment Tag Helpers for error UI and replace them with the following Razor markup:
+   Remove the Environment Tag Helpers for error UI and replace them with the following Razor markup.
+
+   Remove:
 
    ```diff
    - <environment include="Staging,Production">
@@ -172,6 +184,8 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
    -     An unhandled exception has occurred. See browser dev tools for details.
    - </environment>
    ```
+
+   Replace the preceding lines with the following:
 
    ```razor
    @if (Env.IsDevelopment())
@@ -210,22 +224,26 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
   
    Replace `AddServerSideBlazor` with `AddRazorComponents` and a chained call to `AddInteractiveServerComponents`.
    
-   Remove the following line and replace it with Razor component and interactive server component services:
+   Remove:
 
    ```diff
    - builder.Services.AddServerSideBlazor();
    ```
+
+   Rplace the preceding line with Razor component and interactive server component services:
 
    ```csharp
    builder.Services.AddRazorComponents()
        .AddInteractiveServerComponents();
    ```
 
-   Remove the following line and replace it with a call to `MapRazorComponents`, supplying the `App` component as the root component type, and add a chained call to `AddInteractiveServerRenderMode`:
+   Remove the following line:
   
    ```diff
    - app.MapBlazorHub();
    ```
+
+   Replace the preceding line with a call to `MapRazorComponents`, supplying the `App` component as the root component type, and add a chained call to `AddInteractiveServerRenderMode`:
 
    ```csharp
    app.MapRazorComponents<App>()
@@ -246,14 +264,11 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
 
 1. If the Blazor Server app was configured to disable prerendering, you can continue to disable prerendering for the updated app. In the `App` component, change the value assigned to the `@rendermode` Razor directive attributes for the `HeadOutlet` and `Routes` components.
 
-   Remove the following from the `HeadOutlet` and `Routes` components and replace them with the following `@rendermode` that disables prerendering:
+   Change the value of the `@rendermode` directive attribute for both the `HeadOutlet` and `Routes` components to disable prerendering:
 
    ```diff
    - @rendermode="InteractiveServer"
-   ```
-
-   ```razor
-   @rendermode="new InteractiveServerRenderMode(prerender: false)"
+   + @rendermode="new InteractiveServerRenderMode(prerender: false)"
    ```
 
    For more information, see <xref:blazor/components/render-modes?view=aspnetcore-8.0&preserve-view=true#prerendering>.
@@ -310,6 +325,8 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
    - </div>
    ```
 
+   Replace the preceding markup with the following line:
+
    ```razor
    <Routes @rendermode="new InteractiveWebAssemblyRenderMode(prerender: false)"
    ```
@@ -349,11 +366,13 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
    - app.UseBlazorFrameworkFiles();
    ```
 
-   Remove the following line and replace it with a call to `MapRazorComponents`, supplying the `App` component as the root component type, and add chained calls to `AddInteractiveWebAssemblyRenderMode` and `AddAdditionalAssemblies`:
+   Remove the following line:
    
    ```diff
    - app.MapFallbackToFile("index.html");
    ```
+
+   Replace the preceding line with a call to `MapRazorComponents`, supplying the `App` component as the root component type, and add chained calls to `AddInteractiveWebAssemblyRenderMode` and `AddAdditionalAssemblies`:
 
    ```csharp
    app.MapRazorComponents<App>()

--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -143,7 +143,7 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
 
    Remove the Component Tag Helper for the `HeadOutlet` component and replace it with the `HeadOutlet` component.
 
-   Remove:
+   Remove the following line:
 
    ```diff
    - <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
@@ -157,7 +157,7 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
 
    Remove the Component Tag Helper for the `App` component and replace it with the `Routes` component.
 
-   Remove:
+   Remove the following line:
 
    ```diff
    - <component type="typeof(App)" render-mode="ServerPrerendered" />
@@ -174,7 +174,7 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
 
    Remove the Environment Tag Helpers for error UI and replace them with the following Razor markup.
 
-   Remove:
+   Remove the following lines:
 
    ```diff
    - <environment include="Staging,Production">
@@ -224,7 +224,7 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
   
    Replace `AddServerSideBlazor` with `AddRazorComponents` and a chained call to `AddInteractiveServerComponents`.
    
-   Remove:
+   Remove the following line:
 
    ```diff
    - builder.Services.AddServerSideBlazor();

--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -149,7 +149,7 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
    - <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
    ```
 
-   Replace the preceding line with the following line:
+   Replace the preceding line with the following:
 
    ```razor
    <HeadOutlet @rendermode="InteractiveServer" />
@@ -163,7 +163,7 @@ Blazor Server apps are supported in .NET 8 without any code changes. Use the fol
    - <component type="typeof(App)" render-mode="ServerPrerendered" />
    ```
 
-   Replace the preceding line with the following line:
+   Replace the preceding line with the following:
 
    ```razor
    <Routes @rendermode="InteractiveServer" />
@@ -325,7 +325,7 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
    - </div>
    ```
 
-   Replace the preceding markup with the following line:
+   Replace the preceding markup with the following:
 
    ```razor
    <Routes @rendermode="new InteractiveWebAssemblyRenderMode(prerender: false)"


### PR DESCRIPTION
Addresses #28161 

I didn't care for the shortened DIFF-CODE block pairs without an intervening line. It's better in the long form with the added line.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/70-80.md](https://github.com/dotnet/AspNetCore.Docs/blob/9ba53a48edaf26a2dd659640ea39dae38dbb74c9/aspnetcore/migration/70-80.md) | [Migrate from ASP.NET Core 7.0 to 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/migration/70-80?branch=pr-en-us-30817) |


<!-- PREVIEW-TABLE-END -->