### PR TITLE
Heading update

### DIFF
--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -342,7 +342,7 @@ public class EmailController : Controller
 }
 ```
 
-## Avoid `IHttpContextAccessor`/`HttpContext` in Razor components
+## `IHttpContextAccessor`/`HttpContext` in Razor components (Blazor)
 
 [!INCLUDE[](~/blazor/security/includes/httpcontext.md)]
 


### PR DESCRIPTION
Minor heading update.

The INCLUDE has already been updated on earlier PRs for 8.0. We just need the heading here to drop "avoid" language, since its use is qualified in certain situations now.