### PR TITLE
Fix ASP.NET metric instrument name in example

### DIFF
--- a/aspnetcore/log-mon/metrics/metrics/samples/web-metrics/Program.cs
+++ b/aspnetcore/log-mon/metrics/metrics/samples/web-metrics/Program.cs
@@ -8,7 +8,7 @@ builder.Services.AddOpenTelemetry()
 
         builder.AddMeter("Microsoft.AspNetCore.Hosting",
                          "Microsoft.AspNetCore.Server.Kestrel");
-        builder.AddView("http-server-request-duration",
+        builder.AddView("http.server.request.duration",
             new ExplicitBucketHistogramConfiguration
             {
                 Boundaries = new double[] { 0, 0.005, 0.01, 0.025, 0.05,


### PR DESCRIPTION
As [documented elsewhere](https://learn.microsoft.com/en-us/dotnet/core/diagnostics/built-in-metrics-aspnetcore#instrument-httpserveractive_requests) (and [implemented](https://github.com/dotnet/aspnetcore/blob/6c1b3dfb66a1b66cc32ee26bbc23f6472f1dc985/src/Hosting/Hosting/src/Internal/HostingMetrics.cs#L30)) the instrument name uses dots rather than slashes: 

It seems that slashes were used in the [initial proposal](https://github.com/dotnet/aspnetcore/issues/47536).

