### PR TITLE
[Blazor] Update WebAssembly docs for handling compressed static assets

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -189,7 +189,7 @@ Blazor relies on the host to serve the appropriate compressed files. When using 
       import { BrotliDecode } from './decode.min.js';
       Blazor.start({
         loadBootResource: function (type, name, defaultUri, integrity) {
-          if (type !== 'dotnetjs' && location.hostname !== 'localhost' && type !== 'configuration') {
+          if (type !== 'dotnetjs' && location.hostname !== 'localhost' && type !== 'configuration' && type !== 'manifest') {
             return (async function () {
               const response = await fetch(defaultUri + '.br', { cache: 'no-cache' });
               if (!response.ok) {


### PR DESCRIPTION
Updates the example to exclude assets with the type `manifest` (usually `blazor.boot.json`).

This prevents headers like `Blazor-Environment` from getting lost when generating a decompressed response.

Fixes https://github.com/dotnet/aspnetcore/issues/51552

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/5ecd97fb3016b2cb3dfb6aaeaff91c88d677570d/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-30867) |

<!-- PREVIEW-TABLE-END -->