### PR TITLE
SignalR loglevel nuance in javascript

### DIFF
--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -72,7 +72,7 @@ When using the JavaScript client, you can configure logging options using the `c
 
 [!code-javascript[](diagnostics/logging-config-js.js?highlight=3)]
 
-To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method. Note that certain logs related to websockets are [emitted directly](https://websockets.spec.whatwg.org/#eventdef-websocket-error) by the browser and [cannot be disabled](https://github.com/dotnet/aspnetcore/issues/43822#issuecomment-1241205216) via the LogLevel or any other means.
+To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method. Note that some logging related to WebSockets are emitted directly by the browser and can't be disabled via setting the log level or any other means.
 
 The following table shows log levels available to the JavaScript client. Setting the log level to one of these values enables logging at that level and all levels above it in the table.
 

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -72,7 +72,7 @@ When using the JavaScript client, you can configure logging options using the `c
 
 [!code-javascript[](diagnostics/logging-config-js.js?highlight=3)]
 
-To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method.
+To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method. Note that certain logs related to websockets are [emitted directly](https://websockets.spec.whatwg.org/#eventdef-websocket-error) by the browser and [cannot be disabled](https://github.com/dotnet/aspnetcore/issues/43822#issuecomment-1241205216) via the LogLevel or any other means.
 
 The following table shows log levels available to the JavaScript client. Setting the log level to one of these values enables logging at that level and all levels above it in the table.
 

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -72,7 +72,7 @@ When using the JavaScript client, you can configure logging options using the `c
 
 [!code-javascript[](diagnostics/logging-config-js.js?highlight=3)]
 
-To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method. Note that some logging is emitted directly by the browser and can't be disabled via setting the log level or any other means.
+To disable framework logging, specify `signalR.LogLevel.None` in the `configureLogging` method. Note that some logging is emitted directly by the browser and can't be disabled via setting the log level.
 
 The following table shows log levels available to the JavaScript client. Setting the log level to one of these values enables logging at that level and all levels above it in the table.
 

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -72,7 +72,7 @@ When using the JavaScript client, you can configure logging options using the `c
 
 [!code-javascript[](diagnostics/logging-config-js.js?highlight=3)]
 
-To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method. Note that some logging related to WebSockets are emitted directly by the browser and can't be disabled via setting the log level or any other means.
+To disable logging entirely, specify `signalR.LogLevel.None` in the `configureLogging` method. Note that some logging is emitted directly by the browser and can't be disabled via setting the log level or any other means.
 
 The following table shows log levels available to the JavaScript client. Setting the log level to one of these values enables logging at that level and all levels above it in the table.
 


### PR DESCRIPTION
Spent a couple hours stuck on this until I found the github issue. Might be appropriate to mention it here as well?

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/signalr/diagnostics.md](https://github.com/dotnet/AspNetCore.Docs/blob/55e0509513347b19cba0910d32a1f210534189e6/aspnetcore/signalr/diagnostics.md) | [Logging and diagnostics in ASP.NET Core SignalR](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/diagnostics?branch=pr-en-us-30874) |


<!-- PREVIEW-TABLE-END -->