### PR TITLE
Drop Yarp-Blazor workaround 8.0

### DIFF
--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -83,6 +83,7 @@ The following migration scenarios are covered:
 * [Update a Blazor WebAssembly app](#update-a-blazor-webassembly-app)
 * [Convert a hosted Blazor WebAssembly app into a Blazor Web App](#convert-a-hosted-blazor-webassembly-app-into-a-blazor-web-app)
 * [Update service and endpoint option configuration](#update-service-and-endpoint-option-configuration)
+* [Drop Blazor Server with Yarp routing workaround](#drop-blazor-server-with-yarp-routing-workaround)
 
 For guidance on adding Blazor support to an ASP.NET Core app, see <xref:blazor/components/integration#add-blazor-support-to-an-aspnet-core-app>.
 
@@ -432,6 +433,10 @@ Updated configuration guidance appears in the following locations:
 * [Form binding options](xref:blazor/forms/binding?view=aspnetcore-8.0&preserve-view=true#additional-binding-options): Covers form binding options configuration.
 
 -->
+
+### Drop Blazor Server with Yarp routing workaround
+
+If you previously followed the guidance in <xref:migration/inc/blazor?view=aspnetcore-7.0&preserve-view=true> for migration .NET 6 or .NET 7, you can reverse the workaround steps that you took when following the article when you adopt .NET 8. Routing and deep linking for Blazor Server with Yarp work correctly in .NET 8.
 
 ## Update Docker images
 

--- a/aspnetcore/migration/inc/blazor.md
+++ b/aspnetcore/migration/inc/blazor.md
@@ -2,7 +2,7 @@
 title: Enable ASP.NET Core Blazor Server support with Yarp in incremental migration
 author: twsouthwick
 description: Learn how to enable ASP.NET Core Blazor Server support with Yarp in incremental migration.
-monikerRange: '>= aspnetcore-6.0'
+monikerRange: '>= aspnetcore-6.0 < aspnetcore-8.0'
 ms.author: tasou
 ms.custom: "mvc"
 ms.date: 03/01/2023

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -284,6 +284,12 @@ The UI components also support advanced Identity concepts, such as multifactor a
 
 Authentication samples for other app types are in development, including Blazor WebAssembly and single page apps (Angular, React).
 
+## Blazor Server with Yarp routing
+
+Routing and deep linking for Blazor Server with Yarp work correctly in .NET 8.
+
+For more information, see <xref:migration/70-to-80#drop-blazor-server-with-yarp-routing-workaround>.
+
 ## SignalR
 
 ### New approach to set the server timeout and Keep-Alive interval


### PR DESCRIPTION
Fixes #30528

* Capping the version of the Blazor Server with Yarp migration article for <8.0.
* Indicating to readers that they can drop the workaround ...
  * In the *Migration* guidance for Blazor.
  * As a *What's new* article entry.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/70-80.md](https://github.com/dotnet/AspNetCore.Docs/blob/dba3c307f0efebab69029e9b0b084f34f1e0c33a/aspnetcore/migration/70-80.md) | [Migrate from ASP.NET Core 7.0 to 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/migration/70-80?branch=pr-en-us-30885) |
| [aspnetcore/migration/inc/blazor.md](https://github.com/dotnet/AspNetCore.Docs/blob/dba3c307f0efebab69029e9b0b084f34f1e0c33a/aspnetcore/migration/inc/blazor.md) | [Enable ASP.NET Core Blazor Server support with Yarp in incremental migration](https://review.learn.microsoft.com/en-us/aspnet/core/migration/inc/blazor?branch=pr-en-us-30885) |
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/dba3c307f0efebab69029e9b0b084f34f1e0c33a/aspnetcore/release-notes/aspnetcore-8.0.md) | [What's new in ASP.NET Core 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-30885) |


<!-- PREVIEW-TABLE-END -->