### PR TITLE
Update .NET IL trimming remarks 8.0

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -122,9 +122,13 @@ In the app's project file:
 
 This setting trims away the IL code for most compiled methods, including methods from libraries and methods in the app. Not all compiled methods can be trimmed, as some are still required by the .NET interpreter at runtime.
 
-<!-- UPDATE 8.0 Remove the next line after some time has passed -->
+To report a problem with the trimming option, [open an issue on the `dotnet/runtime` GitHub repository](https://github.com/dotnet/runtime/issues).
 
-If you hit any issues using this trimming option, [open an issue on the `dotnet/runtime` GitHub repository](https://github.com/dotnet/runtime/issues).
+Disable the trimming property if it prevents your app from running normally:
+
+```xml
+<WasmStripILAfterAOT>false</WasmStripILAfterAOT>
+```
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #30535

Thanks @AceHack! 🚀 ... For now, we'll go with this. I'll keep an 👂 open on the `dotnet/runtime` issue for additional information and perhaps some firm guidance from that team on what to say (e.g., known, specific cases where it will fail that we can call out).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e1602912acfdb6792dfe63d57178b84664a1047/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-30886) |

<!-- PREVIEW-TABLE-END -->