### PR TITLE
Add a note about SignalR Hub.OnDisconnectedAsync method

### DIFF
--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -278,7 +278,7 @@ Override the `OnDisconnectedAsync` virtual method to perform actions when a clie
 <xref:Microsoft.AspNetCore.SignalR.IGroupManager.RemoveFromGroupAsync%2A> does not need to be called in <xref:Microsoft.AspNetCore.SignalR.Hub.OnDisconnectedAsync%2A>, it's automatically handled for you.
 
 > [!NOTE]
-> If the [SignalR transport method](/aspnet/core/signalr/introduction#transports) is `Long Polling`, the `OnDisconnectedAsync` will not be called by closing the browser tab when the debugger is attached.
+> If the [SignalR transport method](/aspnet/core/signalr/introduction#transports) is Long Polling, the `OnDisconnectedAsync` isn't called by closing the browser tab when the debugger is attached.
 
 ## Handle errors
 

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -278,7 +278,7 @@ Override the `OnDisconnectedAsync` virtual method to perform actions when a clie
 <xref:Microsoft.AspNetCore.SignalR.IGroupManager.RemoveFromGroupAsync%2A> does not need to be called in <xref:Microsoft.AspNetCore.SignalR.Hub.OnDisconnectedAsync%2A>, it's automatically handled for you.
 
 > [!NOTE]
-> If the [SignalR transport method](/aspnet/core/signalr/introduction#transports) is Long Polling, the `OnDisconnectedAsync` isn't called by closing the browser tab when the debugger is attached.
+> If the [SignalR transport method](xref:signalr/introduction#transports) is Long Polling, <xref:Microsoft.AspNetCore.SignalR.Hub.OnDisconnectedAsync%2A> isn't called by closing the browser tab when the debugger is attached.
 
 ## Handle errors
 

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -276,6 +276,10 @@ Override the `OnDisconnectedAsync` virtual method to perform actions when a clie
 :::code language="csharp" source="~/../AspNetCore.Docs.Samples/signalr/hubs/samples/6.x/SignalRHubsSample/Snippets/Hubs/ChatHub.cs" id="snippet_OnDisconnectedAsync":::
 
 <xref:Microsoft.AspNetCore.SignalR.IGroupManager.RemoveFromGroupAsync%2A> does not need to be called in <xref:Microsoft.AspNetCore.SignalR.Hub.OnDisconnectedAsync%2A>, it's automatically handled for you.
+
+> [!NOTE]
+> If the [SignalR transport method](/aspnet/core/signalr/introduction#transports) is `Long Polling`, the `OnDisconnectedAsync` will not be called by closing the browser tab when the debugger is attached.
+
 ## Handle errors
 
 Exceptions thrown in hub methods are sent to the client that invoked the method. On the JavaScript client, the `invoke` method returns a [JavaScript `Promise`](https://developer.mozilla.org/docs/Web/JavaScript/Guide/Using_promises). Clients can attach a `catch` handler to the returned promise or use `try`/`catch` with `async`/`await` to handle exceptions:


### PR DESCRIPTION


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/signalr/hubs.md](https://github.com/dotnet/AspNetCore.Docs/blob/5c3ebe88e1c8eeadb622c168a507f0afd8b18563/aspnetcore/signalr/hubs.md) | [Use hubs in SignalR for ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/hubs?branch=pr-en-us-30911) |


<!-- PREVIEW-TABLE-END -->