### PR TITLE
Update use-http-context.md

### DIFF
--- a/aspnetcore/fundamentals/use-http-context.md
+++ b/aspnetcore/fundamentals/use-http-context.md
@@ -99,6 +99,9 @@ An app can't modify headers after the response has started. Once the response st
 
 > System.InvalidOperationException: Headers are read-only, response has already started.
 
+> [!NOTE]
+> Unless response buffering is enabled, all write operations (`WriteAsync`, etc) will flush the response body internally, and will mark the response as started. Response buffering is disabled by default.
+
 ### Write response body
 
 An HTTP response can include a response body. The response body is data associated with the response, such as generated web page content, UTF-8 JSON payload, or a file.

--- a/aspnetcore/fundamentals/use-http-context.md
+++ b/aspnetcore/fundamentals/use-http-context.md
@@ -100,7 +100,7 @@ An app can't modify headers after the response has started. Once the response st
 > System.InvalidOperationException: Headers are read-only, response has already started.
 
 > [!NOTE]
-> Unless response buffering is enabled, all write operations (for example, `WriteAsync`) flush the response body internally and mark the response as started. Response buffering is disabled by default.
+> Unless response buffering is enabled, all write operations (for example, <xref:Microsoft.AspNetCore.Http.HttpResponseWritingExtensions.WriteAsync%2A>) flush the response body internally and mark the response as started. Response buffering is disabled by default.
 
 ### Write response body
 

--- a/aspnetcore/fundamentals/use-http-context.md
+++ b/aspnetcore/fundamentals/use-http-context.md
@@ -100,7 +100,7 @@ An app can't modify headers after the response has started. Once the response st
 > System.InvalidOperationException: Headers are read-only, response has already started.
 
 > [!NOTE]
-> Unless response buffering is enabled, all write operations (`WriteAsync`, etc) will flush the response body internally, and will mark the response as started. Response buffering is disabled by default.
+> Unless response buffering is enabled, all write operations (for example, `WriteAsync`) flush the response body internally and mark the response as started. Response buffering is disabled by default.
 
 ### Write response body
 


### PR DESCRIPTION
to clarify that WriteAsync counts as starting the response

for: docathon; fixes https://github.com/dotnet/aspnetcore/issues/45719

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/use-http-context.md](https://github.com/dotnet/AspNetCore.Docs/blob/810382789a8cafa048e887bcb437cabe37cd66a1/aspnetcore/fundamentals/use-http-context.md) | [Use HttpContext in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/use-http-context?branch=pr-en-us-30919) |


<!-- PREVIEW-TABLE-END -->