### PR TITLE
Update binding.md

### DIFF
--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -155,7 +155,7 @@ Use the `FormName` parameter to assign a form name. Form names must be unique to
 Supplying a form name:
 
 * Is required for all forms that are submitted by statically-rendered server-side components.
-* Isn't strictly required for forms that are submitted by interactively-rendered components, which includes forms in Blazor WebAssembly apps and components marked with an interactive render mode. However, we recommend supplying a unique form name for every form to prevent runtime form posting errors.
+* Isn't required for forms that are submitted by interactively-rendered components, which includes forms in Blazor WebAssembly apps and components marked with an interactive render mode. However, we recommend supplying a unique form name for every form to prevent runtime form posting errors if interactivity is ever dropped for a form.
 
 The form name is only checked when the form is posted to an endpoint as a traditional HTTP POST request from a statically-rendered server-side component. The framework doesn't throw an exception at the point of rendering a form, but only at the point that an HTTP POST arrives and doesn't specify a form name.
 

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -154,17 +154,16 @@ Use the `FormName` parameter to assign a form name. Form names must be unique to
 
 Supplying a form name:
 
-* Is required on all forms that are submitted via interactivity with server rendering.
-* Not required for interactive rendering, which includes forms in Blazor WebAssembly apps and components marked with an interactive render mode.
+* Is required for all forms that are submitted by statically-rendered server-side components.
+* Isn't strictly required for forms that are submitted by interactively-rendered components, which includes forms in Blazor WebAssembly apps and components marked with an interactive render mode.
 
-The form name is only checked when the form is posted to an endpoint as a traditional HTTP POST request (an SSR form post). The framework doesn't throw an exception at the point of rendering a form, but only at the point that an HTTP POST arrives and doesn't specify a form name.
+By default, there's an empty-named form scope above the app's root component, which suffices when there are no form name collisions. However, we recommend supplying a unique form name for every form to prevent runtime form posting errors.
 
-> [!WARNING]
-> We recommend supplying a unique form name for every form to prevent runtime form posting errors.
+The form name is only checked when the form is posted to an endpoint as a traditional HTTP POST request from a statically-rendered server-side component. The framework doesn't throw an exception at the point of rendering a form, but only at the point that an HTTP POST arrives and doesn't specify a form name.
 
-Define a scope for form names using the `FormMappingScope` component, which is useful for preventing form name collisions when a library supplies a form to a component and you have no way to control the form name used by the library's developer. By default, there's an empty-named scope above the app's root component, which suffices when there are no form name collisions.
-The FormMappingScope should be used in the `SSR project` as setting it in the `Web Assembly client project will trigger a warning.
-In the following example, the `FormMappingScope` scope name is `ParentContext` for the library-supplied form. POST events are routed to the correct form.
+To prevent form name collisions, add a scope for form names with the `FormMappingScope` component in the server-side project (not the `.Client` project). The `FormMappingScope` component and a unique form scope is especially useful for including forms supplied by a library and you have no way to control the form name used by the library's developer. 
+
+In the following example, the `HelloFromLibrary` component has a form named `Hello` and is supplied to the project by a library. The `NamedFormsWithScope` component uses the library's `HelloFromLibrary` component and also has a form named `Hello`. The `FormMappingScope` component's scope name is `ParentContext` for the library-supplied form. Although both of the forms have the form name `Hello`, the form names don't collide and events are routed to the correct form for POST events.
 
 `HelloFormFromLibrary.razor`:
 

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -163,7 +163,7 @@ The form name is only checked when the form is posted to an endpoint as a tradit
 > We recommend supplying a unique form name for every form to prevent runtime form posting errors.
 
 Define a scope for form names using the `FormMappingScope` component, which is useful for preventing form name collisions when a library supplies a form to a component and you have no way to control the form name used by the library's developer. By default, there's an empty-named scope above the app's root component, which suffices when there are no form name collisions.
-
+The FormMappingScope should be used in the `SSR project` as setting it in the `Web Assembly client project will trigger a warning.
 In the following example, the `FormMappingScope` scope name is `ParentContext` for the library-supplied form. POST events are routed to the correct form.
 
 `HelloFormFromLibrary.razor`:

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -161,7 +161,7 @@ By default, there's an empty-named form scope above the app's root component, wh
 
 The form name is only checked when the form is posted to an endpoint as a traditional HTTP POST request from a statically-rendered server-side component. The framework doesn't throw an exception at the point of rendering a form, but only at the point that an HTTP POST arrives and doesn't specify a form name.
 
-To prevent form name collisions, add a scope for form names with the `FormMappingScope` component in the server-side project (not the `.Client` project). The `FormMappingScope` component and a unique form scope is especially useful for including forms supplied by a library and you have no way to control the form name used by the library's developer. 
+To prevent form name collisions, add a scope for form names with the `FormMappingScope` component in the server-side project (not the `.Client` project of a Blazor Web App). The `FormMappingScope` component and a unique form scope is especially useful for including forms supplied by a library when you have no control of the form names used by the library's developer. 
 
 In the following example, the `HelloFromLibrary` component has a form named `Hello` and is supplied to the project by a library. The `NamedFormsWithScope` component uses the library's `HelloFromLibrary` component and also has a form named `Hello`. The `FormMappingScope` component's scope name is `ParentContext` for the library-supplied form. Although both of the forms have the form name `Hello`, the form names don't collide and events are routed to the correct form for POST events.
 

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -155,15 +155,13 @@ Use the `FormName` parameter to assign a form name. Form names must be unique to
 Supplying a form name:
 
 * Is required for all forms that are submitted by statically-rendered server-side components.
-* Isn't strictly required for forms that are submitted by interactively-rendered components, which includes forms in Blazor WebAssembly apps and components marked with an interactive render mode.
-
-By default, there's an empty-named form scope above the app's root component, which suffices when there are no form name collisions. However, we recommend supplying a unique form name for every form to prevent runtime form posting errors.
+* Isn't strictly required for forms that are submitted by interactively-rendered components, which includes forms in Blazor WebAssembly apps and components marked with an interactive render mode. However, we recommend supplying a unique form name for every form to prevent runtime form posting errors.
 
 The form name is only checked when the form is posted to an endpoint as a traditional HTTP POST request from a statically-rendered server-side component. The framework doesn't throw an exception at the point of rendering a form, but only at the point that an HTTP POST arrives and doesn't specify a form name.
 
-To prevent form name collisions, add a scope for form names with the `FormMappingScope` component in the server-side project. The `FormMappingScope` component and a unique form scope is especially useful for including forms supplied by a library when you have no control of the form names used by the library's developer. 
+By default, there's an unnamed (empty string) form scope above the app's root component, which suffices when there are no form name collisions in the app. If form name collisions are possible, such as when including a form from a library and you have no control of the form name used by the library's developer, provide a form name scope with the `FormMappingScope` component in the Blazor Web App's main project.
 
-In the following example, the `HelloFromLibrary` component has a form named `Hello` and is supplied to the project by a library. The `NamedFormsWithScope` component uses the library's `HelloFromLibrary` component and also has a form named `Hello`. The `FormMappingScope` component's scope name is `ParentContext` for the library-supplied form. Although both of the forms have the form name `Hello`, the form names don't collide and events are routed to the correct form for POST events.
+In the following example, the `HelloFormFromLibrary` component has a form named `Hello` and is in a library.
 
 `HelloFormFromLibrary.razor`:
 
@@ -175,7 +173,7 @@ In the following example, the `HelloFromLibrary` component has a form named `Hel
 
 @if (submitted)
 {
-    <p>Hello @Name from the library form!</p>
+    <p>Hello @Name from the library's form!</p>
 }
 
 @code {
@@ -187,6 +185,8 @@ In the following example, the `HelloFromLibrary` component has a form named `Hel
     private void Submit() => submitted = true;
 }
 ```
+
+The following `NamedFormsWithScope` component uses the library's `HelloFormFromLibrary` component and also has a form named `Hello`. The `FormMappingScope` component's scope name is `ParentContext` for any forms supplied by the `HelloFormFromLibrary` component. Although both of the forms in this example have the form name (`Hello`), the form names don't collide and events are routed to the correct form for form POST events.
 
 `NamedFormsWithScope.razor`:
 

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -161,7 +161,7 @@ By default, there's an empty-named form scope above the app's root component, wh
 
 The form name is only checked when the form is posted to an endpoint as a traditional HTTP POST request from a statically-rendered server-side component. The framework doesn't throw an exception at the point of rendering a form, but only at the point that an HTTP POST arrives and doesn't specify a form name.
 
-To prevent form name collisions, add a scope for form names with the `FormMappingScope` component in the server-side project (not the `.Client` project of a Blazor Web App). The `FormMappingScope` component and a unique form scope is especially useful for including forms supplied by a library when you have no control of the form names used by the library's developer. 
+To prevent form name collisions, add a scope for form names with the `FormMappingScope` component in the server-side project. The `FormMappingScope` component and a unique form scope is especially useful for including forms supplied by a library when you have no control of the form names used by the library's developer. 
 
 In the following example, the `HelloFromLibrary` component has a form named `Hello` and is supplied to the project by a library. The `NamedFormsWithScope` component uses the library's `HelloFromLibrary` component and also has a form named `Hello`. The `FormMappingScope` component's scope name is `ParentContext` for the library-supplied form. Although both of the forms have the form name `Hello`, the form names don't collide and events are routed to the correct form for POST events.
 

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -155,7 +155,7 @@ Use the `FormName` parameter to assign a form name. Form names must be unique to
 Supplying a form name:
 
 * Is required for all forms that are submitted by statically-rendered server-side components.
-* Isn't required for forms that are submitted by interactively-rendered components, which includes forms in Blazor WebAssembly apps and components marked with an interactive render mode. However, we recommend supplying a unique form name for every form to prevent runtime form posting errors if interactivity is ever dropped for a form.
+* Isn't required for forms that are submitted by interactively-rendered components, which includes forms in Blazor WebAssembly apps and components with an interactive render mode. However, we recommend supplying a unique form name for every form to prevent runtime form posting errors if interactivity is ever dropped for a form.
 
 The form name is only checked when the form is posted to an endpoint as a traditional HTTP POST request from a statically-rendered server-side component. The framework doesn't throw an exception at the point of rendering a form, but only at the point that an HTTP POST arrives and doesn't specify a form name.
 


### PR DESCRIPTION
The FormMappingScope works in the SSR project but triggers the warning below when used in the web assembly project
```
Error: One or more errors occurred. 
(Cannot instantiate implementation type 
'Microsoft.AspNetCore.Components.Forms.Mapping.IFormValueMapper'
 for service type
 'Microsoft.AspNetCore.Components.Forms.Mapping.IFormValueMapper'.)
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/4276e16c671745d92f71fab3ab122385d92b6d89/aspnetcore/blazor/forms/binding.md) | [ASP.NET Core Blazor forms binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?branch=pr-en-us-30938) |


<!-- PREVIEW-TABLE-END -->