### PR TITLE
fix moniker range security claims .NET 8

### DIFF
--- a/aspnetcore/security/authentication/claims.md
+++ b/aspnetcore/security/authentication/claims.md
@@ -54,7 +54,7 @@ ASP.NET Core adds default namespaces to some known claims, which might not be re
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-6.0 <= aspnetcore-8.0"
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
 [!code-csharp[](~/security/authentication/claims/sample6/WebRPmapClaims/Program.cs?name=snippet_NS&highlight=5)]
 


### PR DESCRIPTION
bugfix moniker range, code from .NET 6 displayed in .NET 8

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/claims.md](https://github.com/dotnet/AspNetCore.Docs/blob/0577565d7da141544bc33d8e02a00e8694fb8722/aspnetcore/security/authentication/claims.md) | [Mapping, customizing, and transforming claims in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/claims?branch=pr-en-us-30956) |

<!-- PREVIEW-TABLE-END -->