### PR TITLE
gRPC  interprocess: Move Named pipes content to 8.0 topic

### DIFF
--- a/aspnetcore/grpc/interprocess.md
+++ b/aspnetcore/grpc/interprocess.md
@@ -143,4 +143,4 @@ The client and server must be configured to use an inter-process communication (
 
 :::moniker-end
 
-[!INCLUDE[](~/grpc/interprocess/interprocess5-7.md)]
+[!INCLUDE[](~/grpc/interprocess/includes/interprocess5-7.md)]

--- a/aspnetcore/grpc/interprocess.md
+++ b/aspnetcore/grpc/interprocess.md
@@ -4,16 +4,18 @@ author: jamesnk
 description: Learn how to use gRPC for inter-process communication.
 monikerRange: '>= aspnetcore-5.0'
 ms.author: jamesnk
-ms.date: 09/12/2023
+ms.date: 11/08/2023
 uid: grpc/interprocess
 ---
 # Inter-process communication with gRPC
 
-By [James Newton-King](https://twitter.com/jamesnk)
+:::moniker range=">= aspnetcore-8.0"
 
 Processes running on the same machine can be designed to communicate with each other. Operating systems provide technologies for enabling fast and efficient [inter-process communication (IPC)](https://wikipedia.org/wiki/Inter-process_communication). Popular examples of IPC technologies are Unix domain sockets and Named pipes.
 
 .NET provides support for inter-process communication using gRPC.
+
+Built-in support for Named pipes in ASP.NET Core requires .NET 8 or later.
 
 ## Get started
 
@@ -138,3 +140,7 @@ The client and server must be configured to use an inter-process communication (
 
 > [!NOTE]
 > Built-in support for Named pipes in ASP.NET Core requires .NET 8 or later. .NET 8 is currently in preview and will be released near the end of 2023.
+
+:::moniker-end
+
+[!INCLUDE[](~/grpc/interprocess/interprocess5-7.md)]

--- a/aspnetcore/grpc/interprocess/includes/interprocess5-7.md
+++ b/aspnetcore/grpc/interprocess/includes/interprocess5-7.md
@@ -1,0 +1,122 @@
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-8.0"
+
+Processes running on the same machine can be designed to communicate with each other. Operating systems provide technologies for enabling fast and efficient [inter-process communication (IPC)](https://wikipedia.org/wiki/Inter-process_communication). Popular examples of IPC technologies are Unix domain sockets and Named pipes.
+
+.NET provides support for inter-process communication using gRPC.
+
+> [!NOTE]
+> Built-in support for Named pipes in ASP.NET Core requires .NET 8 or later.  
+> For more information, see [the .NET 8 or later version of this topic](xref:grpc/interprocess?view=aspnetcore-8.0)
+
+## Get started
+
+gRPC calls are sent from a client to a server. To communicate between apps on a machine with gRPC, at least one app must host an ASP.NET Core gRPC server.
+
+ASP.NET Core and gRPC can be hosted in any app using .NET Core 3.1 or later by adding the `Microsoft.AspNetCore.App` framework to the project.
+
+[!code-xml[](~/grpc/interprocess/Server.csproj?highlight=4-6)]
+
+The preceding project file:
+
+* Adds a framework reference to `Microsoft.AspNetCore.App`. The framework reference allows non-ASP.NET Core apps, such as Windows Services, WPF apps, or WinForms apps to use ASP.NET Core and host an ASP.NET Core server.
+* Adds a NuGet package reference to [`Grpc.AspNetCore`](https://www.nuget.org/packages/Grpc.AspNetCore).
+* Adds a `.proto` file.
+
+## Configure Unix domain sockets
+
+gRPC calls between a client and server on different machines are usually sent over TCP sockets. TCP was designed for communicating across a network. [Unix domain sockets (UDS)](https://wikipedia.org/wiki/Unix_domain_socket) are a widely supported IPC technology that's more efficient than TCP when the client and server are on the same machine. .NET provides built-in support for UDS in client and server apps.
+
+Requirements:
+
+* .NET 5 or later
+* Linux, macOS, or [Windows 10/Windows Server 2019 or later](https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/)
+
+### Server configuration
+
+Unix domain sockets (UDS) are supported by [Kestrel](xref:fundamentals/servers/kestrel), which is configured in `Program.cs`:
+
+```csharp
+public static readonly string SocketPath = Path.Combine(Path.GetTempPath(), "socket.tmp");
+
+public static IHostBuilder CreateHostBuilder(string[] args) =>
+    Host.CreateDefaultBuilder(args)
+        .ConfigureWebHostDefaults(webBuilder =>
+        {
+            webBuilder.UseStartup<Startup>();
+            webBuilder.ConfigureKestrel(options =>
+            {
+                if (File.Exists(SocketPath))
+                {
+                    File.Delete(SocketPath);
+                }
+                options.ListenUnixSocket(SocketPath, listenOptions =>
+                {
+                    listenOptions.Protocols = HttpProtocols.Http2;
+                });
+            });
+        });
+```
+
+The preceding example:
+
+* Configures Kestrel's endpoints in `ConfigureKestrel`.
+* Calls <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.ListenUnixSocket%2A> to listen to a UDS with the specified path.
+* Creates a UDS endpoint that isn't configured to use HTTPS. For information about enabling HTTPS, see [Kestrel HTTPS endpoint configuration](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps).
+
+### Client configuration
+
+`GrpcChannel` supports making gRPC calls over custom transports. When a channel is created, it can be configured with a `SocketsHttpHandler` that has a custom `ConnectCallback`. The callback allows the client to make connections over custom transports and then send HTTP requests over that transport.
+
+Unix domain sockets connection factory example:
+
+```csharp
+public class UnixDomainSocketConnectionFactory
+{
+    private readonly EndPoint _endPoint;
+
+    public UnixDomainSocketConnectionFactory(EndPoint endPoint)
+    {
+        _endPoint = endPoint;
+    }
+
+    public async ValueTask<Stream> ConnectAsync(SocketsHttpConnectionContext _,
+        CancellationToken cancellationToken = default)
+    {
+        var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+
+        try
+        {
+            await socket.ConnectAsync(_endPoint, cancellationToken).ConfigureAwait(false);
+            return new NetworkStream(socket, true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+}
+```
+
+Using the custom connection factory to create a channel:
+
+```csharp
+public static readonly string SocketPath = Path.Combine(Path.GetTempPath(), "socket.tmp");
+
+public static GrpcChannel CreateChannel()
+{
+    var udsEndPoint = new UnixDomainSocketEndPoint(SocketPath);
+    var connectionFactory = new UnixDomainSocketConnectionFactory(udsEndPoint);
+    var socketsHttpHandler = new SocketsHttpHandler
+    {
+        ConnectCallback = connectionFactory.ConnectAsync
+    };
+
+    return GrpcChannel.ForAddress("http://localhost", new GrpcChannelOptions
+    {
+        HttpHandler = socketsHttpHandler
+    });
+}
+```
+
+Channels created using the preceding code send gRPC calls over Unix domain sockets. Support for other IPC technologies can be implemented using the extensibility in Kestrel and `SocketsHttpHandler`.

--- a/aspnetcore/grpc/interprocess/includes/interprocess5-7.md
+++ b/aspnetcore/grpc/interprocess/includes/interprocess5-7.md
@@ -120,3 +120,5 @@ public static GrpcChannel CreateChannel()
 ```
 
 Channels created using the preceding code send gRPC calls over Unix domain sockets. Support for other IPC technologies can be implemented using the extensibility in Kestrel and `SocketsHttpHandler`.
+
+:::moniker-end


### PR DESCRIPTION
Internal review:
[.NET 8 version: Interprocess](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/interprocess?view=aspnetcore-8.0&branch=pr-en-us-30981)
[.NET 5-7 versions: Interprocess](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/interprocess?view=aspnetcore-7.0&branch=pr-en-us-30981)


Fixes #30823 

Goal:  Move all Named pipes support information to the .NET 8 topic only so it is not in previous versions.

**Added file include versioning:**

- Moved to file include type versioning.  There was previously only one version of this topic.  Now there is a .NET 5-7 version and .NET 8 version.

**For the .NET 8 version of the Interprocess topic:**

- Added at the top that Named pipe support requires .NET 8 or later.

**For .NET versions 5-7 of the Interprocess topic:**

- Reverted to pre-.NET 8 so  v5-7 does not include the new .NET 8 Named pipes content.  Includes all changes made up to, but not including PR #28129 which centered on adding Named pipes support.
- Add a note at the top of the v5-7 topics that Named pipes support was added with .NET 8 and link to the .NET 8 version of the topic for more detail.
- Verified any changes to v5-7 of the topic after PR #28129 were .NET 8 specific.  I did not find changes to incorporate back into v5-7.





<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/interprocess.md](https://github.com/dotnet/AspNetCore.Docs/blob/9415f93275e1cce39b42e778376945b1a754adcb/aspnetcore/grpc/interprocess.md) | [Inter-process communication with gRPC](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/interprocess?branch=pr-en-us-30981) |


<!-- PREVIEW-TABLE-END -->