### PR TITLE
Create Min Web API: Link to code sample

### DIFF
--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -624,6 +624,10 @@ Verify you can post and get all fields except the secret field.
 
 <a name="diff-v7"></a>
 
+## Troubleshooting with the completed sample
+
+If you run into a problem you can't resolve, compare your code to the completed project. [View or download completed project](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/min-web-api/samples) ([how to download](xref:index#how-to-download-a-sample)).
+
 ## Next steps
 
 * [Configure JSON serialization options](xref:fundamentals/minimal-apis/responses#configure-json-serialization-options).

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
@@ -414,6 +414,10 @@ Verify you can post and get all fields except the secret field.
 
 <a name="diff-v7"></a>
 
+## Troubleshooting with the completed sample
+
+If you run into a problem you can't resolve, compare your code to the completed project. [View or download completed project](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/min-web-api/samples) ([how to download](xref:index#how-to-download-a-sample)).
+
 ## Next steps
 
 ### Configure JSON serialization options
@@ -898,6 +902,10 @@ The following code uses <xref:System.Text.Json.JsonSerializerOptions>:
 [!code-csharp[](~/tutorials/min-web-api/samples/6.x/WebMinJson/Program.cs?name=snippet_2)]
 
 The preceding code uses [web defaults](/dotnet/standard/serialization/system-text-json-configure-options#web-defaults-for-jsonserializeroptions), which converts property names to camel case.
+
+## Troubleshooting with the completed sample
+
+If you run into a problem you can't resolve, compare your code to the completed project. [View or download completed project](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/min-web-api/samples) ([how to download](xref:index#how-to-download-a-sample)).
 
 ## Test minimal API
 


### PR DESCRIPTION
Fixes #30588

Made the code samples for this tutorial discoverable at bottom of the topic.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/min-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/eae06ccaefe22508a8854c6421726608efbce57b/aspnetcore/tutorials/min-web-api.md) | [Tutorial: Create a minimal API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?branch=pr-en-us-30999) |


<!-- PREVIEW-TABLE-END -->