### PR TITLE
Fix typo (EventUntil -> EventUtil)

### DIFF
--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -474,7 +474,7 @@ In the following example, no event handler added to the component triggers a rer
 
 In addition to preventing rerenders after event handlers fire in a component in a global fashion, it's possible to prevent rerenders after a single event handler by employing the following utility method.
 
-Add the following `EventUntil` class to a Blazor app. The static actions and functions at the top of the `EventUtil` class provide handlers that cover several combinations of arguments and return types that Blazor uses when handling events.
+Add the following `EventUtil` class to a Blazor app. The static actions and functions at the top of the `EventUtil` class provide handlers that cover several combinations of arguments and return types that Blazor uses when handling events.
 
 `EventUtil.cs`:
 


### PR DESCRIPTION
Fix typo (EventUntil -> EventUtil).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/performance.md](https://github.com/dotnet/AspNetCore.Docs/blob/6e1ea6cbe22f98415760ec9a4c7b7120caf6535f/aspnetcore/blazor/performance.md) | [ASP.NET Core Blazor performance best practices](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/performance?branch=pr-en-us-31069) |

<!-- PREVIEW-TABLE-END -->