### PR TITLE
Apply a CSP in non-Development environments

### DIFF
--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -314,10 +314,11 @@ When a CSP is applied to a Blazor app's `<head>` content, it interferes with loc
 > [!NOTE]
 > The examples in this section don't show the full `<meta>` tag for the CSPs. The complete `<meta>` tags are found in the subsections of the [Apply the policy](#apply-the-policy) section.
 
-Two approaches are available for server-side and client-side Blazor Apps:
+Three general approaches are available for server-side and client-side Blazor Apps:
 
 * Apply the CSP via the `App` component, which applies the CSP to all layouts of the app.
 * Apply the CSP to the app's layout files using the [`<HeadContent>` tag](xref:blazor/components/control-head-content). For complete effectiveness, every app layout file must adopt the approach.
+* The hosting service or server can append the CSP via a [`Content-Security-Policy` header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) to an app's outgoing responses. Because this approach varies quite a bit by hosting service or server, it isn't addressed in the following examples. If you wish to adopt this approach, consult the hosting service provider or hosting server documentation.
 
 ### Blazor Web App approaches
 
@@ -409,6 +410,7 @@ Test and update an app's policy every release.
 ## Additional resources
 
 * [Apply a CSP in C# code at startup](xref:blazor/fundamentals/startup#control-headers-in-c-code)
-* [MDN web docs: Content-Security-Policy](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy)
+* [MDN web docs: Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+* [MDN web docs: Content-Security-Policy response header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy)
 * [Content Security Policy Level 2](https://www.w3.org/TR/CSP2/)
 * [Google CSP Evaluator](https://csp-evaluator.withgoogle.com/)

--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -312,13 +312,13 @@ The particular script associated with the error is displayed in the console next
 When a CSP is applied to a Blazor app's `<head>` content, it interferes with local testing in the Development environment. For example, [Browser Link](xref:client-side/using-browserlink) and the browser refresh script fail to load. The following examples demonstrate how to apply the CSP's `<meta>` tag in non-Development environments.
 
 > [!NOTE]
-> The examples in this section don't show the full `<meta>` tag for the CSPs. The complete `<meta>` tags are found in the subsections of the [Apply the policy](#apply-the-policy) section.
+> The examples in this section don't show the full `<meta>` tag for the CSPs. The complete `<meta>` tags are found in the subsections of the [Apply the policy](#apply-the-policy) section earlier in this article.
 
-Three general approaches are available for server-side and client-side Blazor Apps:
+Three general approaches are available:
 
 * Apply the CSP via the `App` component, which applies the CSP to all layouts of the app.
 * Apply the CSP to the app's layout files using the [`<HeadContent>` tag](xref:blazor/components/control-head-content). For complete effectiveness, every app layout file must adopt the approach.
-* The hosting service or server can append the CSP via a [`Content-Security-Policy` header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) to an app's outgoing responses. Because this approach varies quite a bit by hosting service or server, it isn't addressed in the following examples. If you wish to adopt this approach, consult the hosting service provider or hosting server documentation.
+* The hosting service or server can provide a CSP via a [`Content-Security-Policy` header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) added an app's outgoing responses. Because this approach varies by hosting service or server, it isn't addressed in the following examples. If you wish to adopt this approach, consult the documentation for your hosting service provider or server.
 
 ### Blazor Web App approaches
 

--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -317,7 +317,7 @@ When a CSP is applied to a Blazor app's `<head>` content, it interferes with loc
 Three general approaches are available:
 
 * Apply the CSP via the `App` component, which applies the CSP to all layouts of the app.
-* Apply the CSP to the app's layout files using the [`<HeadContent>` tag](xref:blazor/components/control-head-content). For complete effectiveness, every app layout file must adopt the approach.
+* If you need to apply CSPs to different areas of the app, for example a custom CSP for only the admin pages, apply the CSPs on a per-layout basis using the [`<HeadContent>` tag](xref:blazor/components/control-head-content). For complete effectiveness, every app layout file must adopt the approach.
 * The hosting service or server can provide a CSP via a [`Content-Security-Policy` header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy) added an app's outgoing responses. Because this approach varies by hosting service or server, it isn't addressed in the following examples. If you wish to adopt this approach, consult the documentation for your hosting service provider or server.
 
 ### Blazor Web App approaches
@@ -337,7 +337,7 @@ In the `App` component's `<head>` content, apply the CSP when not in the Develop
 }
 ```
 
-Alternatively, apply the CSP in every app layout file in the `Components/Layout` folder:
+Alternatively, apply CSPs on a per-layout basis in the `Components/Layout` folder, as the following example demonstrates. Make sure that every layout specifies a CSP.
 
 ```razor
 @inject IHostEnvironment Env
@@ -370,7 +370,7 @@ In the `App` component's `<head>` content, apply the CSP when not in the Develop
 }
 ```
 
-Alternatively, use the preceding code but apply the CSP in every app layout file in the `Layout` folder.
+Alternatively, use the preceding code but apply CSPs on a per-layout basis in the `Layout` folder. Make sure that every layout specifies a CSP.
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #31105

Mackinnon ...

* Our CSP guidance seems ok. We addressed it during an early preview.
* I wanted to confirm all is well anyway and was reminded that we never had guidance on how to only apply CSPs in non-Development environments. It's always been a PITA 😠 during development just plopping a CSP into `<head>` content. I add a new section (just picking up with 8.0+, I won't sweat prior releases) that will assist devs with this problem.
* ***Section order change***: When you look at the DIFF, the first thing that you'll see is the *Server-side Blazor apps* section, which isn't being added as new content. It's just moving from below the *Client-side Blazor apps* section to above it. We're generally ordering our server-side coverage above our client-side coverage these days. Scroll down to the new *Apply a CSP in non-Development environments* section for the real 🍖 part of the PR.

If you want to see all of the Development errors that hit when a CSP is just dropped in and the app is run in the Development environment, they're in the opening comment of the issue at ...

https://github.com/dotnet/AspNetCore.Docs/issues/31105

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/content-security-policy.md](https://github.com/dotnet/AspNetCore.Docs/blob/7db5898b856e9d69e42b24279c0cc39a5b0f64cd/aspnetcore/blazor/security/content-security-policy.md) | [Enforce a Content Security Policy for ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/content-security-policy?branch=pr-en-us-31106) |


<!-- PREVIEW-TABLE-END -->