### PR TITLE
Clarify timeout middleware ordering

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -288,7 +288,7 @@ ASP.NET Core ships with the following middleware components. The *Order* column 
 | [Request Decompression](xref:fundamentals/middleware/request-decompression) | Provides support for decompressing requests. | Before components that read the request body. |
 | [Response Compression](xref:performance/response-compression) | Provides support for compressing responses. | Before components that require compression. |
 | [Request Localization](xref:fundamentals/localization) | Provides localization support. | Before localization sensitive components. Must appear after Routing Middleware when using <xref:Microsoft.AspNetCore.Localization.Routing.RouteDataRequestCultureProvider>. |
-| [Request Timeouts](xref:performance/timeouts) | Provides support for configuring request timeouts, global and per endpoint. | `UseRouting` must come before `UseRequestTimeouts`. |
+| [Request Timeouts](xref:performance/timeouts) | Provides support for configuring request timeouts, global and per endpoint. | `UseRequestTimeouts` must come after `UseExceptionHandler`, `UseDeveloperExceptionPage`, and `UseRouting`. |
 | [Endpoint Routing](xref:fundamentals/routing) | Defines and constrains request routes. | Terminal for matching routes. |
 | [SPA](xref:Microsoft.AspNetCore.Builder.SpaApplicationBuilderExtensions.UseSpa%2A) | Handles all requests from this point in the middleware chain by returning the default page for the Single Page Application (SPA) | Late in the chain, so that other middleware for serving static files, MVC actions, etc., takes precedence.|
 | [Session](xref:fundamentals/app-state) | Provides support for managing user sessions. | Before components that require Session. | 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/52295

All three of these middleware can handle an exception and not re-throw it, the most specific middleware (timeouts) needs to be last so it can handle them first.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/middleware/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/4c52cf71e26455278a284467a6094ac66dc44620/aspnetcore/fundamentals/middleware/index.md) | [ASP.NET Core Middleware](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/index?branch=pr-en-us-31110) |

<!-- PREVIEW-TABLE-END -->