### PR TITLE
Custom Blazor WASM loading progress indicator

### DIFF
--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -245,3 +245,10 @@ For approaches to manage state, see the following resources:
 For the state manager approach, C# events are outside the Blazor rendering pipeline. Call <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> on other components you wish to rerender in response to the state manager's events.
 
 The state manager approach is similar to the earlier case with <xref:System.Timers.Timer?displayProperty=fullName> in the [previous section](#receiving-a-call-from-something-external-to-the-blazor-rendering-and-event-handling-system). Since the execution call stack typically remains on the renderer's synchronization context, calling <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A> isn't normally required. Calling <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A> is only required if the logic escapes the synchronization context, such as calling <xref:System.Threading.Tasks.Task.ContinueWith%2A> on a <xref:System.Threading.Tasks.Task> or awaiting a <xref:System.Threading.Tasks.Task> with [`ConfigureAwait(false)`](xref:System.Threading.Tasks.Task.ConfigureAwait%2A). For more information, see the [Receiving a call from something external to the Blazor rendering and event handling system](#receiving-a-call-from-something-external-to-the-blazor-rendering-and-event-handling-system) section.
+
+## WebAssembly loading progress indicator for Blazor Web Apps
+
+<!-- UPDATE 9.0 Will be removed for a new feature in this area. 
+                Tracked by: https://github.com/dotnet/aspnetcore/issues/49056 -->
+
+A loading progress indicator isn't present in an app created from the Blazor Web App project template. A new loading progress indicator feature is planned for a future release of .NET. In the meantime, an app can adopt custom code to create a loading progress indicator. For more information, see <xref:blazor/fundamentals/startup#client-side-loading-progress-indicators>.

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -528,7 +528,7 @@ A loading progress indicator shows the loading progress of the app to users, ind
 
 ### Blazor Web App loading progress
 
-The loading progress indicator used in Blazor WebAssembly apps isn't present in an app created from the Blazor Web App project template. Usually, a loading progress indicator isn't desirable for interactive components because Blazor Web Apps prerender components on the server for fast initial load times. For mixed-render-mode situations, the framework or developer code must also be careful to avoid the following problems:
+The loading progress indicator used in Blazor WebAssembly apps isn't present in an app created from the Blazor Web App project template. Usually, a loading progress indicator isn't desirable for interactive WebAssembly components because Blazor Web Apps prerender client-side components on the server for fast initial load times. For mixed-render-mode situations, the framework or developer code must also be careful to avoid the following problems:
 
 * Showing multiple loading indicators on the same rendered page.
 * Inadvertently discarding prerendered content while the WebAssembly runtime is loading.
@@ -536,23 +536,14 @@ The loading progress indicator used in Blazor WebAssembly apps isn't present in 
 <!-- UPDATE 9.0 Will be removed for a new feature in this area. 
                 Tracked by: https://github.com/dotnet/aspnetcore/issues/49056 -->
 
-A future release of .NET might provide a framework-based loading progress indicator. In the meantime, you can add a custom loading progress indicator to a Blazor Web App that only adopts interactive client-side rendering.
-
-> [!IMPORTANT]
->The demonstration in this section only applies to apps that implement global Interactive WebAssembly rendering via the `App` component (`Components/App.razor`) in the server project:
->
-> ```razor
-> <HeadOutlet @rendermode="InteractiveWebAssembly" />
-> ...
-> <Routes @rendermode="InteractiveWebAssembly" />
-> ```
+A future release of .NET might provide a framework-based loading progress indicator. In the meantime, you can add a custom loading progress indicator to a Blazor Web App.
 
 Create a `LoadingProgress` component in the `.Client` app that calls <xref:System.OperatingSystem.IsBrowser%2A?displayProperty=nameWithType>:
 
-* When <xref:System.OperatingSystem.IsBrowser%2A> is `false`, display a loading progress indicator while the Blazor bundle is downloaded and before the Blazor runtime activates on the client.
-* When <xref:System.OperatingSystem.IsBrowser%2A> is `true`, render the requested component.
+* When `false`, display a loading progress indicator while the Blazor bundle is downloaded and before the Blazor runtime activates on the client.
+* When `true`, render the requested component.
 
-The following demonstration uses the loading progress indicator found in apps created from the Blazor WebAssembly template, including the styles that the template provides. The styles are loaded into the app's `<head>` content by <xref:Microsoft.AspNetCore.Components.Web.HeadContent> component. For more information, see <xref:blazor/components/control-head-content>.
+The following demonstration uses the loading progress indicator found in apps created from the Blazor WebAssembly template, including a modification of the styles that the template provides. The styles are loaded into the app's `<head>` content by <xref:Microsoft.AspNetCore.Components.Web.HeadContent> component. For more information, see <xref:blazor/components/control-head-content>.
 
 `LoadingProgress.razor`:
 
@@ -586,10 +577,10 @@ The following demonstration uses the loading progress indicator found in apps cr
                     }
 
             .loading-progress-text {
-                position: absolute;
+                position: relative;
                 text-align: center;
                 font-weight: bold;
-                inset: calc(20vh + 3.25rem) 0 auto 0.2rem;
+                top: -90px;
             }
 
                 .loading-progress-text:after {
@@ -618,18 +609,32 @@ else
 }
 ```
 
-In the `Routes` component, wrap the `<Found>` content with the `LoadingProgress` component. In the following example, the `.Client` project's namespace is `BlazorSample.Client`, and the `LoadingProgress` component is in the project's `Pages` folder:
+In a component that adopts Interactive WebAssembly rendering, wrap the component's Razor markup with the `LoadingProgress` component. The following example demonstrates the approach with the `Counter` component of an app created from the Blazor Web App project template.
+
+`Pages/Counter.razor`:
 
 ```razor
-<Router AppAssembly="@typeof(Program).Assembly">
-    <Found Context="routeData">
-        <BlazorSample.Client.Pages.LoadingProgress>
-            <RouteView RouteData="@routeData" 
-                DefaultLayout="@typeof(Layout.MainLayout)" />
-            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-        </BlazorSample.Client.Pages.LoadingProgress>
-    </Found>
-</Router>
+@page "/counter"
+@rendermode InteractiveWebAssembly
+
+<PageTitle>Counter</PageTitle>
+
+<LoadingProgress>
+    <h1>Counter</h1>
+
+    <p role="status">Current count: @currentCount</p>
+
+    <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+</LoadingProgress>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+}
 ```
 
 ### Blazor WebAssembly app loading progress

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -520,7 +520,40 @@ For more information on CSPs, see <xref:blazor/security/content-security-policy>
 
 ## Client-side loading progress indicators
 
-*This section only applies to Blazor WebAssembly apps.*
+A loading progress indicator shows the loading progress of the app to users, indicating that the app is loading normally and that the user should wait until loading is finished.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
+
+### Blazor Web App loading progress
+
+The loading progress indicator used in Blazor WebAssembly apps isn't present in an app created from the Blazor Web App project template. Usually, a loading progress indicator isn't desirable for interactive client-side components (Interactive WebAssembly rendering) because Blazor Web Apps prerender the components on the server for fast initial load times. The framework or developer code must also be careful to avoid the following problems:
+
+* Showing multiple loading indicators on the same rendered page.
+* Inadvertently discarding prerendered content while the WebAssembly runtime is loading.
+
+<!-- UPDATE 9.0 Will be removed for a new feature in this area. 
+                Tracked by: https://github.com/dotnet/aspnetcore/issues/49056 -->
+
+A future release of .NET might provide a framework-based loading progress indicator for times when you need to explicitly disable prerendering. In the meantime, you can add a custom loading progress indicator to a Blazor Web App for WebAssembly components that aren't prerendered:
+
+
+
+
+* Prerender a wrapper component that displays the placeholder on the page. Inside the wrapper, render the component with prerendering disabled.
+* Have the wrapper use `@if(OsPlatform.IsBrowser())` to distinguish between SSR and WebAssembly and render your placeholder or the actual component.
+
+
+
+
+
+
+### Blazor WebAssembly app loading progress
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0"
 
 The project template contains Scalable Vector Graphics (SVG) and text indicators that show the loading progress of the app.
 

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -541,9 +541,9 @@ A future release of .NET might provide a framework-based loading progress indica
 Create a `LoadingProgress` component in the `.Client` app that calls <xref:System.OperatingSystem.IsBrowser%2A?displayProperty=nameWithType>:
 
 * When `false`, display a loading progress indicator while the Blazor bundle is downloaded and before the Blazor runtime activates on the client.
-* When `true`, render the requested component.
+* When `true`, render the requested component's content.
 
-The following demonstration uses the loading progress indicator found in apps created from the Blazor WebAssembly template, including a modification of the styles that the template provides. The styles are loaded into the app's `<head>` content by <xref:Microsoft.AspNetCore.Components.Web.HeadContent> component. For more information, see <xref:blazor/components/control-head-content>.
+The following demonstration uses the loading progress indicator found in apps created from the Blazor WebAssembly template, including a modification of the styles that the template provides. The styles are loaded into the app's `<head>` content by the <xref:Microsoft.AspNetCore.Components.Web.HeadContent> component. For more information, see <xref:blazor/components/control-head-content>.
 
 `LoadingProgress.razor`:
 


### PR DESCRIPTION
Fixes #31048
Addresses #28161 

I built something that doesn't match what Javier described at https://github.com/dotnet/aspnetcore/issues/52076#issuecomment-1812541641. The 🦖 ***RexHax!***&trade; approach on the PR seems to work, but I suspect it has some 🐉🐉🐉. It at least doesn't seem to be right for WASM components that don't prerender.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/rendering.md](https://github.com/dotnet/AspNetCore.Docs/blob/3d02c3358740da57251f2f2b1fdda65d222bdf30/aspnetcore/blazor/components/rendering.md) | [ASP.NET Core Razor component rendering](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/rendering?branch=pr-en-us-31145) |
| [aspnetcore/blazor/fundamentals/startup.md](https://github.com/dotnet/AspNetCore.Docs/blob/3d02c3358740da57251f2f2b1fdda65d222bdf30/aspnetcore/blazor/fundamentals/startup.md) | [ASP.NET Core Blazor startup](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/startup?branch=pr-en-us-31145) |


<!-- PREVIEW-TABLE-END -->