### PR TITLE
Fix example code

### DIFF
--- a/aspnetcore/blazor/tutorials/build-a-blazor-app.md
+++ b/aspnetcore/blazor/tutorials/build-a-blazor-app.md
@@ -419,7 +419,41 @@ The completed `Todo` component:
 
 :::moniker range=">= aspnetcore-8.0"
 
-:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_WebAssembly/Components/Pages/build-a-blazor-app/Todo.razor":::
+```razor
+@page "/todo"
+@rendermode InteractiveServer
+
+<PageTitle>Todo</PageTitle>
+
+<h1>Todo (@todos.Count(todo => !todo.IsDone))</h1>
+
+<ul>
+    @foreach (var todo in todos)
+    {
+        <li>
+            <input type="checkbox" @bind="todo.IsDone" />
+            <input @bind="todo.Title" />
+        </li>
+    }
+</ul>
+
+<input placeholder="Something todo" @bind="newTodo" />
+<button @onclick="AddTodo">Add todo</button>
+
+@code {
+    private List<TodoItem> todos = new();
+    private string? newTodo;
+
+    private void AddTodo()
+    {
+        if (!string.IsNullOrWhiteSpace(newTodo))
+        {
+            todos.Add(new TodoItem { Title = newTodo });
+            newTodo = string.Empty;
+        }
+    }
+}
+```
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #31163

Thanks @vjojic-dev! 🚀 ... I'll patch it quickly. The reason this happened is because I haven't created the Blazor Web App snippet sample yet. The article is pulling code from the Blazor WebAssembly sample app, where the render mode wouldn't be applied. What I'll do here is just drop some code in place temporarily with the `@rendermode` line present.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tutorials/build-a-blazor-app.md](https://github.com/dotnet/AspNetCore.Docs/blob/2c468e734f8f537fdc192ae8e44760f58d2babf8/aspnetcore/blazor/tutorials/build-a-blazor-app.md) | [Build a Blazor todo list app](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/build-a-blazor-app?branch=pr-en-us-31164) |

<!-- PREVIEW-TABLE-END -->