### PR TITLE
Fix broken code-fencing

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -493,7 +493,7 @@ If a single object requires disposal, a lambda can be used to dispose of the obj
 > [!NOTE]
 > In the preceding example, the call to <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is wrapped by a call to <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType> because the callback is invoked outside of Blazor's synchronization context. For more information, see <xref:blazor/components/rendering#receiving-a-call-from-something-external-to-the-blazor-rendering-and-event-handling-system>.
 
-If the object is created in a lifecycle method, such as [`OnInitialized{Async}](#component-initialization-oninitializedasync), check for `null` before calling `Dispose`.
+If the object is created in a lifecycle method, such as [`OnInitialized{Async}`](#component-initialization-oninitializedasync), check for `null` before calling `Dispose`.
 
 `CounterWithTimerDisposal2.razor`:
 


### PR DESCRIPTION
Fixes #31171

Thanks @QueryCoordinator! 🚀 ... Indeed! A missing backtick is the cause 😈.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/lifecycle.md](https://github.com/dotnet/AspNetCore.Docs/blob/9a3d24f84be91b622a92643caa76c86cf7b1de43/aspnetcore/blazor/components/lifecycle.md) | [ASP.NET Core Razor component lifecycle](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?branch=pr-en-us-31172) |

<!-- PREVIEW-TABLE-END -->