### PR TITLE
Patch example

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -546,10 +546,10 @@ Additional assemblies must be disclosed to the Blazor framework to discover rout
 
 The `@rendermode` directive takes a single parameter that's a static instance of type <xref:Microsoft.AspNetCore.Components.IComponentRenderMode>. The `@rendermode` directive attribute can take any render mode instance, static or not. The Blazor framework provides the <xref:Microsoft.AspNetCore.Components.Web.RenderMode> static class with some predefined render modes for convenience, but you can create your own.
 
-Normally, a component uses the following `@attribute` directive to [disable prerendering](#prerendering):
+Normally, a component uses the following `@rendermode` directive to [disable prerendering](#prerendering):
 
 ```razor
-@attribute [RenderModeInteractiveServer(prerender: false)]
+@rendermode @(new InteractiveServerRenderMode(prerender: false))
 ```
 
 However, consider the following example that creates a shorthand interactive server-side render mode without prerendering via the app's `_Imports` file (`Components/_Imports.razor`):


### PR DESCRIPTION
Patch that escaped the RTM updates :smiling_imp:.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/a6814e156ea08d5a78f0c815ba673a5cd8873e3e/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-31211) |

<!-- PREVIEW-TABLE-END -->