### PR TITLE
Token authentication updates

### DIFF
--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -62,7 +62,7 @@ The following guidance begins the process of implementing token-based authentica
 
 Instead of the backend server API establishing cookie authentication with a call to <xref:Microsoft.AspNetCore.Identity.IdentityCookieAuthenticationBuilderExtensions.AddIdentityCookies%2A> on the authentication builder, the server API sets up bearer token auth with the <xref:Microsoft.Extensions.DependencyInjection.BearerTokenExtensions.AddBearerToken%2A> extension method. Specify the scheme for bearer authentication tokens with <xref:Microsoft.AspNetCore.Identity.IdentityConstants.BearerScheme%2A?displayProperty=nameWithType>.
 
-In `Backend/Program.cs`: 
+In `Backend/Program.cs`, change the authentication services and configuration to the following: 
 
 ```csharp
 builder.Services

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -52,13 +52,23 @@ builder.Services
     .AddIdentityCookies();
 ```
 
+## Additional authentication scenarios
+
+For additional Identity scenarios provided by the API, see <xref:security/authentication/identity/spa>:
+
+* Secure selected endpoints
+* Token authentication
+* Two-factor authentication (2FA)
+* Recovery codes
+* User info management
+
 ## Token authentication
 
 For native and mobile scenarios where clients don't support cookies, the login API provides a parameter to request tokens. A custom token (one that is proprietary to the ASP.NET Core Identity platform) is issued that can be used to authenticate subsequent requests. The token is passed in the `Authorization` header as a bearer token. A refresh token is also provided. This token allows the app to request a new token when the old one expires without forcing the user to log in again.
 
 The tokens are not standard JSON Web Tokens (JWTs). The use of custom tokens is intentional, as the built-in Identity API is meant primarily for simple scenarios. The token option is not intended to be a fully-featured identity service provider or token server, but instead an alternative to the cookie option for clients that can't use cookies.
 
-The following guidance begins the process of implementing token-based authentication with the login API. Custom code is required to complete the implementation. 
+The following guidance begins the process of implementing token-based authentication with the login API. Custom code is required to complete the implementation. For more information, see <xref:security/authentication/identity/spa>.
 
 Instead of the backend server API establishing cookie authentication with a call to <xref:Microsoft.AspNetCore.Identity.IdentityCookieAuthenticationBuilderExtensions.AddIdentityCookies%2A> on the authentication builder, the server API sets up bearer token auth with the <xref:Microsoft.Extensions.DependencyInjection.BearerTokenExtensions.AddBearerToken%2A> extension method.
 
@@ -77,7 +87,7 @@ In `BlazorWasmAuth/Identity/CookieAuthenticationStateProvider.cs`, remove the `u
 + /login
 ```
 
-At this point, you must provide custom code to parse the <xref:Microsoft.AspNetCore.Authentication.BearerToken.AccessTokenResponse> on the client and manage the access and refresh tokens.
+At this point, you must provide custom code to parse the <xref:Microsoft.AspNetCore.Authentication.BearerToken.AccessTokenResponse> on the client and manage the access and refresh tokens. For more information, see <xref:security/authentication/identity/spa>.
 
 ## Sample apps
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -60,9 +60,9 @@ The tokens are not standard JSON Web Tokens (JWTs). The use of custom tokens is 
 
 The following guidance begins the process of implementing token-based authentication with the login API. Custom code is required to complete the implementation. For more information, see <xref:security/authentication/identity/spa>.
 
-Instead of the backend server API establishing cookie authentication with a call to <xref:Microsoft.AspNetCore.Identity.IdentityCookieAuthenticationBuilderExtensions.AddIdentityCookies%2A> on the authentication builder, the server API sets up bearer token auth with the <xref:Microsoft.Extensions.DependencyInjection.BearerTokenExtensions.AddBearerToken%2A> extension method.
+Instead of the backend server API establishing cookie authentication with a call to <xref:Microsoft.AspNetCore.Identity.IdentityCookieAuthenticationBuilderExtensions.AddIdentityCookies%2A> on the authentication builder, the server API sets up bearer token auth with the <xref:Microsoft.Extensions.DependencyInjection.BearerTokenExtensions.AddBearerToken%2A> extension method. Specify the scheme for bearer authentication tokens with <xref:Microsoft.AspNetCore.Identity.IdentityConstants.BearerScheme%2A?displayProperty=nameWithType>.
 
-In `Backend/Program.cs`:
+In `Backend/Program.cs`: 
 
 ```csharp
 builder.Services

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -54,24 +54,30 @@ builder.Services
 
 ## Token authentication
 
-For clients that don't support cookies, the login API provides a parameter to request tokens. A custom token (one that is proprietary to the ASP.NET Core identity platform) is issued that can be used to authenticate subsequent requests. The token is passed in the `Authorization` header as a bearer token. A refresh token is also provided. This token allows the app to request a new token when the old one expires without forcing the user to log in again.
+For native and mobile scenarios where clients don't support cookies, the login API provides a parameter to request tokens. A custom token (one that is proprietary to the ASP.NET Core Identity platform) is issued that can be used to authenticate subsequent requests. The token is passed in the `Authorization` header as a bearer token. A refresh token is also provided. This token allows the app to request a new token when the old one expires without forcing the user to log in again.
 
 The tokens are not standard JSON Web Tokens (JWTs). The use of custom tokens is intentional, as the built-in Identity API is meant primarily for simple scenarios. The token option is not intended to be a fully-featured identity service provider or token server, but instead an alternative to the cookie option for clients that can't use cookies.
 
-To use token-based authentication with the login API, set the `useCookies` query string parameter to `false`:
+The following guidance begins the process of implementing token-based authentication with the login API. Custom code is required to complete the implementation. 
 
-```diff
-- /login?useCookies=true
-+ /login?useCookies=false
-```
+Instead of the backend server API establishing cookie authentication with a call to <xref:Microsoft.AspNetCore.Identity.IdentityCookieAuthenticationBuilderExtensions.AddIdentityCookies%2A> on the authentication builder, the server API sets up bearer token auth with the <xref:Microsoft.Extensions.DependencyInjection.BearerTokenExtensions.AddBearerToken%2A> extension method.
 
-Instead of the backend server API establishing cookie authentication with a call to <xref:Microsoft.AspNetCore.Identity.IdentityCookieAuthenticationBuilderExtensions.AddIdentityCookies%2A> on the authentication builder, the server API sets up bearer token auth with the <xref:Microsoft.Extensions.DependencyInjection.BearerTokenExtensions.AddBearerToken%2A> extension method:
+In `Backend/Program.cs`:
 
 ```csharp
 builder.Services
     .AddAuthentication(IdentityConstants.ApplicationScheme)
     .AddBearerToken();
 ```
+
+In `BlazorWasmAuth/Identity/CookieAuthenticationStateProvider.cs`, remove the `useCookies` query string parameter in the `LoginAsync` method of the `CookieAuthenticationStateProvider`:
+
+```diff
+- /login?useCookies=true
++ /login
+```
+
+At this point, you must provide custom code to parse the <xref:Microsoft.AspNetCore.Authentication.BearerToken.AccessTokenResponse> on the client and manage the access and refresh tokens.
 
 ## Sample apps
 
@@ -119,7 +125,7 @@ User identity with cookie authentication is added by calling <xref:Microsoft.Ext
 
 Only recommended for demonstrations, the app uses the [EF Core in-memory database provider](/ef/core/providers/in-memory/) for the database context registration (<xref:Microsoft.Extensions.DependencyInjection.EntityFrameworkServiceCollectionExtensions.AddDbContext%2A>). The in-memory database provider makes it easy to restart the app and test the registration and login user flows. However, each run starts with a fresh database. If the database is changed to SQLite, users are saved between sessions, but the database must be created through [migrations](/ef/core/managing-schemas/migrations/),as shown in the [EF Core getting started tutorial](/ef/core/get-started/overview/first-app). You can use other relational providers such as SQL Server for your production code.
 
-Configure identity to use the EF Core database and expose the Identity endpoints via the calls to <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentityCore%2A>, <xref:Microsoft.Extensions.DependencyInjection.IdentityEntityFrameworkBuilderExtensions.AddEntityFrameworkStores%2A>, and <xref:Microsoft.AspNetCore.Identity.IdentityBuilderExtensions.AddApiEndpoints%2A>.
+Configure Identity to use the EF Core database and expose the Identity endpoints via the calls to <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentityCore%2A>, <xref:Microsoft.Extensions.DependencyInjection.IdentityEntityFrameworkBuilderExtensions.AddEntityFrameworkStores%2A>, and <xref:Microsoft.AspNetCore.Identity.IdentityBuilderExtensions.AddApiEndpoints%2A>.
 
 A [Cross-Origin Resource Sharing (CORS)](xref:security/cors) policy is established to permit requests from the frontend and backend apps. Fallback URLs are configured for the CORS policy if app settings don't provide them:
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -54,7 +54,7 @@ builder.Services
 
 ## Token authentication
 
-For native and mobile scenarios where some clients don't support cookies, the login API provides a parameter to request tokens. A custom token (one that is proprietary to the ASP.NET Core Identity platform) is issued that can be used to authenticate subsequent requests. The token is passed in the `Authorization` header as a bearer token. A refresh token is also provided. This token allows the app to request a new token when the old one expires without forcing the user to log in again.
+For native and mobile scenarios where some clients don't support cookies, the login API provides a parameter to request tokens. A custom token (one that is proprietary to the ASP.NET Core Identity platform) is issued that can be used to authenticate subsequent requests. The token should be passed in the `Authorization` header as a bearer token. A refresh token is also provided. This token allows the app to request a new token when the old one expires without forcing the user to log in again.
 
 The tokens are not standard JSON Web Tokens (JWTs). The use of custom tokens is intentional, as the built-in Identity API is meant primarily for simple scenarios. The token option is not intended to be a fully-featured identity service provider or token server, but instead an alternative to the cookie option for clients that can't use cookies.
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -54,7 +54,7 @@ builder.Services
 
 ## Token authentication
 
-For native and mobile scenarios where clients don't support cookies, the login API provides a parameter to request tokens. A custom token (one that is proprietary to the ASP.NET Core Identity platform) is issued that can be used to authenticate subsequent requests. The token is passed in the `Authorization` header as a bearer token. A refresh token is also provided. This token allows the app to request a new token when the old one expires without forcing the user to log in again.
+For native and mobile scenarios where some clients don't support cookies, the login API provides a parameter to request tokens. A custom token (one that is proprietary to the ASP.NET Core Identity platform) is issued that can be used to authenticate subsequent requests. The token is passed in the `Authorization` header as a bearer token. A refresh token is also provided. This token allows the app to request a new token when the old one expires without forcing the user to log in again.
 
 The tokens are not standard JSON Web Tokens (JWTs). The use of custom tokens is intentional, as the built-in Identity API is meant primarily for simple scenarios. The token option is not intended to be a fully-featured identity service provider or token server, but instead an alternative to the cookie option for clients that can't use cookies.
 
@@ -66,8 +66,8 @@ In `Backend/Program.cs`:
 
 ```csharp
 builder.Services
-    .AddAuthentication(IdentityConstants.ApplicationScheme)
-    .AddBearerToken();
+    .AddAuthentication()
+    .AddBearerToken(IdentityConstants.BearerScheme);
 ```
 
 In `BlazorWasmAuth/Identity/CookieAuthenticationStateProvider.cs`, remove the `useCookies` query string parameter in the `LoginAsync` method of the `CookieAuthenticationStateProvider`:

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -52,16 +52,6 @@ builder.Services
     .AddIdentityCookies();
 ```
 
-## Additional authentication scenarios
-
-For additional Identity scenarios provided by the API, see <xref:security/authentication/identity/spa>:
-
-* Secure selected endpoints
-* Token authentication
-* Two-factor authentication (2FA)
-* Recovery codes
-* User info management
-
 ## Token authentication
 
 For native and mobile scenarios where clients don't support cookies, the login API provides a parameter to request tokens. A custom token (one that is proprietary to the ASP.NET Core Identity platform) is issued that can be used to authenticate subsequent requests. The token is passed in the `Authorization` header as a bearer token. A refresh token is also provided. This token allows the app to request a new token when the old one expires without forcing the user to log in again.
@@ -88,6 +78,16 @@ In `BlazorWasmAuth/Identity/CookieAuthenticationStateProvider.cs`, remove the `u
 ```
 
 At this point, you must provide custom code to parse the <xref:Microsoft.AspNetCore.Authentication.BearerToken.AccessTokenResponse> on the client and manage the access and refresh tokens. For more information, see <xref:security/authentication/identity/spa>.
+
+## Additional Identity scenarios
+
+For additional Identity scenarios provided by the API, see <xref:security/authentication/identity/spa>:
+
+* Secure selected endpoints
+* Token authentication
+* Two-factor authentication (2FA)
+* Recovery codes
+* User info management
 
 ## Sample apps
 


### PR DESCRIPTION
Fixes #31194

Thanks @SandroRiz.

Stephen, Jeremy ... These changes take into account that the dev will need to write custom code. I have a feeling that this is going to generate doc issues from devs asking for a complete implementation. I presume that you want me to tell them that we're not going to support it in our docs and that they should research it on the Net and use public support channels for assistance.

Also, @halter73 ... You didn't mention in your PU issue remarks the piece on `AddBearerToken`. I left that in the section, so let me know if it gets the 🔪 *chop* ... or a change to something else.

**UPDATE**: I see what you and Tom did in the main article. That's better, but it still isn't a complete, fully working implementation. The text over there is below. I'll make cross-link to that article because there's other scenarios there that should be surfaced, too.

If `useCookies` is `false` or omitted, token-based authentication is enabled. The response body includes the following properties:
```json
{
  "tokenType": "string",
  "accessToken": "string",
  "expiresIn": 0,
  "refreshToken": "string"
}
```
For more information about these properties, see <xref:Microsoft.AspNetCore.Authentication.BearerToken.AccessTokenResponse>.
Put the access token in a header to make authenticated requests, as shown in the following example
```http
Authorization: Bearer {access token}
```
When the access token is about to expire, call the [/refresh](#use-the-post-refresh-endpoint) endpoint.
## Use the `POST /refresh` endpoint
For use only with token-based authentication. Gets a new access token without forcing the user to log in again. Call this endpoint when the access token is about to expire.
The request body contains only the <xref:Microsoft.AspNetCore.Identity.Data.RefreshRequest.RefreshToken>. Here's a request body example:
```json
{
  "refreshToken": "string"
}
```
If the call is successful, the response body is a new <xref:Microsoft.AspNetCore.Authentication.BearerToken.AccessTokenResponse>, as shown in the following example:
```json
{
  "tokenType": "string",
  "accessToken": "string",
  "expiresIn": 0,
  "refreshToken": "string"
}
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/webassembly/standalone-with-identity.md](https://github.com/dotnet/AspNetCore.Docs/blob/d6593e9b437329f558cb1614f18a396a5289a172/aspnetcore/blazor/security/webassembly/standalone-with-identity.md) | [Secure ASP.NET Core Blazor WebAssembly with ASP.NET Core Identity](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-identity?branch=pr-en-us-31214) |


<!-- PREVIEW-TABLE-END -->