### PR TITLE
MAUI deep linking guidance

### DIFF
--- a/aspnetcore/blazor/hybrid/routing.md
+++ b/aspnetcore/blazor/hybrid/routing.md
@@ -277,6 +277,216 @@ For more information, see the following resources:
 
 Deep linking support is planned for .NET 9 in late 2024. For more information, see [Support deep linking into .NET MAUI Blazor apps (dotnet/maui #3788)](https://github.com/dotnet/maui/issues/3788#issuecomment-1421550198).
 
+Until the framework supports deep linking, the following guidance provides a suitable deep linking approach for Android and iOS devices.
+
+### Sample app
+
+For an example implementation of the following guidance, see the [`MAUI.AppLinks.Sample` app](https://github.com/redth/maui.applinks.sample).
+
+### Android
+
+Android supports [handling Android app links](https://developer.android.com/training/app-links) with `Intent` filters on activities.
+
+Links can be based on a custom scheme (for example, `myappname://`) or use an `http`/`https` scheme. Writing custom code isn't required to handle custom scheme links. The following approach shows how to support handling `http`/`https` URLs. A well-known association file is hosted on the domain that describes the domain's relationship to the app.
+
+Hosting the association file:
+
+* Proves ownership of the domain.
+* Permits Android to verify that the app seeking to handle the URL has ownership of the URL's domain. This prevents an arbitrary app from intercepting links.
+
+#### Verify domain ownership
+
+Verify ownership of the domain in the [Google Search Console](https://search.google.com/search-console).
+
+#### Host a `.well-known` association file
+
+Create an `assetlinks.json` file hosted on the domain's server under the `/.well-known/` folder. The URL should look like `https://redth.dev/.well-known/assetlinks.json`.
+
+The following is an example of the file's content:
+
+```json
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "dev.redth.applinkssample",
+      "sha256_cert_fingerprints":
+      [
+        "AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:10:11:12:13:14:15:16:17:18:19:20:21:22:23:24:25"
+      ]
+    }
+  }
+]
+```
+
+Find the `.keystore SHA256` fingerprints for the app. In this example, only the `androiddebug.keystore` file's fingerprint is included, which is used by default to sign .NET Android apps.
+
+You can use the [Statement List Generator Tool](https://developers.google.com/digital-asset-links/tools/generator) to help generate and validate the file.
+
+#### Setup the Android `Activity`
+
+Reuse `Platforms/Android/MainActivity.cs` in the .NET MAUI app by adding the following class attribute to it. Update the `DataHost` parameter for your app:
+
+```csharp
+[IntentFilter(
+    new string[] { Intent.ActionView },
+    AutoVerify = true,
+    Categories = new[] { Intent.CategoryDefault, Intent.CategoryBrowsable },
+    DataScheme = "https",
+    DataHost = "redth.dev")]
+```
+
+Use your own data scheme and host values. It's possible to associate multiple schemes/hosts.
+
+To mark the activity as exportable, add the `Exported = true` property to the existing `[Activity(...)]` attribute.
+
+#### Handle the lifecycle events for the `Intent` activation
+
+In the `MauiProgram.cs` file, set up the lifecycle events with the app builder:
+
+```csharp
+builder.ConfigureLifecycleEvents(lifecycle =>
+{
+    #if IOS || MACCATALYST
+        // ...
+    #elif ANDROID
+    lifecycle.AddAndroid(android => {
+        android.OnCreate((activity, bundle) =>
+        {
+            var action = activity.Intent?.Action;
+            var data = activity.Intent?.Data?.ToString();
+
+            if (action == Intent.ActionView && data is not null)
+            {
+                HandleAppLink(data);
+            }
+        });
+    });
+    #endif
+});
+```
+
+#### Test a URL
+
+Use `adb` to simulate opening a URL to ensure the app's links work correctly, as the following example shell command demonstrates. Update the data URI (`-d`) to match a link in the app for testing:
+
+```shell
+adb shell am start -a android.intent.action.VIEW -c android.intent.category.BROWSABLE -d "https://redth.dev/items/1234"
+```
+
+Intent arguments in the preceding command:
+
+* `-a`: Action
+* `-c`: Category
+* `-d`: Data URI
+
+For more information, see [Android Debug Bridge (adb) (Android Developer documentation)](https://developer.android.com/tools/adb#IntentSpec).
+
+### iOS
+
+Apple supports registering an app to handle both custom URI schemes (for example, `myappname://`) and `http`/`https` schemes. The example in this section focuses on `http`/`https`. Custom schemes require additional configuration in the `Info.plist` file, which isn't covered here.
+
+Apple refers to handling `http`/`https` URLs as [*supporting universal links*](https://developer.apple.com/documentation/xcode/supporting-universal-links-in-your-app). Apple requires that you host a well-known `apple-app-site-association` file at the domain that describes the domain's relationship to the app.
+
+Hosting the association file:
+
+* Proves ownership of the domain.
+* Permits Apple to verify that the app seeking to handle the URL has ownership of the URL's domain. This prevents an arbitrary app from intercepting links.
+
+#### Host a `.well-known` association File
+
+Create a `apple-app-site-association` JSON file hosted on the domain's server under the `/.well-known/` folder. The URL should look like `https://redth.dev/.well-known/apple-app-site-association`.
+
+The file contents must include the following JSON. Replace the app identifiers with the correct values for your app:
+
+```json
+{
+  "activitycontinuation": {
+    "apps": [ "85HMA3YHJX.dev.redth.applinkssample" ]
+  },
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "85HMA3YHJX.dev.redth.applinkssample",
+        "paths": [ "*", "/*" ]
+      }
+    ]
+  }
+}
+```
+
+This step may require some trial and error to get working. Public implementation guidance indicates that the `activitycontinuation` property is required.
+
+#### Add domain association entitlements to the app
+
+Add custom entitlements to the app to declare one or more associated domains. Accomplish this either by adding an `Entitlements.plist` file to the app or by adding the following `<ItemGroup>` to the app's project file (`.csproj`) file.
+
+Replace `applinks:redth.dev` with the correct domain value. Note that the `Condition` only includes the entitlement when the app is built for iOS or MacCatalyst.
+
+```xml
+<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
+
+    <!-- For debugging, use '?mode=developer' for debug to bypass apple's CDN cache -->
+    <CustomEntitlements
+        Condition="$(Configuration) == 'Debug'"
+        Include="com.apple.developer.associated-domains"
+        Type="StringArray"
+        Value="applinks:redth.dev?mode=developer" />
+
+    <!-- Non debugging, use normal applinks:url value -->
+    <CustomEntitlements
+        Condition="$(Configuration) != 'Debug'"
+        Include="com.apple.developer.associated-domains"
+        Type="StringArray"
+        Value="applinks:redth.dev" />
+
+</ItemGroup>
+```
+
+#### Add lifecycle handlers
+
+In the `MauiProgram.cs` file, add lifecycle events with the `builder`. If the app doesn't use `Scenes` for multi-window support, omit the lifecycle handlers for `Scene` methods.
+
+```csharp
+builder.ConfigureLifecycleEvents(lifecycle =>
+{
+    #if IOS || MACCATALYST
+    lifecycle.AddiOS(ios =>
+    {
+        ios.FinishedLaunching((app, data)
+            => HandleAppLink(app.UserActivity));
+
+        ios.ContinueUserActivity((app, userActivity, handler)
+            => HandleAppLink(userActivity));
+
+        if (OperatingSystem.IsIOSVersionAtLeast(13) || 
+            OperatingSystem.IsMacCatalystVersionAtLeast(13))
+        {
+            ios.SceneWillConnect((scene, sceneSession, sceneConnectionOptions)
+                => HandleAppLink(sceneConnectionOptions.UserActivities.ToArray()
+                    .FirstOrDefault(
+                        a => a.ActivityType == NSUserActivityType.BrowsingWeb)));
+
+            ios.SceneContinueUserActivity((scene, userActivity)
+                => HandleAppLink(userActivity));
+        }
+    });
+    #elif ANDROID
+        // ...
+    #endif
+});
+```
+
+#### Test a URL
+
+Testing on iOS might be more tedious than testing on Android. There are many public reports of mixed results with iOS simulators working. For example, Simulator didn't work when this guidance was tested. Even if an arbitrary simulator works during testing, testing with an iOS device is recommended.
+
+After the app is deployed to a device, test the URLs by going to **Settings** > **Developer** > **Universal Links** and enable **Associated Domains Development**. Open **Diagnostics**. Enter the URL to test. For the demonstration in this section, the test URL is `https://redth.dev`. You should see a green checkmark with **Opens Installed Application** and the App ID of the app.
+
+It's also worth noting from the [Add domain association entitlements to the app](#add-domain-association-entitlements-to-the-app) step that adding the `applink` entitlement with `?mode=developer` to the app results in the app bypassing Apple's CDN cache when testing and debugging, which is helpful for iterating on your `apple-app-site-association` JSON file.
+
 :::zone-end
 
 :::moniker-end

--- a/aspnetcore/blazor/hybrid/routing.md
+++ b/aspnetcore/blazor/hybrid/routing.md
@@ -128,6 +128,12 @@ In the `MainPage` XAML markup (`MainPage.xaml`), specify the start path. The fol
 <BlazorWebView>
 ```
 
+Alternatively, the start path can be set in the `MainPage` constructor (`MainPage.xaml.cs`):
+
+```csharp
+blazorWebView.StartPath = "/welcome";
+```
+
 :::zone-end
 
 :::zone pivot="wpf"
@@ -275,9 +281,7 @@ For more information, see the following resources:
 
 ## Deep linking
 
-Deep linking support is planned for .NET 9 in late 2024. For more information, see [Support deep linking into .NET MAUI Blazor apps (dotnet/maui #3788)](https://github.com/dotnet/maui/issues/3788#issuecomment-1421550198).
-
-Until the framework supports deep linking, the following guidance provides a suitable deep linking approach for Android and iOS devices.
+The guidance in this section describes deep linking approaches for Android and iOS devices.
 
 ### Sample app
 
@@ -486,6 +490,10 @@ Testing on iOS might be more tedious than testing on Android. There are many pub
 After the app is deployed to a device, test the URLs by going to **Settings** > **Developer** > **Universal Links** and enable **Associated Domains Development**. Open **Diagnostics**. Enter the URL to test. For the demonstration in this section, the test URL is `https://redth.dev`. You should see a green checkmark with **Opens Installed Application** and the App ID of the app.
 
 It's also worth noting from the [Add domain association entitlements to the app](#add-domain-association-entitlements-to-the-app) step that adding the `applink` entitlement with `?mode=developer` to the app results in the app bypassing Apple's CDN cache when testing and debugging, which is helpful for iterating on your `apple-app-site-association` JSON file.
+
+### Apps launched via a deep link
+
+If the app is launched via a deep link, set the path for initial navigation in the [`BlazorWebView.StartPath` property](#get-or-set-a-path-for-initial-navigation).
 
 :::zone-end
 


### PR DESCRIPTION
Fixes #28401

* I made a couple of guesses at wording for tech that I'm not very familiar with. Check carefully to correct any 💥 in meaning that I introduced 🙈.
* You could update the README of the sample app to just point to this article/section. The link is ...

  `https://learn.microsoft.com/aspnet/core/blazor/hybrid/routing?pivots=maui#deep-linking`

* Not sure what's going on with the original PU issue ... if this content just provides a workaround approach until the framework has formal API at .NET 9. Adjust the lead-in wording accordingly. If something is coming for .NET 9, I recommend leaving something in the opening remarks like what I have. Devs may schedule a revisit on deep linking in 2024 on that basis.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/f2e47cbf3bc88630ea4af98b4d07048f73cd8736/aspnetcore/blazor/hybrid/routing.md) | [ASP.NET Core Blazor Hybrid routing and navigation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/routing?branch=pr-en-us-31231) |


<!-- PREVIEW-TABLE-END -->