### PR TITLE
Add .NET docs crosslink

### DIFF
--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -512,15 +512,8 @@ For more information on template options, see the following resources:
 
 :::moniker range=">= aspnetcore-8.0"
 
-<!-- UPDATE 8.0 Add the following after the template is
-                added to the .NET doc. Tracked by
-                https://github.com/dotnet/docs/issues/38507
-
-* [`blazor`](/dotnet/core/tools/dotnet-new-sdk-templates#blazor)
-
--->
-
 * The *.NET default templates for dotnet new* article in the .NET Core documentation:
+  * [`blazor`](/dotnet/core/tools/dotnet-new-sdk-templates#blazor)
   * [`blazorwasm`](/dotnet/core/tools/dotnet-new-sdk-templates#blazorwasm)
 * Passing the help option (`-h` or `--help`) to the [`dotnet new`](/dotnet/core/tools/dotnet-new) CLI command in a command shell:
   * `dotnet new blazor -h`


### PR DESCRIPTION
Addresses #28161 

The new section just went live in their article.

https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-new-sdk-templates#blazor

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tooling.md](https://github.com/dotnet/AspNetCore.Docs/blob/eb07d7cf38045be157a5deac4cc469fcce2d97c0/aspnetcore/blazor/tooling.md) | [Tooling for ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tooling?branch=pr-en-us-31244) |

<!-- PREVIEW-TABLE-END -->