### PR TITLE
Cross-link to app base path guidance

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -549,6 +549,8 @@ If a standalone app is hosted as an IIS sub-app, perform either of the following
 
 Removing the handler or disabling inheritance is performed in addition to [configuring the app's base path](xref:blazor/host-and-deploy/index#app-base-path). Set the app base path in the app's `index.html` file to the IIS alias used when configuring the sub-app in IIS.
 
+Configure the app's base path by following the guidance in the <xref:blazor/host-and-deploy/index#app-base-path> article.
+
 #### Brotli and Gzip compression
 
 :::moniker range=">= aspnetcore-8.0"


### PR DESCRIPTION
Fixes #31250

Thanks @sam-wheat! 🚀 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/9e60986e26d637c1ae94db46278c1689116dad9e/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-31251) |

<!-- PREVIEW-TABLE-END -->