### PR TITLE
Fix typo in first-mongo-app.md

### DIFF
--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -243,7 +243,7 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 
 The `BooksService` class uses the following `MongoDB.Driver` members to run CRUD operations against the database:
 
-* [MongoClient](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/T_MongoDB_Driver_MongoClient.htm): Reads the server instance for running database operations. The constructor of this class is provided the MongoDB connection string:
+* [MongoClient](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/T_MongoDB_Driver_MongoClient.htm): Reads the server instance for running database operations. The constructor of this class is provided in the MongoDB connection string:
 
   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_ctor" highlight="4-5":::
 


### PR DESCRIPTION
Fix a typographical error under Add a CRUD operation service


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mongo-app.md](https://github.com/dotnet/AspNetCore.Docs/blob/4adf324e29c31cdffcb44e662dd83312b7c34430/aspnetcore/tutorials/first-mongo-app.md) | [Create a web API with ASP.NET Core and MongoDB](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mongo-app?branch=pr-en-us-31279) |

<!-- PREVIEW-TABLE-END -->