### PR TITLE
Fix casing of "isValid" in form code examples

### DIFF
--- a/aspnetcore/blazor/forms/validation.md
+++ b/aspnetcore/blazor/forms/validation.md
@@ -1356,7 +1356,7 @@ public class CustomFieldClassProvider : FieldCssClassProvider
     public override string GetFieldCssClass(EditContext editContext, 
         in FieldIdentifier fieldIdentifier)
     {
-        var isValid = editContext.isValid(fieldIdentifier);
+        var isValid = editContext.IsValid(fieldIdentifier);
 
         return isValid ? "validField" : "invalidField";
     }
@@ -1507,7 +1507,7 @@ public class CustomFieldClassProvider2 : FieldCssClassProvider
     {
         if (fieldIdentifier.FieldName == "Name")
         {
-            var isValid = editContext.isValid(fieldIdentifier);
+            var isValid = editContext.IsValid(fieldIdentifier);
 
             return isValid ? "validField" : "invalidField";
         }
@@ -1609,7 +1609,7 @@ public class CustomFieldClassProvider3 : FieldCssClassProvider
     public override string GetFieldCssClass(EditContext editContext,
         in FieldIdentifier fieldIdentifier)
     {
-        var isValid = editContext.isValid(fieldIdentifier);
+        var isValid = editContext.IsValid(fieldIdentifier);
 
         if (fieldIdentifier.FieldName == "Name")
         {


### PR DESCRIPTION
Fixes #31311

Thanks @MorneZaayman! 🚀 ... This will at least get the topic fixed for the time being. I might continue to work on the issue next week because the sample app should use the `IsValid` approach. Also, the topic has this code inlined into the article, I'm in the process now (on another issue) of using the sample apps to provide code for the new 8.0 examples. I'll get that squared away, too. Thanks for the report. This will go live shortly after I merge it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/validation.md](https://github.com/dotnet/AspNetCore.Docs/blob/340c18ad45e2d39367eeaf3481e1e97c8b73426e/aspnetcore/blazor/forms/validation.md) | [ASP.NET Core Blazor forms validation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/validation?branch=pr-en-us-31313) |

<!-- PREVIEW-TABLE-END -->