### PR TITLE
Add example with endpoints to middleware testing doc

### DIFF
--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -108,6 +108,45 @@ public async Task TestMiddleware_ExpectedResponse()
 
 As with the earlier example that tested for a *404 - Not Found* response, check the opposite for each `Assert` statement in the preceding test. The check confirms that the test fails correctly when the middleware is operating normally. After you've confirmed that the false positive test works, set the final `Assert` statements for the expected conditions and values of the test. Run it again to confirm that the test passes.
 
+## Adding request routes
+
+Often it is helpful to add some routes to the TestServer for more realistic scenarios. This can be done by configuring routing add adding routes in the configuration, this time using the test HttpClient (but the same approach works with the test `server.SendAsync` approach used above:
+
+```csharp
+	[Fact]
+	public async Task TestWithEndpoint_ExpectedResponse ()
+	{
+		using var host = await new HostBuilder()
+			.ConfigureWebHost(webBuilder =>
+			{
+				webBuilder
+					.UseTestServer()
+					.ConfigureServices(services =>
+					{
+						services.AddRouting();
+					})
+					.Configure(app =>
+					{
+						app.UseRouting();
+						app.UseEndpoints(endpoints =>
+						{
+							endpoints.MapGet("/hello", () =>
+								TypedResults.Text("Hello Tests"));
+						});
+					});
+			})
+			.StartAsync();
+
+		var client = host.GetTestClient();
+
+		var response = await client.GetAsync("/hello");
+
+		Assert.True(response.IsSuccessStatusCode);
+		var responseBody = await response.Content.ReadAsStringAsync();
+		Assert.Equal("Hello Tests", responseBody);
+```
+
+
 ## TestServer limitations
 
 TestServer:

--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -108,9 +108,10 @@ public async Task TestMiddleware_ExpectedResponse()
 
 As with the earlier example that tested for a *404 - Not Found* response, check the opposite for each `Assert` statement in the preceding test. The check confirms that the test fails correctly when the middleware is operating normally. After you've confirmed that the false positive test works, set the final `Assert` statements for the expected conditions and values of the test. Run it again to confirm that the test passes.
 
-## Adding request routes
+## Add request routes
 
-Often it is helpful to add some routes to the TestServer for more realistic scenarios. This can be done by configuring routing add adding routes in the configuration, this time using the test HttpClient (but the same approach works with the test `server.SendAsync` approach used above:
+Additional routes can be added by configuration using the test `HttpClient`:
+
 
 ```csharp
 	[Fact]
@@ -147,6 +148,7 @@ Often it is helpful to add some routes to the TestServer for more realistic scen
 		Assert.Equal("Hello Tests", responseBody);
 ```
 
+Additional routes can also be added using the approach `server.SendAsync`.
 
 ## TestServer limitations
 

--- a/aspnetcore/test/middleware.md
+++ b/aspnetcore/test/middleware.md
@@ -128,6 +128,7 @@ Often it is helpful to add some routes to the TestServer for more realistic scen
 					.Configure(app =>
 					{
 						app.UseRouting();
+						app.UseMiddleware<MyMiddleware>();
 						app.UseEndpoints(endpoints =>
 						{
 							endpoints.MapGet("/hello", () =>


### PR DESCRIPTION
I spent a lot of time noodling for how to do this for building some middleware tests so thought it would be good to contribute an example back here.


Fixes #31337
<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/middleware.md](https://github.com/dotnet/AspNetCore.Docs/blob/ede5f67776c3093c4f10f2ae42aa14fa7048ebc7/aspnetcore/test/middleware.md) | [Test ASP.NET Core middleware](https://review.learn.microsoft.com/en-us/aspnet/core/test/middleware?branch=pr-en-us-31323) |


<!-- PREVIEW-TABLE-END -->