### PR TITLE
Add a word to cspell file

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -4,7 +4,7 @@
   "words": [
     "antiforgery","appsettings","aspnet","aspnetcore","Blazor","Blazor's","blazorwasm","blazorserver","blazor",
     "dotnetcli","guardrex","Linq","Microservices","microservices","NuGet","nuget","Prerender","prerendering",
-    "signalr","rerender","rerenders","rerendering","riande","Routable","routable","Prerendered",
+    "signalr","rendermode","rerender","rerenders","rerendering","riande","Routable","routable","Prerendered",
     "prerendered","wadepickett","wasm","webassembly","webform","webforms","websocket","websockets","wwwroot"
   ],
   "flagWords": [


### PR DESCRIPTION
Adding "rendermode" to spelling list, as it's used quite a lot and triggers many misspelling warnings.