### PR TITLE
Web API tutorial - Add EF tools package

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to build a web API with ASP.NET Core.
 ms.author: wpickett
 ms.custom: mvc, engagement-fy24
-ms.date: 12/04/2023
+ms.date: 01/03/2024
 uid: tutorials/first-web-api
 ---
 
@@ -310,6 +310,7 @@ Run the following commands:
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
 dotnet add package Microsoft.EntityFrameworkCore.Design
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package Microsoft.EntityFrameworkCore.Tools
 dotnet tool uninstall -g dotnet-aspnet-codegenerator
 dotnet tool install -g dotnet-aspnet-codegenerator
 dotnet tool update -g dotnet-aspnet-codegenerator

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -293,6 +293,7 @@ Run the following commands:
 dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design -v 7.0.0
 dotnet add package Microsoft.EntityFrameworkCore.Design -v 7.0.0
 dotnet add package Microsoft.EntityFrameworkCore.SqlServer -v 7.0.0
+dotnet add package Microsoft.EntityFrameworkCore.Tools -v 7.0.0
 dotnet tool uninstall -g dotnet-aspnet-codegenerator
 dotnet tool install -g dotnet-aspnet-codegenerator
 dotnet tool update -g dotnet-aspnet-codegenerator

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -54,15 +54,15 @@ The following diagram shows the design of the app.
 * Run the following commands:
 
    ```dotnetcli
-   dotnet new webapi -o TodoApi
+   dotnet new webapi -o TodoApi -f net7.0
    cd TodoApi
-   dotnet add package Microsoft.EntityFrameworkCore.InMemory
+   dotnet add package Microsoft.EntityFrameworkCore.InMemory -v 7.0.0
    code -r ../TodoApi
    ```
 
   These commands:
 
-  * Create a new web API project and open it in Visual Studio Code.
+  * Create a new web API project using .NET 7.0 and open it in Visual Studio Code.
   * Add a NuGet package that is needed for the next section.
   * Open the *TodoApi* folder in the current instance of Visual Studio Code.
 

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -62,7 +62,7 @@ The following diagram shows the design of the app.
 
   These commands:
 
-  * Create a new web API project using .NET 7.0 and open it in Visual Studio Code.
+  * Create a new web API project that targets .NET 7.0 and open it in Visual Studio Code.
   * Add a NuGet package that is needed for the next section.
   * Open the *TodoApi* folder in the current instance of Visual Studio Code.
 


### PR DESCRIPTION
Fixes #31620

- Added EF tools package in scaffolding step for version 7 specifying version 7.0.0, and then added same package for version 8 but allowing it to use the very latest version.
- Designated to use .NET 7.0 SDK in project creation for version 7 topic since using a later SDK simply targeting 7 will result in an 8.0 openAPI package loaded which will error at build when targeting .NET 7 for build.
- Specified v7.0.0 for InMemory package for version 7 of the doc.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/388e61e642499c76ce0031ba7c98785a7fde4011/aspnetcore/tutorials/first-web-api.md) | [Tutorial: Create a web API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?branch=pr-en-us-31344) |


<!-- PREVIEW-TABLE-END -->