### PR TITLE
DelegateHealthCheck /8

### DIFF
--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -289,10 +289,18 @@ The following example registers a health check publisher as a singleton and conf
 
 :::code language="csharp" source="~/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs" id="snippet_HealthCheckPublisherOptionsService":::
 
-> [!NOTE]
-> [`AspNetCore.Diagnostics.HealthChecks`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) includes publishers for several systems, including [Application Insights](/azure/application-insights/app-insights-overview).
->
-> [`AspNetCore.Diagnostics.HealthChecks`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) isn't maintained or supported by Microsoft.
+[`AspNetCore.Diagnostics.HealthChecks`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks):
+
+* Includes publishers for several systems, including [Application Insights](/azure/application-insights/app-insights-overview).
+* Is ***not*** maintained or supported by Microsoft.
+
+### Individual Healthchecks
+
+The [DelegateHealthCheck class](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/HealthChecks/src/DelegateHealthCheck.cs) enables setting [`Delay` and `Period`](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/Abstractions/src/HealthCheckRegistration.cs#L161-L185) on each health check individually. This is useful when you want to run some health checks more frequently than the period set in <xref:Microsoft.Extensions.Diagnostics.HealthChecks.snippet_MapHealthChecksComplete2>.
+
+The following code sets the `Delay` and `Period` for the `SampleHealthCheck1`:
+
+:::code language="csharp" source="~/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs" id="snippet_HealthCheckPublisherOptionsService":::
 
 ## Dependency Injection and Health Checks
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -5,7 +5,7 @@ description: Learn how to set up health checks for ASP.NET Core infrastructure, 
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 1/1/2024
+ms.date: 1/11/2024
 uid: host-and-deploy/health-checks
 ---
 # Health checks in ASP.NET Core

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -296,7 +296,8 @@ The following example registers a health check publisher as a singleton and conf
 
 ### Individual Healthchecks
 
-The [DelegateHealthCheck class](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/HealthChecks/src/DelegateHealthCheck.cs) enables setting [`Delay` and `Period`](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/Abstractions/src/HealthCheckRegistration.cs#L161-L185) on each health check individually. This is useful when you want to run some health checks more frequently than the period set in <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions>.
+[`Delay` and `Period`](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/Abstractions/src/HealthCheckRegistration.cs#L161-L185) can be set on each each <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration> individually. This is useful when you want to run some health checks more frequently than the period set in <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions>.
+
 
 The following code sets the `Delay` and `Period` for the `SampleHealthCheck1`:
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -296,8 +296,7 @@ The following example registers a health check publisher as a singleton and conf
 
 ### Individual Healthchecks
 
-[`Delay` and `Period`](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/Abstractions/src/HealthCheckRegistration.cs#L161-L185) can be set on each each <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration> individually. This is useful when you want to run some health checks more frequently than the period set in <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions>.
-
+[`Delay` and `Period`](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/Abstractions/src/HealthCheckRegistration.cs#L161-L185) can be set on each each <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckRegistration> individually. This is useful when you want to run some health checks at a different rate than the period set in <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions>.
 
 The following code sets the `Delay` and `Period` for the `SampleHealthCheck1`:
 

--- a/aspnetcore/host-and-deploy/health-checks.md
+++ b/aspnetcore/host-and-deploy/health-checks.md
@@ -296,11 +296,11 @@ The following example registers a health check publisher as a singleton and conf
 
 ### Individual Healthchecks
 
-The [DelegateHealthCheck class](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/HealthChecks/src/DelegateHealthCheck.cs) enables setting [`Delay` and `Period`](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/Abstractions/src/HealthCheckRegistration.cs#L161-L185) on each health check individually. This is useful when you want to run some health checks more frequently than the period set in <xref:Microsoft.Extensions.Diagnostics.HealthChecks.snippet_MapHealthChecksComplete2>.
+The [DelegateHealthCheck class](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/HealthChecks/src/DelegateHealthCheck.cs) enables setting [`Delay` and `Period`](https://github.com/dotnet/aspnetcore/blob/main/src/HealthChecks/Abstractions/src/HealthCheckRegistration.cs#L161-L185) on each health check individually. This is useful when you want to run some health checks more frequently than the period set in <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthCheckPublisherOptions>.
 
 The following code sets the `Delay` and `Period` for the `SampleHealthCheck1`:
 
-:::code language="csharp" source="~/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs" id="snippet_HealthCheckPublisherOptionsService":::
+:::code language="csharp" source="~/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs" id="snippet_MapHealthChecksComplete2":::
 
 ## Dependency Injection and Health Checks
 

--- a/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/HealthChecksSample.csproj
+++ b/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/HealthChecksSample.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.*-*"/>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.*-*"/>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs
@@ -166,9 +166,14 @@ public static class Program
     public static void AddHealthChecksSqlServer(WebApplicationBuilder builder)
     {
         // <snippet_AddHealthChecksSqlServer>
+        var conStr = builder.Configuration.GetConnectionString("DefaultConnection");
+        if (string.IsNullOrEmpty(conStr))
+        {
+            throw new InvalidOperationException(
+                               "Could not find a connection string named 'DefaultConnection'.");
+        }
         builder.Services.AddHealthChecks()
-            .AddSqlServer(
-                builder.Configuration.GetConnectionString("DefaultConnection"));
+            .AddSqlServer(conStr);
         // </snippet_AddHealthChecksSqlServer>
     }
 

--- a/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs
@@ -26,6 +26,31 @@ public static class Program
         // </snippet_MapHealthChecksComplete>
     }
 
+    public static void MapHealthChecksComplete2(string[] args)
+    {
+        // <snippet_MapHealthChecksComplete2>
+        var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddHealthChecks()
+           .Add(new HealthCheckRegistration(
+               name: "SampleHealthCheck1",
+               instance: new DelegateHealthCheck(_ => Task.FromResult(HealthCheckResult.Healthy(HealthyMessage))),
+               failureStatus: null,
+               tags: null,
+               timeout: default)
+   {
+       Delay = TimeSpan.FromSeconds(40),
+       Period = TimeSpan.FromSeconds(30)
+   });
+
+        var app = builder.Build();
+
+        app.MapHealthChecks("/healthz");
+
+        app.Run();
+        // </snippet_MapHealthChecksComplete2>
+    }
+
     public static void AddHealthChecks(WebApplicationBuilder builder)
     {
         // <snippet_AddHealthChecks>

--- a/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs
@@ -32,10 +32,16 @@ public static class Program
         var builder = WebApplication.CreateBuilder(args);
 
         builder.Services.AddHealthChecks()
-           .AddAsyncCheck(name: "SampleHealthCheck1",
-               check: _ => Task.FromResult(HealthCheckResult.Healthy("HealthyMessage")),
+           .Add(new HealthCheckRegistration(
+               name: "SampleHealthCheck1",
+               instance: new SampleHealthCheck(),
+               failureStatus: null,
                tags: null,
-               timeout: default);
+               timeout: default)
+           {
+               Delay = TimeSpan.FromSeconds(40),
+               Period = TimeSpan.FromSeconds(30)
+           });
 
         var app = builder.Build();
 

--- a/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs
+++ b/aspnetcore/host-and-deploy/health-checks/samples/8.x/HealthChecksSample/Snippets/Program.cs
@@ -32,16 +32,10 @@ public static class Program
         var builder = WebApplication.CreateBuilder(args);
 
         builder.Services.AddHealthChecks()
-           .Add(new HealthCheckRegistration(
-               name: "SampleHealthCheck1",
-               instance: new DelegateHealthCheck(_ => Task.FromResult(HealthCheckResult.Healthy(HealthyMessage))),
-               failureStatus: null,
+           .AddAsyncCheck(name: "SampleHealthCheck1",
+               check: _ => Task.FromResult(HealthCheckResult.Healthy("HealthyMessage")),
                tags: null,
-               timeout: default)
-   {
-       Delay = TimeSpan.FromSeconds(40),
-       Period = TimeSpan.FromSeconds(30)
-   });
+               timeout: default);
 
         var app = builder.Build();
 


### PR DESCRIPTION
Fixes #31143

Error	CS0122	'DelegateHealthCheck' is inaccessible due to its protection level
cc @francedot @JuergenGutsch @JoshKeegan @tdykstra @viktorpeacock

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/health-checks.md](https://github.com/dotnet/AspNetCore.Docs/blob/556e757800c37d2c3b88425e1cb55c8d1f6088b6/aspnetcore/host-and-deploy/health-checks.md) | [Health checks in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks?branch=pr-en-us-31357) |


<!-- PREVIEW-TABLE-END -->