### PR TITLE
Updated app-secrets.md to show how to use user secrets in a console app

### DIFF
--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -353,8 +353,6 @@ class Program
     }
 }
 ```
-
-
 ## How the Secret Manager tool works
 
 The Secret Manager tool hides implementation details, such as where and how the values are stored. You can use the tool without knowing these implementation details. The values are stored in a JSON file in the local machine's user profile folder:

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -318,7 +318,7 @@ Projects which target `Microsoft.NET.Sdk.Web` automatically include support for 
 
 ## User secrets in non-web applications 
 
-For projects which target `Microsoft.NET.Sdk`, such as console applications, you must install the configuration extension and user secrets nuget packages explicitly
+For projects which target `Microsoft.NET.Sdk`, such as console applications, install the configuration extension and user secrets NuGet packages explicitly.
 
 Installing with PowerShell:
 

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -327,7 +327,7 @@ Install-Package Microsoft.Extensions.Configuration
 Install-Package Microsoft.Extensions.Configuration.UserSecrets
 ```
 
-Installing with the .NET CLI:
+Using the .NET CLI:
 
 ```dotnetcli
 dotnet add package Microsoft.Extensions.Configuration

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -309,7 +309,7 @@ Consider an ASP.NET Core web app in which **Individual User Accounts** security 
 
 ## Secret Manager
 
-The Secret Manager tool stores sensitive data during application development.In this context, a piece of sensitive data is an app secret. App secrets are stored in a separate location from the project tree. The app secrets are associated with a specific project or shared across several projects. The app secrets aren't checked into source control.
+The Secret Manager tool stores sensitive data during application development. In this context, a piece of sensitive data is an app secret. App secrets are stored in a separate location from the project tree. The app secrets are associated with a specific project or shared across several projects. The app secrets aren't checked into source control.
 
 > [!WARNING]
 > The Secret Manager tool doesn't encrypt the stored secrets and shouldn't be treated as a trusted store. It's for development purposes only. The keys and values are stored in a JSON configuration file in the user profile directory.

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -320,7 +320,7 @@ Projects which target `Microsoft.NET.Sdk.Web` automatically include support for 
 
 For projects which target `Microsoft.NET.Sdk`, such as console applications, install the configuration extension and user secrets NuGet packages explicitly.
 
-Installing with PowerShell:
+Using PowerShell:
 
 ```powershell
 Install-Package Microsoft.Extensions.Configuration

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -309,10 +309,51 @@ Consider an ASP.NET Core web app in which **Individual User Accounts** security 
 
 ## Secret Manager
 
-The Secret Manager tool stores sensitive data during the development of an ASP.NET Core project. In this context, a piece of sensitive data is an app secret. App secrets are stored in a separate location from the project tree. The app secrets are associated with a specific project or shared across several projects. The app secrets aren't checked into source control.
+The Secret Manager tool stores sensitive data during application development.In this context, a piece of sensitive data is an app secret. App secrets are stored in a separate location from the project tree. The app secrets are associated with a specific project or shared across several projects. The app secrets aren't checked into source control.
 
 > [!WARNING]
 > The Secret Manager tool doesn't encrypt the stored secrets and shouldn't be treated as a trusted store. It's for development purposes only. The keys and values are stored in a JSON configuration file in the user profile directory.
+
+Projects which target `Microsoft.NET.Sdk.Web` automatically include support for user secrets. 
+
+## Installing the User Secrets Extension for Non-Web Applications 
+
+For projects which target `Microsoft.NET.Sdk`, such as console applications, you must install the configuration extension and user secrets nuget packages explicitly
+
+Installing with PowerShell:
+
+```powershell
+Install-Package Microsoft.Extensions.Configuration
+Install-Package Microsoft.Extensions.Configuration.UserSecrets
+```
+
+Installing with the .NET CLI:
+
+```dotnetcli
+dotnet add package Microsoft.Extensions.Configuration
+dotnet add package Microsoft.Extensions.Configuration.UserSecrets
+```
+
+Once installed, you can load and use user secrets in your app like this (requires a user secret called "Foo" [to be set](#set-a-secret):
+
+```csharp
+using Microsoft.Extensions.Configuration;
+
+namespace ConsoleApp;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        IConfigurationRoot config = new ConfigurationBuilder()
+            .AddUserSecrets<Program>()
+            .Build();
+
+        Console.WriteLine(config["Foo"]);
+    }
+}
+```
+
 
 ## How the Secret Manager tool works
 

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -334,7 +334,7 @@ dotnet add package Microsoft.Extensions.Configuration
 dotnet add package Microsoft.Extensions.Configuration.UserSecrets
 ```
 
-Once installed, you can load and use user secrets in your app like this (requires a user secret called "Foo" [to be set](#set-a-secret):
+Once the packages are installed, [initialize the project](#enable-secret-storage) and [set secrets](#set-a-secret) the same way as for a web app. The following example shows a console application that retrieves the value of a secret that was set with the key "Foo":
 
 ```csharp
 using Microsoft.Extensions.Configuration;

--- a/aspnetcore/security/app-secrets.md
+++ b/aspnetcore/security/app-secrets.md
@@ -316,7 +316,7 @@ The Secret Manager tool stores sensitive data during application development. In
 
 Projects which target `Microsoft.NET.Sdk.Web` automatically include support for user secrets. 
 
-## Installing the User Secrets Extension for Non-Web Applications 
+## User secrets in non-web applications 
 
 For projects which target `Microsoft.NET.Sdk`, such as console applications, you must install the configuration extension and user secrets nuget packages explicitly
 


### PR DESCRIPTION
Fixes #31370 

Adds documentation for explicitly using the dotnet user-secrets in projects that target `Microsoft.NET.Sdk` and not the web SDK `Microsoft.NET.Sdk`.

See issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/app-secrets.md](https://github.com/dotnet/AspNetCore.Docs/blob/5a41051b6917251882dca7eef92066b714730ff6/aspnetcore/security/app-secrets.md) | [Safe storage of app secrets in development in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/app-secrets?branch=pr-en-us-31371) |


<!-- PREVIEW-TABLE-END -->