### PR TITLE
Client services during prerendering

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -93,6 +93,32 @@ builder.Services.AddScoped(sp =>
     });
 ```
 
+:::moniker range=">= aspnetcore-8.0"
+
+## Client-side services for `HttpClient` fail during prerendering
+
+*This section only applies to WebAssembly components in Blazor Web Apps.*
+
+Blazor Web Apps normally prerender client-side WebAssembly components. <xref:System.Net.Http.HttpClient> services aren't registered by default in a Blazor Web App's main project. If the app is run with only the <xref:System.Net.Http.HttpClient> services registered in the `.Client` project, as described in the [Add the `HttpClient` service](#add-the-httpclient-service) section, executing the app results in a runtime error:
+
+> :::no-loc text="InvalidOperationException: Cannot provide a value for property 'Http' on type '{ASSEMBLY}.Client.Pages.{COMPONENT}'. There is no registered service of type 'System.Net.Http.HttpClient'.":::
+
+Use ***either*** of the following approaches to resolve this problem:
+
+* Add the <xref:System.Net.Http.HttpClient> services to the main project to make them available during component prerendering. Use the following service registration in the main project's `Program` file:
+
+  ```csharp
+  builder.Services.AddHttpClient();
+  ```
+
+  No explicit package reference is required for the main project because <xref:System.Net.Http.HttpClient> services are provided by the shared framework.
+
+* If prerendering isn't required for the component, disable prerendering by following the guidance in <xref:blazor/components/render-modes#prerendering>. If you adopt this approach, you don't need to add <xref:System.Net.Http.HttpClient> services to the main project of the Blazor Web App.
+
+For more information, see [Client-side services fail to resolve during prerendering](xref:blazor/components/render-modes#client-side-services-fail-to-resolve-during-prerendering).
+
+:::moniker-end
+
 ## `HttpClient` and JSON helpers
 
 <xref:System.Net.Http.HttpClient> is available as a preconfigured service for making requests back to the origin server.

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -341,7 +341,7 @@ For example, consider the following `Home` component in the `.Client` project in
 
 No compile time error occurs, but a runtime error occurs during prerendering:
 
-> :::no-loc text="Cannot provide a value for property 'Environment' on type 'BlazorWebAppSample.Client.Pages.Home'. There is no registered service of type 'Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment'.":::
+> :::no-loc text="Cannot provide a value for property 'Environment' on type 'BlazorSample.Client.Pages.Home'. There is no registered service of type 'Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment'.":::
 
 This error occurs because the component must compile and execute on the server during prerendering, but <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.IWebAssemblyHostEnvironment> isn't a registered service on the server.
 
@@ -379,7 +379,9 @@ You can also avoid the problem if you [disable prerendering](#prerendering) for 
 
 There are a three approaches that you can take to address this scenario. The following are listed from most recommended to least recommended:
 
-* *Recommended*: Create a custom service implementation for the service on the server. Use the service normally in interactive components of the `.Client` project. For a demonstration of this approach, see <xref:blazor/fundamentals/environments#read-the-environment-client-side-in-a-blazor-web-app>.
+* *Recommended* for shared framework services: For shared framework services that merely aren't registered server-side in the main project, register the services in the main project, which makes them available during prerendering. For an example of this scenario, see the guidance for <xref:System.Net.Http.HttpClient> services in <xref:blazor/call-web-api?pivots=webassembly#client-side-services-for-httpclient-fail-during-prerendering>.
+
+* *Recommended* for services outside of the shared framework: Create a custom service implementation for the service on the server. Use the service normally in interactive components of the `.Client` project. For a demonstration of this approach, see <xref:blazor/fundamentals/environments#read-the-environment-client-side-in-a-blazor-web-app>.
 
 * Create a service abstraction and create implementations for the service in the `.Client` and server projects. Register the services in each project. Inject the custom service in the component.
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -180,6 +180,25 @@ Client.Program.ConfigureCommonServices(builder.Services);
 
 For an example of this approach, see <xref:blazor/security/webassembly/additional-scenarios#prerendering-with-authentication>.
 
+:::moniker range=">= aspnetcore-8.0"
+
+## Client-side services that fail during prerendering
+
+*This section only applies to WebAssembly components in Blazor Web Apps.*
+
+Blazor Web Apps normally prerender client-side WebAssembly components. If an app is run with a required service only registered in the `.Client` project, executing the app results in a runtime error similar to the following when a component attempts to use the required service during prerendering:
+
+> :::no-loc text="InvalidOperationException: Cannot provide a value for {PROPERTY} on type '{ASSEMBLY}}.Client.Pages.{COMPONENT NAME}'. There is no registered service of type '{SERVICE}'.":::
+
+Use ***either*** of the following approaches to resolve this problem:
+
+* Register the service in the main project to make it available during component prerendering.
+* If prerendering isn't required for the component, disable prerendering by following the guidance in <xref:blazor/components/render-modes#prerendering>. If you adopt this approach, you don't need to register the service in the main project.
+
+For more information, see [Client-side services fail to resolve during prerendering](xref:blazor/components/render-modes#client-side-services-fail-to-resolve-during-prerendering).
+
+:::moniker-end
+
 ## Service lifetime
 
 Services can be configured with the lifetimes shown in the following table.


### PR DESCRIPTION
Fixes  #31267
Addresses #28161 

Thanks @BrettSandham! 🚀 ... I think this expansion of the existing coverage will help devs avoid (and resolve) this situation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/call-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/364818a6fcb86892fb3a9664d9150060a88996dd/aspnetcore/blazor/call-web-api.md) | [Call a web API from ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/call-web-api?branch=pr-en-us-31382) |
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/364818a6fcb86892fb3a9664d9150060a88996dd/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-31382) |
| [aspnetcore/blazor/fundamentals/dependency-injection.md](https://github.com/dotnet/AspNetCore.Docs/blob/364818a6fcb86892fb3a9664d9150060a88996dd/aspnetcore/blazor/fundamentals/dependency-injection.md) | [ASP.NET Core Blazor dependency injection](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/dependency-injection?branch=pr-en-us-31382) |

<!-- PREVIEW-TABLE-END -->