### PR TITLE
Minor typo in object pool documentations

### DIFF
--- a/aspnetcore/performance/ObjectPool/ObjectPoolSample8/Program.cs
+++ b/aspnetcore/performance/ObjectPool/ObjectPoolSample8/Program.cs
@@ -37,7 +37,7 @@ app.MapGet("/hash/{name}", (string name, ObjectPool<ReusableBuffer> bufferPool) 
     }
     finally
     {
-        // Data is automatically reset because thit type implemented IResettable
+        // Data is automatically reset because this type implemented IResettable
         bufferPool.Return(buffer); 
     }
 });


### PR DESCRIPTION
Minor typo fix in the object pooling documentation