### PR TITLE
Additional programmatic render mode guidance

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -188,32 +188,45 @@ A component definition can define a render mode via a private field:
 
 ```razor
 @rendermode componentRenderMode
+```
 
-...
-
-@code {
-    private static IComponentRenderMode componentRenderMode =
-        new InteractiveServerRenderMode();
-}
+```csharp
+private static IComponentRenderMode componentRenderMode = new InteractiveServerRenderMode();
 ```
 
 ### By component instance
 
-<xref:Microsoft.AspNetCore.Http.HttpContext> is available in statically-rendered root components, such as the `App` component (`App.razor`). You can use [`HttpContext.Request.Path`](xref:Microsoft.AspNetCore.Http.HttpContext.Request%2A) to specify a render mode for a group of pages.
+<xref:Microsoft.AspNetCore.Http.HttpContext> is available in statically-rendered root components, such as the `App` component (`App.razor`). You can use [`HttpContext.Request.Path`](xref:Microsoft.AspNetCore.Http.HttpContext.Request%2A) to specify a render mode for a group of pages from a statically-rendered root component.
 
 The following example applies interactive server-side rendering (interactive SSR) to any request for a component in the app's `Admin` folder (`Components/Admin`), including subfolders. Components at any other path don't receive a render mode (`null`) from the `Routes` component, and they either render statically, inherit a render mode from a parent component, or set their own render mode.
 
 ```razor
 <Routes @rendermode="@RenderModeForPage" />
+```
 
-...
-
+```csharp
 [CascadingParameter]
 private HttpContext HttpContext { get; set; } = default!;
 
 private IComponentRenderMode? RenderModeForPage => 
     HttpContext.Request.Path.StartsWithSegments("/Admin") ? InteractiveServer : null;
 ```
+
+You can also set the render mode of the app dynamically based on the render modes of the components in the app. Each component sets a render mode, and the `App` component assigns the render mode of the loaded component to the `Routes` component:
+
+```razor
+<Routes @rendermode="@RenderModeForPage" />
+```
+
+```csharp
+[CascadingParameter]
+private HttpContext HttpContext { get; set; } = default!;
+
+private IComponentRenderMode? RenderModeForPage =>
+    HttpContext.GetEndpoint()?.Metadata.GetMetadata<RenderModeAttribute>()?.Mode;
+```
+
+A final approach for applying a render mode programatically is to apply the render mode to a <xref:Microsoft.AspNetCore.Components.ComponentBase> base class and [use the base class](xref:blazor/components/index#specify-a-base-class) to create components.
 
 Additional information on render mode propagation is provided in the [Render mode propagation](#render-mode-propagation) section later in this article.
 


### PR DESCRIPTION
Addresses #31403
Addresses #28161

Follow-up to PR earlier this morning #31404 that added a new section on programmatic render modes. There are some additional scenarios to cover in the section.

Mackinnon ... two problems with what I'm adding ...

* The description of the code is ***very likely incorrect*** 🙈 (or at least incomplete) ...

  > set the render mode of the app dynamically based on the render modes of the components in the app

  What is this code doing? ... because when the router becomes interactive it seems like whatever was set on `Routes` is what is then going to be used thereafter for each navigation ... well 🤔 ... is it that the router will continue working interactively until a route for a static SSR component can't be matched? ... and then a request is made back to the server, where the root component re-renders and then sucks in the render mode of the requested component and applies that to the `Routes` component?

* ***Why bother?*** 😄 ... I don't understand what this approach going to do for devs? I think we need to tell devs exactly what scenario(s) this approach applies to.

  This PR is based on the cross-linked discussion between a dev and Javier at https://github.com/dotnet/aspnetcore/issues/52176. It looks like a workaround to avoid the flash-over from the server-rendered error page to the `NotFound` router content. Also possibly related are these various `NotFound`/`NotAuthorized` no-op situations, where under static SSR the server isn't going to render content from those components ... described by Javier at https://github.com/dotnet/aspnetcore/issues/52176#issuecomment-1825677291.

  If you look just above what this PR is adding, I placed some content earlier this morning on what seems like a simpler scenario where there's an app that defaults to static SSR components or per-component render modes but has this one area of components that you would like to explicitly configure globally for interactive SSR. Let me know if that bit is correct, but I want to mention that it seems simpler to understand ***why*** one would do that ... e.g., the `Admin` area of pages/components that the example uses. The dev wants to globally apply interactive SSR to that area of administrator pages and default the rest to static SSR or per-component render mode assignment. For the new content that I'm seeking to add on this PR, it's not as clear ***why*** one would adopt it, and I hope we can add a why to the approach.

I'll also mention that I'm working a related issue at https://github.com/dotnet/AspNetCore.Docs/issues/31402. I'm going sleep on it because I just hit a *brain fry* 🧠🔥. I'll test locally soon with some scenarios to experience what's being discussed in PU issues (not authorized and not found scenarios) and figure out what updates to draft.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/c155473188b25d3535d0a45bb008381b5a959054/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-31405) |

<!-- PREVIEW-TABLE-END -->