### PR TITLE
Clarify lazy loading is only for dev assemblies

### DIFF
--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -12,11 +12,13 @@ uid: blazor/webassembly-lazy-load-assemblies
 
 [!INCLUDE[](~/includes/not-latest-version.md)]
 
-Blazor WebAssembly app startup performance can be improved by waiting to load app assemblies until the assemblies are required, which is called *lazy loading*.
+Blazor WebAssembly app startup performance can be improved by waiting to load developer-created app assemblies until the assemblies are required, which is called *lazy loading*.
 
 This article's initial sections cover the app configuration. For a working demonstration, see the [Complete example](#complete-example) section at the end of this article.
 
 *This article only applies to Blazor WebAssembly apps.* Assembly lazy loading doesn't benefit server-side apps because server-rendered apps don't download assemblies to the client.
+
+Lazy loading shouldn't be used for core runtime assemblies, which might be trimmed on publish and unavailable on the client when the app loads.
 
 ## File extension placeholder (`{FILE EXTENSION}`) for assembly files
 


### PR DESCRIPTION
Fixes #31394

Artak ... Can I say ***why***? The line I added to the opening remarks is ...

> Lazy loading shouldn't be used for core runtime assemblies, which might be trimmed on publish and unavailable on the client when the app loads.

**UPDATE**: I'm going to go ahead and get this in. I'm 🏃 to get things closed out to slim my backlog ⛰️⛏️😅.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/webassembly-lazy-load-assemblies.md](https://github.com/dotnet/AspNetCore.Docs/blob/293557e804f8444d4c9b461f3991df4229bbae65/aspnetcore/blazor/webassembly-lazy-load-assemblies.md) | [Lazy load assemblies in ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-lazy-load-assemblies?branch=pr-en-us-31407) |

<!-- PREVIEW-TABLE-END -->