### PR TITLE
Update integration-tests.md

### DIFF
--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -252,7 +252,7 @@ See [this GitHub repository](https://github.com/blowdart/idunno.Authentication/t
 
 Set the [environment](xref:fundamentals/environments) in the custom application factory:
 
-[!code-csharp[](~/../AspNetCore.Docs.Samples/test/integration-tests/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs?name=snippet1&highlight=20)]
+[!code-csharp[](~/../AspNetCore.Docs.Samples/test/integration-tests/IntegrationTestsSample/tests/RazorPagesProject.Tests/CustomWebApplicationFactory.cs?name=snippet1&highlight=36)]
 
 ## How the test infrastructure infers the app content root path
 


### PR DESCRIPTION
The line highlight for the *Set the environment* snippet isn't right.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/integration-tests.md](https://github.com/dotnet/AspNetCore.Docs/blob/6da208755e5a2b42ed484e988ff3f1dff4b1a26f/aspnetcore/test/integration-tests.md) | [Integration tests in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/test/integration-tests?branch=pr-en-us-31408) |

<!-- PREVIEW-TABLE-END -->