### PR TITLE
Integration article updates

### DIFF
--- a/aspnetcore/blazor/components/integration.md
+++ b/aspnetcore/blazor/components/integration.md
@@ -58,11 +58,16 @@ Add the following `_Imports` file for namespaces used by Razor components.
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
+@using {APP NAMESPACE}
+@using {APP NAMESPACE}.Components
+```
+
+Change the namespace placeholder (`{APP NAMESPACE}`) to the namespace of the app. For example:
+
+```razor
 @using BlazorSample
 @using BlazorSample.Components
 ```
-
-Change the namespace `BlazorSample` in the preceding example to match the app.
 
 Add the Blazor router (`<Router>`, <xref:Microsoft.AspNetCore.Components.Routing.Router>) to the app in a `Routes` component, which is placed in the app's `Components` folder.
 
@@ -141,10 +146,14 @@ In the ASP.NET Core project's `Program` file:
 * Add a `using` statement to the top of the file for the project's components:
 
   ```csharp
-  using BlazorSample.Components;
+  using {APP NAMESPACE}.Components;
   ```
 
-  In the preceding example, change `BlazorSample` in the namespace to match the app.
+  In the preceding line, change the `{APP NAMESPACE}` placeholder to the app's namespace. For example:
+
+  ```csharp
+  using BlazorSample.Components;
+  ```
 
 * Add Razor component services (<xref:Microsoft.Extensions.DependencyInjection.RazorComponentsServiceCollectionExtensions.AddRazorComponents%2A>). Add the following line before the line that calls `builder.Build()`):
 
@@ -177,7 +186,7 @@ builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();
 ```
 
-Also in the `Program` file, add a call to <xref:Microsoft.AspNetCore.Builder.ServerRazorComponentsEndpointConventionBuilderExtensions.AddInteractiveServerRenderMode%2A> where Razor components are mapped with <xref:Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions.MapRazorComponents%2A>:
+Add a call to <xref:Microsoft.AspNetCore.Builder.ServerRazorComponentsEndpointConventionBuilderExtensions.AddInteractiveServerRenderMode%2A> where Razor components are mapped with <xref:Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions.MapRazorComponents%2A>:
 
 ```csharp
 app.MapRazorComponents<App>()
@@ -390,6 +399,7 @@ Add an imports file to the `Components` folder with the following content. Chang
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using {APP NAMESPACE}
@@ -421,7 +431,27 @@ In the project's layout file (`Pages/Shared/_Layout.cshtml` in Razor Pages apps 
 > [!NOTE]
 > Typically, the layout loads via a `_ViewStart.cshtml` file.
 
+Add an non-operational (no-op) `App` component to the project.
+
+`Components/App.razor`:
+
+```razor
+@* No-op App component *@
+```
+
 Where services are registered, add services for Razor components and services to support rendering Interactive Server components.
+
+At the top of the `Program` file, add a `using` statement to the top of the file for the project's components:
+
+```csharp
+using {APP NAMESPACE}.Components;
+```
+
+In the preceding line, change the `{APP NAMESPACE}` placeholder to the app's namespace. For example:
+
+```csharp
+using BlazorSample.Components;
+```
 
 In the `Program` file before the line that builds the app (`builder.Build()`):
 
@@ -432,7 +462,7 @@ builder.Services.AddRazorComponents()
 
 For more information on adding support for Interactive Server and WebAssembly components, see <xref:blazor/components/render-modes>.
 
-In the `Program` file immediately after the call to map Razor Pages (<xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapRazorPages%2A>), call <xref:Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions.MapRazorComponents%2A> to discover available components and specify the app's root component (the first component loaded). By default, the app's root component is the `App` component (`App.razor`). Chain a call to `AddInteractiveInteractiveServerRenderMode` to configure interactive server-side rendering (interactive SSR) for the app:
+In the `Program` file immediately after the call to map Razor Pages (<xref:Microsoft.AspNetCore.Builder.RazorPagesEndpointRouteBuilderExtensions.MapRazorPages%2A>) in a Razor Pages app or to map the default controller route (<xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapControllerRoute%2A>) in an MVC app, call <xref:Microsoft.AspNetCore.Builder.RazorComponentsEndpointRouteBuilderExtensions.MapRazorComponents%2A> to discover available components and specify the app's root component (the first component loaded). By default, the app's root component is the `App` component (`App.razor`). Chain a call to `AddInteractiveInteractiveServerRenderMode` to configure interactive server-side rendering (interactive SSR) for the app:
 
 ```csharp
 app.MapRazorComponents<App>()
@@ -522,6 +552,7 @@ Add an imports file to the `Components` folder with the following content.
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using {APP NAMESPACE}
@@ -747,6 +778,18 @@ In the preceding code update the app title and stylesheet file name:
   ```
 
 Where services are registered, add services for Razor components and services to support rendering Interactive Server components.
+
+At the top of the `Program` file, add a `using` statement to the top of the file for the project's components:
+
+```csharp
+using {APP NAMESPACE}.Components;
+```
+
+In the preceding line, change the `{APP NAMESPACE}` placeholder to the app's namespace. For example:
+
+```csharp
+using BlazorSample.Components;
+```
 
 In the `Program` file before the line that builds the app (`builder.Build()`):
 


### PR DESCRIPTION
Fixes #31429

Thanks @nitrospaz! 🚀 ... and sorry that you ran into trouble with the guidance.

### Touch-ups

I made a few light touch-ups to where setting the namespace for components are called out. These didn't really need to be changed, but I made improvements that show an example of the `using`/`@using` statement(s) with a placeholder (`{APP NAMESPACE}`) and then an example of an actual statement with `BlazorSample` as the app's namespace (e.g., `using BlazorSample.Components`).

### Bug 1 🪲 

In order to use the shortened syntax for render modes, such as ...

```razor
@rendermode InteractiveServer
```

... the `_Imports.razor` file needs an additional `@using` ...

```razor
@using static Microsoft.AspNetCore.Components.Web.RenderMode
```

Right at the time of release of the 8.0 framework, they tossed that `@using` statement into the `_Imports.razor` file. I went around the repo updating examples to include the line; but unfortunately, I missed this article for that update 😢. Therefore, I'm adding that line now. I'm making a tracking note to confirm that there are no other spots around the repo that need the line.

### Bug 2 😈 

This one is a little more painful to see, but I understand why it happened. It turns out ... ***AFAICT***&dagger; ... that in order to embed ***an interactive*** Razor component into a page or view with the Component Tag Helper that the guidance is correct that `MapRazorComponents` is called with `AddInteractiveServerRenderMode` chained on the call ...

```csharp
app.MapRazorComponents<App>()
    .AddInteractiveServerRenderMode();
```

As you said in the issue, that section doesn't show or explain that the `App` component must be added to the app (and the namespace for it). The section that follows this section, the one that addresses ***routable*** components (i.e., not embedded into a page or view but actually routable by URL request) has the `App` component, but this section on embedding them doesn't. It only shows `MapRazorComponents` with the root `App` component specified.

The interesting thing is that in order to embed components with the Component TH per this section, one doesn't really need a functional `App` component for that line ***AFAICT***&dagger;. The `EmbeddedCounter` component works following the guidance in this section if the `App` component is just a no-op file ...

`Components/App.razor`:

```razor
@* No-op App component *@
```

That brings me to the ...............

***AFAICT***&dagger; ... This didn't come up in conversations with the product unit (PU) when I was working on the coverage. We need to ask Mackinnon what he thinks about a no-op `App` component. If he thinks it's totally fine in this scenario, namely a RP/MVC app that will ***only*** embed non-routable interactive components into pages and views, then we can go ahead with these updates. He may have a known solution for this scenario that doesn't require a no-op `App` component. If he feels that we need to get more PU 👁️👁️👁️👁️ on this because the idea of a no-op `App` component seems strange or just flat-out wrong 🙈, then he'll ping some additional folks to look.

The reason that this was missed is that the test app I was using here already had the `App` component present because I worked up the ***routable*** scenario first. Because it was already present, the `MapRazorComponents` line didn't throw. I'm sorry now that I didn't work this section from a clean MVC app. At that time, I was 🏃 like crazy 😵 to get a massive amount of work done for release. Gremlins 😈 like this are virtually impossible to avoid working that fast.

Because we're on a three-day weekend holiday, we probably won't get a response until next week. *Stand-by .............*

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/integration.md](https://github.com/dotnet/AspNetCore.Docs/blob/c5a3f89934e37f92aa50f52d6ef033aebee13d07/aspnetcore/blazor/components/integration.md) | [Integrate ASP.NET Core Razor components into ASP.NET Core apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/integration?branch=pr-en-us-31445) |

<!-- PREVIEW-TABLE-END -->