### PR TITLE
Remove reference to Swashbuckle

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-NSwag.md
+++ b/aspnetcore/tutorials/getting-started-with-NSwag.md
@@ -211,8 +211,6 @@ The Swagger UI now clearly documents the expected HTTP response codes (and the [
 
 Conventions can be used as an alternative to explicitly decorating individual actions with `[ProducesResponseType]`. For more information, see <xref:web-api/advanced/conventions>.
 
-To support the `[ProducesResponseType]` decoration, the [Swashbuckle.AspNetCore.Annotations](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/README.md#swashbuckleaspnetcoreannotations) package offers extensions to enable and enrich the response, schema, and parameter metadata.
-
 ### Redoc
 
 Redoc is an alternative to the Swagger UI.


### PR DESCRIPTION
Remove reference to Swashbuckle from NSwag documentation.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/getting-started-with-NSwag.md](https://github.com/dotnet/AspNetCore.Docs/blob/fce2e9dc846426ece5832ea6d66768c98116efae/aspnetcore/tutorials/getting-started-with-NSwag.md) | [Get started with NSwag and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-NSwag?branch=pr-en-us-31447) |

<!-- PREVIEW-TABLE-END -->