### PR TITLE
Event handling/data binding article order swap

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -5,7 +5,7 @@ description: Learn about data binding features for Razor components and DOM elem
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/14/2023
+ms.date: 01/16/2024
 uid: blazor/components/data-binding
 ---
 # ASP.NET Core Blazor data binding
@@ -144,7 +144,7 @@ Razor attribute binding is case-sensitive:
 
 To execute asynchronous logic after binding, use `@bind:after="{EVENT}"` with a DOM event for the `{EVENT}` placeholder. An assigned C# method isn't executed until the bound value is assigned synchronously.
 
-Using an event callback parameter (`[Parameter] public EventCallback<string> ValueChanged { get; set; }`) with `@bind:after` isn't supported. Instead, pass a method that returns an <xref:System.Action> or <xref:System.Threading.Tasks.Task> to `@bind:after`.
+Using an [event callback parameter (`EventCallback`/`EventCallback<T>`)](xref:blazor/components/event-handling#eventcallback) with `@bind:after` isn't supported. Instead, pass a method that returns an <xref:System.Action> or <xref:System.Threading.Tasks.Task> to `@bind:after`.
 
 In the following example:
 

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -5,7 +5,7 @@ description: Learn about Blazor's event handling features, including event argum
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/14/2023
+ms.date: 01/16/2024
 uid: blazor/components/event-handling
 ---
 # ASP.NET Core Blazor event handling

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -500,10 +500,10 @@ items:
                 uid: blazor/components/control-head-content
               - name: Cascading values and parameters
                 uid: blazor/components/cascading-values-and-parameters
-              - name: Data binding
-                uid: blazor/components/data-binding
               - name: Event handling
                 uid: blazor/components/event-handling
+              - name: Data binding
+                uid: blazor/components/data-binding
               - name: Lifecycle
                 uid: blazor/components/lifecycle
               - name: Virtualization


### PR DESCRIPTION
Fixes #30960

Thanks @voroninp! 🚀 ...

* I updated three event handling article examples in the `dotnet/blazor-samples` repo to avoid binding data (i.e., using `@bind`) on https://github.com/dotnet/blazor-samples/pull/166.
* That permitted me to swap the order of the event handling and binding articles in the ToC so that the event handling doc comes first.
* In the binding article, I added a link to the remark on `@bind:after` back to the `EventCallback`/`EventCallback<T>` section of the event handling article, where the reader can review the content.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/data-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/dc7922cd6d0fb700c9701a4b4c4cbbc62e0e7fde/aspnetcore/blazor/components/data-binding.md) | [ASP.NET Core Blazor data binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?branch=pr-en-us-31474) |
| [aspnetcore/blazor/components/event-handling.md](https://github.com/dotnet/AspNetCore.Docs/blob/dc7922cd6d0fb700c9701a4b4c4cbbc62e0e7fde/aspnetcore/blazor/components/event-handling.md) | [ASP.NET Core Blazor event handling](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?branch=pr-en-us-31474) |

<!-- PREVIEW-TABLE-END -->