### PR TITLE
Update required Windows version for WinHttpHandler to include WS2019

### DIFF
--- a/aspnetcore/grpc/netstandard.md
+++ b/aspnetcore/grpc/netstandard.md
@@ -68,9 +68,9 @@ For more information, see [Configure gRPC-Web with the .NET gRPC client](xref:gr
 
 Requirements and restrictions to using `WinHttpHandler`:
 
-* Windows 11 or later, Windows Server 2022 or later.
+* Windows 11 or later, Windows Server 2019 or later.
   * gRPC client is fully supported on Windows 11 or later.
-  * gRPC client is partially supported on Windows Server 2022. Unary and server streaming methods are supported. Client and bidirectional streaming methods are **_not_** supported.
+  * gRPC client is partially supported on Windows Server 2019 and Windows Server 2022. Unary and server streaming methods are supported. Client and bidirectional streaming methods are **_not_** supported.
 * A reference to [`System.Net.Http.WinHttpHandler`](https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/) version 6.0.1 or later.
 * Configure `WinHttpHandler` on the channel using `GrpcChannelOptions.HttpHandler`.
 * .NET Framework 4.6.1 or later.


### PR DESCRIPTION
Ready for review, **not ready for merge**. A new release is required before merging the documentation.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/netstandard.md](https://github.com/dotnet/AspNetCore.Docs/blob/62cde09a63d4acb157ee850d13c5246fc88c6e91/aspnetcore/grpc/netstandard.md) | [Use gRPC client with .NET Standard 2.0](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/netstandard?branch=pr-en-us-31482) |

<!-- PREVIEW-TABLE-END -->