### PR TITLE
Patch text for sample change

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -226,7 +226,7 @@ Additional assemblies are scanned in addition to the assembly specified to <xref
 
 ## Route parameters
 
-The router uses route parameters to populate the corresponding [component parameters](xref:blazor/components/index#component-parameters) with the same name. Route parameter names are case insensitive. In the following example, the `text` parameter assigns the value of the route segment to the component's `Text` property. When a request is made for `/route-parameter-1/amazing`, the `<h1>` tag content is rendered as `Blazor is amazing!`.
+The router uses route parameters to populate the corresponding [component parameters](xref:blazor/components/index#component-parameters) with the same name. Route parameter names are case insensitive. In the following example, the `text` parameter assigns the value of the route segment to the component's `Text` property. When a request is made for `/route-parameter-1/amazing`, the content is rendered as `Blazor is amazing!`.
 
 `RouteParameter1.razor`:
 


### PR DESCRIPTION
Fixes #31513

Thanks @Masoud-Sal! 🚀 ... I'll make it generic since the earlier samples probably do set the text in an `<h1>`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/75a686868c377a57ea9ed998c86401fe5ee5fd49/aspnetcore/blazor/fundamentals/routing.md) | [ASP.NET Core Blazor routing and navigation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?branch=pr-en-us-31514) |

<!-- PREVIEW-TABLE-END -->