### PR TITLE
Resolve minor typo on authorization roles/claims documentation page

### DIFF
--- a/aspnetcore/security/authorization/claims/samples/6.x/WebAll/Pages/Index.cshtml.cs
+++ b/aspnetcore/security/authorization/claims/samples/6.x/WebAll/Pages/Index.cshtml.cs
@@ -7,7 +7,7 @@ namespace WebAll.Pages
     [Authorize(Policy = "EmployeeOnly")]
     public class IndexModel : PageModel
     {
-       public void OnGet()
+        public void OnGet()
         {
 
         }

--- a/aspnetcore/security/authorization/roles/samples/6_0/WebAll/Pages/Index.cshtml.cs
+++ b/aspnetcore/security/authorization/roles/samples/6_0/WebAll/Pages/Index.cshtml.cs
@@ -7,7 +7,7 @@ namespace WebAll.Pages
     [Authorize(Policy = "EmployeeOnly")]
     public class IndexModel : PageModel
     {
-       public void OnGet()
+        public void OnGet()
         {
 
         }


### PR DESCRIPTION
There is a single space character missing before the OnGet method access modifier:
![image](https://github.com/dotnet/AspNetCore.Docs/assets/155370942/6717c168-b3a1-4478-bdbc-47d7152cdd7d)
