### PR TITLE
Fix typo in route-handlers.md

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/includes/route-handlers.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/route-handlers.md
@@ -53,7 +53,7 @@ Route parameters can be captured as part of the route pattern definition:
 
 The preceding code returns `The user id is 3 and book id is 7` from the URI `/users/3/books/7`.
 
-The route handler can declare the parameters to capture. When a request is made a route with parameters declared to capture, the parameters are parsed and passed to the handler. This makes it easy to capture the values in a type safe way. In the preceding code, `userId` and `bookId` are both `int`.
+The route handler can declare the parameters to capture. When a request is made to a route with parameters declared to capture, the parameters are parsed and passed to the handler. This makes it easy to capture the values in a type safe way. In the preceding code, `userId` and `bookId` are both `int`.
 
 In the preceding code, if either route value cannot be converted to an `int`, an exception is thrown. The GET request `/users/hello/books/3` throws the following exception:
 


### PR DESCRIPTION
The sentence:

> When a request is **made a route** with parameters...

Should read:

> When a request is made **to** a route with parameters...