### PR TITLE
Fix typo in min-api-filters.md

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/min-api-filters.md
+++ b/aspnetcore/fundamentals/minimal-apis/min-api-filters.md
@@ -85,7 +85,7 @@ In the preceding code:
 * The `EndpointFilterInvocationContext` object provides access to the parameters associated with a particular request issued to the endpoint via the `GetArguments` method.
 * The filter is registered using a `delegate` that takes a `EndpointFilterInvocationContext` and returns a `EndpointFilterDelegate`.
 
-In addition to being passed as delegates, filters can be registered by implementing the `IEndpointFilter` interface. The follow code shows the preceding filter encapsulated in a class which implements `IEndpointFilter`:
+In addition to being passed as delegates, filters can be registered by implementing the `IEndpointFilter` interface. The following code shows the preceding filter encapsulated in a class which implements `IEndpointFilter`:
 
 [!code-csharp[](~/fundamentals/minimal-apis/min-api-filters/7samples/todo/EndpointFilters/ToDoIsValidFilter.cs?name=snippet)]
 


### PR DESCRIPTION
The sentence:

> The **follow** code shows...

Should read:

> The **following** code shows...

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/min-api-filters.md](https://github.com/dotnet/AspNetCore.Docs/blob/806a68c64e6ddff43bd024251f1027695d262264/aspnetcore/fundamentals/minimal-apis/min-api-filters.md) | [Filters in Minimal API apps](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/min-api-filters?branch=pr-en-us-31558) |

<!-- PREVIEW-TABLE-END -->