### PR TITLE
Fix aspnetcore\tutorials\min-web-api\samples\7.x\todo\ build

### DIFF
--- a/aspnetcore/tutorials/min-web-api/samples/7.x/todo/Message.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/7.x/todo/Message.cs
@@ -1,6 +1,3 @@
-namespace TodoApi;
-
-
 public class Message
 {
     public Message()


### PR DESCRIPTION
Hello,

When building the current version of [this example for .NET 7](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/min-web-api/samples/7.x/todo) there is an error:
```log
G:\AspNetCore.Docs\aspnetcore\tutorials\min-web-api\samples\7.x\todo\Message.cs(6,12): warning CS8618: Non-nullable pro
perty 'Text' must contain a non-null value when exiting constructor. Consider declaring the property as nullable. [G:\A
spNetCore.Docs\aspnetcore\tutorials\min-web-api\samples\7.x\todo\TodoApi.csproj]
G:\AspNetCore.Docs\aspnetcore\tutorials\min-web-api\samples\7.x\todo\Program.cs(120,43): error CS0246: The type or name
space name 'Message' could not be found (are you missing a using directive or an assembly reference?) [G:\AspNetCore.Do
cs\aspnetcore\tutorials\min-web-api\samples\7.x\todo\TodoApi.csproj]
G:\AspNetCore.Docs\aspnetcore\tutorials\min-web-api\samples\7.x\todo\Program.cs(121,15): error CS0246: The type or name
space name 'Message' could not be found (are you missing a using directive or an assembly reference?) [G:\AspNetCore.Do
cs\aspnetcore\tutorials\min-web-api\samples\7.x\todo\TodoApi.csproj]
G:\AspNetCore.Docs\aspnetcore\tutorials\min-web-api\samples\7.x\todo\Program.cs(125,49): error CS0246: The type or name
space name 'Message' could not be found (are you missing a using directive or an assembly reference?) [G:\AspNetCore.Do
cs\aspnetcore\tutorials\min-web-api\samples\7.x\todo\TodoApi.csproj]
    1 Warning(s)
    3 Error(s)

Time Elapsed 00:00:02.66
```

This PR fixes the issue.