### PR TITLE
Fix typo in responses.md

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -217,7 +217,7 @@ We recommend adding an extension method to <xref:Microsoft.AspNetCore.Http.IResu
 
 [!code-csharp[](7.0-samples/WebMinAPIs/Program.cs?name=snippet_xtn)]
 
-Also, a custom `IResult` type can provide its own annotation by implementing the <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider> interface. For example, the following code adds an annotation to the preceding `HtmlResult` type that describe the response produced by the endpoint.
+Also, a custom `IResult` type can provide its own annotation by implementing the <xref:Microsoft.AspNetCore.Http.Metadata.IEndpointMetadataProvider> interface. For example, the following code adds an annotation to the preceding `HtmlResult` type that describes the response produced by the endpoint.
 
 [!code-csharp[](7.0-samples/WebMinAPIs/Snippets/ResultsExtensions.cs?name=snippet_IEndpointMetadataProvider&highlight=1,17-20)]
 


### PR DESCRIPTION
The sentence:

> ...adds an annotation to the preceding `HtmlResult` type that **describe** the response...

Should read:

> ...adds an annotation to the preceding `HtmlResult` type that **describes** the response...

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/responses.md](https://github.com/dotnet/AspNetCore.Docs/blob/3e79c7a5dd586e5e84635214a1a9767f8bc484e5/aspnetcore/fundamentals/minimal-apis/responses.md) | [How to create responses in Minimal API apps](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/responses?branch=pr-en-us-31585) |

<!-- PREVIEW-TABLE-END -->