### PR TITLE
Add a note about certificate file watching

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -705,6 +705,14 @@ Time to create 100,000 connections:
 
 .NET 8 adds support for Application-Layer Protocol Negotiation (ALPN) to macOS. ALPN is a TLS feature used to negotiate which HTTP protocol a connection will use. For example, ALPN allows browsers and other HTTP clients to request an HTTP/2 connection. This feature is especially useful for gRPC apps, which require HTTP/2. For more information, see <xref:fundamentals/servers/kestrel/http2>.
 
+### Certificate file watching in Kestrel
+
+TLS certificates [configured](dotnet/core/extensions/configuration) by path are now monitored for changes when `reloadOnChange` is passed to [KestrelServerOptions.Configure](dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserveroptions.configure).  A change to the certificate file is treated the same way as a change to the configured path (i.e. endpoints are reloaded).
+
+Note that file deletions are specifically not tracked since they arise transiently and would crash the server if non-transient.
+
+The former behavior or `reloadOnChange` can be restored by setting the app context switch `Microsoft.AspNetCore.Server.Kestrel.DisableCertificateFileWatching`.  If you find this is necessary, please [file an issue](https://github.com/dotnet/aspnetcore/issues/new/choose) to let us know why.
+
 ### Warning when specified HTTP protocols won't be used
 
 If TLS is disabled and HTTP/1.x is available, HTTP/2 and HTTP/3 will be disabled, even if they've been specified. This can cause some nasty surprises, so we've added warning output to let you know when it happens.

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -707,7 +707,7 @@ Time to create 100,000 connections:
 
 ### Certificate file watching in Kestrel
 
-TLS certificates [configured](dotnet/core/extensions/configuration) by path are now monitored for changes when `reloadOnChange` is passed to [KestrelServerOptions.Configure](dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserveroptions.configure).  A change to the certificate file is treated the same way as a change to the configured path (i.e. endpoints are reloaded).
+TLS certificates [configured](xref:fundamentals/configuration/index) by path are now monitored for changes when `reloadOnChange` is passed to <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Configure?displayProperty=nameWithType>.  A change to the certificate file is treated the same way as a change to the configured path (that is, endpoints are reloaded).
 
 Note that file deletions are specifically not tracked since they arise transiently and would crash the server if non-transient.
 

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -711,8 +711,6 @@ TLS certificates [configured](dotnet/core/extensions/configuration) by path are 
 
 Note that file deletions are specifically not tracked since they arise transiently and would crash the server if non-transient.
 
-The former behavior or `reloadOnChange` can be restored by setting the app context switch `Microsoft.AspNetCore.Server.Kestrel.DisableCertificateFileWatching`.  If you find this is necessary, please [file an issue](https://github.com/dotnet/aspnetcore/issues/new/choose) to let us know why.
-
 ### Warning when specified HTTP protocols won't be used
 
 If TLS is disabled and HTTP/1.x is available, HTTP/2 and HTTP/3 will be disabled, even if they've been specified. This can cause some nasty surprises, so we've added warning output to let you know when it happens.


### PR DESCRIPTION
Add a note about certificate file watching in Kestrel.

Fixes #30404

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/046b993f426f6d10c72d25ac03bc5d5bfeda1a71/aspnetcore/release-notes/aspnetcore-8.0.md) | [What's new in ASP.NET Core 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-31588) |


<!-- PREVIEW-TABLE-END -->