### PR TITLE
Fix typo in routing.md

### DIFF
--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -281,7 +281,7 @@ When a routing middleware executes, it sets an `Endpoint` and route values to a 
 * Calling [HttpContext.GetEndpoint](xref:Microsoft.AspNetCore.Http.EndpointHttpContextExtensions.GetEndpoint%2A) gets the endpoint.
 * `HttpRequest.RouteValues` gets the collection of route values.
 
-[Middleware](xref:fundamentals/middleware/index) runs after the routing middleware can inspect the endpoint and take action. For example, an authorization middleware can interrogate the endpoint's metadata collection for an authorization policy. After all of the middleware in the request processing pipeline is executed, the selected endpoint's delegate is invoked.
+[Middleware](xref:fundamentals/middleware/index) that runs after the routing middleware can inspect the endpoint and take action. For example, an authorization middleware can interrogate the endpoint's metadata collection for an authorization policy. After all of the middleware in the request processing pipeline is executed, the selected endpoint's delegate is invoked.
 
 The routing system in endpoint routing is responsible for all dispatching decisions. Because the middleware applies policies based on the selected endpoint, it's important that:
 


### PR DESCRIPTION
The sentence:

> Middleware runs after the routing middleware can inspect the endpoint...

Should read:

> Middleware **that** runs after the routing middleware can inspect the endpoint...



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/e154e1008605276156e11ea4306457bbef8f1b95/aspnetcore/fundamentals/routing.md) | [Routing in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/routing?branch=pr-en-us-31592) |

<!-- PREVIEW-TABLE-END -->