### PR TITLE
Fix typo in routing.md

### DIFF
--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -933,7 +933,7 @@ It is unlikely for an app to run into a situation where this is a problem unless
 
 #### How to address this issue
 
-There are several techniques and optimizations can be applied to routes that will largely improve this scenario:
+There are several techniques and optimizations which can be applied to routes that will largely improve this scenario:
 * Apply route constraints to your parameters, for example `{parameter:int}`, `{parameter:guid}`, `{parameter:regex(\\d+)}`, etc. where possible.
   * This allows the routing algorithm to internally optimize the structures used for matching and drastically reduce the memory used.
   * In the vast majority of cases this will suffice to get back to an acceptable behavior.


### PR DESCRIPTION
The sentence:

> There are several techniques and optimizations **can** be applied...

Should read:

> There are several techniques and optimizations **which** can be applied...

It may be worth going further and adding some commas somewhere in there so it reads:

> There are several techniques and optimizations`,` which can be applied to routes`,` that will largely improve this scenario:

...but comma placement is tricky so I defer to the team on that point 👍