### PR TITLE
Update getting-started-with-swashbuckle.md

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -11,7 +11,7 @@ uid: tutorials/get-started-with-swashbuckle
 # Get started with Swashbuckle and ASP.NET Core
 
 > [!NOTE]
-> Swashbuckle is not supported in .NET 8 and later. For a supported alternative, see <xref:tutorials/web-api-help-pages-using-swagger>.
+> Build-time OpenAPI document generation with Swashbuckle is not supported in .NET 8 and later. For a supported alternative, see <xref:tutorials/web-api-help-pages-using-swagger>.
 
 :::moniker range=">= aspnetcore-6.0"
 


### PR DESCRIPTION
Although Swashbuckle.AspNetCore hasn't been updated to target the net8.0 TFM, the only meaningful impact this has is on scenarios that use the Swashbuckle CLI to generate OpenAPI documents.

AFAIK, dev-time consumption of Swashbuckle is fine in .NET 8 so I think it's fair to specify here.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/getting-started-with-swashbuckle.md](https://github.com/dotnet/AspNetCore.Docs/blob/2cc23807b6d5a755b6952f6f6cbfdc968a846f9c/aspnetcore/tutorials/getting-started-with-swashbuckle.md) | [Get started with Swashbuckle and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?branch=pr-en-us-31602) |

<!-- PREVIEW-TABLE-END -->