### PR TITLE
Suggestion: Update best practice Fire-And-Forget example to use AsyncScope

### DIFF
--- a/aspnetcore/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs
+++ b/aspnetcore/performance/performance-best-practices/samples/3.0/Controllers/FireAndForgetSecondController.cs
@@ -59,7 +59,7 @@ namespace performance_best_practices.Controllers
             {
                 await Task.Delay(1000);
 
-                using (var scope = serviceScopeFactory.CreateScope())
+                await using (var scope = serviceScopeFactory.CreateAsyncScope())
                 {
                     var context = scope.ServiceProvider.GetRequiredService<ContosoDbContext>();
 


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->
###  Fixes:  https://github.com/dotnet/AspNetCore.Docs/issues/31628

I think the usage of `AsyncServiceScope` should be encouraged in this example, given that the example shows usage of resolving a service that implements `IAsyncDisposable`.

I realize there is some documentation elsewhere in this repository referencing `IServiceScope` and I don't think there are other places referencing `AsyncServiceScope`, so this could be a little misleading/incohesive. 