### PR TITLE
Remove incorrect comments about kestrel limits

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/options.md
+++ b/aspnetcore/fundamentals/servers/kestrel/options.md
@@ -198,76 +198,8 @@ The following examples use the <xref:Microsoft.AspNetCore.Server.Kestrel.Core> n
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 ```
 
-In examples shown later in this article, Kestrel options are configured in C# code. Kestrel options can also be set using a [configuration provider](xref:fundamentals/configuration/index). For example, the [File Configuration Provider](xref:fundamentals/configuration/index#file-configuration-provider) can load Kestrel configuration from an `appsettings.json` or `appsettings.{Environment}.json` file:
-
-```json
-{
-  "Kestrel": {
-    "Limits": {
-      "MaxConcurrentConnections": 100,
-      "MaxConcurrentUpgradedConnections": 100
-    },
-    "DisableStringReuse": true
-  }
-}
-```
-
 > [!NOTE]
 > <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> and [endpoint configuration](xref:fundamentals/servers/kestrel/endpoints) are configurable from configuration providers. Remaining Kestrel configuration must be configured in C# code.
-
-Use **one** of the following approaches:
-
-* Configure Kestrel in `Startup.ConfigureServices`:
-
-  1. Inject an instance of `IConfiguration` into the `Startup` class. The following example assumes that the injected configuration is assigned to the `Configuration` property.
-  2. In `Startup.ConfigureServices`, load the `Kestrel` section of configuration into Kestrel's configuration:
-
-     ```csharp
-     using Microsoft.Extensions.Configuration
-     
-     public class Startup
-     {
-         public Startup(IConfiguration configuration)
-         {
-             Configuration = configuration;
-         }
-
-         public IConfiguration Configuration { get; }
-
-         public void ConfigureServices(IServiceCollection services)
-         {
-             services.Configure<KestrelServerOptions>(
-                 Configuration.GetSection("Kestrel"));
-         }
-
-         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-         {
-             ...
-         }
-     }
-     ```
-
-* Configure Kestrel when building the host:
-
-  In `Program.cs`, load the `Kestrel` section of configuration into Kestrel's configuration:
-
-  ```csharp
-  // using Microsoft.Extensions.DependencyInjection;
-
-  public static IHostBuilder CreateHostBuilder(string[] args) =>
-      Host.CreateDefaultBuilder(args)
-          .ConfigureServices((context, services) =>
-          {
-              services.Configure<KestrelServerOptions>(
-                  context.Configuration.GetSection("Kestrel"));
-          })
-          .ConfigureWebHostDefaults(webBuilder =>
-          {
-              webBuilder.UseStartup<Startup>();
-          });
-  ```
-
-Both of the preceding approaches work with any [configuration provider](xref:fundamentals/configuration/index).
 
 ## General limits
 

--- a/aspnetcore/fundamentals/servers/kestrel/options.md
+++ b/aspnetcore/fundamentals/servers/kestrel/options.md
@@ -18,25 +18,6 @@ The Kestrel web server has constraint configuration options that are especially 
 
 Set constraints on the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions.Limits%2A?displayProperty=nameWithType> property. This property holds an instance of the <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerLimits> class.
 
-In examples shown later in this article, Kestrel options are configured in C# code. Kestrel options can also be set using a [configuration provider](xref:fundamentals/configuration/index). For example, the [File Configuration Provider](xref:fundamentals/configuration/index#file-configuration-provider) can load Kestrel configuration from an `appsettings.json` or `appsettings.{Environment}.json` file:
-
-```json
-{
-  "Kestrel": {
-    "Limits": {
-      "MaxConcurrentConnections": 100,
-      "MaxConcurrentUpgradedConnections": 100
-    },
-    "DisableStringReuse": true
-  }
-}
-```
-
-By default, Kestrel configuration is loaded from the `Kestrel` section using a preconfigured set of configuration providers. For more information on the default set of configuration providers, see [Default configuration](xref:fundamentals/configuration/index#default-configuration).
-
-> [!NOTE]
-> <xref:Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> and [endpoint configuration](xref:fundamentals/servers/kestrel/endpoints) are configurable from configuration providers. Set other Kestrel configuration in C# code.
-
 ## General limits
 
 ### Keep-alive timeout


### PR DESCRIPTION
Presently, they can't conveniently be configured from appsettings.json.  There are [workarounds](https://github.com/dotnet/aspnetcore/issues/4765), but none that seem worth recommending.

Fixes #31108



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/kestrel/options.md](https://github.com/dotnet/AspNetCore.Docs/blob/49d9d1fcbbe0b588305458266a8d46b32baea8a4/aspnetcore/fundamentals/servers/kestrel/options.md) | [Configure options for the ASP.NET Core Kestrel web server](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/options?branch=pr-en-us-31633) |

<!-- PREVIEW-TABLE-END -->