### PR TITLE
edit search.md: in Note that describes LINQ Contains and SQLite case (in)sensitivity, include links in the Note instead of outside

### DIFF
--- a/aspnetcore/tutorials/razor-pages/search.md
+++ b/aspnetcore/tutorials/razor-pages/search.md
@@ -52,10 +52,9 @@ The `s => s.Title.Contains()` code is a [Lambda Expression](/dotnet/csharp/progr
 
 > [!NOTE]
 > The <xref:System.Data.Objects.DataClasses.EntityCollection%601.Contains%2A> method is run on the database, not in the C# code. The case sensitivity on the query depends on the database and the collation. On SQL Server, `Contains` maps to [SQL LIKE](/sql/t-sql/language-elements/like-transact-sql), which is case insensitive. SQLite with the default collation is a mixture of case sensitive and case ***IN***sensitive, depending on the query. For information on making case insensitive SQLite queries, see the following:
-
-* [This GitHub issue](https://github.com/dotnet/efcore/issues/11414)
-* [This GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/22314)
-* [Collations and Case Sensitivity](/ef/core/miscellaneous/collations-and-case-sensitivity)
+> * [This GitHub issue](https://github.com/dotnet/efcore/issues/11414)
+> * [This GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/22314)
+> * [Collations and Case Sensitivity](/ef/core/miscellaneous/collations-and-case-sensitivity)
 
 Navigate to the Movies page and append a query string such as `?searchString=Ghost` to the URL. For example, `https://localhost:5001/Movies?searchString=Ghost`. The filtered movies are displayed.
 

--- a/aspnetcore/tutorials/razor-pages/search.md
+++ b/aspnetcore/tutorials/razor-pages/search.md
@@ -52,8 +52,9 @@ The `s => s.Title.Contains()` code is a [Lambda Expression](/dotnet/csharp/progr
 
 > [!NOTE]
 > The <xref:System.Data.Objects.DataClasses.EntityCollection%601.Contains%2A> method is run on the database, not in the C# code. The case sensitivity on the query depends on the database and the collation. On SQL Server, `Contains` maps to [SQL LIKE](/sql/t-sql/language-elements/like-transact-sql), which is case insensitive. SQLite with the default collation is a mixture of case sensitive and case ***IN***sensitive, depending on the query. For information on making case insensitive SQLite queries, see the following:
-> * [This GitHub issue](https://github.com/dotnet/efcore/issues/11414)
-> * [This GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/22314)
+> 
+> * [How to use case-insensitive query with Sqlite provider? (dotnet/efcore #11414)](https://github.com/dotnet/efcore/issues/11414)
+> * [How to make a SQLite column case insensitive (dotnet/AspNetCore.Docs #22314)](https://github.com/dotnet/AspNetCore.Docs/issues/22314)
 > * [Collations and Case Sensitivity](/ef/core/miscellaneous/collations-and-case-sensitivity)
 
 Navigate to the Movies page and append a query string such as `?searchString=Ghost` to the URL. For example, `https://localhost:5001/Movies?searchString=Ghost`. The filtered movies are displayed.


### PR DESCRIPTION
Before this change:

![20240201-note-on-sqlite-case-sensitivity-before](https://github.com/dotnet/AspNetCore.Docs/assets/47086307/d6c58508-c1a5-4f17-aed8-c47643c22ebc)


^ Links are outside purple box.

After this change (what I intend):

![20240201-note-on-sqlite-case-sensitivity-after](https://github.com/dotnet/AspNetCore.Docs/assets/47086307/f38d9df3-3baa-4a48-aa7c-1c70ede65efa)

^ Links are inside purple box.

Because the links are part of the note's message, I claim the links should be inside the note's box (if possible).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/razor-pages/search.md](https://github.com/dotnet/AspNetCore.Docs/blob/04a3ab9636d73a3825c229dd44e8b311152a6cb0/aspnetcore/tutorials/razor-pages/search.md) | [Part 6, add search to ASP.NET Core Razor Pages](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/search?branch=pr-en-us-31641) |


<!-- PREVIEW-TABLE-END -->