### PR TITLE
edit validation.md: remove stray comma

### DIFF
--- a/aspnetcore/includes/RP-MVC/validation.md
+++ b/aspnetcore/includes/RP-MVC/validation.md
@@ -14,7 +14,7 @@ The validation attributes specify behavior that you want to enforce on the model
 * The `RegularExpression` attribute is used to limit what characters can be input. In the preceding code, "Genre":
 
   * Must only use letters.
-  * The first letter is required to be uppercase. White spaces are allowed while numbers, and special
+  * The first letter is required to be uppercase. White spaces are allowed while numbers and special
    characters are not allowed.
 
 * The `RegularExpression` "Rating":

--- a/aspnetcore/includes/RP-MVC/validation.md
+++ b/aspnetcore/includes/RP-MVC/validation.md
@@ -14,8 +14,7 @@ The validation attributes specify behavior that you want to enforce on the model
 * The `RegularExpression` attribute is used to limit what characters can be input. In the preceding code, "Genre":
 
   * Must only use letters.
-  * The first letter is required to be uppercase. White spaces are allowed while numbers and special
-   characters are not allowed.
+  * The first letter must be uppercase. White spaces are allowed, while numbers and special characters aren't allowed.
 
 * The `RegularExpression` "Rating":
 

--- a/aspnetcore/tutorials/razor-pages/validation.md
+++ b/aspnetcore/tutorials/razor-pages/validation.md
@@ -46,8 +46,7 @@ The validation attributes specify behavior to enforce on the model properties th
 * The `[RegularExpression]` attribute is used to limit what characters can be input. In the preceding code, `Genre`:
 
   * Must only use letters.
-  * The first letter is required to be uppercase. White spaces are allowed while numbers and special
-   characters are not allowed.
+  * The first letter must be uppercase. White spaces are allowed, while numbers and special characters aren't allowed.
 
 * The `RegularExpression` `Rating`:
 

--- a/aspnetcore/tutorials/razor-pages/validation.md
+++ b/aspnetcore/tutorials/razor-pages/validation.md
@@ -46,7 +46,7 @@ The validation attributes specify behavior to enforce on the model properties th
 * The `[RegularExpression]` attribute is used to limit what characters can be input. In the preceding code, `Genre`:
 
   * Must only use letters.
-  * The first letter is required to be uppercase. White spaces are allowed while numbers, and special
+  * The first letter is required to be uppercase. White spaces are allowed while numbers and special
    characters are not allowed.
 
 * The `RegularExpression` `Rating`:


### PR DESCRIPTION
https://github.com/dotnet/AspNetCore.Docs/commit/bff9fa8741e8e10f95df9c5f930297b22307f917 permit whitespace characters in the Genre field.

That commit changed
```
The first letter is required to be uppercase. White space, numbers, and special characters are not allowed.
```
to 
```
The first letter is required to be uppercase. White spaces are allowed while numbers, and special characters are not allowed.
```

After that edit the comma after 'numbers' is stray.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/razor-pages/validation.md](https://github.com/dotnet/AspNetCore.Docs/blob/75c0b5c8d368a63cfeb7d2dbe62083b00559450f/aspnetcore/tutorials/razor-pages/validation.md) | [Part 8 of tutorial series on Razor Pages](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/validation?branch=pr-en-us-31643) |


<!-- PREVIEW-TABLE-END -->