### PR TITLE
edit validation.md: use `dotnet ef database update` in Visual Studio Code section. Use `Update-Database` in Visual Studio section

### DIFF
--- a/aspnetcore/tutorials/razor-pages/validation.md
+++ b/aspnetcore/tutorials/razor-pages/validation.md
@@ -215,7 +215,6 @@ Use the following commands to add a migration for the new DataAnnotations:
 ```dotnetcli
 dotnet ef migrations add New_DataAnnotations
 dotnet ef database update
-
 ```
 `dotnet ef database update` runs the `Up` method of the `New_DataAnnotations` class.
 

--- a/aspnetcore/tutorials/razor-pages/validation.md
+++ b/aspnetcore/tutorials/razor-pages/validation.md
@@ -206,6 +206,7 @@ In the PMC, enter the following commands:
 Add-Migration New_DataAnnotations
 Update-Database
 ```
+`Update-Database` runs the `Up` method of the `New_DataAnnotations` class.
 
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
@@ -216,10 +217,11 @@ dotnet ef migrations add New_DataAnnotations
 dotnet ef database update
 
 ```
+`dotnet ef database update` runs the `Up` method of the `New_DataAnnotations` class.
 
 ---
 
-`Update-Database` runs the `Up` methods of the `New_DataAnnotations` class. Examine the `Up` method:
+Examine the `Up` method:
 
 [!code-csharp[](~/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie80/Migrations/20230606012811_New_DataAnnotations.cs?name=snippet_1)]
 


### PR DESCRIPTION
![20240201-visual-studio-command-though-visual-studio-code-selected](https://github.com/dotnet/AspNetCore.Docs/assets/47086307/923fa8fa-6acb-4616-a378-c9b7b7fee1c8)

^ When the reader selects the 'Visual Studio Code' toggle, the reader sees `dotnet ef database update` then a use of `Update-Database` rather than `dotnet ef database update`.

This commit puts the use of `Update-Database` in the Visual Studio tab and a corresponding use of `dotnet ef database update` in the Visual Studio Code tab.

Separately, this commit changes '`Up` methods' to '`Up` method` because I see only one method in the code block that follows. 
### Aside
[A previous page ](https://learn.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/new-field?view=aspnetcore-8.0&tabs=visual-studio-code) uses `dotnet-ef` rather than `dotnet ef`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/razor-pages/validation.md](https://github.com/dotnet/AspNetCore.Docs/blob/02a948a0548ca1934afa0a6755ee3cd88fd44569/aspnetcore/tutorials/razor-pages/validation.md) | [Part 8 of tutorial series on Razor Pages](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/validation?branch=pr-en-us-31645) |


<!-- PREVIEW-TABLE-END -->