### PR TITLE
Razor Pages Get Started: Fix VS Code and MacOS explanation for Up

### DIFF
--- a/aspnetcore/tutorials/razor-pages/validation.md
+++ b/aspnetcore/tutorials/razor-pages/validation.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Part 8 of tutorial series on Razor Pages.
 ms.author: wpickett
 ms.custom: engagement-fy23
-ms.date: 08/16/2023
+ms.date: 02/01/2024
 uid: tutorials/razor-pages/validation
 ---
 # Part 8 of tutorial series on Razor Pages
@@ -206,6 +206,7 @@ In the PMC, enter the following commands:
 Add-Migration New_DataAnnotations
 Update-Database
 ```
+
 `Update-Database` runs the `Up` method of the `New_DataAnnotations` class.
 
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
@@ -216,6 +217,7 @@ Use the following commands to add a migration for the new DataAnnotations:
 dotnet ef migrations add New_DataAnnotations
 dotnet ef database update
 ```
+
 `dotnet ef database update` runs the `Up` method of the `New_DataAnnotations` class.
 
 ---

--- a/aspnetcore/tutorials/razor-pages/validation/includes/validation6.md
+++ b/aspnetcore/tutorials/razor-pages/validation/includes/validation6.md
@@ -193,6 +193,8 @@ Add-Migration New_DataAnnotations
 Update-Database
 ```
 
+`Update-Database` runs the `Up` method of the `New_DataAnnotations` class.
+
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
 Use the following commands to add a migration for the new DataAnnotations:
@@ -200,12 +202,13 @@ Use the following commands to add a migration for the new DataAnnotations:
 ```dotnetcli
 dotnet ef migrations add New_DataAnnotations
 dotnet ef database update
-
 ```
+
+`dotnet ef database update` runs the `Up` method of the `New_DataAnnotations` class.
 
 ---
 
-`Update-Database` runs the `Up` methods of the `New_DataAnnotations` class. Examine the `Up` method:
+Examine the `Up` method:
 
 [!code-csharp[](~/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie60/Migrations/20210830233901_New_DataAnnotations.cs?name=snippet)]
 

--- a/aspnetcore/tutorials/razor-pages/validation/includes/validation7.md
+++ b/aspnetcore/tutorials/razor-pages/validation/includes/validation7.md
@@ -193,6 +193,8 @@ Add-Migration New_DataAnnotations
 Update-Database
 ```
 
+`Update-Database` runs the `Up` method of the `New_DataAnnotations` class.
+
 # [Visual Studio Code / Visual Studio for Mac](#tab/visual-studio-code+visual-studio-mac)
 
 Use the following commands to add a migration for the new DataAnnotations:
@@ -200,12 +202,13 @@ Use the following commands to add a migration for the new DataAnnotations:
 ```dotnetcli
 dotnet ef migrations add New_DataAnnotations
 dotnet ef database update
-
 ```
+
+`dotnet ef database update` runs the `Up` method of the `New_DataAnnotations` class.
 
 ---
 
-`Update-Database` runs the `Up` methods of the `New_DataAnnotations` class. Examine the `Up` method:
+Examine the `Up` method:
 
 [!code-csharp[](~/tutorials/razor-pages/razor-pages-start/sample/RazorPagesMovie70/Migrations/20221031235618_New_DataAnnotations.cs?name=snippet_1)]
 


### PR DESCRIPTION
Fixes #31650 

Explanation for what runs `Up` in Razor Pages Get Started - Validation tutorial was used for both VS and VS Code/MacOS tabs but should have been separate and different for the latter.

Fix already added by community member for v8.  Adding it to versions 6-7 and a space correction on version 8.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/razor-pages/validation.md](https://github.com/dotnet/AspNetCore.Docs/blob/180ff75839e86f0503dbfe4bf41c83102d2001f1/aspnetcore/tutorials/razor-pages/validation.md) | [Part 8 of tutorial series on Razor Pages](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/validation?branch=pr-en-us-31653) |

<!-- PREVIEW-TABLE-END -->