### PR TITLE
Code-fence repo names

### DIFF
--- a/aspnetcore/tutorials/razor-pages/search.md
+++ b/aspnetcore/tutorials/razor-pages/search.md
@@ -53,8 +53,8 @@ The `s => s.Title.Contains()` code is a [Lambda Expression](/dotnet/csharp/progr
 > [!NOTE]
 > The <xref:System.Data.Objects.DataClasses.EntityCollection%601.Contains%2A> method is run on the database, not in the C# code. The case sensitivity on the query depends on the database and the collation. On SQL Server, `Contains` maps to [SQL LIKE](/sql/t-sql/language-elements/like-transact-sql), which is case insensitive. SQLite with the default collation is a mixture of case sensitive and case ***IN***sensitive, depending on the query. For information on making case insensitive SQLite queries, see the following:
 > 
-> * [How to use case-insensitive query with Sqlite provider? (dotnet/efcore #11414)](https://github.com/dotnet/efcore/issues/11414)
-> * [How to make a SQLite column case insensitive (dotnet/AspNetCore.Docs #22314)](https://github.com/dotnet/AspNetCore.Docs/issues/22314)
+> * [How to use case-insensitive query with Sqlite provider? (`dotnet/efcore` #11414)](https://github.com/dotnet/efcore/issues/11414)
+> * [How to make a SQLite column case insensitive (`dotnet/AspNetCore.Docs` #22314)](https://github.com/dotnet/AspNetCore.Docs/issues/22314)
 > * [Collations and Case Sensitivity](/ef/core/miscellaneous/collations-and-case-sensitivity)
 
 Navigate to the Movies page and append a query string such as `?searchString=Ghost` to the URL. For example, `https://localhost:5001/Movies?searchString=Ghost`. The filtered movies are displayed.


### PR DESCRIPTION
Ooooops, @zipperer 🙈 ... I missed code-fencing the repo names. In these cases, it's good because it prevents the machine translation from localizing any of the text in the repo names.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/razor-pages/search.md](https://github.com/dotnet/AspNetCore.Docs/blob/1ec3998c52cc556c87d04735c125153feaf114d6/aspnetcore/tutorials/razor-pages/search.md) | [Part 6, add search to ASP.NET Core Razor Pages](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/razor-pages/search?branch=pr-en-us-31655) |

<!-- PREVIEW-TABLE-END -->