### PR TITLE
Avoid referring to components or RenderFragment parameters as "tags"

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -308,7 +308,7 @@ To provide `Component1`'s `my-component` CSS class, link to the library's styles
 
 To make routable components in the RCL available for direct requests, the RCL's assembly must be disclosed to the app's router.
 
-Open the app's `App` component (`App.razor`). Add or update the `AdditionalAssemblies` parameter of the `<Router>` tag to include the RCL's assembly. In the following example, the `ComponentLibrary.Component1` component is used to discover the RCL's assembly.
+Open the app's `App` component (`App.razor`). Add or update the `AdditionalAssemblies` parameter of the `<Router>` component to include the RCL's assembly. In the following example, the `ComponentLibrary.Component1` component is used to discover the RCL's assembly.
 
 ```razor
 AdditionalAssemblies="new[] { typeof(ComponentLibrary.Component1).Assembly }"

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -308,7 +308,7 @@ To provide `Component1`'s `my-component` CSS class, link to the library's styles
 
 To make routable components in the RCL available for direct requests, the RCL's assembly must be disclosed to the app's router.
 
-Open the app's `App` component (`App.razor`). Add or update the `AdditionalAssemblies` parameter of the `<Router>` component to include the RCL's assembly. In the following example, the `ComponentLibrary.Component1` component is used to discover the RCL's assembly.
+Open the app's `App` component (`App.razor`). Assign an <xref:System.Reflection.Assembly> collection to the <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies%2A> parameter of the <xref:Microsoft.AspNetCore.Components.Routing.Router> component to include the RCL's assembly. In the following example, the `ComponentLibrary.Component1` component is used to discover the RCL's assembly.
 
 ```razor
 AdditionalAssemblies="new[] { typeof(ComponentLibrary.Component1).Assembly }"

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -153,7 +153,7 @@ Set custom content in the <xref:Microsoft.AspNetCore.Components.Routing.Router> 
 </Router>
 ```
 
-Arbitrary items are supported as content of the `<NotFound>` tags, such as other interactive components. To apply a default layout to <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> content, see <xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component>.
+Arbitrary items are supported as content of the `<NotFound>` template, such as other interactive components. To apply a default layout to <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> content, see <xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component>.
 
 ## Route to components from multiple assemblies
 
@@ -1250,7 +1250,7 @@ At the top of the component that specifies the <xref:Microsoft.AspNetCore.Compon
 @using Microsoft.AspNetCore.Components.Routing
 ```
 
-Add a `<Navigating>` tag to the component with markup to display during page transition events. For more information, see <xref:Microsoft.AspNetCore.Components.Routing.Router.Navigating> (API documentation).
+Add a `<Navigating>` template to the component with markup to display during page transition events. For more information, see <xref:Microsoft.AspNetCore.Components.Routing.Router.Navigating> (API documentation).
 
 In the router element content (`<Router>...</Router>`):
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -136,13 +136,13 @@ When the <xref:Microsoft.AspNetCore.Components.Routing.Router> component navigat
 
 :::moniker range=">= aspnetcore-8.0"
 
-*This section only applies to Blazor WebAssembly apps.* Blazor Web Apps don't use the <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> template (`<NotFound>...</NotFound>`), but the template is supported for backward compatibility to avoid a breaking change in the framework. Blazor Web Apps typically process bad URL requests by either displaying the browser's built-in 404 UI or returning a custom 404 page from the ASP.NET Core server via ASP.NET Core middleware (for example, [`UseStatusCodePagesWithRedirects`](xref:fundamentals/error-handling#usestatuscodepageswithredirects) / [API documentation](xref:Microsoft.AspNetCore.Builder.StatusCodePagesExtensions.UseStatusCodePagesWithRedirects%2A)).
+*This section only applies to Blazor WebAssembly apps.* Blazor Web Apps don't use the <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> parameter (`<NotFound>...</NotFound>` markup), but the parameter is supported for backward compatibility to avoid a breaking change in the framework. Blazor Web Apps typically process bad URL requests by either displaying the browser's built-in 404 UI or returning a custom 404 page from the ASP.NET Core server via ASP.NET Core middleware (for example, [`UseStatusCodePagesWithRedirects`](xref:fundamentals/error-handling#usestatuscodepageswithredirects) / [API documentation](xref:Microsoft.AspNetCore.Builder.StatusCodePagesExtensions.UseStatusCodePagesWithRedirects%2A)).
 
 :::moniker-end
 
 The <xref:Microsoft.AspNetCore.Components.Routing.Router> component allows the app to specify custom content if content isn't found for the requested route.
 
-Set custom content in the <xref:Microsoft.AspNetCore.Components.Routing.Router> component's <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> template:
+Set custom content for the <xref:Microsoft.AspNetCore.Components.Routing.Router> component's <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> parameter:
 
 ```razor
 <Router ...>
@@ -153,7 +153,7 @@ Set custom content in the <xref:Microsoft.AspNetCore.Components.Routing.Router> 
 </Router>
 ```
 
-Arbitrary items are supported as content of the `<NotFound>` template, such as other interactive components. To apply a default layout to <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> content, see <xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component>.
+Arbitrary items are supported as content of the <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> parameter, such as other interactive components. To apply a default layout to <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> content, see <xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component>.
 
 ## Route to components from multiple assemblies
 
@@ -1250,9 +1250,9 @@ At the top of the component that specifies the <xref:Microsoft.AspNetCore.Compon
 @using Microsoft.AspNetCore.Components.Routing
 ```
 
-Add a `<Navigating>` template to the component with markup to display during page transition events. For more information, see <xref:Microsoft.AspNetCore.Components.Routing.Router.Navigating> (API documentation).
+Provide content to the <xref:Microsoft.AspNetCore.Components.Routing.Router.Navigating> parameter for display during page transition events.
 
-In the router element content (`<Router>...</Router>`):
+In the router element (`<Router>...</Router>`) content:
 
 ```razor
 <Navigating>

--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -383,7 +383,7 @@ The component exposes a `context` variable of type <xref:Microsoft.AspNetCore.Co
 </AuthorizeView>
 ```
 
-You can also supply different content for display if the user isn't authorized:
+You can also supply different content for display if the user isn't authorized with a combination of the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.Authorized%2A> and <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.NotAuthorized%2A> parameters:
 
 ```razor
 <AuthorizeView>
@@ -406,7 +406,7 @@ A default event handler for an authorized element, such as the `SecureMethod` me
 > [!WARNING]
 > Client-side markup and methods associated with an <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> are only protected from view and execution in the ***rendered UI*** in client-side Blazor apps. In order to protect authorized content and secure methods in client-side Blazor, the content is usually supplied by a secure, authorized web API call to a server API and never stored in the app. For more information, see <xref:blazor/call-web-api> and <xref:blazor/security/webassembly/additional-scenarios>.
 
-The content of `<Authorized>` and `<NotAuthorized>` templates can include arbitrary items, such as other interactive components.
+The content of <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.Authorized%2A> and <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.NotAuthorized%2A> can include arbitrary items, such as other interactive components.
 
 Authorization conditions, such as roles or policies that control UI options or access, are covered in the [Authorization](#authorization) section.
 
@@ -484,7 +484,7 @@ Pascal case is typically used for role and policy names (for example, `BillingAd
 
 Blazor allows for authentication state to be determined *asynchronously*. The primary scenario for this approach is in client-side Blazor apps that make a request to an external endpoint for authentication.
 
-While authentication is in progress, <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> displays no content by default. To display content while authentication occurs, use the `<Authorizing>` template:
+While authentication is in progress, <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> displays no content by default. To display content while authentication occurs, assign content to the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.Authorizing%2A> parameter:
 
 ```razor
 <AuthorizeView>
@@ -667,7 +667,7 @@ The <xref:Microsoft.AspNetCore.Components.Routing.Router> component, in conjunct
 </Router>
 ```
 
-The content of `<NotAuthorized>` and `<Authorizing>` templates can include arbitrary items, such as other interactive components.
+The content of <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.Authorized%2A> and <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.NotAuthorized%2A> can include arbitrary items, such as other interactive components.
 
 > [!NOTE]
 > The preceding requires cascading authentication state services registration in the app's `Program` file:
@@ -697,11 +697,11 @@ The content of `<NotAuthorized>` and `<Authorizing>` templates can include arbit
 </CascadingAuthenticationState>
 ```
 
-The content of `<NotFound>`, `<NotAuthorized>`, and `<Authorizing>` templates can include arbitrary items, such as other interactive components.
+The content of <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound%2A>, <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.Authorized%2A>, and <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.NotAuthorized%2A> can include arbitrary items, such as other interactive components.
 
 :::moniker-end
 
-If the `<NotAuthorized>` template isn't specified, the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView> uses the following fallback message:
+If <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeViewCore.NotAuthorized%2A> content isn't specified, the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView> uses the following fallback message:
 
 ```html
 Not authorized.

--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -406,7 +406,7 @@ A default event handler for an authorized element, such as the `SecureMethod` me
 > [!WARNING]
 > Client-side markup and methods associated with an <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> are only protected from view and execution in the ***rendered UI*** in client-side Blazor apps. In order to protect authorized content and secure methods in client-side Blazor, the content is usually supplied by a secure, authorized web API call to a server API and never stored in the app. For more information, see <xref:blazor/call-web-api> and <xref:blazor/security/webassembly/additional-scenarios>.
 
-The content of `<Authorized>` and `<NotAuthorized>` tags can include arbitrary items, such as other interactive components.
+The content of `<Authorized>` and `<NotAuthorized>` templates can include arbitrary items, such as other interactive components.
 
 Authorization conditions, such as roles or policies that control UI options or access, are covered in the [Authorization](#authorization) section.
 
@@ -484,7 +484,7 @@ Pascal case is typically used for role and policy names (for example, `BillingAd
 
 Blazor allows for authentication state to be determined *asynchronously*. The primary scenario for this approach is in client-side Blazor apps that make a request to an external endpoint for authentication.
 
-While authentication is in progress, <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> displays no content by default. To display content while authentication occurs, use the `<Authorizing>` tag:
+While authentication is in progress, <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> displays no content by default. To display content while authentication occurs, use the `<Authorizing>` template:
 
 ```razor
 <AuthorizeView>
@@ -667,7 +667,7 @@ The <xref:Microsoft.AspNetCore.Components.Routing.Router> component, in conjunct
 </Router>
 ```
 
-The content of `<NotAuthorized>` and `<Authorizing>` tags can include arbitrary items, such as other interactive components.
+The content of `<NotAuthorized>` and `<Authorizing>` templates can include arbitrary items, such as other interactive components.
 
 > [!NOTE]
 > The preceding requires cascading authentication state services registration in the app's `Program` file:
@@ -697,11 +697,11 @@ The content of `<NotAuthorized>` and `<Authorizing>` tags can include arbitrary 
 </CascadingAuthenticationState>
 ```
 
-The content of `<NotFound>`, `<NotAuthorized>`, and `<Authorizing>` tags can include arbitrary items, such as other interactive components.
+The content of `<NotFound>`, `<NotAuthorized>`, and `<Authorizing>` templates can include arbitrary items, such as other interactive components.
 
 :::moniker-end
 
-If the `<NotAuthorized>` tag isn't specified, the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView> uses the following fallback message:
+If the `<NotAuthorized>` template isn't specified, the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView> uses the following fallback message:
 
 ```html
 Not authorized.


### PR DESCRIPTION
I recommend not referring to RenderFragment parameters and components as "tags".
In other parts of the documentation, the term "template" is commonly used for RenderFragment parameters, and "content" is also an appropriate choice. Although "parameter" might be the most precise term, it could be considered too technical for some contexts.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/class-libraries.md](https://github.com/dotnet/AspNetCore.Docs/blob/76a70966921f0318e2b438ec5fc145e54257068e/aspnetcore/blazor/components/class-libraries.md) | [Consume ASP.NET Core Razor components from a Razor class library (RCL)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries?branch=pr-en-us-31662) |
| [aspnetcore/blazor/fundamentals/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/76a70966921f0318e2b438ec5fc145e54257068e/aspnetcore/blazor/fundamentals/routing.md) | [ASP.NET Core Blazor routing and navigation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?branch=pr-en-us-31662) |
| [aspnetcore/blazor/security/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/76a70966921f0318e2b438ec5fc145e54257068e/aspnetcore/blazor/security/index.md) | [ASP.NET Core Blazor authentication and authorization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/index?branch=pr-en-us-31662) |


<!-- PREVIEW-TABLE-END -->