### PR TITLE
Blazor built-in components include components from project templates

### DIFF
--- a/aspnetcore/blazor/components/built-in-components.md
+++ b/aspnetcore/blazor/components/built-in-components.md
@@ -12,7 +12,7 @@ uid: blazor/components/built-in-components
 
 [!INCLUDE[](~/includes/not-latest-version.md)]
 
-The following Razor components are built-in within the Blazor framework, or serve as structural elements of Blazor project templates:
+The following built-in Razor components are provided by the Blazor framework. For more information on built-in components that are used by the Blazor project templates, see <xref:blazor/project-structure>.
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/components/built-in-components.md
+++ b/aspnetcore/blazor/components/built-in-components.md
@@ -12,7 +12,7 @@ uid: blazor/components/built-in-components
 
 [!INCLUDE[](~/includes/not-latest-version.md)]
 
-The following built-in Razor components are provided by the Blazor framework:
+The following Razor components are built-in within the Blazor framework, or serve as structural elements of Blazor project templates:
 
 :::moniker range=">= aspnetcore-8.0"
 


### PR DESCRIPTION
The list of Razor components includes both built-in components provided by the Blazor framework and those that come with Blazor project templates.
It's important to note this distinction on the page to prevent confusion, especially when working on projects not based on the official Blazor project templates.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/built-in-components.md](https://github.com/dotnet/AspNetCore.Docs/blob/8282bac47d68247d3c6c6a1e5cc5d6a5660f0232/aspnetcore/blazor/components/built-in-components.md) | [ASP.NET Core built-in Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/built-in-components?branch=pr-en-us-31663) |


<!-- PREVIEW-TABLE-END -->