### PR TITLE
Routing - use @key in NavLink loop warning (instead of NavLink href)

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1592,8 +1592,8 @@ The following HTML markup is rendered:
 > @for (int c = 0; c < 10; c++)
 > {
 >     var current = c;
->     <li ...>
->         <NavLink ... href="@c">
+>     <li @key="@c" ...>
+>         <NavLink ...>
 >             <span ...></span> @current
 >         </NavLink>
 >     </li>
@@ -1607,8 +1607,8 @@ The following HTML markup is rendered:
 > ```razor
 > @foreach (var c in Enumerable.Range(0,10))
 > {
->     <li ...>
->         <NavLink ... href="@c">
+>     <li @key="@c" ...>
+>         <NavLink ...>
 >             <span ...></span> @c
 >         </NavLink>
 >     </li>


### PR DESCRIPTION
I believe the `@key` directive attribute should be emphasized whenever there's a loop in the rendering process. Moreover, in this scenario, it could also serve to demonstrate the difference between using `@c` and `@current`. Specifically, using `<NavLink href="@c" ...>` might not be very clear for numeric values of `c` and could lead to confusion for readers.