### PR TITLE
Add cross-link

### DIFF
--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -414,6 +414,8 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
 
    In the preceding example, the `{CLIENT APP NAMESPACE}` placeholder is the namespace of the `Client` project (for example, `HostedBlazorApp.Client`). Replace the placeholder with the `Client` project's namespace.
 
+1. If the client project must read the environment, see the updated guidance in <xref:blazor/fundamentals/environments>, especially the section titled *Read the environment client-side in a Blazor Web App*.
+
 1. Run the solution from the `Server` project:
 
    For Visual Studio, confirm that the `Server` project is selected in **Solution Explorer** when running the app.


### PR DESCRIPTION
Fixes #31709

Thanks @Stra1ghter ... This will at least get readers to the *Environments* article to consume the new content for the `.Client` project's use of the environment, especially in light of prerendering, where `IWebAssemblyHostEnvironment` isn't on the server by default. Of course, I can't say if the guidance resolves any particular problem that you're reporting in your product unit issue, but I'll keep an 👁️ on it over there for further work here.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/70-80.md](https://github.com/dotnet/AspNetCore.Docs/blob/911cfd4c4b3699492394d3bd83ebe0f4fb60d5ff/aspnetcore/migration/70-80.md) | [Migrate from ASP.NET Core 7.0 to 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/migration/70-80?branch=pr-en-us-31710) |

<!-- PREVIEW-TABLE-END -->