### PR TITLE
Fix grammar in DNS cache flushing instruction

### DIFF
--- a/aspnetcore/blazor/http-caching-issues.md
+++ b/aspnetcore/blazor/http-caching-issues.md
@@ -28,7 +28,7 @@ Upgrade issues typically appear as a failure to start the app in the browser. No
 
 * First, check if the app loads successfully within a clean browser instance. Use a private browser mode to load the app, such as Microsoft Edge InPrivate mode or Google Chrome Incognito mode. If the app fails to load, it likely means that one or more packages or the framework wasn't correctly updated.
 * If the app loads correctly in a clean browser instance, then it's likely that the app is being served from a stale cache. In most cases, a hard browser refresh with <kbd>Ctrl</kbd>+<kbd>F5</kbd> flushes the cache, which permits the app to load and run with the latest assets.
-* If the app continues to fail, then it's likely that a stale CDN cache is serving the app. Try to flushing the DNS cache via whatever mechanism your CDN provider offers.
+* If the app continues to fail, then it's likely that a stale CDN cache is serving the app. Try to flush the DNS cache via whatever mechanism your CDN provider offers.
 
 ## Recommended actions before an upgrade
 


### PR DESCRIPTION
### Fix Documentation for DNS Cache Flushing

#### Description:
This PR corrects a grammatical error in the documentation for DNS cache flushing. The original text, "Try to flushing the DNS cache", has been changed to "Try to flush the DNS cache" for clarity and correctness.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/http-caching-issues.md](https://github.com/dotnet/AspNetCore.Docs/blob/5e3bb3d1d12024bbcba78060702fab07f083eb36/aspnetcore/blazor/http-caching-issues.md) | [Avoid HTTP caching issues when upgrading ASP.NET Core Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/http-caching-issues?branch=pr-en-us-31711) |

<!-- PREVIEW-TABLE-END -->