### PR TITLE
Add CompressionLevel.SmallestSize and actual Gzip/Brotli compression levels

### DIFF
--- a/aspnetcore/performance/response-compression.md
+++ b/aspnetcore/performance/response-compression.md
@@ -128,7 +128,7 @@ Set the compression level with <xref:Microsoft.AspNetCore.ResponseCompression.Br
 See [CompressionLevel Enum](/dotnet/api/system.io.compression.compressionlevel) for values that indicate whether a compression operation emphasizes speed or compression size.
 | [CompressionLevel.SmallestSize](xref:System.IO.Compression.CompressionLevel) | Compression should create output as small as possible, even if the operation takes a longer time to complete. | 9 | 11 |
 
-*The Gzip and Brotli levels corresponds to the compression levels being passed to the underlying compression library* 
+The Gzip and Brotli levels correspond to the compression levels being passed to the underlying compression library. 
 
 [!code-csharp[](response-compression/samples/6.x/SampleApp/Program.cs?name=snippet2&highlight=13-21)]
 

--- a/aspnetcore/performance/response-compression.md
+++ b/aspnetcore/performance/response-compression.md
@@ -125,11 +125,14 @@ The following code:
 
 Set the compression level with <xref:Microsoft.AspNetCore.ResponseCompression.BrotliCompressionProviderOptions> and <xref:Microsoft.AspNetCore.ResponseCompression.GzipCompressionProviderOptions>. The Brotli and Gzip compression providers default to the fastest compression level, [CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel), which might not produce the most efficient compression. If the most efficient compression is desired, configure the response compression middleware for optimal compression.
 
-| Compression Level | Description |
-| ----------------- | ----------- |
-| [CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel) | Compression should complete as quickly as possible, even if the resulting output isn't optimally compressed. |
-| [CompressionLevel.NoCompression](xref:System.IO.Compression.CompressionLevel) | No compression should be performed. |
-| [CompressionLevel.Optimal](xref:System.IO.Compression.CompressionLevel) | Responses should be optimally compressed, even if the compression takes more time to complete. |
+| Compression Level | Description | Gzip level | Brotli level |
+| ----------------- | ----------- | ---------- | ------------ |
+| [CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel) | Compression should complete as quickly as possible, even if the resulting output isn't optimally compressed. | 1 | 1 |
+| [CompressionLevel.NoCompression](xref:System.IO.Compression.CompressionLevel) | No compression should be performed. | 0 | 0 |
+| [CompressionLevel.Optimal](xref:System.IO.Compression.CompressionLevel) | Compression should optimally balance compression speed and output size. | -1 (6) | 4 |
+| [CompressionLevel.SmallestSize](xref:System.IO.Compression.CompressionLevel) | Compression should create output as small as possible, even if the operation takes a longer time to complete. | 9 | 11 |
+
+*The Gzip and Brotli levels corresponds to the compression levels being passed to the underlying compression library* 
 
 [!code-csharp[](response-compression/samples/6.x/SampleApp/Program.cs?name=snippet2&highlight=13-21)]
 

--- a/aspnetcore/performance/response-compression.md
+++ b/aspnetcore/performance/response-compression.md
@@ -126,9 +126,6 @@ The following code:
 Set the compression level with <xref:Microsoft.AspNetCore.ResponseCompression.BrotliCompressionProviderOptions> and <xref:Microsoft.AspNetCore.ResponseCompression.GzipCompressionProviderOptions>. The Brotli and Gzip compression providers default to the fastest compression level, [CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel), which might not produce the most efficient compression. If the most efficient compression is desired, configure the response compression middleware for optimal compression.
 
 See [CompressionLevel Enum](/dotnet/api/system.io.compression.compressionlevel) for values that indicate whether a compression operation emphasizes speed or compression size.
-| [CompressionLevel.SmallestSize](xref:System.IO.Compression.CompressionLevel) | Compression should create output as small as possible, even if the operation takes a longer time to complete. | 9 | 11 |
-
-The Gzip and Brotli levels correspond to the compression levels being passed to the underlying compression library. 
 
 [!code-csharp[](response-compression/samples/6.x/SampleApp/Program.cs?name=snippet2&highlight=13-21)]
 

--- a/aspnetcore/performance/response-compression.md
+++ b/aspnetcore/performance/response-compression.md
@@ -125,11 +125,7 @@ The following code:
 
 Set the compression level with <xref:Microsoft.AspNetCore.ResponseCompression.BrotliCompressionProviderOptions> and <xref:Microsoft.AspNetCore.ResponseCompression.GzipCompressionProviderOptions>. The Brotli and Gzip compression providers default to the fastest compression level, [CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel), which might not produce the most efficient compression. If the most efficient compression is desired, configure the response compression middleware for optimal compression.
 
-| Compression Level | Description | Gzip level | Brotli level |
-| ----------------- | ----------- | ---------- | ------------ |
-| [CompressionLevel.Fastest](xref:System.IO.Compression.CompressionLevel) | Compression should complete as quickly as possible, even if the resulting output isn't optimally compressed. | 1 | 1 |
-| [CompressionLevel.NoCompression](xref:System.IO.Compression.CompressionLevel) | No compression should be performed. | 0 | 0 |
-| [CompressionLevel.Optimal](xref:System.IO.Compression.CompressionLevel) | Compression should optimally balance compression speed and output size. | -1 (6) | 4 |
+See [CompressionLevel Enum](/dotnet/api/system.io.compression.compressionlevel) for values that indicate whether a compression operation emphasizes speed or compression size.
 | [CompressionLevel.SmallestSize](xref:System.IO.Compression.CompressionLevel) | Compression should create output as small as possible, even if the operation takes a longer time to complete. | 9 | 11 |
 
 *The Gzip and Brotli levels corresponds to the compression levels being passed to the underlying compression library* 


### PR DESCRIPTION
Since [.Net 6](https://github.com/dotnet/runtime/commit/7d527c33681d0f844639249012f4e16e22fc1192) there has been an additional option: `CompressionLevel.SmallestSize`. And since .Net 7 `CompressionLevel.Optimal` was [also changed for brotli](https://github.com/dotnet/runtime/commit/f281393412758b1345a8dc5073b91f9e950e683d)  to not mean smallest size anymore but rather a balanced value.

This change is also documents what these abstracted `CompressionLevel` values means for underlying Gzip and Brotli compression libraries, given those are enabled by default. In my case I came to this page wanting to get an Idea of balancing CPU use vs size of the response, as there are plenty of pages online benchmarking zlib vs brotli at all possible levels and cpu types.


Fixes #31836
<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/response-compression.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e61050503cde2392bf5b1e04fa291862c442dd8/aspnetcore/performance/response-compression.md) | [Response compression in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/response-compression?branch=pr-en-us-31722) |


<!-- PREVIEW-TABLE-END -->