### PR TITLE
Cross-link (don't show) example code

### DIFF
--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -462,22 +462,22 @@ In spite of the scoped service registration in the `Program` file and the longev
 </ul>
 ```
 
+:::moniker range=">= aspnetcore-6.0"
+
 ### Detect client-side transient disposables
 
 Custom code can be added to a client-side Blazor app to detect disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you have any concern that developers working on a Blazor app in the future consume one or more transient disposable services in the app, including services added by libraries. Demonstration code is availble in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main).
 
-Inspect the following in any version of the `BlazorSample_WebAssembly` sample:
+Inspect the following in .NET 6 or later versions of the `BlazorSample_WebAssembly` sample:
 
 * `DetectIncorrectUsagesOfTransientDisposables.cs`
 * `Services/TransientDisposableService.cs`
-* `Program.cs`:
+* In `Program.cs`:
   * The app's `Services` namespace is provided at the top of the file (`using BlazorSample.Services;`).
   * `DetectIncorrectUsageOfTransients` is called immediately after the `builder` is assigned from <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>.
-  * Where services are registered: `builder.Services.AddTransient<TransientDisposableService>();`
+  * The `TransientDisposableService` is registered (`builder.Services.AddTransient<TransientDisposableService>();`).
   * `EnableTransientDisposableDetection` is called on the built host in the processing pipeline of the app (`host.EnableTransientDisposableDetection();`).
-* The `TransientDisposableService` in `TransientService.razor` is detected. An <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposableService`:
-
-  > System.InvalidOperationException: Trying to resolve transient disposable service TransientDisposableService in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
+* The `TransientDisposableService` in `TransientService.razor` is detected. An <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposableService`.
 
 > [!NOTE]
 > Transient service registrations for <xref:System.Net.Http.IHttpClientFactory> handlers are recommended. If the app contains <xref:System.Net.Http.IHttpClientFactory> handlers and uses the <xref:Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder%602> to add support for authentication, the following transient disposables for client-side authentication are also discovered, which is expected and can be ignored:
@@ -489,15 +489,17 @@ Inspect the following in any version of the `BlazorSample_WebAssembly` sample:
 
 Custom code can be added to a server-side Blazor app to detect server-side disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you have any concern that developers working on a Blazor app in the future register and consume one or more transient disposable services in the app, including services added by libraries. Demonstration code is availble in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main).
 
+:::moniker-end
+
 :::moniker range=">= aspnetcore-8.0"
 
-Inspect the following in any version of the `BlazorSample_BlazorWebApp` sample:
+Inspect the following in .NET 8 or later versions of the `BlazorSample_BlazorWebApp` sample:
 
 :::moniker-end
 
-:::moniker range="< aspnetcore-8.0"
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-8.0"
 
-Inspect the following in any version of the `BlazorSample_Server` sample:
+Inspect the following in .NET 6 or .NET 7 versions of the `BlazorSample_Server` sample:
 
 :::moniker-end
 
@@ -505,34 +507,14 @@ Inspect the following in any version of the `BlazorSample_Server` sample:
 
 * `DetectIncorrectUsagesOfTransientDisposables.cs`
 * `Services/TransitiveTransientDisposableDependency.cs`:
-* `Program.cs`:
-
-  ```csharp
-  builder.DetectIncorrectUsageOfTransients();
-  builder.Services.AddTransient<TransientDependency>();
-  builder.Services.AddTransient<ITransitiveTransientDisposableDependency, 
-      TransitiveTransientDisposableDependency>();
-  ```
+* In `Program.cs`:
+  * The app's `Services` namespace is provided at the top of the file (`using BlazorSample.Services;`).
+  * `DetectIncorrectUsageOfTransients` is called on the host builder (`builder.DetectIncorrectUsageOfTransients();`).
+  * The `TransientDependency` service is registered (`builder.Services.AddTransient<TransientDependency>();`).
+  * The `TransitiveTransientDisposableDependency` is registered for `ITransitiveTransientDisposableDependency` (`builder.Services.AddTransient<ITransitiveTransientDisposableDependency, TransitiveTransientDisposableDependency>();`).
+* The app registers a transient disposable service without throwing an exception. However, attempting to resolve a transient disposable in `TransientService.razor` results in an <xref:System.InvalidOperationException> when the framework attempts to construct an instance of `TransientDependency`.
 
 :::moniker-end
-
-:::moniker range="< aspnetcore-6.0"
-
-* `DetectIncorrectUsagesOfTransientDisposables.cs`
-* `Services/TransitiveTransientDisposableDependency.cs`:
-* `Startup.cs` (`Startup.ConfigureServices`):
-
-  ```csharp
-  services.AddTransient<TransientDependency>();
-  services.AddTransient<ITransitiveTransientDisposableDependency, 
-      TransitiveTransientDisposableDependency>();
-  ```
-
-:::moniker-end
-
-* The app registers a transient disposable service without throwing an exception. However, attempting to resolve a transient disposable in `TransientService.razor` results in an <xref:System.InvalidOperationException> when the framework attempts to construct an instance of `TransientDependency`:
-
-  > System.InvalidOperationException: Trying to resolve transient disposable service TransientDependency in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
 
 ## Use of an Entity Framework Core (EF Core) DbContext from DI
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -466,7 +466,7 @@ In spite of the scoped service registration in the `Program` file and the longev
 
 ### Detect client-side transient disposables
 
-Custom code can be added to a client-side Blazor app to detect disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you have any concern that developers working on a Blazor app in the future consume one or more transient disposable services in the app, including services added by libraries. Demonstration code is availble in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main).
+Custom code can be added to a client-side Blazor app to detect disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you're concerned that code added to the app in the future consumes one or more transient disposable services, including services added by libraries. Demonstration code is availble in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main).
 
 Inspect the following in .NET 6 or later versions of the `BlazorSample_WebAssembly` sample:
 
@@ -487,7 +487,7 @@ Inspect the following in .NET 6 or later versions of the `BlazorSample_WebAssemb
 
 ### Detect server-side transient disposables
 
-Custom code can be added to a server-side Blazor app to detect server-side disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you have any concern that developers working on a Blazor app in the future register and consume one or more transient disposable services in the app, including services added by libraries. Demonstration code is availble in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main).
+Custom code can be added to a server-side Blazor app to detect server-side disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you're concerned that code added to the app in the future consumes one or more transient disposable services, including services added by libraries. Demonstration code is availble in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -323,12 +323,6 @@ In interactive server-side Blazor apps, the request scope lasts for the duration
 
 Even in client-side Blazor apps that don't operate over a circuit, services registered with a scoped lifetime are treated as singletons, so they live longer than scoped services in typical ASP.NET Core apps. Client-side transient services can also live longer than expected because there's no request-response-based lifetime to trigger DI system disposal of transient services. Although long-lived transient services are of greater concern on the server, they should generally be avoided as client service registrations as well. Use of the <xref:Microsoft.AspNetCore.Components.OwningComponentBase> type is also recommended for client-side services to control service lifetime.
 
-> [!NOTE]
-> To detect disposable transient services in an app, see the following sections later in this article:
->
-> * [Detect client-side transient disposables](#detect-client-side-transient-disposables)
-> * [Detect server-side transient disposables](#detect-server-side-transient-disposables)
-
 An approach that limits a service lifetime is use of the <xref:Microsoft.AspNetCore.Components.OwningComponentBase> type. <xref:Microsoft.AspNetCore.Components.OwningComponentBase> is an abstract type derived from <xref:Microsoft.AspNetCore.Components.ComponentBase> that creates a DI scope corresponding to the *lifetime of the component*. Using this scope, it's possible to use DI services with a scoped lifetime and have them live as long as the component. When the component is destroyed, services from the component's scoped service provider are disposed as well. This can be useful for services that:
 
 * Should be reused within a component, as the transient lifetime is inappropriate.
@@ -468,153 +462,22 @@ In spite of the scoped service registration in the `Program` file and the longev
 </ul>
 ```
 
-## Use of an Entity Framework Core (EF Core) DbContext from DI
+### Detect client-side transient disposables
 
-For more information, see <xref:blazor/blazor-ef-core>.
+Custom code can be added to a client-side Blazor app to detect disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you have any concern that developers working on a Blazor app in the future consume one or more transient disposable services in the app, including services added by libraries. Demonstration code is availble in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main).
 
-## Detect client-side transient disposables
+Inspect the following in any version of the `BlazorSample_WebAssembly` sample:
 
-The following Blazor WebAssembly example shows how to detect client-side disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you have any concern that developers working on a Blazor app in the future register and consume one or more transient disposable services in the app. For more information, see the [Utility base component classes to manage a DI scope](#utility-base-component-classes-to-manage-a-di-scope) section.
+* `DetectIncorrectUsagesOfTransientDisposables.cs`
+* `Services/TransientDisposableService.cs`
+* `Program.cs`:
+  * The app's `Services` namespace is provided at the top of the file (`using BlazorSample.Services;`).
+  * `DetectIncorrectUsageOfTransients` is called immediately after the `builder` is assigned from <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>.
+  * Where services are registered: `builder.Services.AddTransient<TransientDisposableService>();`
+  * `EnableTransientDisposableDetection` is called on the built host in the processing pipeline of the app (`host.EnableTransientDisposableDetection();`).
+* The `TransientDisposableService` in `TransientService.razor` is detected. An <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposableService`:
 
-`DetectIncorrectUsagesOfTransientDisposables.cs`:
-
-:::moniker range=">= aspnetcore-8.0"
-
-:::code language="csharp" source="~/../blazor-samples/8.0/BlazorSample_WebAssembly/DetectIncorrectUsagesOfTransientDisposables.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
-
-:::code language="csharp" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-:::code language="csharp" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-:::code language="csharp" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs":::
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-5.0"
-
-:::code language="csharp" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs":::
-
-:::moniker-end
-
-The following service doesn't require implementing any service features merely to demonstrate how transient services are detected with the approach in this section.
-
-`Services/TransientDisposableService.cs`:
-
-:::moniker range=">= aspnetcore-8.0"
-
-:::code language="csharp" source="~/../blazor-samples/8.0/BlazorSample_WebAssembly/Services/TransientDisposableService.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
-
-:::code language="csharp" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Services/TransientDisposableService.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-:::code language="csharp" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Services/TransientDisposableService.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-:::code language="csharp" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/Services/TransientDisposableService.cs":::
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-5.0"
-
-:::code language="csharp" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/Services/TransientDisposableService.cs":::
-
-:::moniker-end
-
-The `TransientDisposableService` in the following example is detected.
-
-In the `Program` file of the Blazor WebAssembly app:
-
-* Add or confirm the presence of the app's `Services` namespace:
-
-  ```csharp
-  using BlazorSample.Services;
-  ```
-
-* Immediately after the `builder` is assigned from <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>:
-
-  ```csharp
-  builder.DetectIncorrectUsageOfTransients();
-  ```
-
-* Where services are registered:
-
-  ```csharp
-  builder.Services.AddTransient<TransientDisposableService>();
-  ```
-
-* Remove the line that builds and runs the host:
-
-  ```diff
-  - await builder.Build().RunAsync();
-  ```
-
-  Replace the line with the following code, which calls `EnableTransientDisposableDetection` in the processing pipeline of the app:
-
-  ```csharp
-  var host = builder.Build();
-  host.EnableTransientDisposableDetection();
-  await host.RunAsync();
-  ```
-
-The app can register transient disposables without throwing an exception. However, attempting to resolve a transient disposable results in an <xref:System.InvalidOperationException>, as the following example shows.
-
-`Pages/TransientService.razor`:
-
-:::moniker range=">= aspnetcore-8.0"
-
-:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_WebAssembly/Pages/TransientService.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
-
-:::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Pages/dependency-injection/TransientService.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/dependency-injection/TransientService.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-:::code language="razor" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/Pages/dependency-injection/TransientService.razor":::
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-5.0"
-
-:::code language="razor" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/Pages/dependency-injection/TransientService.razor":::
-
-:::moniker-end
-
-Navigate to the `TransientService` component at `/transient-service` and an <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposableService`:
-
-> System.InvalidOperationException: Trying to resolve transient disposable service TransientDisposableService in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
+  > System.InvalidOperationException: Trying to resolve transient disposable service TransientDisposableService in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
 
 > [!NOTE]
 > Transient service registrations for <xref:System.Net.Http.IHttpClientFactory> handlers are recommended. If the app contains <xref:System.Net.Http.IHttpClientFactory> handlers and uses the <xref:Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder%602> to add support for authentication, the following transient disposables for client-side authentication are also discovered, which is expected and can be ignored:
@@ -622,155 +485,59 @@ Navigate to the `TransientService` component at `/transient-service` and an <xre
 > * <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.BaseAddressAuthorizationMessageHandler>
 > * <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler>
 
-## Detect server-side transient disposables
+### Detect server-side transient disposables
 
-The following example shows how to detect server-side disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you have any concern that developers working on a Blazor app in the future register and consume one or more transient disposable services in the app. For more information, see the [Utility base component classes to manage a DI scope](#utility-base-component-classes-to-manage-a-di-scope) section.
-
-`DetectIncorrectUsagesOfTransientDisposables.cs`:
+Custom code can be added to a server-side Blazor app to detect server-side disposable transient services in an app that should use <xref:Microsoft.AspNetCore.Components.OwningComponentBase>. This approach is useful if you have any concern that developers working on a Blazor app in the future register and consume one or more transient disposable services in the app, including services added by libraries. Demonstration code is availble in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main).
 
 :::moniker range=">= aspnetcore-8.0"
 
-:::code language="csharp" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/DetectIncorrectUsagesOfTransientDisposables.cs":::
+Inspect the following in any version of the `BlazorSample_BlazorWebApp` sample:
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
+:::moniker range="< aspnetcore-8.0"
 
-:::code language="csharp" source="~/../blazor-samples/7.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-:::code language="csharp" source="~/../blazor-samples/6.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs":::
+Inspect the following in any version of the `BlazorSample_Server` sample:
 
 :::moniker-end
-
-:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-:::code language="csharp" source="~/../blazor-samples/5.0/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs":::
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-5.0"
-
-:::code language="csharp" source="~/../blazor-samples/3.1/BlazorSample_Server/dependency-injection/DetectIncorrectUsagesOfTransientDisposables.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-8.0"
-
-`Services/TransitiveTransientDisposableDependency.cs`:
-
-:::code language="csharp" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Services/TransitiveTransientDisposableDependency.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
-
-`TransitiveTransientDisposableDependency.cs`:
-
-:::code language="csharp" source="~/../blazor-samples/7.0/BlazorSample_Server/dependency-injection/TransitiveTransientDisposableDependency.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-`TransitiveTransientDisposableDependency.cs`:
-
-:::code language="csharp" source="~/../blazor-samples/6.0/BlazorSample_Server/dependency-injection/TransitiveTransientDisposableDependency.cs":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-`TransitiveTransientDisposableDependency.cs`:
-
-:::code language="csharp" source="~/../blazor-samples/5.0/BlazorSample_Server/dependency-injection/TransitiveTransientDisposableDependency.cs":::
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-5.0"
-
-`TransitiveTransientDisposableDependency.cs`:
-
-:::code language="csharp" source="~/../blazor-samples/3.1/BlazorSample_Server/dependency-injection/TransitiveTransientDisposableDependency.cs":::
-
-:::moniker-end
-
-The `TransientDependency` in the following example is detected.
 
 :::moniker range=">= aspnetcore-6.0"
 
-In the `Program` file:
+* `DetectIncorrectUsagesOfTransientDisposables.cs`
+* `Services/TransitiveTransientDisposableDependency.cs`:
+* `Program.cs`:
 
-```csharp
-builder.DetectIncorrectUsageOfTransients();
-builder.Services.AddTransient<TransientDependency>();
-builder.Services.AddTransient<ITransitiveTransientDisposableDependency, 
-    TransitiveTransientDisposableDependency>();
-```
+  ```csharp
+  builder.DetectIncorrectUsageOfTransients();
+  builder.Services.AddTransient<TransientDependency>();
+  builder.Services.AddTransient<ITransitiveTransientDisposableDependency, 
+      TransitiveTransientDisposableDependency>();
+  ```
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-6.0"
 
-In `Startup.cs` where services are registered in `ConfigureServices`:
+* `DetectIncorrectUsagesOfTransientDisposables.cs`
+* `Services/TransitiveTransientDisposableDependency.cs`:
+* `Startup.cs` (`Startup.ConfigureServices`):
 
-```csharp
-services.AddTransient<TransientDependency>();
-services.AddTransient<ITransitiveTransientDisposableDependency, 
-    TransitiveTransientDisposableDependency>();
-```
-
-:::moniker-end
-
-The app can register transient disposables without throwing an exception. However, attempting to resolve a transient disposable results in an <xref:System.InvalidOperationException>, as the following example shows.
-
-:::moniker range=">= aspnetcore-8.0"
-
-`Components/Pages/TransientService.razor`:
-
-:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/Pages/TransientService.razor":::
+  ```csharp
+  services.AddTransient<TransientDependency>();
+  services.AddTransient<ITransitiveTransientDisposableDependency, 
+      TransitiveTransientDisposableDependency>();
+  ```
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
+* The app registers a transient disposable service without throwing an exception. However, attempting to resolve a transient disposable in `TransientService.razor` results in an <xref:System.InvalidOperationException> when the framework attempts to construct an instance of `TransientDependency`:
 
-`Pages/TransientService.razor`:
+  > System.InvalidOperationException: Trying to resolve transient disposable service TransientDependency in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
 
-:::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_Server/Pages/dependency-injection/TransientService.razor":::
+## Use of an Entity Framework Core (EF Core) DbContext from DI
 
-:::moniker-end
+For more information, see <xref:blazor/blazor-ef-core>.
 
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-`Pages/TransientService.razor`:
-
-:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_Server/Pages/dependency-injection/TransientService.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-`Pages/TransientService.razor`:
-
-:::code language="razor" source="~/../blazor-samples/5.0/BlazorSample_Server/Pages/dependency-injection/TransientService.razor":::
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-5.0"
-
-`Pages/TransientService.razor`:
-
-:::code language="razor" source="~/../blazor-samples/3.1/BlazorSample_Server/Pages/dependency-injection/TransientService.razor":::
-
-:::moniker-end
-
-Navigate to the `TransientService` component at `/transient-service` and an <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDependency`:
-
-> System.InvalidOperationException: Trying to resolve transient disposable service TransientDependency in the wrong scope. Use an 'OwningComponentBase\<T>' component base class for the service 'T' you are trying to resolve.
-  
 ## Access server-side Blazor services from a different DI scope
 
 :::moniker range=">= aspnetcore-8.0"

--- a/aspnetcore/blazor/fundamentals/dependency-injection.md
+++ b/aspnetcore/blazor/fundamentals/dependency-injection.md
@@ -477,7 +477,7 @@ Inspect the following in .NET 6 or later versions of the `BlazorSample_WebAssemb
   * `DetectIncorrectUsageOfTransients` is called immediately after the `builder` is assigned from <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>.
   * The `TransientDisposableService` is registered (`builder.Services.AddTransient<TransientDisposableService>();`).
   * `EnableTransientDisposableDetection` is called on the built host in the processing pipeline of the app (`host.EnableTransientDisposableDetection();`).
-* The `TransientDisposableService` in `TransientService.razor` is detected. An <xref:System.InvalidOperationException> is thrown when the framework attempts to construct an instance of `TransientDisposableService`.
+* The app registers the `TransientDisposableService` service without throwing an exception. However, attempting to resolve the service in `TransientService.razor` throws an <xref:System.InvalidOperationException> when the framework attempts to construct an instance of `TransientDisposableService`.
 
 > [!NOTE]
 > Transient service registrations for <xref:System.Net.Http.IHttpClientFactory> handlers are recommended. If the app contains <xref:System.Net.Http.IHttpClientFactory> handlers and uses the <xref:Microsoft.Extensions.DependencyInjection.IRemoteAuthenticationBuilder%602> to add support for authentication, the following transient disposables for client-side authentication are also discovered, which is expected and can be ignored:
@@ -512,7 +512,7 @@ Inspect the following in .NET 6 or .NET 7 versions of the `BlazorSample_Server` 
   * `DetectIncorrectUsageOfTransients` is called on the host builder (`builder.DetectIncorrectUsageOfTransients();`).
   * The `TransientDependency` service is registered (`builder.Services.AddTransient<TransientDependency>();`).
   * The `TransitiveTransientDisposableDependency` is registered for `ITransitiveTransientDisposableDependency` (`builder.Services.AddTransient<ITransitiveTransientDisposableDependency, TransitiveTransientDisposableDependency>();`).
-* The app registers a transient disposable service without throwing an exception. However, attempting to resolve a transient disposable in `TransientService.razor` results in an <xref:System.InvalidOperationException> when the framework attempts to construct an instance of `TransientDependency`.
+* The app registers the `TransientDependency` service without throwing an exception. However, attempting to resolve the service in `TransientService.razor` throws an <xref:System.InvalidOperationException> when the framework attempts to construct an instance of `TransientDependency`.
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #31724

@hakenr ... 

* I couldn't fully integrate the "detector" sections with the `OwningComponentBase` section because there's still too much code and too many remarks. However, I did re-organize the presentation to make these sections into sub-sections of the *Utility base component classes to manage a DI scope* section. That should be fine.
* WRT your other remark about the lead-in paragraph. The earlier work from yesterday hasn't merged to the live branch yet. That's stale content on the live site at this time. Let me finish this up first, then I'll take the new content live. We can see if a new issue should be opened to talk to Mackinnon about it. I'll ping you back in a bit.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/dependency-injection.md](https://github.com/dotnet/AspNetCore.Docs/blob/ae6ff4046bff0fbf0a1e007c39f1472e6112e66b/aspnetcore/blazor/fundamentals/dependency-injection.md) | [ASP.NET Core Blazor dependency injection](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/dependency-injection?branch=pr-en-us-31725) |


<!-- PREVIEW-TABLE-END -->