### PR TITLE
Enforce HTTPS in ASP.NET Core: Use Status308PermanentRedirect

### DIFF
--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program2.cs
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program2.cs
@@ -1,4 +1,4 @@
-using System.Net;
+using static Microsoft.AspNetCore.Http.StatusCodes;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,7 +15,7 @@ builder.Services.AddHsts(options =>
 
 builder.Services.AddHttpsRedirection(options =>
 {
-    options.RedirectStatusCode = (int)HttpStatusCode.TemporaryRedirect;
+    options.RedirectStatusCode = Status307TemporaryRedirect;
     options.HttpsPort = 5001;
 });
 

--- a/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program3.cs
+++ b/aspnetcore/security/enforcing-ssl/sample-snapshot/6.x/Program3.cs
@@ -1,4 +1,4 @@
-using System.Net;
+using static Microsoft.AspNetCore.Http.StatusCodes;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -8,7 +8,7 @@ if (!builder.Environment.IsDevelopment())
 {
     builder.Services.AddHttpsRedirection(options =>
     {
-        options.RedirectStatusCode = (int)HttpStatusCode.PermanentRedirect;
+        options.RedirectStatusCode = Status308PermanentRedirect;
         options.HttpsPort = 443;
     });
 }


### PR DESCRIPTION
The previous paragraph says
> Use the fields of the [StatusCodes](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.statuscodes) class for assignments to `RedirectStatusCode`.

But the sample code then uses the status code defined in `System.Net` and a cast to `int`.