### PR TITLE
Startup - manually start Standalone Blazor WebAssembly

### DIFF
--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -72,18 +72,21 @@ Blazor Web App:
 </script>
 ```
 
-Blazor Server:
+Standalone Blazor WebAssembly and Blazor Server:
 
 :::moniker-end
 
 * Add an `autostart="false"` attribute and value to the Blazor `<script>` tag.
 * Place a script that calls `Blazor.start()` after the Blazor `<script>` tag and inside the closing `</body>` tag.
+* You can provide additional options in the `Blazor.start()` parameter.
 
 ```html
 <script src="{BLAZOR SCRIPT}" autostart="false"></script>
 <script>
   ...
-  Blazor.start();
+  Blazor.start({
+    ...
+  });
   ...
 </script>
 ```


### PR DESCRIPTION
It appears that the _Standalone Blazor WebAssembly_ is missing here, unlike in many subsequent sections where the _Blazor Web App_ is typically presented first, followed by WASM/Server code snippets.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/startup.md](https://github.com/dotnet/AspNetCore.Docs/blob/6eecbe366adfa0cfd908f0c00b69d52c8d7ebd13/aspnetcore/blazor/fundamentals/startup.md) | [ASP.NET Core Blazor startup](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/startup?branch=pr-en-us-31746) |

<!-- PREVIEW-TABLE-END -->