### PR TITLE
Blazor Startup - sample environment variable name

### DIFF
--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -734,7 +734,7 @@ In `wwwroot/index.html`, remove the default SVG round indicator in `<div id="app
 
 To configure the .NET WebAssembly runtime, use the `configureRuntime` function with the `dotnet` runtime host builder.
 
-The following example sets an environment variable, `CONFIGURE_RUNTIME`, to `true`:
+The following example sets an environment variable, `MY_VARIABLE`, to `my value`:
 
 Blazor Web App:
 
@@ -744,7 +744,7 @@ Blazor Web App:
   Blazor.start({
     webAssembly: {
       configureRuntime: dotnet => {
-        dotnet.withEnvironmentVariable("CONFIGURE_RUNTIME", "true");
+        dotnet.withEnvironmentVariable("MY_VARIABLE", "my value");
       }
     }
   });
@@ -758,7 +758,7 @@ Standalone Blazor WebAssembly:
 <script>
   Blazor.start({
     configureRuntime: dotnet => {
-      dotnet.withEnvironmentVariable("CONFIGURE_RUNTIME", "true");
+      dotnet.withEnvironmentVariable("MY_VARIABLE", "my value");
     }
   });
 </script>

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -734,7 +734,7 @@ In `wwwroot/index.html`, remove the default SVG round indicator in `<div id="app
 
 To configure the .NET WebAssembly runtime, use the `configureRuntime` function with the `dotnet` runtime host builder.
 
-The following example sets an environment variable, `MY_VARIABLE`, to `my value`:
+In the following examples, the `{NAME}` placeholder is the environment variable's name, and the `{VALUE}` placeholder is the environment variable's value.
 
 Blazor Web App:
 
@@ -744,7 +744,7 @@ Blazor Web App:
   Blazor.start({
     webAssembly: {
       configureRuntime: dotnet => {
-        dotnet.withEnvironmentVariable("MY_VARIABLE", "my value");
+        dotnet.withEnvironmentVariable("{NAME}", "{VALUE}");
       }
     }
   });
@@ -758,7 +758,7 @@ Standalone Blazor WebAssembly:
 <script>
   Blazor.start({
     configureRuntime: dotnet => {
-      dotnet.withEnvironmentVariable("MY_VARIABLE", "my value");
+      dotnet.withEnvironmentVariable("{NAME}", "{VALUE}");
     }
   });
 </script>


### PR DESCRIPTION
I think demonstrating how to pass environment variables using a variable named `CONFIGURE_RUNTIME` in the section titled _Configure the .NET WebAssembly runtime_ can be confusing. An inexperienced user might be puzzled about whether using `CONFIGURE_RUNTIME = true` activates something that allows configuring the .NET WebAssembly runtime.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/startup.md](https://github.com/dotnet/AspNetCore.Docs/blob/a3e456ef165af322e7d48ffd6420941e7e58acfd/aspnetcore/blazor/fundamentals/startup.md) | [ASP.NET Core Blazor startup](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/startup?branch=pr-en-us-31747) |


<!-- PREVIEW-TABLE-END -->