### PR TITLE
[Blazor] Handle Errors - fire & forget DispatchExceptionAsync

### DIFF
--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -135,7 +135,7 @@ catch (Exception ex)
 }
 ```
 
-A common scenario is if a component wants to start an asynchronous operation but doesn't await a <xref:System.Threading.Tasks.Task>. If the operation fails, you may still want the component to treat the failure as a component lifecycle exception for the following example goals:
+A common scenario is if a component wants to start an asynchronous operation but doesn't await a <xref:System.Threading.Tasks.Task> (a technique sometimes called _fire and forget_). If the operation fails, you may still want the component to treat the failure as a component lifecycle exception for the following example goals:
 
 * Put the component into a faulted state, for example, to trigger an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
 * Terminate the circuit if there's no error boundary.


### PR DESCRIPTION
I think incorporating the term "fire and forget" could enhance understanding and might also improve the article's search engine discoverability.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/handle-errors.md](https://github.com/dotnet/AspNetCore.Docs/blob/456f4ab259a207dcda920173f863d30c02fb51b8/aspnetcore/blazor/fundamentals/handle-errors.md) | [Handle errors in ASP.NET Core Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/handle-errors?branch=pr-en-us-31764) |

<!-- PREVIEW-TABLE-END -->