### PR TITLE
Add missing await call

### DIFF
--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -69,7 +69,7 @@ var reader =
 
 ```csharp
 var memoryStream = new MemoryStream();
-browserFile.OpenReadStream().CopyToAsync(memoryStream);
+await browserFile.OpenReadStream().CopyToAsync(memoryStream);
 await blobContainerClient.UploadBlobAsync(
     trustedFileName, memoryStream));
 ```


### PR DESCRIPTION
Although the code snippet in this commit is representing a non-recommended practice, the `async` call should be awaited.

The problem being highlighted in the code snippet is the practice of loading the file into the `MemoryStream`. Having an non-awaited `async` call in the same example confuses the example because it is unclear if the problem is the lack of `await` or the overall approach.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/file-uploads.md](https://github.com/dotnet/AspNetCore.Docs/blob/8b1076f7a93b155ec6d91c2d012198cd8822962e/aspnetcore/blazor/file-uploads.md) | [ASP.NET Core Blazor file uploads](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/file-uploads?branch=pr-en-us-31779) |

<!-- PREVIEW-TABLE-END -->