### PR TITLE
Use correct after image for ASPNetCore 9 Debugger release notes section

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-9/includes/debugger.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/debugger.md
@@ -8,7 +8,7 @@ Before:
 
 After:
 
-:::image type="content" source="~/release-notes/aspnetcore-9/_static/debugger-before.png" alt-text="The new debugger experience":::
+:::image type="content" source="~/release-notes/aspnetcore-9/_static/debugger-after.png" alt-text="The new debugger experience":::
 
 ASP.NET Core has many key-value collections. This improved debugging experience applies to:
 


### PR DESCRIPTION
This fixes the "before" image being used twice.

Before/Before:

![image](https://github.com/dotnet/AspNetCore.Docs/assets/1657182/f7743b12-8090-4e74-a52e-78b65cf27561)

Before/After:

![image](https://github.com/dotnet/AspNetCore.Docs/assets/1657182/8955806a-7b7c-461f-9e97-c7a80a2528e0)
