### PR TITLE
Add roles and test user guidance

### DIFF
--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -235,9 +235,9 @@ For security reasons, role claims aren't sent back from the `manage/info` endpoi
 
 In the `CookieAuthenticationStateProvider`, a roles request is made to the `/roles` endpoint of the `Backend` server API project. The response is read into a string by calling <xref:System.Net.Http.HttpContent.ReadAsStringAsync>. <xref:System.Text.Json.JsonSerializer.Deserialize%2A?displayProperty=nameWithType> deserializes the string into a custom `RoleClaim` array. Finally, the claims are added to the user's claims collection.
 
-In the `Backend` server API's `Program` file, a [Minimal API](fundamentals/minimal-apis/overview) manages the `/roles` endpoint. Claims of <xref:System.Security.Claims.ClaimsIdentity.RoleClaimType%2A> are [selected](xref:System.Linq.Enumerable.Select%2A) into an [anonymous type](/dotnet/csharp/fundamentals/types/anonymous-types) and serialized for return to the `BlazorWasmAuth` project with <xref:Microsoft.AspNetCore.Http.TypedResults.Json%2A?displayProperty=nameWithType>.
+In the `Backend` server API's `Program` file, a [Minimal API](xref:fundamentals/minimal-apis/overview) manages the `/roles` endpoint. Claims of <xref:System.Security.Claims.ClaimsIdentity.RoleClaimType%2A> are [selected](xref:System.Linq.Enumerable.Select%2A) into an [anonymous type](/dotnet/csharp/fundamentals/types/anonymous-types) and serialized for return to the `BlazorWasmAuth` project with <xref:Microsoft.AspNetCore.Http.TypedResults.Json%2A?displayProperty=nameWithType>.
 
-The roles endpoint requires authorization by calling <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization>. If you decide not to use Minimal APIs in favor of controllers for secure server API endpoints, be sure to set the [`[Authorize]` attribute](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) on controllers or actions.
+The roles endpoint requires authorization by calling <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization%2A>. If you decide not to use Minimal APIs in favor of controllers for secure server API endpoints, be sure to set the [`[Authorize]` attribute](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) on controllers or actions.
 
 ## Troubleshoot
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -144,7 +144,7 @@ Services and endpoints for [Swagger/OpenAPI](xref:tutorials/web-api-help-pages-u
 
 -->
 
-User role claims are sent from a [Minimal API](fundamentals/minimal-apis/overview) at the `/roles` endpoint.
+User role claims are sent from a [Minimal API](xref:fundamentals/minimal-apis/overview) at the `/roles` endpoint.
 
 Routes are mapped for Identity endpoints by calling `MapIdentityApi<AppUser>()`.
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -231,7 +231,7 @@ The `SeedData` class ([`SeedData.cs`](https://github.com/dotnet/blazor-samples/b
 
 ## Roles
 
-For security reasons, role claims aren't sent back from the `manage/info` endpoint to create user claims for users of the `BlazorWasmAuth` app. Role claims are managed independently via a separate request in the `GetAuthenticationStateAsync` method of the [`CookieAuthenticationStateProvider` class (`Identity/CookieAuthenticationStateProvider.cs`)](https://github.com/dotnet/blazor-samples/blob/main/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Identity/CookieAuthenticationStateProvider.cs) after the user is authenticated in the `Backend` project. 
+Due to a [framework design issue (`dotnet/aspnetcore` #50037)](https://github.com/dotnet/aspnetcore/issues/50037), role claims aren't sent back from the `manage/info` endpoint to create user claims for users of the `BlazorWasmAuth` app. Role claims are managed independently via a separate request in the `GetAuthenticationStateAsync` method of the [`CookieAuthenticationStateProvider` class (`Identity/CookieAuthenticationStateProvider.cs`)](https://github.com/dotnet/blazor-samples/blob/main/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Identity/CookieAuthenticationStateProvider.cs) after the user is authenticated in the `Backend` project. 
 
 In the `CookieAuthenticationStateProvider`, a roles request is made to the `/roles` endpoint of the `Backend` server API project. The response is read into a string by calling <xref:System.Net.Http.HttpContent.ReadAsStringAsync>. <xref:System.Text.Json.JsonSerializer.Deserialize%2A?displayProperty=nameWithType> deserializes the string into a custom `RoleClaim` array. Finally, the claims are added to the user's claims collection.
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -231,6 +231,8 @@ The `SeedData` class ([`SeedData.cs`](https://github.com/dotnet/blazor-samples/b
 
 ## Roles
 
+<!-- UPDATE 9.0 Check on the role claims situation for resolution at .NET 9 -->
+
 Due to a [framework design issue (`dotnet/aspnetcore` #50037)](https://github.com/dotnet/aspnetcore/issues/50037), role claims aren't sent back from the `manage/info` endpoint to create user claims for users of the `BlazorWasmAuth` app. Role claims are managed independently via a separate request in the `GetAuthenticationStateAsync` method of the [`CookieAuthenticationStateProvider` class (`Identity/CookieAuthenticationStateProvider.cs`)](https://github.com/dotnet/blazor-samples/blob/main/8.0/BlazorWebAssemblyStandaloneWithIdentity/BlazorWasmAuth/Identity/CookieAuthenticationStateProvider.cs) after the user is authenticated in the `Backend` project. 
 
 In the `CookieAuthenticationStateProvider`, a roles request is made to the `/roles` endpoint of the `Backend` server API project. The response is read into a string by calling <xref:System.Net.Http.HttpContent.ReadAsStringAsync>. <xref:System.Text.Json.JsonSerializer.Deserialize%2A?displayProperty=nameWithType> deserializes the string into a custom `RoleClaim` array. Finally, the claims are added to the user's claims collection.


### PR DESCRIPTION
Fixes #31045

cc: @julioct ... My guesses on dealing with roles/role claims were good. The approach of ***NOT*** trying to fight the JSON serializer/deserializer to work with `Claim` arrays turns out to be the right way to go. Use of an anonymous type on the `/roles` endpoint side (backend server API) is fine, and using a custom `RoleClaim` type on the frontend is also good. These are the low-hanging-fruit ***happy paths*** 😄.

WRT other claim types, we're going to leave that to the devs to work out from this example. It's a straightforward update to this code to send all of the claims. The frontend code will take whatever is sent back and make user claims out of it. We might do more in this area down the road, but I need to get on with other work for now 🏃‍♂️😅. I'll take feedback from the community in the meantime.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/webassembly/standalone-with-identity.md](https://github.com/dotnet/AspNetCore.Docs/blob/22774f096b2d9f56ad1965cf6840fc490be6be67/aspnetcore/blazor/security/webassembly/standalone-with-identity.md) | [Secure ASP.NET Core Blazor WebAssembly with ASP.NET Core Identity](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-identity?branch=pr-en-us-31839) |


<!-- PREVIEW-TABLE-END -->