### PR TITLE
Add WebAssembly (runtime) startup callbacks

### DIFF
--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -172,6 +172,7 @@ Additional .NET WebAssembly runtime callbacks:
   }
   ```
 Both callbacks can return a `Promise`, and the promise is awaited before the startup continues.
+
 :::moniker-end
 
 :::moniker range=">= aspnetcore-6.0"

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -147,34 +147,31 @@ For Blazor Server, Blazor WebAssembly, and Blazor Hybrid apps:
 
 Additional .NET WebAssembly runtime callbacks:
 
-* `onRuntimeConfigLoaded(config)`: Called when the boot configuration is downloaded. Allows the app to modify parameters (config) before the runtime starts:
+* `onRuntimeConfigLoaded(config)`: Called when the boot configuration is downloaded. Allows the app to modify parameters (config) before the runtime starts (the parameter is `MonoConfig` from [`dotnet.d.ts`](https://github.com/dotnet/runtime/blob/main/src/mono/browser/runtime/dotnet.d.ts)):
 
   ```javascript
-  const params = new URLSearchParams(location.search);
-
   export function onRuntimeConfigLoaded(config) {
-    config.environmentVariables["LIBRARY_INITIALIZER_TEST"] = "1";
-
-    if (params.get("throwError") === "true") {
-        throw new Error("Error thrown from library initializer");
+    // Sample: Enable startup diagnostic logging when the URL contains 
+    // parameter debug=1
+    const params = new URLSearchParams(location.search);
+    if (params.get("debug") == "1") {
+      config.diagnosticTracing = true;
     }
   }
   ```
 
-* `onRuntimeReady({ getAssemblyExports, getConfig })`: Called after the .NET WebAssembly runtime has started:
+* `onRuntimeReady({ getAssemblyExports, getConfig })`: Called after the .NET WebAssembly runtime has started (the parameter is `RuntimeAPI` from [`dotnet.d.ts`](https://github.com/dotnet/runtime/blob/main/src/mono/browser/runtime/dotnet.d.ts)):
 
   ```javascript
-  export async function onRuntimeReady({ getAssemblyExports, getConfig }) {
-    const testCase = params.get("test");
-    if (testCase == "LibraryInitializerTest") {
+  export function onRuntimeReady({ getAssemblyExports, getConfig }) {
+        // Sample: After the runtime starts, but before Main method is called, 
+        // call [JSExport]ed method.
         const config = getConfig();
         const exports = await getAssemblyExports(config.mainAssemblyName);
-
-        exports.LibraryInitializerTest.Run();
-    }
+        exports.Sample.Greet();
   }
   ```
-
+Both callbacks can return a `Promise`, and the promise is awaited before the startup continues.
 :::moniker-end
 
 :::moniker range=">= aspnetcore-6.0"

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -161,7 +161,7 @@ Additional .NET WebAssembly runtime callbacks:
   }
   ```
 
-* `onRuntimeReady({ getAssemblyExports, getConfig })`: Called after the .NET WebAssembly runtime has started and passed in the .NET runtime API ():
+* `onRuntimeReady({ getAssemblyExports, getConfig })`: Called after the .NET WebAssembly runtime has started:
 
   ```javascript
   export async function onRuntimeReady({ getAssemblyExports, getConfig }) {

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -164,11 +164,11 @@ Additional .NET WebAssembly runtime callbacks:
 
   ```javascript
   export function onRuntimeReady({ getAssemblyExports, getConfig }) {
-        // Sample: After the runtime starts, but before Main method is called, 
-        // call [JSExport]ed method.
-        const config = getConfig();
-        const exports = await getAssemblyExports(config.mainAssemblyName);
-        exports.Sample.Greet();
+    // Sample: After the runtime starts, but before Main method is called, 
+    // call [JSExport]ed method.
+    const config = getConfig();
+    const exports = await getAssemblyExports(config.mainAssemblyName);
+    exports.Sample.Greet();
   }
   ```
 Both callbacks can return a `Promise`, and the promise is awaited before the startup continues.

--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -141,6 +141,44 @@ For Blazor Server, Blazor WebAssembly, and Blazor Hybrid apps:
   * In a [`BlazorWebView`](/mobile-blazor-bindings/walkthroughs/hybrid-hello-world#mainrazor-native-ui-page), no options are passed.
 * `afterStarted(blazor)`: Called after Blazor is ready to receive calls from JS. For example, `afterStarted` is used to initialize libraries by making JS interop calls and registering custom elements. The Blazor instance is passed to `afterStarted` as an argument (`blazor`).
 
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
+
+Additional .NET WebAssembly runtime callbacks:
+
+* `onRuntimeConfigLoaded(config)`: Called when the boot configuration is downloaded. Allows the app to modify parameters (config) before the runtime starts:
+
+  ```javascript
+  const params = new URLSearchParams(location.search);
+
+  export function onRuntimeConfigLoaded(config) {
+    config.environmentVariables["LIBRARY_INITIALIZER_TEST"] = "1";
+
+    if (params.get("throwError") === "true") {
+        throw new Error("Error thrown from library initializer");
+    }
+  }
+  ```
+
+* `onRuntimeReady({ getAssemblyExports, getConfig })`: Called after the .NET WebAssembly runtime has started and passed in the .NET runtime API ():
+
+  ```javascript
+  export async function onRuntimeReady({ getAssemblyExports, getConfig }) {
+    const testCase = params.get("test");
+    if (testCase == "LibraryInitializerTest") {
+        const config = getConfig();
+        const exports = await getAssemblyExports(config.mainAssemblyName);
+
+        exports.LibraryInitializerTest.Run();
+    }
+  }
+  ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0"
+
 For the file name:
 
 * If the JS initializers are consumed as a static asset in the project, use the format `{ASSEMBLY NAME}.lib.module.js`, where the `{ASSEMBLY NAME}` placeholder is the app's assembly name. For example, name the file `BlazorSample.lib.module.js` for a project with an assembly name of `BlazorSample`. Place the file in the app's `wwwroot` folder.


### PR DESCRIPTION
Fixes #31811

Marek ...

* Along with correcting any mistakes that a 🦖  made 🙈😄, is there any additional info that should appear?
* Was the bit of text you stated for `onRuntimeReady` ... "*and passed in the .NET runtime API*" ... important to keep? I 🔪 it, but I'll add it back if it's important to call that out.
* Is the sample code that you cross-linked OK to show here with these?
* Are there any gotchas 😈 that devs should be aware of?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/startup.md](https://github.com/dotnet/AspNetCore.Docs/blob/4cea4de517e8ac7498c8575adbc9029b758a3381/aspnetcore/blazor/fundamentals/startup.md) | [ASP.NET Core Blazor startup](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/startup?branch=pr-en-us-31852) |


<!-- PREVIEW-TABLE-END -->