### PR TITLE
Fixed formatting on "Configuration in ASP.NET Core" page

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -131,7 +131,7 @@ Using the [default](#default) configuration, the `appsettings.json` and `appsett
 
 ### Comments in appsettings.json
 
-Comments in `appsettings.json` and `appsettings.{Environment}.json`files are supported using JavaScript or [C# style comments](/dotnet/csharp/language-reference/tokens/comments).
+Comments in `appsettings.json` and `appsettings.{Environment}.json` files are supported using JavaScript or [C# style comments](/dotnet/csharp/language-reference/tokens/comments).
 
 <a name="optpat"></a>
 


### PR DESCRIPTION
Added a space between "`appsettings.{Environment}.json`" and "files" on line 134 of [`aspnetcore/fundamentals/configuration/index.md`](https://github.com/dotnet/AspNetCore.Docs/blob/178d2b6b3a29eae4935fd24d90d330e5513d6273/aspnetcore/fundamentals/configuration/index.md?plain=1#L134) in order to match the formatting of the rest of the document.

Current:
![image](https://github.com/dotnet/AspNetCore.Docs/assets/8939745/f71d83db-42cf-4757-a8e4-90b0aa94d393)


Proposed:
![image](https://github.com/dotnet/AspNetCore.Docs/assets/8939745/bf7350b2-ebe5-424f-98f2-05d8b72b2238)
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->