### PR TITLE
Middleware in Minimal API: Add links

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/includes/middleware7.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/middleware7.md
@@ -1,6 +1,6 @@
 :::moniker range="= aspnetcore-7.0"
 
-`WebApplication` automatically adds the following middleware depending on certain conditions:
+[`WebApplication`](xref:fundamentals/minimal-apis/webapplication) automatically adds the following middleware in [`Minimal API applications`](xref:fundamentals/minimal-apis/overview) depending on certain conditions:
 * [`UseDeveloperExceptionPage`](/dotnet/api/microsoft.aspnetcore.diagnostics.developerexceptionpagemiddleware) is added first when the [`HostingEnvironment`](xref:fundamentals/environments) is `"Development"`.
 * [`UseRouting`](/dotnet/api/microsoft.aspnetcore.builder.endpointroutingapplicationbuilderextensions.userouting) is added second if user code didn't already call `UseRouting` and if there are endpoints configured, for example `app.MapGet`.
 * [`UseEndpoints`](/dotnet/api/microsoft.aspnetcore.builder.endpointroutingapplicationbuilderextensions.useendpoints) is added at the end of the middleware pipeline if any endpoints are configured.

--- a/aspnetcore/fundamentals/minimal-apis/includes/middleware8.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/middleware8.md
@@ -1,6 +1,6 @@
 :::moniker range=">= aspnetcore-8.0"
 
-`WebApplication` automatically adds the following middleware depending on certain conditions:
+[`WebApplication`](xref:fundamentals/minimal-apis/webapplication) automatically adds the following middleware in [`Minimal API applications`](xref:fundamentals/minimal-apis/overview) depending on certain conditions:
 * [`UseDeveloperExceptionPage`](/dotnet/api/microsoft.aspnetcore.diagnostics.developerexceptionpagemiddleware) is added first when the [`HostingEnvironment`](xref:fundamentals/environments) is `"Development"`.
 * [`UseRouting`](/dotnet/api/microsoft.aspnetcore.builder.endpointroutingapplicationbuilderextensions.userouting) is added second if user code didn't already call `UseRouting` and if there are endpoints configured, for example `app.MapGet`.
 * [`UseEndpoints`](/dotnet/api/microsoft.aspnetcore.builder.endpointroutingapplicationbuilderextensions.useendpoints) is added at the end of the middleware pipeline if any endpoints are configured.

--- a/aspnetcore/fundamentals/minimal-apis/middleware.md
+++ b/aspnetcore/fundamentals/minimal-apis/middleware.md
@@ -3,7 +3,7 @@ title: Middleware with Minimal API applications
 author: BrennanConroy
 description: Use middleware in Minimal API applications
 ms.author: brecon
-ms.date: 8/25/2023
+ms.date: 02/16/2024
 monikerRange: '>= aspnetcore-7.0'
 uid: fundamentals/minimal-apis/middleware
 ---
@@ -14,3 +14,5 @@ uid: fundamentals/minimal-apis/middleware
 [!INCLUDE [webapplication8](~/fundamentals/minimal-apis/includes/middleware8.md)]
 
 For more information about middleware see [ASP.NET Core Middleware](xref:fundamentals/middleware/index), and the [list of built-in middleware](xref:fundamentals/middleware/index#built-in-middleware) that can be added to applications.
+
+For more information about Minimal APIs see [`Minimal APIs overview`](xref:fundamentals/minimal-apis/overview).


### PR DESCRIPTION
Fixes #31502

Clarified first paragraph and added links for WebApplication and Minimal APIs Overview.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/middleware.md](https://github.com/dotnet/AspNetCore.Docs/blob/ce95704df012f545f5166ccde696505a388684be/aspnetcore/fundamentals/minimal-apis/middleware.md) | [Middleware in Minimal API apps](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/middleware?branch=pr-en-us-31857) |

<!-- PREVIEW-TABLE-END -->