### PR TITLE
Blazor Render Modes - Visual Studio project template options

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -40,7 +40,7 @@ Prerendering is enabled by default for interactive components. Guidance on contr
 
 The following examples demonstrate setting the component's render mode with a few basic Razor component features.
 
-To test the render mode behaviors locally, you can place the following components in an app created from the *Blazor Web App* project template. When you create the app, select the checkboxes (Visual Studio) or apply the CLI options (.NET CLI) to enable both server-side and client-side interactivity. For guidance on how to create a Blazor Web App, see <xref:blazor/tooling>.
+To test the render mode behaviors locally, you can place the following components in an app created from the *Blazor Web App* project template. When you create the app, select options from dropdown menus (Visual Studio) or apply the CLI options (.NET CLI) to enable both server-side and client-side interactivity. For guidance on how to create a Blazor Web App, see <xref:blazor/tooling>.
 
 ## Enable support for interactive render modes
 


### PR DESCRIPTION
Current Visual Studio New Blazor Web App project wizzard no longer uses checkboxes for render-mode related options.
![image](https://github.com/dotnet/AspNetCore.Docs/assets/12828888/fd4be680-8327-43b9-bb67-6afb4e1954b5)

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/ec26dd79afc972b1819ed7094e75897e9985e2b7/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-31864) |

<!-- PREVIEW-TABLE-END -->