### PR TITLE
Update DispatchExceptionAsync example

### DIFF
--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -233,8 +233,8 @@ To dispatch exceptions from the timer service back to the `Notifications` compon
 * Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the `Task` is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away). The `StartTimer` method's signature changes to adopt the fire and forget pattern:
 
   ```diff
-  - Task StartTimer()
-  + void StartTimer()
+  - Task StartTimer();
+  + void StartTimer();
   ```
 
 In the `@code` block of the `Notifications` component (`Notifications.razor`):

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -179,7 +179,7 @@ To treat failures like lifecycle method exceptions, explicitly dispatch exceptio
 }
 ```
 
-An alternative approach for sending the report and discarding the <xref:System.Threading.Tasks.Task> is to leverage <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>:
+An alternative approach for sending the report and discarding the <xref:System.Threading.Tasks.Task> is to leverage <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>. This pattern is often called *fire and forget* because the method (<xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>) is *fired* (started) and the result of the method (the <xref:System.Threading.Tasks.Task> returned by the <xref:System.Action> delegate) is *forgotten* (thrown away).
 
 ```csharp
 private void SendReport()
@@ -248,15 +248,10 @@ If you run the app at this point, the exception is thrown when the elapsed count
 
 To dispatch exceptions from the timer service back to the `Notifications` component, the following changes are made to the component:
 
-* An asynchronous method is added that starts the timer in a [`try-catch` statement](/dotnet/csharp/language-reference/statements/exception-handling-statements#the-try-catch-statement). In the `catch` clause of the `try-catch` block, exceptions are dispatched back to the component by passing the <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and awaiting the result.
-* Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the <xref:System.Threading.Tasks.Task> is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the <xref:System.Threading.Tasks.Task>, is *forgotten* (thrown away). The `StartTimer` method's signature changes to adopt the fire and forget pattern:
+* Start the timer in a [`try-catch` statement](/dotnet/csharp/language-reference/statements/exception-handling-statements#the-try-catch-statement). In the `catch` clause of the `try-catch` block, exceptions are dispatched back to the component by passing the <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and awaiting the result.
+* In the `StartTimer` method, start the asynchronous timer service in the <xref:System.Action> delegate of <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType> and intentionally discard the returned <xref:System.Threading.Tasks.Task>.
 
-  ```diff
-  - Task StartTimer();
-  + void StartTimer();
-  ```
-
-In the `StartTimer` method of the `Notifications` component (`Notifications.razor`):
+The `StartTimer` method of the `Notifications` component (`Notifications.razor`):
 
 ```csharp
 private void StartTimer()

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -227,11 +227,19 @@ In Blazor Web Apps with the error boundary only applied to a static `MainLayout`
 
 If you run the app at this point, the exception is thrown when the elapsed count reaches a value of two. However, the UI doesn't change. The error boundary doesn't show the error content.
 
-In the `@code` block of the `Notifications` component (`Notifications.razor`):
+To dispatch exceptions back to the component, the timer example is updated in the following way:
 
-* Add an asynchronous method named `StartTimerFireAndForgetAsync` that starts the timer in a [`try-catch` statement](/dotnet/csharp/language-reference/statements/exception-handling-statements#the-try-catch-statement).
-* In the `catch` clause of the `try-catch` block, dispatch any exceptions back to the component by passing the <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and awaiting the result.
-* Instead of calling `Timer.Start` from `StartTimer`, call the `StartTimerFireAndForgetAsync` method and intentionally discard the `Task`, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away).
+* An asynchronous method is added that starts the timer in a [`try-catch` statement](/dotnet/csharp/language-reference/statements/exception-handling-statements#the-try-catch-statement). In the `catch` clause of the `try-catch` block, exceptions are dispatched back to the component by passing the <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and awaiting the result.
+* Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the `Task` is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away).
+
+Note the following change in the `StartTimer` method's signature in the following example:
+
+```diff
+- private async Task StartTimer()
++ private void StartTimer()
+```
+
+In the `@code` block of the `Notifications` component (`Notifications.razor`):
 
 ```csharp
 private async Task StartTimerFireAndForgetAsync()

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -227,7 +227,7 @@ In Blazor Web Apps with the error boundary only applied to a static `MainLayout`
 
 If you run the app at this point, the exception is thrown when the elapsed count reaches a value of two. However, the UI doesn't change. The error boundary doesn't show the error content.
 
-To dispatch exceptions back to the component, the timer example is updated in the following way:
+To dispatch exceptions from the timer service back to the `Notifications` component, the following changes are made to the component:
 
 * An asynchronous method is added that starts the timer in a [`try-catch` statement](/dotnet/csharp/language-reference/statements/exception-handling-statements#the-try-catch-statement). In the `catch` clause of the `try-catch` block, exceptions are dispatched back to the component by passing the <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and awaiting the result.
 * Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the `Task` is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away).

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -230,14 +230,12 @@ If you run the app at this point, the exception is thrown when the elapsed count
 To dispatch exceptions from the timer service back to the `Notifications` component, the following changes are made to the component:
 
 * An asynchronous method is added that starts the timer in a [`try-catch` statement](/dotnet/csharp/language-reference/statements/exception-handling-statements#the-try-catch-statement). In the `catch` clause of the `try-catch` block, exceptions are dispatched back to the component by passing the <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and awaiting the result.
-* Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the `Task` is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away).
+* Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the `Task` is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away). The `StartTimer` method's signature changes to adopt the fire and forget pattern:
 
-Note the following change in the `StartTimer` method's signature in the following example:
-
-```diff
-- private async Task StartTimer()
-+ private void StartTimer()
-```
+  ```diff
+  - async Task StartTimer()
+  + void StartTimer()
+  ```
 
 In the `@code` block of the `Notifications` component (`Notifications.razor`):
 

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -141,7 +141,7 @@ A common scenario for the preceding approach is when a component starts an async
 * Terminate the circuit if there's no error boundary.
 * Trigger the same logging that occurs for lifecycle exceptions.
 
-In the following example, the user selects the **Send report** button to trigger a background method, `ReportSender.SendAsync`, that sends a report. In most cases, a component awaits the <xref:System.Threading.Tasks.Task> of an asynchronous call and updates the UI to indicate the operation completed. In the following example, the `SendReport` method doesn't await a <xref:System.Threading.Tasks.Task> and doesn't report the result to the user. Because the component intentionally discards the <xref:System.Threading.Tasks.Task> in `SendReport`, any asynchronous failures occur off of the normal lifecycle call stack, hence aren't seen by Blazor:
+In the following example, the user selects the **Send report** button to trigger a background method, `ReportSender.SendAsync`, that sends a report. In most cases, a component awaits the <xref:System.Threading.Tasks.Task> of an asynchronous call and updates the UI to indicate the operation completed. In the following example, the `SendReport` method doesn't await a <xref:System.Threading.Tasks.Task> and doesn't report the result to the user, which is often called *fire and forget* because the method is *fired* (started) and the result of the method is *forgotten* (thrown away). Because the component intentionally discards the <xref:System.Threading.Tasks.Task> in `SendReport`, any asynchronous failures occur off of the normal lifecycle call stack, hence aren't seen by Blazor:
 
 ```razor
 <button @onclick="SendReport">Send report</button>
@@ -179,7 +179,7 @@ To treat failures like lifecycle method exceptions, explicitly dispatch exceptio
 }
 ```
 
-An alternative approach for sending the report and discarding the <xref:System.Threading.Tasks.Task> is to leverage <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>. This pattern is often called *fire and forget* because the method (<xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>) is *fired* (started) and the result of the method (the <xref:System.Threading.Tasks.Task> returned by the <xref:System.Action> delegate) is *forgotten* (thrown away).
+An alternative approach for sending the report and discarding the <xref:System.Threading.Tasks.Task> is to leverage <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>:
 
 ```csharp
 private void SendReport()

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -233,7 +233,7 @@ To dispatch exceptions from the timer service back to the `Notifications` compon
 * Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the `Task` is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away). The `StartTimer` method's signature changes to adopt the fire and forget pattern:
 
   ```diff
-  - async Task StartTimer()
+  - Task StartTimer()
   + void StartTimer()
   ```
 

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -179,6 +179,25 @@ To treat failures like lifecycle method exceptions, explicitly dispatch exceptio
 }
 ```
 
+An alternative approach for sending the report and discarding the <xref:System.Threading.Tasks.Task> is to leverage <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>:
+
+```csharp
+private void SendReport()
+{
+    _ = Task.Run(async () =>
+    {
+        try
+        {
+            await ReportSender.SendAsync();
+        }
+        catch (Exception ex)
+        {
+            await DispatchExceptionAsync(ex);
+        }
+    });
+}
+```
+
 For a working demonstration, implement the timer notification example in [Invoke component methods externally to update state](xref:blazor/components/sync-context#invoke-component-methods-externally-to-update-state). In a Blazor app, add the following files from the timer notification example and register the services in the `Program` file as the section explains:
 
 * `TimerService.cs`
@@ -230,31 +249,29 @@ If you run the app at this point, the exception is thrown when the elapsed count
 To dispatch exceptions from the timer service back to the `Notifications` component, the following changes are made to the component:
 
 * An asynchronous method is added that starts the timer in a [`try-catch` statement](/dotnet/csharp/language-reference/statements/exception-handling-statements#the-try-catch-statement). In the `catch` clause of the `try-catch` block, exceptions are dispatched back to the component by passing the <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and awaiting the result.
-* Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the `Task` is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away). The `StartTimer` method's signature changes to adopt the fire and forget pattern:
+* Instead of calling `Timer.Start` from `StartTimer`, the asynchronous method is called and the <xref:System.Threading.Tasks.Task> is intentionally discarded, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the <xref:System.Threading.Tasks.Task>, is *forgotten* (thrown away). The `StartTimer` method's signature changes to adopt the fire and forget pattern:
 
   ```diff
   - Task StartTimer();
   + void StartTimer();
   ```
 
-In the `@code` block of the `Notifications` component (`Notifications.razor`):
+In the `StartTimer` method of the `Notifications` component (`Notifications.razor`):
 
 ```csharp
-private async Task StartTimerFireAndForgetAsync()
-{
-    try
-    {
-        await Timer.Start();
-    }
-    catch (Exception ex)
-    {
-        await DispatchExceptionAsync(ex);
-    }
-}
-
 private void StartTimer()
 {
-    _ = StartTimerFireAndForgetAsync();
+    _ = Task.Run(async () =>
+    {
+        try
+        {
+            await Timer.Start();
+        }
+        catch (Exception ex)
+        {
+            await DispatchExceptionAsync(ex);
+        }
+    });
 }
 ```
 

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -135,13 +135,13 @@ catch (Exception ex)
 }
 ```
 
-A common scenario for the preceding approach is when a component starts an asynchronous operation but doesn't await a <xref:System.Threading.Tasks.Task>, often called the *fire and forget* pattern. If the operation fails, you may want the component to treat the failure as a component lifecycle exception for any of the following goals:
+A common scenario for the preceding approach is when a component starts an asynchronous operation but doesn't await a <xref:System.Threading.Tasks.Task>, often called the *fire and forget* pattern because the method is *fired* (started) and the result of the method is *forgotten* (thrown away). If the operation fails, you may want the component to treat the failure as a component lifecycle exception for any of the following goals:
 
 * Put the component into a faulted state, for example, to trigger an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
 * Terminate the circuit if there's no error boundary.
 * Trigger the same logging that occurs for lifecycle exceptions.
 
-In the following example, the user selects the **Send report** button to trigger a background method, `ReportSender.SendAsync`, that sends a report. In most cases, a component awaits the <xref:System.Threading.Tasks.Task> of an asynchronous call and updates the UI to indicate the operation completed. In the following example, the `SendReport` method doesn't await a <xref:System.Threading.Tasks.Task> and doesn't report the result to the user, which is often called *fire and forget* because the method is *fired* (started) and the result of the method is *forgotten* (thrown away). Because the component intentionally discards the <xref:System.Threading.Tasks.Task> in `SendReport`, any asynchronous failures occur off of the normal lifecycle call stack, hence aren't seen by Blazor:
+In the following example, the user selects the **Send report** button to trigger a background method, `ReportSender.SendAsync`, that sends a report. In most cases, a component awaits the <xref:System.Threading.Tasks.Task> of an asynchronous call and updates the UI to indicate the operation completed. In the following example, the `SendReport` method doesn't await a <xref:System.Threading.Tasks.Task> and doesn't report the result to the user. Because the component intentionally discards the <xref:System.Threading.Tasks.Task> in `SendReport`, any asynchronous failures occur off of the normal lifecycle call stack, hence aren't seen by Blazor:
 
 ```razor
 <button @onclick="SendReport">Send report</button>

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -179,7 +179,7 @@ To treat failures like lifecycle method exceptions, explicitly dispatch exceptio
 }
 ```
 
-An alternative approach for sending the report and discarding the <xref:System.Threading.Tasks.Task> is to leverage <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>:
+An alternative approach leverages <xref:System.Threading.Tasks.Task.Run%2A?displayProperty=nameWithType>:
 
 ```csharp
 private void SendReport()

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -227,26 +227,28 @@ In Blazor Web Apps with the error boundary only applied to a static `MainLayout`
 
 If you run the app at this point, the exception is thrown when the elapsed count reaches a value of two. However, the UI doesn't change. The error boundary doesn't show the error content.
 
-Change the `OnNotify` method of the `Notifications` component (`Notifications.razor`):
+In the `@code` block of the `Notifications` component (`Notifications.razor`):
 
-* Wrap the call to <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType> in a `try-catch` block.
-* Pass any <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and await the result.
+* Add an asynchronous method named `StartTimerFireAndForgetAsync` that starts the timer in a [`try-catch` statement](/dotnet/csharp/language-reference/statements/exception-handling-statements#the-try-catch-statement).
+* In the `catch` clause of the `try-catch` block, dispatch any exceptions back to the component by passing the <xref:System.Exception> to <xref:Microsoft.AspNetCore.Components.ComponentBase.DispatchExceptionAsync%2A> and awaiting the result.
+* Instead of calling `Timer.Start` from `StartTimer`, call the `StartTimerFireAndForgetAsync` method and intentionally discard the `Task`, which is often called *fire and forget* because the method is *fired* (started) and the result of the method, the `Task`, is *forgotten* (thrown away).
 
 ```csharp
-public async Task OnNotify(string key, int value)
+private async Task StartTimerFireAndForgetAsync()
 {
     try
     {
-        await InvokeAsync(() =>
-        {
-            lastNotification = (key, value);
-            StateHasChanged();
-        });
+        await Timer.Start();
     }
     catch (Exception ex)
     {
         await DispatchExceptionAsync(ex);
     }
+}
+
+private void StartTimer()
+{
+    _ = StartTimerFireAndForgetAsync();
 }
 ```
 

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -135,7 +135,7 @@ catch (Exception ex)
 }
 ```
 
-A common scenario is if a component wants to start an asynchronous operation but doesn't await a <xref:System.Threading.Tasks.Task>. If the operation fails, you may still want the component to treat the failure as a component lifecycle exception for the following example goals:
+A common scenario for the preceding approach is when a component starts an asynchronous operation but doesn't await a <xref:System.Threading.Tasks.Task>, often called the *fire and forget* pattern. If the operation fails, you may want the component to treat the failure as a component lifecycle exception for any of the following goals:
 
 * Put the component into a faulted state, for example, to trigger an [error boundary](xref:blazor/fundamentals/handle-errors#error-boundaries).
 * Terminate the circuit if there's no error boundary.


### PR DESCRIPTION
Fixes  #31765

@hakenr ... I'd like to try and fix what's here. It seems faster to just adopt Steve's pattern ... ***the correct approach*** 🙈 ... by merely ...

* 🔪 out the `OnNotify` piece.
* Call `DispatchExceptionAsync` for the timer in the component in the way that Steve proposed calling it.

This only requires a few small changes to what's here, which makes this a quick 🏃‍♂️ update.

WRT a component example for this in the sample apps, I placed a tracking item for it on my long-range tracking issue. I also cross-linked the example that you provided. It might be a good idea to include your example. The text could receive a cross-link and quick description of the alternative approach. I'll consider it further when I reach that item on my long-range tracking issue.

Sorry about the churn pings. I found a number of NITs 😈 to change after I pinged this time.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/handle-errors.md](https://github.com/dotnet/AspNetCore.Docs/blob/8164562d336c72a5151d50e776461bb83510f313/aspnetcore/blazor/fundamentals/handle-errors.md) | [Handle errors in ASP.NET Core Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/handle-errors?branch=pr-en-us-31872) |


<!-- PREVIEW-TABLE-END -->