### PR TITLE
Use generic Enum.GetValues<T>() method instead of (T[])Enum.GetValues(typeof(T)) (net5+)

### DIFF
--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -334,8 +334,7 @@ Update the `Starfleet Starship Database` form (`Starship3` component) of the [Ex
 <fieldset>
     <legend>Manufacturer</legend>
     <InputRadioGroup @bind-Value="Model!.Manufacturer">
-        @foreach (var manufacturer in (Manufacturer[])Enum
-            .GetValues(typeof(Manufacturer)))
+        @foreach (var manufacturer in Enum.GetValues<Manufacturer>())
         {
             <div>
                 <label>

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -412,8 +412,7 @@ Add the following component to the root of the RCL project. The component permit
 
 <EditForm FormName="RobotForm" Model="robotModel" OnValidSubmit="HandleValidSubmit">
     <InputRadioGroup @bind-Value="robotModel.AxisSelection">
-        @foreach (var entry in (Axis[])Enum
-            .GetValues(typeof(Axis)))
+        @foreach (var entry in Enum.GetValues<Axis>())
         {
             <InputRadio Value="entry" />
             <text>&nbsp;</text>@entry<br>
@@ -461,8 +460,7 @@ Add the following component to the root of the RCL project. The component permit
 
 <EditForm Model="robotModel" OnValidSubmit="HandleValidSubmit">
     <InputRadioGroup @bind-Value="robotModel.AxisSelection">
-        @foreach (var entry in (Axis[])Enum
-            .GetValues(typeof(Axis)))
+        @foreach (var entry in Enum.GetValues<Axis>())
         {
             <InputRadio Value="entry" />
             <text>&nbsp;</text>@entry<br>


### PR DESCRIPTION
Improves readability.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/36db048b89d62b71aa0c953525f26d026f519d04/aspnetcore/blazor/forms/binding.md) | [ASP.NET Core Blazor forms binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?branch=pr-en-us-31883) |
| [aspnetcore/blazor/webassembly-lazy-load-assemblies.md](https://github.com/dotnet/AspNetCore.Docs/blob/36db048b89d62b71aa0c953525f26d026f519d04/aspnetcore/blazor/webassembly-lazy-load-assemblies.md) | [Lazy load assemblies in ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-lazy-load-assemblies?branch=pr-en-us-31883) |

<!-- PREVIEW-TABLE-END -->