### PR TITLE
WASM+Identity same-site & antiforgery updates

### DIFF
--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -50,7 +50,7 @@ ASP.NET Core abstractions, such as <xref:Microsoft.AspNetCore.Identity.SignInMan
 
 ## Antiforgery support
 
-Blazor adds Antiforgery Middleware and requires endpoint [antiforgery protection](xref:security/anti-request-forgery) by default to mitigate the threats of Cross-Site Request Forgery (CSRF/XSRF).
+The Blazor template adds Antiforgery Middleware and requires endpoint [antiforgery protection](xref:security/anti-request-forgery) by default to mitigate the threats of Cross-Site Request Forgery (CSRF/XSRF).
 
 The <xref:Microsoft.AspNetCore.Components.Forms.AntiforgeryToken> component renders an antiforgery token as a hidden field, and this component is automatically added to form (<xref:Microsoft.AspNetCore.Components.Forms.EditForm>) instances. For more information, see <xref:blazor/forms/index#antiforgery-support>.
 
@@ -59,9 +59,7 @@ The <xref:Microsoft.AspNetCore.Components.Forms.AntiforgeryStateProvider> servic
 Blazor stores request tokens in component state, which guarantees that antiforgery tokens are available to interactive components, even when they don't have access to the request.
 
 > [!NOTE]
-> [Antiforgery mitigation](xref:security/anti-request-forgery) is only required when submitting form data to the server encoded as `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`. For more information, see <xref:blazor/forms/index#antiforgery-support>.
->
-> Requests to server API endpoints (web API) with `application/json`-encoded content and [CORS](xref:security/cors) enabled doesn't require CSRF protection.
+> [Antiforgery mitigation](xref:security/anti-request-forgery) is only required when submitting form data to the server encoded as `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain` since these are the [only valid form enctypes](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-enctype). For more information, see <xref:blazor/forms/index#antiforgery-support>.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -50,13 +50,18 @@ ASP.NET Core abstractions, such as <xref:Microsoft.AspNetCore.Identity.SignInMan
 
 ## Antiforgery support
 
-Blazor adds Antiforgery Middleware and requires endpoint [antiforgery protection](xref:security/anti-request-forgery) by default. 
+Blazor adds Antiforgery Middleware and requires endpoint [antiforgery protection](xref:security/anti-request-forgery) by default to mitigate the threats of Cross-Site Request Forgery (CSRF/XSRF).
 
 The <xref:Microsoft.AspNetCore.Components.Forms.AntiforgeryToken> component renders an antiforgery token as a hidden field, and this component is automatically added to form (<xref:Microsoft.AspNetCore.Components.Forms.EditForm>) instances. For more information, see <xref:blazor/forms/index#antiforgery-support>.
 
 The <xref:Microsoft.AspNetCore.Components.Forms.AntiforgeryStateProvider> service provides access to an antiforgery token associated with the current session. Inject the service and call its <xref:Microsoft.AspNetCore.Components.Forms.AntiforgeryStateProvider.GetAntiforgeryToken> method to obtain the current <xref:Microsoft.AspNetCore.Components.Forms.AntiforgeryRequestToken>. For more information, see <xref:blazor/call-web-api#antiforgery-support>.
 
 Blazor stores request tokens in component state, which guarantees that antiforgery tokens are available to interactive components, even when they don't have access to the request.
+
+> [!NOTE]
+> [Antiforgery mitigation](xref:security/anti-request-forgery) is only required when submitting form data to the server encoded as `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`. For more information, see <xref:blazor/forms/index#antiforgery-support>.
+>
+> Requests to server API endpoints (web API) with `application/json`-encoded content and [CORS](xref:security/cors) enabled doesn't require CSRF protection.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -265,7 +265,7 @@ For more information on same-site cookie settings, see the following resources:
 
 Only the logout endpoint (`/logout`) in the `Backend` app requires attention to mitigate the threat of [Cross-Site Request Forgery (CSRF)](xref:security/anti-request-forgery).
 
-The logout endpoint checks for an empty body to prevent CSRF attacks. By requiring a body, the request must be made from JavaScript, which is the only way to access the authentication cookie. The cookie can't be accessed by a form-based POST. This prevents a malicious site from logging the user out.
+The logout endpoint checks for an empty body to prevent CSRF attacks. By requiring a body, the request must be made from JavaScript, which is the only way to access the authentication cookie. The logout endpoint can't be accessed by a form-based POST. This prevents a malicious site from logging the user out.
 
 Furthermore, the endpoint is protected by authorization (<xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization%2A>) to prevent anonymous access.
 
@@ -273,7 +273,7 @@ The `BlazorWasmAuth` client app is simply required to pass an empty object `{}` 
 
 Outside of the logout endpoint, [antiforgery mitigation](xref:security/anti-request-forgery) is only required when submitting form data to the server encoded as `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`. Blazor manages CSRF mitigation for forms in most cases. For more information, see <xref:blazor/forms/index#antiforgery-support>.
 
-Requests to other server API endpoints (web API) with `application/json`-encoded content and [CORS](xref:security/cors) enabled doesn't require CSRF protection. No CSRF protection is required for the `Backend` app's roles (`/roles`) and data processing (`/data-processing`) endpoints.
+Requests to other server API endpoints (web API) with `application/json`-encoded content and [CORS](xref:security/cors) enabled doesn't require CSRF protection. This is why no CSRF protection is required for the `Backend` app's data processing (`/data-processing`) endpoint. The roles (`/roles`) endpoint doesn't need CSRF protection because it's a GET endpoint that doesn't modify any state.
 
 ## Troubleshoot
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity.md
@@ -237,6 +237,44 @@ In the `Backend` server API's `Program` file, a [Minimal API](xref:fundamentals/
 
 The roles endpoint requires authorization by calling <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization%2A>. If you decide not to use Minimal APIs in favor of controllers for secure server API endpoints, be sure to set the [`[Authorize]` attribute](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) on controllers or actions.
 
+## Cross-domain hosting (same-site configuration)
+
+The [sample apps](#sample-apps) are configured for hosting both apps at the same domain. If you host the `Backend` app at a different domain than the `BlazorWasmAuth` app, uncomment the code that configures the cookie (<xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.ConfigureApplicationCookie%2A>) in the `Backend` app's `Program` file. The default values are:
+
+* Same-site mode: <xref:Microsoft.AspNetCore.Http.SameSiteMode.Lax?displayProperty=nameWithType>
+* Secure policy: <xref:Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest?displayProperty=nameWithType>
+
+Change the values to:
+
+* Same-site mode: <xref:Microsoft.AspNetCore.Http.SameSiteMode.None?displayProperty=nameWithType>
+* Secure policy: <xref:Microsoft.AspNetCore.Http.CookieSecurePolicy.Always?displayProperty=nameWithType>
+
+```diff
+- options.Cookie.SameSite = SameSiteMode.Lax;
+- options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
++ options.Cookie.SameSite = SameSiteMode.None;
++ options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+```
+
+For more information on same-site cookie settings, see the following resources:
+
+* [Set-Cookie: `SameSite=<samesite-value>` (MDN documentation)](https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value)
+* [Cookies: HTTP State Management Mechanism (RFC Draft 6265, Section 4.1)](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1)
+
+## Antiforgery support
+
+Only the logout endpoint (`/logout`) in the `Backend` app requires attention to mitigate the threat of [Cross-Site Request Forgery (CSRF)](xref:security/anti-request-forgery).
+
+The logout endpoint checks for an empty body to prevent CSRF attacks. By requiring a body, the request must be made from JavaScript, which is the only way to access the authentication cookie. The cookie can't be accessed by a form-based POST. This prevents a malicious site from logging the user out.
+
+Furthermore, the endpoint is protected by authorization (<xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization%2A>) to prevent anonymous access.
+
+The `BlazorWasmAuth` client app is simply required to pass an empty object `{}` in the body of the request.
+
+Outside of the logout endpoint, [antiforgery mitigation](xref:security/anti-request-forgery) is only required when submitting form data to the server encoded as `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain`. Blazor manages CSRF mitigation for forms in most cases. For more information, see <xref:blazor/forms/index#antiforgery-support>.
+
+Requests to other server API endpoints (web API) with `application/json`-encoded content and [CORS](xref:security/cors) enabled doesn't require CSRF protection. No CSRF protection is required for the `Backend` app's roles (`/roles`) and data processing (`/data-processing`) endpoints.
+
 ## Troubleshoot
 
 ### Logging


### PR DESCRIPTION
Fixes #31389
Addresses #31205
Addresses #28161

## Sample updates

FIRST ... before reviewing the article DIFF on this PR ... let's sort out the sample updates at ...

https://github.com/dotnet/blazor-samples/pull/210

* NIT updates on the PR
  * Move CORS in the pipeline above the logout endpoint.
  * Lowercase the logout endpoint from `/Logout` to `/logout`.
  * Change conditional check `empty != null` to `empty is not null`.
  * Place a line of spacing above `return`s ... that's by convention for Blazor example code.
  * Remove null-forgiving ops from `email` and `password`, as they can't be null.
  * Remove the `UserBasic` class, as it isn't used.
 * Same-site/secure policy settings: Add commented-out default-setting code for it.
 * Add a quick-'n-dirty data processing experience.
   * Form in a page that uses the `Auth` client to POST to the `Backend` app.
   * Minimal API endpoint that processes the data and returns a string.
   * ~NOTE: The same errors shown in https://github.com/dotnet/blazor-samples/issues/161 are seen here when that code processes an unauthenticated request to the `/data-processing` endpoint. I'll place the error at the bottom of this OP.~ We think now that this is resolved by the sample updates.

## Article updates

### Security Overview

This section applies to all Blazor app hosting models/templates. The primary goal here is to add a reminder that ...

* ~Antiforgery mitigation is for form submissions encoded as `application/x-www-form-urlencoded`, `multipart/form-data`, or `text/plain` with a cross-link to the Blazor Forms article coverage on forms antiforgery support.~ ***Updated on review.***
* ~Server API endpoints with `application/json`-encoded content and CORS don't require CSRF protection.~ ***Updated on review.***

### Standalone with Identity article

* Adds a new section on *Cross-domain hosting (same-site configuration)*.
* Adds a new section on antiforgery support.
  * Explain the situation with the logout endpoint.
  * Add the reminders on forms antiforgery and server API/JSON/CORS.

I'm still a bit concerned ... even if this is all correct (or close to correct) ... that the bit about forms submission in a standalone WASM situation could use more work. Using an HTTP client with a JSON request and CORS is what we focus on throughout the docs. This will be the first time that we explicitly say that antiforgery isn't a concern in that scenario. However, `EditForm` is useful client-side ***to just collect the data*** for a JSON POST to a server API. I don't want readers to think that anything is happening for `EditForm` in such an app vis-a-vis antiforgery. I might need to add more content on this point.

... and BTW Jeremy ... it seems to me that one day if I ever get the time that I should convert your plain forms over to `EditForm` forms with the nice validation ... and roll in the bits to trigger validation failures with the `ValidationMessage` component. I can do all that ... it's just a question of ***TIME*** ⏲️ ... and I won't have any for the foreseeable future 🏃‍♂️😄.

## Error

***This has been addressed by the updates to the sample app.***

~Error for unauthenticated hit on the `/data-processing` endpoint. What the sample is doing now is trapping it in a `try-catch` and showing a message. ***Can't we work out something more graceful than that?*** ... or does this all resolve back to your remarks here ...~

~https://github.com/dotnet/blazor-samples/issues/161#issuecomment-1887754626~

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/718c5e767f17850b39268243a61059eb477b3eb7/aspnetcore/blazor/security/index.md) | [ASP.NET Core Blazor authentication and authorization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/index?branch=pr-en-us-31888) |
| [aspnetcore/blazor/security/webassembly/standalone-with-identity.md](https://github.com/dotnet/AspNetCore.Docs/blob/718c5e767f17850b39268243a61059eb477b3eb7/aspnetcore/blazor/security/webassembly/standalone-with-identity.md) | [Secure ASP.NET Core Blazor WebAssembly with ASP.NET Core Identity](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-identity?branch=pr-en-us-31888) |

<!-- PREVIEW-TABLE-END -->