### PR TITLE
Add BWA global Auto approach

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -185,9 +185,9 @@ Optionally, add a menu item to the navigation in the `NavMenu` component (`NavMe
 
 Add the [`Microsoft.Extensions.Localization`](https://www.nuget.org/packages/Microsoft.Extensions.Localization) package to the app.
 
-The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Language) is set by the browser and controlled by the user's language preferences in browser settings. In browser settings, a user sets one or more preferred languages in order of preference. The order of preference is used by the browser to set quality values (`q`, 0-1) for each language in the header. The following example specifies United States English, English, and Chilean Spanish with a preference for United States English or English:
+The [`Accept-Language` header](https://developer.mozilla.org/docs/Web/HTTP/Headers/Accept-Language) is set by the browser and controlled by the user's language preferences in browser settings. In browser settings, a user sets one or more preferred languages in order of preference. The order of preference is used by the browser to set quality values (`q`, 0-1) for each language in the header. The following example specifies United States English, English, and Costa Rican Spanish with a preference for United States English or English:
 
-**Accept-Language**: en-US,en;q=0.9,es-CL;q=0.8
+**Accept-Language**: en-US,en;q=0.9,es-CR;q=0.8
 
 The app's culture is set by matching the first requested language that matches a supported culture of the app.
 
@@ -220,17 +220,17 @@ Add the following line to the `Program` file where services are registered:
 builder.Services.AddLocalization();
 ```
 
-In ***server-side development***, you can specify the app's supported cultures immediately after Routing Middleware is added to the processing pipeline. The following example configures supported cultures for United States English and Chilean Spanish:
+In ***server-side development***, you can specify the app's supported cultures immediately after Routing Middleware is added to the processing pipeline. The following example configures supported cultures for United States English and Costa Rican Spanish:
 
 ```csharp
 app.UseRequestLocalization(new RequestLocalizationOptions()
-    .AddSupportedCultures(new[] { "en-US", "es-CL" })
-    .AddSupportedUICultures(new[] { "en-US", "es-CL" }));
+    .AddSupportedCultures(new[] { "en-US", "es-CR" })
+    .AddSupportedUICultures(new[] { "en-US", "es-CR" }));
 ```
 
 For information on ordering the Localization Middleware in the middleware pipeline of the `Program` file, see <xref:fundamentals/middleware/index#middleware-order>.
 
-Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again.
+Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Costa Rican Spanish (`es-CR`) in the browser's language settings. Request the webpage again.
 
 > [!NOTE]
 > Some browsers force you to use the default language setting for both requests and the browser's own UI settings. This can make changing the language back to one that you understand difficult because all of the setting UI screens might end up in a language that you can't read. A browser such as [Opera](https://www.opera.com/download) is a good choice for testing because it permits you to set a default language for webpage requests but leave the browser's settings UI in your language.
@@ -240,7 +240,7 @@ When the culture is United States English (`en-US`), the rendered component uses
 * **Date**: 6/7/2021 6:45:22 AM
 * **Number**: 1,999.69
 
-When the culture is Chilean Spanish (`es-CL`), the rendered component uses day/month date formatting (`7/6`), 24-hour time, and period separators in numbers with a comma for the decimal value (`1.999,69`):
+When the culture is Costa Rican Spanish (`es-CR`), the rendered component uses day/month date formatting (`7/6`), 24-hour time, and period separators in numbers with a comma for the decimal value (`1.999,69`):
 
 * **Date**: 7/6/2021 6:49:38
 * **Number**: 1.999,69
@@ -323,7 +323,7 @@ CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 > [!IMPORTANT]
 > Always set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> to the same culture in order to use <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>.
 
-Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again. When the requested language is Chilean Spanish, the app's culture remains United States English (`en-US`).
+Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Costa Rican Spanish (`es-CR`) in the browser's language settings. Request the webpage again. When the requested language is Costa Rican Spanish, the app's culture remains United States English (`en-US`).
 
 ## Statically set the server-side culture
 
@@ -371,7 +371,7 @@ For information on ordering the Localization Middleware in the middleware pipeli
 
 :::moniker-end
 
-Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Chilean Spanish (`es-CL`) in the browser's language settings. Request the webpage again. When the requested language is Chilean Spanish, the app's culture remains United States English (`en-US`).
+Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Costa Rican Spanish (`es-CR`) in the browser's language settings. Request the webpage again. When the requested language is Costa Rican Spanish, the app's culture remains United States English (`en-US`).
 
 ## Dynamically set the client-side culture by user preference
 
@@ -482,7 +482,7 @@ The following `CultureSelector` component shows how to perform the following act
     private CultureInfo[] supportedCultures = new[]
     {
         new CultureInfo("en-US"),
-        new CultureInfo("es-CL"),
+        new CultureInfo("es-CR"),
     };
 
     private CultureInfo Culture
@@ -559,7 +559,7 @@ After the call to `app.UseRouting` in the request processing pipeline, place the
 :::moniker-end
 
 ```csharp
-var supportedCultures = new[] { "en-US", "es-CL" };
+var supportedCultures = new[] { "en-US", "es-CR" };
 var localizationOptions = new RequestLocalizationOptions()
     .SetDefaultCulture(supportedCultures[0])
     .AddSupportedCultures(supportedCultures)
@@ -701,7 +701,7 @@ The following `CultureSelector` component shows how to call the `Set` method of 
     private CultureInfo[] supportedCultures = new[]
     {
         new CultureInfo("en-US"),
-        new CultureInfo("es-CL"),
+        new CultureInfo("es-CR"),
     };
 
     protected override void OnInitialized()
@@ -870,13 +870,13 @@ The component adopts the following approaches to work for either SSR or CSR comp
         new()
         {
             { "en-US", "English (United States)" },
-            { "es-CL", "Spanish (Chile)" }
+            { "es-CR", "Spanish (Costa Rica)" }
         };
 
     private CultureInfo[] supportedCultures = new[]
     {
         new CultureInfo("en-US"),
-        new CultureInfo("es-CL"),
+        new CultureInfo("es-CR"),
     };
 
     private CultureInfo Culture
@@ -996,7 +996,7 @@ Set the app's default and supported cultures with <xref:Microsoft.AspNetCore.Bui
 Before the call to `app.MapRazorComponents` in the request processing pipeline, place the following code:
 
 ```csharp
-var supportedCultures = new[] { "en-US", "es-CL" };
+var supportedCultures = new[] { "en-US", "es-CR" };
 var localizationOptions = new RequestLocalizationOptions()
     .SetDefaultCulture(supportedCultures[0])
     .AddSupportedCultures(supportedCultures)
@@ -1228,7 +1228,7 @@ If the app doesn't already support dynamic culture selection:
 :::moniker range=">= aspnetcore-6.0"
 
 * Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
-* Specify the app's default and supported cultures in the `Program` file. The following example configures supported cultures for United States English and Chilean Spanish.
+* Specify the app's default and supported cultures in the `Program` file. The following example configures supported cultures for United States English and Costa Rican Spanish.
 
 ```csharp
 builder.Services.AddLocalization();
@@ -1237,7 +1237,7 @@ builder.Services.AddLocalization();
 Immediately after Routing Middleware is added to the processing pipeline:
 
 ```csharp
-var supportedCultures = new[] { "en-US", "es-CL" };
+var supportedCultures = new[] { "en-US", "es-CR" };
 var localizationOptions = new RequestLocalizationOptions()
     .SetDefaultCulture(supportedCultures[0])
     .AddSupportedCultures(supportedCultures)
@@ -1253,7 +1253,7 @@ For information on ordering the Localization Middleware in the middleware pipeli
 :::moniker range="< aspnetcore-6.0"
 
 * Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
-* Specify the app's default and supported cultures in `Startup.Configure` (`Startup.cs`). The following example configures supported cultures for United States English and Chilean Spanish.
+* Specify the app's default and supported cultures in `Startup.Configure` (`Startup.cs`). The following example configures supported cultures for United States English and Costa Rican Spanish.
 
 In `Startup.ConfigureServices` (`Startup.cs`):
 
@@ -1264,7 +1264,7 @@ services.AddLocalization();
 In `Startup.Configure` immediately after Routing Middleware is added to the processing pipeline:
 
 ```csharp
-var supportedCultures = new[] { "en-US", "es-CL" };
+var supportedCultures = new[] { "en-US", "es-CR" };
 var localizationOptions = new RequestLocalizationOptions()
     .SetDefaultCulture(supportedCultures[0])
     .AddSupportedCultures(supportedCultures)

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -819,18 +819,15 @@ builder.Services.AddLocalization();
 
 var host = builder.Build();
 
-CultureInfo culture;
+const string defaultCulture = "en-US";
+
 var js = host.Services.GetRequiredService<IJSRuntime>();
 var result = await js.InvokeAsync<string>("blazorCulture.get");
+var culture = CultureInfo.GetCulture(result ?? defaultCulture);
 
-if (result != null)
+if (result == null)
 {
-    culture = new CultureInfo(result);
-}
-else
-{
-    culture = new CultureInfo("en-US");
-    await js.InvokeVoidAsync("blazorCulture.set", "en-US");
+    await js.InvokeVoidAsync("blazorCulture.set", defaultCulture);
 }
 
 CultureInfo.DefaultThreadCurrentCulture = culture;

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -267,7 +267,7 @@ By default, the Intermediate Language (IL) Linker configuration for client-side 
 
 The app's culture can be set in JavaScript when Blazor starts with the `applicationCulture` Blazor start option. The following example configures the app to launch using the United States English (`en-US`) culture.
 
-Prevent Blazor autostart by adding `autostart="false"` to Blazor's script tag:
+Prevent Blazor autostart by adding `autostart="false"` to [Blazor's `<script>` tag](xref:blazor/project-structure#location-of-the-blazor-script):
 
 ```html
 <script src="{BLAZOR SCRIPT}" autostart="false"></script>
@@ -275,7 +275,7 @@ Prevent Blazor autostart by adding `autostart="false"` to Blazor's script tag:
 
 In the preceding example, the `{BLAZOR SCRIPT}` placeholder is the Blazor script path and file name. For the location of the script, see <xref:blazor/project-structure#location-of-the-blazor-script>.
 
-Add the following `<script>` block after Blazor's `<script>` tag and before the closing `</body>` tag:
+Add the following `<script>` block after [Blazor's `<script>` tag](xref:blazor/project-structure#location-of-the-blazor-script) and before the closing `</body>` tag:
 
 :::moniker range=">= aspnetcore-8.0"
 
@@ -395,7 +395,7 @@ Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the pr
 
 The app's culture for client-side rendering is set using the Blazor framework's API. A user's culture selection can be persisted in browser local storage.
 
-Provide JS functions to get and set the user's culture selection with browser local storage:
+Provide JS functions after [Blazor's `<script>` tag](xref:blazor/project-structure#location-of-the-blazor-script) to get and set the user's culture selection with browser local storage:
 
 ```html
 <script>
@@ -677,7 +677,7 @@ public class CultureController : Controller
 ```
 
 > [!WARNING]
-> Use the <xref:Microsoft.AspNetCore.Mvc.ControllerBase.LocalRedirect%2A> action result to prevent open redirect attacks. For more information, see <xref:security/preventing-open-redirects>.
+> Use the <xref:Microsoft.AspNetCore.Mvc.ControllerBase.LocalRedirect%2A> action result, as shown in the preceding example, to prevent open redirect attacks. For more information, see <xref:security/preventing-open-redirects>.
 
 The following `CultureSelector` component shows how to call the `Set` method of the `CultureController` with the new culture. The component is placed in the `Shared` folder for use throughout the app.
 
@@ -739,7 +739,7 @@ Add the `CultureSelector` component to the `MainLayout` component. Place the fol
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-8.0"
+:::moniker range="< aspnetcore-8.0"
 
 Add the `CultureSelector` component to the `MainLayout` component. Place the following markup inside the closing `</main>` tag in the `Shared/MainLayout.razor` file:
 
@@ -774,6 +774,422 @@ If the app adopts ***per-page/component*** interactivity, make the following cha
   ```razor
   <CultureSelector @rendermode="InteractiveServer" />
   ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
+
+## Dynamically set the culture in a Blazor Web App by user preference
+
+*This section applies to Blazor Web Apps that adopt Auto (Server and WebAssembly) interactivity with per-component interactivity location.*
+
+Examples of locations where an app might store a user's preference include in [browser local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (common for client-side scenarios), in a localization cookie or database (common for server-side scenarios), both local storage and a localization cookie (Blazor Web Apps with server and WebAssembly components), or in an external service attached to an external database and accessed by a [web API](xref:blazor/call-web-api). The following example demonstrates how to use browser local storage for client-side rendered (CSR) components and a localization cookie for server-side rendered (SSR) components.
+
+### Updates to the `.Client` project
+
+Add the [`Microsoft.Extensions.Localization`](https://www.nuget.org/packages/Microsoft.Extensions.Localization) package to the `.Client` project.
+
+[!INCLUDE[](~/includes/package-reference.md)]
+
+Set the `BlazorWebAssemblyLoadAllGlobalizationData` property to `true` in the `.Client` project file:
+
+```xml
+<PropertyGroup>
+  <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
+</PropertyGroup>
+```
+
+Add the namespaces for <xref:System.Globalization?displayProperty=fullName> and <xref:Microsoft.JSInterop?displayProperty=fullName> to the top of the `.Client` project's `Program` file:
+
+```csharp
+using System.Globalization;
+using Microsoft.JSInterop;
+```
+
+Remove the following line:
+
+```diff
+- await builder.Build().RunAsync();
+```
+
+Replace the preceding line with the following code. The code adds Blazor's localization service to the app's service collection with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A> and uses [JS interop](xref:blazor/js-interop/call-javascript-from-dotnet) to call into JS and retrieve the user's culture selection from local storage. If local storage doesn't contain a culture for the user, the code sets a default value of United States English (`en-US`).
+
+```csharp
+builder.Services.AddLocalization();
+
+var host = builder.Build();
+
+CultureInfo culture;
+var js = host.Services.GetRequiredService<IJSRuntime>();
+var result = await js.InvokeAsync<string>("blazorCulture.get");
+
+if (result != null)
+{
+    culture = new CultureInfo(result);
+}
+else
+{
+    culture = new CultureInfo("en-US");
+    await js.InvokeVoidAsync("blazorCulture.set", "en-US");
+}
+
+CultureInfo.DefaultThreadCurrentCulture = culture;
+CultureInfo.DefaultThreadCurrentUICulture = culture;
+
+await host.RunAsync();
+```
+
+> [!IMPORTANT]
+> Always set <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture> and <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture> to the same culture in order to use <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601>.
+
+Add the following `CultureSelector` component to the `.Client` project.
+
+The component adopts the following approaches to work for either SSR or CSR components:
+
+* The display name of each available culture in the dropdown list is provided by a dictionary because client-side globalization data include localized text of culture display names that server-side globalization data provides. For example, server-side localization displays `English (United States)` when `en-US` is the culture and `Ingles ()` when a different culture is used. Because localization of the culture display names isn't available with Blazor WebAssembly globalization, the display name for United States English on the client for any loaded culture is just `en-US`. Using a custom dictionary permits the component to at least display full English culture names.
+* When the user selects a different culture from the dropdown list and the component is rendered on the client, JS interop sets the culture in local browser storage.
+* When user changes the culture and the component is rendered on the server, JS interop sets the culture in local browser storage and a controller action updates the localization cookie with the culture. The controller is added to the app later in the [Server project updates](#server-project-updates) section.
+
+`Pages/CultureSelector.razor`:
+
+```razor
+@using System.Globalization
+@using System.Runtime.InteropServices
+@inject IJSRuntime JS
+@inject NavigationManager Navigation
+
+<p>
+    <label>
+        Select your locale:
+        <select @bind="Culture">
+            @foreach (var culture in supportedCultures)
+            {
+                <option value="@culture">@cultureDict[culture.Name]</option>
+            }
+        </select>
+    </label>
+</p>
+
+@code
+{
+    private Dictionary<string, string> cultureDict = 
+        new()
+        {
+            { "en-US", "English (United States)" },
+            { "es-CL", "Spanish (Chile)" }
+        };
+
+    private CultureInfo[] supportedCultures = new[]
+    {
+        new CultureInfo("en-US"),
+        new CultureInfo("es-CL"),
+    };
+
+    private CultureInfo Culture
+    {
+        get => CultureInfo.CurrentCulture;
+        set
+        {
+            if (CultureInfo.CurrentCulture != value)
+            {
+                if (RuntimeInformation.IsOSPlatform(
+                    OSPlatform.Create("WEBASSEMBLY")))
+                {
+                    // Running on WebAssembly in the browser
+                    var js = (IJSInProcessRuntime)JS;
+                    js.InvokeVoid("blazorCulture.set", value.Name);
+
+                    Navigation.NavigateTo(Navigation.Uri, forceLoad: true);
+                }
+                else
+                {
+                    // Running on the server
+                    if (CultureInfo.CurrentCulture != value)
+                    {
+                        var js = (IJSRuntime)JS;
+                        js.InvokeVoidAsync("blazorCulture.set", value.Name);
+
+                        var uri = new Uri(Navigation.Uri).GetComponents(
+                            UriComponents.PathAndQuery, UriFormat.Unescaped);
+                        var cultureEscaped = Uri.EscapeDataString(value.Name);
+                        var uriEscaped = Uri.EscapeDataString(uri);
+
+                        Navigation.NavigateTo(
+                            $"Culture/Set?culture={cultureEscaped}" +
+                            $"&redirectUri={uriEscaped}",
+                            forceLoad: true);
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+> [!NOTE]
+> For more information on <xref:Microsoft.JSInterop.IJSInProcessRuntime>, see <xref:blazor/js-interop/call-javascript-from-dotnet#synchronous-js-interop-in-client-side-components>.
+
+In the `.Client` project, place the following `CultureClient` component to study how globalization works for CSR components.
+
+`Pages/CultureClient.razor`:
+
+```razor
+@page "/culture-client"
+@rendermode InteractiveWebAssembly
+@using System.Globalization
+
+<PageTitle>Culture Client</PageTitle>
+
+<h1>Culture Client</h1>
+
+<p>
+    <b>CurrentCulture</b>: @CultureInfo.CurrentCulture
+</p>
+
+<h2>Rendered values</h2>
+
+<ul>
+    <li><b>Date</b>: @dt</li>
+    <li><b>Number</b>: @number.ToString("N2")</li>
+</ul>
+
+<h2><code>&lt;input&gt;</code> elements that don't set a <code>type</code></h2>
+
+<p>
+    The following <code>&lt;input&gt;</code> elements use
+    <code>CultureInfo.CurrentCulture</code>.
+</p>
+
+<ul>
+    <li><label><b>Date:</b> <input @bind="dt" /></label></li>
+    <li><label><b>Number:</b> <input @bind="number" /></label></li>
+</ul>
+
+<h2><code>&lt;input&gt;</code> elements that set a <code>type</code></h2>
+
+<p>
+    The following <code>&lt;input&gt;</code> elements use
+    <code>CultureInfo.InvariantCulture</code>.
+</p>
+
+<ul>
+    <li><label><b>Date:</b> <input type="date" @bind="dt" /></label></li>
+    <li><label><b>Number:</b> <input type="number" @bind="number" /></label></li>
+</ul>
+
+@code {
+    private DateTime dt = DateTime.Now;
+    private double number = 1999.69;
+}
+```
+
+### Server project updates
+
+Add the [`Microsoft.Extensions.Localization`](https://www.nuget.org/packages/Microsoft.Extensions.Localization) package to the server project.
+
+[!INCLUDE[](~/includes/package-reference.md)]
+
+Server-side apps are localized using [Localization Middleware](xref:fundamentals/localization#localization-middleware). Add localization services to the app with <xref:Microsoft.Extensions.DependencyInjection.LocalizationServiceCollectionExtensions.AddLocalization%2A>.
+
+In the server project's `Program` file where services are registered:
+
+```csharp
+builder.Services.AddLocalization();
+```
+
+Set the app's default and supported cultures with <xref:Microsoft.AspNetCore.Builder.RequestLocalizationOptions>.
+
+Before the call to `app.MapRazorComponents` in the request processing pipeline, place the following code:
+
+```csharp
+var supportedCultures = new[] { "en-US", "es-CL" };
+var localizationOptions = new RequestLocalizationOptions()
+    .SetDefaultCulture(supportedCultures[0])
+    .AddSupportedCultures(supportedCultures)
+    .AddSupportedUICultures(supportedCultures);
+
+app.UseRequestLocalization(localizationOptions);
+```
+
+The following example shows how to set the current culture in a cookie that can be read by the Localization Middleware.
+
+The following namespaces are required for the `App` component:
+
+* <xref:System.Globalization?displayProperty=fullName>
+* <xref:Microsoft.AspNetCore.Localization?displayProperty=fullName>
+
+Add the following to the top of the `App` component file (`Components/App.razor`):
+
+```razor
+@using System.Globalization
+@using Microsoft.AspNetCore.Localization
+```
+
+The app's culture for client-side rendering is set using the Blazor framework's API. A user's culture selection can be persisted in browser local storage for CSR components.
+
+After the [Blazor's `<script>` tag](xref:blazor/project-structure#location-of-the-blazor-script), provide JS functions to get and set the user's culture selection with browser local storage:
+
+```html
+<script>
+  window.blazorCulture = {
+    get: () => window.localStorage['BlazorCulture'],
+    set: (value) => window.localStorage['BlazorCulture'] = value
+  };
+</script>
+```
+
+> [!NOTE]
+> The preceding example pollutes the client with global functions. For a better approach in production apps, see [JavaScript isolation in JavaScript modules](xref:blazor/js-interop/call-javascript-from-dotnet#javascript-isolation-in-javascript-modules).
+
+Add the following `@code` block to the bottom of the `App` component file:
+
+```razor
+@code {
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
+    protected override void OnInitialized()
+    {
+        HttpContext?.Response.Cookies.Append(
+            CookieRequestCultureProvider.DefaultCookieName,
+            CookieRequestCultureProvider.MakeCookieValue(
+                new RequestCulture(
+                    CultureInfo.CurrentCulture,
+                    CultureInfo.CurrentUICulture)));
+    }
+}
+```
+
+If the server project isn't configured to process controller actions:
+
+* Add MVC services by calling <xref:Microsoft.Extensions.DependencyInjection.MvcServiceCollectionExtensions.AddControllers%2A> on the service collection in the `Program` file:
+
+  ```csharp
+  builder.Services.AddControllers();
+  ```
+
+* Add controller endpoint routing in the `Program` file by calling <xref:Microsoft.AspNetCore.Builder.ControllerEndpointRouteBuilderExtensions.MapControllers%2A> on the <xref:Microsoft.AspNetCore.Routing.IEndpointRouteBuilder> (`app`):
+
+  ```csharp
+  app.MapControllers();
+  ```
+
+To allow a user to select a culture for SSR components, use a *redirect-based approach* with a localization cookie. The app persists the user's selected culture via a redirect to a controller. The controller sets the user's selected culture into a cookie and redirects the user back to the original URI. The process is similar to what happens in a web app when a user attempts to access a secure resource, where the user is redirected to a sign-in page and then redirected back to the original resource.
+
+`Controllers/CultureController.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Localization;
+using Microsoft.AspNetCore.Mvc;
+
+[Route("[controller]/[action]")]
+public class CultureController : Controller
+{
+    public IActionResult Set(string culture, string redirectUri)
+    {
+        if (culture != null)
+        {
+            HttpContext.Response.Cookies.Append(
+                CookieRequestCultureProvider.DefaultCookieName,
+                CookieRequestCultureProvider.MakeCookieValue(
+                    new RequestCulture(culture, culture)));
+        }
+
+        return LocalRedirect(redirectUri);
+    }
+}
+```
+
+> [!WARNING]
+> Use the <xref:Microsoft.AspNetCore.Mvc.ControllerBase.LocalRedirect%2A> action result, as shown in the preceding example, to prevent open redirect attacks. For more information, see <xref:security/preventing-open-redirects>.
+
+Add the `CultureSelector` component to the `MainLayout` component. Place the following markup inside the closing `</main>` tag in the `Components/Layout/MainLayout.razor` file:
+
+```razor
+<article class="bottom-row px-4">
+    <CultureSelector @rendermode="InteractiveAuto" />
+</article>
+```
+
+Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how the preceding example works.
+
+In the server project, place the following `CultureServer` component to study how globalization works for SSR components.
+
+`Components/Pages/CultureServer.razor`:
+
+```razor
+@page "/culture-server"
+@rendermode InteractiveServer
+@using System.Globalization
+
+<PageTitle>Culture Server</PageTitle>
+
+<h1>Culture Server</h1>
+
+<p>
+    <b>CurrentCulture</b>: @CultureInfo.CurrentCulture
+</p>
+
+<h2>Rendered values</h2>
+
+<ul>
+    <li><b>Date</b>: @dt</li>
+    <li><b>Number</b>: @number.ToString("N2")</li>
+</ul>
+
+<h2><code>&lt;input&gt;</code> elements that don't set a <code>type</code></h2>
+
+<p>
+    The following <code>&lt;input&gt;</code> elements use
+    <code>CultureInfo.CurrentCulture</code>.
+</p>
+
+<ul>
+    <li><label><b>Date:</b> <input @bind="dt" /></label></li>
+    <li><label><b>Number:</b> <input @bind="number" /></label></li>
+</ul>
+
+<h2><code>&lt;input&gt;</code> elements that set a <code>type</code></h2>
+
+<p>
+    The following <code>&lt;input&gt;</code> elements use
+    <code>CultureInfo.InvariantCulture</code>.
+</p>
+
+<ul>
+    <li><label><b>Date:</b> <input type="date" @bind="dt" /></label></li>
+    <li><label><b>Number:</b> <input type="number" @bind="number" /></label></li>
+</ul>
+
+@code {
+    private DateTime dt = DateTime.Now;
+    private double number = 1999.69;
+}
+```
+
+Add both the `CultureClient` and `CultureServer` components to the sidebar navigation in `Components/Layout/NavMenu.razor`:
+
+```razor
+<div class="nav-item px-3">
+    <NavLink class="nav-link" href="culture-server">
+        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Culture (Server)
+    </NavLink>
+</div>
+
+<div class="nav-item px-3">
+    <NavLink class="nav-link" href="culture-client">
+        <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Culture (Client)
+    </NavLink>
+</div>
+```
+
+### Interactive Auto components
+
+The guidance in this section also works for components that adopt the Interactive Auto render mode:
+
+```razor
+@rendermode InteractiveAuto
+```
 
 :::moniker-end
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -433,18 +433,15 @@ builder.Services.AddLocalization();
 
 var host = builder.Build();
 
-CultureInfo culture;
+const string defaultCulture = "en-US";
+
 var js = host.Services.GetRequiredService<IJSRuntime>();
 var result = await js.InvokeAsync<string>("blazorCulture.get");
+var culture = CultureInfo.GetCulture(result ?? defaultCulture);
 
-if (result != null)
+if (result == null)
 {
-    culture = new CultureInfo(result);
-}
-else
-{
-    culture = new CultureInfo("en-US");
-    await js.InvokeVoidAsync("blazorCulture.set", "en-US");
+    await js.InvokeVoidAsync("blazorCulture.set", defaultCulture);
 }
 
 CultureInfo.DefaultThreadCurrentCulture = culture;

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -778,7 +778,7 @@ If the app adopts ***per-page/component*** interactivity, make the following cha
 
 ## Dynamically set the culture in a Blazor Web App by user preference
 
-*This section applies to Blazor Web Apps that adopt Auto (Server and WebAssembly) interactivity with per-component interactivity location.*
+*This section applies to Blazor Web Apps that adopt Auto (Server and WebAssembly) interactivity.*
 
 Examples of locations where an app might store a user's preference include in [browser local storage](https://developer.mozilla.org/docs/Web/API/Window/localStorage) (common for client-side scenarios), in a localization cookie or database (common for server-side scenarios), both local storage and a localization cookie (Blazor Web Apps with server and WebAssembly components), or in an external service attached to an external database and accessed by a [web API](xref:blazor/call-web-api). The following example demonstrates how to use browser local storage for client-side rendered (CSR) components and a localization cookie for server-side rendered (SSR) components.
 
@@ -885,16 +885,16 @@ The component adopts the following approaches to work for either SSR or CSR comp
         {
             if (CultureInfo.CurrentCulture != value)
             {
-                    JS.InvokeVoidAsync("blazorCulture.set", value.Name);
+                JS.InvokeVoidAsync("blazorCulture.set", value.Name);
 
-                    var uri = new Uri(Navigation.Uri)
-                        .GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
-                    var cultureEscaped = Uri.EscapeDataString(value.Name);
-                    var uriEscaped = Uri.EscapeDataString(uri);
+                var uri = new Uri(Navigation.Uri)
+                    .GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
+                var cultureEscaped = Uri.EscapeDataString(value.Name);
+                var uriEscaped = Uri.EscapeDataString(uri);
 
-                    Navigation.NavigateTo(
-                        $"Culture/Set?culture={cultureEscaped}&redirectUri={uriEscaped}",
-                        forceLoad: true);
+                Navigation.NavigateTo(
+                    $"Culture/Set?culture={cultureEscaped}&redirectUri={uriEscaped}",
+                    forceLoad: true);
             }
         }
     }
@@ -1150,7 +1150,6 @@ Add both the `CultureClient` and `CultureServer` components to the sidebar navig
         <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Culture (Server)
     </NavLink>
 </div>
-
 <div class="nav-item px-3">
     <NavLink class="nav-link" href="culture-client">
         <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Culture (Client)


### PR DESCRIPTION
Fixes #30002
Addresses #28161

@hishamco ... I have another 🙈 ***RexHacks!***&trade; 🦖 approach here. It ***SEEMS*** to work, but IDK if there are some 🐉🐉🐉 with what I did or some lurking 😈😈😈 in here.

Because of the complexity of this, I thought you might want to pull it down and run it locally, so I placed my test app at ...

https://github.com/guardrex/BlazorCulturePerComponentInteractivity

### Question 1

There is one thing here that I don't understand. When changing the culture from a CSR component (in the sample app, changing it from the `CultureClient` component), it does seem to update the localization cookie and carryover to the server-rendered component (in the sample app if you then navigate to the `CultureServer` component). It's not clear to me where/how the localization cookie is being updated when that happens. The controller action in the server app isn't called when the culture is changed client-side, and I didn't think that Localization Middleware was reading the updated value from local storage. However, it seems to work. If you can see where/how the culture is being carried over to SSR, I'll add an explanation on it to the article text.

### Question 2

... and another ❓on the delta between the Chilean Spanish date format SSR vs. CSR.

SSR it's in the format ... 23-02-2024
CSR it's in the format ... 23/2/2024

Any idea on why that format is changing in an odd way? It's another odd behavioral difference that I'll explain in the article if it's known why it happens.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/globalization-localization.md](https://github.com/dotnet/AspNetCore.Docs/blob/c98c0ad7941d850291b574b1ac0188bd2d857e41/aspnetcore/blazor/globalization-localization.md) | [ASP.NET Core Blazor globalization and localization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?branch=pr-en-us-31894) |


<!-- PREVIEW-TABLE-END -->