### PR TITLE
Add step to hosted Blazor WASM migration guidance

### DIFF
--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -411,7 +411,13 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
        .AddInteractiveWebAssemblyComponents();
    ```
 
-   Add [Antiforgery Middleware](xref:blazor/security/index#antiforgery-support) to the request processing pipeline immediately after the call to `app.UseRouting`. If there are calls to `app.UseRouting` and `app.UseEndpoints`, the call to `app.UseAntiforgery` must go between them. Calls to `app.UseAntiforgery` must be placed after calls to `app.UseAuthentication` and `app.UseAuthorization`.
+   Add [Antiforgery Middleware](xref:blazor/security/index#antiforgery-support) to the request processing pipeline.
+
+   Place the following code:
+
+   * After the call to `app.UseRouting`.
+   * If there are calls to `app.UseRouting` and `app.UseEndpoints`, the call to `app.UseAntiforgery` must go between them.
+   * The call to `app.UseAntiforgery` must be placed after a call to `app.UseAuthorization`, if present.
 
    ```csharp
    app.UseAntiforgery();

--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -356,6 +356,13 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
    - <title>...</title>
    ```
 
+   Change the [CSS style bundle](xref:blazor/components/css-isolation#css-isolation-bundling):
+
+   ```diff
+   - <link href="{CLIENT ASSEMBLY NAME}.styles.css" rel="stylesheet">
+   + <link href="{SERVER ASSEMBLY NAME}.styles.css" rel="stylesheet">
+   ```
+
    Add the `HeadOutlet` component at the end of the `<head>` content with the Interactive WebAssembly render mode (prerendering disabled):
 
    ```razor

--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -359,9 +359,14 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
    Change the [CSS style bundle](xref:blazor/components/css-isolation#css-isolation-bundling):
 
    ```diff
-   - <link href="{CLIENT ASSEMBLY NAME}.styles.css" rel="stylesheet">
-   + <link href="{SERVER ASSEMBLY NAME}.styles.css" rel="stylesheet">
+   - <link href="{CLIENT PROJECT ASSEMBLY NAME}.styles.css" rel="stylesheet">
+   + <link href="{SERVER PROJECT ASSEMBLY NAME}.styles.css" rel="stylesheet">
    ```
+
+   Placeholders in the preceding code:
+
+   * `{CLIENT PROJECT ASSEMBLY NAME}`: Client project assembly name. Example: `BlazorSample.Client`
+   * `{SERVER PROJECT ASSEMBLY NAME}`: Server project assembly name. Example: `HostedBlazorSample`
 
    Add the `HeadOutlet` component at the end of the `<head>` content with the Interactive WebAssembly render mode (prerendering disabled):
 

--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -366,7 +366,7 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
    Placeholders in the preceding code:
 
    * `{CLIENT PROJECT ASSEMBLY NAME}`: Client project assembly name. Example: `BlazorSample.Client`
-   * `{SERVER PROJECT ASSEMBLY NAME}`: Server project assembly name. Example: `HostedBlazorSample`
+   * `{SERVER PROJECT ASSEMBLY NAME}`: Server project assembly name. Example: `BlazorSample`
 
    Add the `HeadOutlet` component at the end of the `<head>` content with the Interactive WebAssembly render mode (prerendering disabled):
 


### PR DESCRIPTION
Fixes #31907

Thanks @Stra1ghter! 🚀 ... I think this should leave the "`.Client`" segment out because that's part of the client project's assembly name, and assembly name is what is used in the placeholder for what to change.

... but I just added a description of the placeholders with examples.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/70-80.md](https://github.com/dotnet/AspNetCore.Docs/blob/345b973391a0b5020342b8138471c03d390eaa30/aspnetcore/migration/70-80.md) | [Migrate from ASP.NET Core in .NET 7 to .NET 8](https://review.learn.microsoft.com/en-us/aspnet/core/migration/70-80?branch=pr-en-us-31908) |


<!-- PREVIEW-TABLE-END -->