### PR TITLE
Blazor - Synchronization context - circuit-scoped emulation of single threaded environment

### DIFF
--- a/aspnetcore/blazor/components/synchronization-context.md
+++ b/aspnetcore/blazor/components/synchronization-context.md
@@ -12,7 +12,7 @@ uid: blazor/components/sync-context
 
 Blazor uses a synchronization context (<xref:System.Threading.SynchronizationContext>) to enforce a single logical thread of execution. A component's [lifecycle methods](xref:blazor/components/lifecycle) and event callbacks raised by Blazor are executed on the synchronization context.
 
-Blazor's server-side synchronization context attempts to emulate a single-threaded environment so that it closely matches the WebAssembly model in the browser, which is single threaded. At any given point in time, work is performed on exactly one thread, which yields the impression of a single logical thread. No two operations execute concurrently.
+Blazor's server-side synchronization context attempts to emulate a single-threaded environment so that it closely matches the WebAssembly model in the browser, which is single threaded. This emulation is scoped only to an individual circuit, meaning two different circuits can run in parallel. At any given point in time within a circuit, work is performed on exactly one thread, which yields the impression of a single logical thread. No two operations execute concurrently within the same circuit.
 
 [!INCLUDE[](~/blazor/includes/location-client-and-server-pre-net8.md)]
 


### PR DESCRIPTION
I believe the emulation of a single-threaded environment in Blazor server-side is scoped only to an individual circuit (or a request for static SSR).

(It seems the multi-threading will be part of net9, but for now...)

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/synchronization-context.md](https://github.com/dotnet/AspNetCore.Docs/blob/589bfabbe2f14181cac69bd931ac390ed7c301cd/aspnetcore/blazor/components/synchronization-context.md) | [ASP.NET Core Blazor synchronization context](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/synchronization-context?branch=pr-en-us-31910) |

<!-- PREVIEW-TABLE-END -->