### PR TITLE
Hub page update per data and OKR

### DIFF
--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -53,6 +53,9 @@ conceptualContent:
     - title: "HTTP API apps"
       summary: Develop HTTP services with ASP.NET Core
       links:
+        - url: fundamentals/apis.md
+          itemType: overview
+          text: "Overview"
         - url: tutorials/min-web-api.md
           itemType: get-started
           text: "Create a minimal web API with ASP.NET Core"
@@ -62,12 +65,6 @@ conceptualContent:
         - url: tutorials/web-api-help-pages-using-swagger.md
           itemType: tutorial
           text: "Generate web API help pages with Swagger / OpenAPI"
-        - url: web-api/action-return-types.md
-          itemType: concept
-          text: "Controller action return types"
-        - url: fundamentals/apis.md
-          itemType: overview
-          text: "See more"
     # Card
     - title: "Interactive client-side Blazor apps"
       summary: Develop with reusable UI components that can take advantage of WebAssembly for near-native performance
@@ -75,15 +72,15 @@ conceptualContent:
         - url: blazor/index.md
           itemType: overview
           text: "Overview"
+        - url: blazor/hosting-models.md
+          itemType: concept
+          text: "Blazor hosting models"
         - url: https://dotnet.microsoft.com/learn/aspnet/blazor-tutorial/intro
           itemType: get-started
           text: "Build your first Blazor app"
         - url: blazor/tutorials/build-a-blazor-app.md
           itemType: get-started
           text: "Build your first Blazor app with reusable components"
-        - url: blazor/hosting-models.md
-          itemType: concept
-          text: "Blazor hosting models"
     # Card
     - title: "Page-focused web UI with Razor Pages"
       summary: "Develop page-focused web apps with a clean separation of concerns"
@@ -123,9 +120,6 @@ conceptualContent:
     - title: Data-driven web apps
       summary: "Create data-driven web apps in ASP.NET Core"
       links:
-        - url: tutorials/first-mvc-app/start-mvc.md
-          itemType: tutorial
-          text: "SQL with ASP.NET Core"
         - url: blazor/components/data-binding.md
           itemType: concept
           text: "Data binding in ASP.NET Core Blazor"
@@ -138,6 +132,9 @@ conceptualContent:
         - url: data/ef-mvc/intro.md
           itemType: tutorial
           text: "Entity Framework Core with ASP.NET Core MVC"
+        - url: tutorials/first-mvc-app/start-mvc.md
+          itemType: tutorial
+          text: "Get started with ASP.NET Core MVC (SQL Server Express and SQLite)"
       # Card
     - title: Real-time web apps with SignalR
       summary: "Add real-time functionality to your web app, enable server-side code to push content instantly"
@@ -176,15 +173,6 @@ conceptualContent:
         - url: grpc/comparison.md
           itemType: concept
           text: "Compare gRPC services with HTTP APIs"
-        - url: grpc/aspnetcore.md
-          itemType: tutorial
-          text: "Add a gRPC service to an ASP.NET Core app"
-        - url: grpc/client.md
-          itemType: tutorial
-          text: "Call gRPC services with the .NET client"
-        - url: grpc/browser.md
-          itemType: tutorial
-          text: "Use gRPC in browser apps"
       # Card
     - title: Previous ASP.NET framework versions
       summary: "Explore overviews, tutorials, fundamental concepts, architecture and API reference for previous ASP.NET framework versions"

--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -65,7 +65,7 @@ conceptualContent:
         - url: web-api/action-return-types.md
           itemType: concept
           text: "Controller action return types"
-        - url: /fundamentals/api.md
+        - url: fundamentals/api.md
           itemType: overview
           text: "See more"
     # Card
@@ -97,7 +97,7 @@ conceptualContent:
         - url: mvc/views/razor.md
           itemType: concept
           text: "Razor syntax"
-        - url: razor-pages.md
+        - url: razor-pages/index.md
           itemType: overview
           text: "See more"
     # Card

--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -65,7 +65,7 @@ conceptualContent:
         - url: web-api/action-return-types.md
           itemType: concept
           text: "Controller action return types"
-        - url: fundamentals/api.md
+        - url: fundamentals/apis.md
           itemType: overview
           text: "See more"
     # Card

--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -11,7 +11,7 @@ metadata:
   ms.topic: hub-page
   author: WadePickett
   ms.author: wpickett
-  ms.date: 05/12/2023
+  ms.date: 02/23/2024
 
 # highlightedContent section (optional)
 # Maximum of 8 items
@@ -22,10 +22,10 @@ highlightedContent:
     - title: "Create an ASP.NET Core app on any platform in 5 minutes"
       itemType: get-started
       url: getting-started/index.md
-      # Card
-    - title: "Give feedback on ASP.NET docs"
-      itemType: whats-new
-      url: https://www.research.net/r/JKSX8BM
+    # Card
+    - title: "Create your first web UI"
+      itemType: get-started
+      url: tutorials/razor-pages/razor-pages-start.md
     # Card
     - title: "ASP.NET Core overview"
       itemType: overview
@@ -35,10 +35,6 @@ highlightedContent:
       itemType: download
       url: https://dotnet.microsoft.com/download
     # Card
-    - title: "Create your first web UI"
-      itemType: get-started
-      url: tutorials/razor-pages/razor-pages-start.md
-    # Card
     - title: "Create your first web API"
       itemType: get-started
       url: tutorials/min-web-api.md
@@ -46,10 +42,6 @@ highlightedContent:
     - title: "Create your first real-time web app"
       itemType: get-started
       url: tutorials/signalr.md
-    # Card
-    - title: "ASP.NET 4.x Documentation"
-      itemType: overview
-      url: /aspnet/overview
 
 # conceptualContent section (optional)
 conceptualContent:
@@ -57,6 +49,25 @@ conceptualContent:
   title: Develop ASP.NET Core apps # < 60 chars (optional)
   summary: "Choose interactive web apps, web API, MVC-patterned apps, real-time apps, and more"
   items:
+    # Card
+    - title: "HTTP API apps"
+      summary: Develop HTTP services with ASP.NET Core
+      links:
+        - url: tutorials/min-web-api.md
+          itemType: get-started
+          text: "Create a minimal web API with ASP.NET Core"
+        - url: /training/modules/build-web-api-net-core/
+          itemType: learn
+          text: "Create a web API with ASP.NET Core Controllers"
+        - url: tutorials/web-api-help-pages-using-swagger.md
+          itemType: tutorial
+          text: "Generate web API help pages with Swagger / OpenAPI"
+        - url: web-api/action-return-types.md
+          itemType: concept
+          text: "Controller action return types"
+        - url: /fundamentals/api.md
+          itemType: overview
+          text: "See more"
     # Card
     - title: "Interactive client-side Blazor apps"
       summary: Develop with reusable UI components that can take advantage of WebAssembly for near-native performance
@@ -74,31 +85,6 @@ conceptualContent:
           itemType: concept
           text: "Blazor hosting models"
     # Card
-    - title: HTTP API apps
-      summary: Develop HTTP services with ASP.NET Core
-      links:
-        - url: tutorials/min-web-api.md
-          itemType: get-started
-          text: "Create a minimal web API with ASP.NET Core"
-        - url: /training/modules/build-web-api-net-core/
-          itemType: learn
-          text: "Create a web API with ASP.NET Core Controllers"
-        - url: tutorials/web-api-help-pages-using-swagger.md
-          itemType: tutorial
-          text: "Generate web API help pages with Swagger / OpenAPI"
-        - url: web-api/action-return-types.md
-          itemType: concept
-          text: "Controller action return types"
-        - url: web-api/advanced/formatting.md
-          itemType: concept
-          text: "Format response data"
-        - url: web-api/handle-errors.md
-          itemType: concept
-          text: "Handle errors"
-        - url: tutorials/web-api-javascript.md
-          itemType: tutorial
-          text: "Call an ASP.NET Core web API with JavaScript"
-    # Card
     - title: "Page-focused web UI with Razor Pages"
       summary: "Develop page-focused web apps with a clean separation of concerns"
       links:
@@ -111,15 +97,9 @@ conceptualContent:
         - url: mvc/views/razor.md
           itemType: concept
           text: "Razor syntax"
-        - url: razor-pages/filter.md
-          itemType: concept
-          text: "Filters"
-        - url: razor-pages/razor-pages-conventions.md
-          itemType: concept
-          text: "Routing"
-        - url: /training/modules/aspnet-core-accessibility
-          itemType: concept
-          text: "Accessible ASP.NET Core web apps"
+        - url: razor-pages.md
+          itemType: overview
+          text: "See more"
     # Card
     - title: Page-focused web UI with MVC
       summary: "Develop web apps using the Model-View-Controller design pattern"
@@ -133,18 +113,31 @@ conceptualContent:
         - url: mvc/views/overview.md
           itemType: concept
           text: "Views"
-        - url: mvc/views/partial.md
-          itemType: concept
-          text: "Partial views"
         - url: mvc/controllers/actions.md
           itemType: concept
           text: "Controllers"
         - url: mvc/controllers/routing.md
           itemType: concept
           text: "Routing to controller actions"
-        - url: mvc/controllers/testing.md
+    # Card
+    - title: Data-driven web apps
+      summary: "Create data-driven web apps in ASP.NET Core"
+      links:
+        - url: tutorials/first-mvc-app/start-mvc.md
+          itemType: tutorial
+          text: "SQL with ASP.NET Core"
+        - url: blazor/components/data-binding.md
           itemType: concept
-          text: "Unit test"
+          text: "Data binding in ASP.NET Core Blazor"
+        - url: tutorials/razor-pages/razor-pages-start.md
+          itemType: tutorial
+          text: "SQL Server Express and Razor Pages"
+        - url: data/ef-rp/intro.md
+          itemType: tutorial
+          text: "Entity Framework Core with Razor Pages"
+        - url: data/ef-mvc/intro.md
+          itemType: tutorial
+          text: "Entity Framework Core with ASP.NET Core MVC"
       # Card
     - title: Real-time web apps with SignalR
       summary: "Add real-time functionality to your web app, enable server-side code to push content instantly"
@@ -164,15 +157,6 @@ conceptualContent:
         - url: https://github.com/aspnet/SignalR-samples
           itemType: sample
           text: "Samples"
-        - url: signalr/hubs.md
-          itemType: concept
-          text: "Hubs"
-        - url: signalr/client-features.md
-          itemType: concept
-          text: "SignalR client features"
-        - url: signalr/scale.md
-          itemType: concept
-          text: "Host and scale"
       # Card
     - title: Remote Procedure Call (RPC) apps - gRPC services
       summary: "Develop contract-first, high-performance services with gRPC in ASP.NET Core"
@@ -201,37 +185,6 @@ conceptualContent:
         - url: grpc/browser.md
           itemType: tutorial
           text: "Use gRPC in browser apps"
-      # Card
-    - title: Data-driven web apps
-      summary: "Create data-driven web apps in ASP.NET Core"
-      links:
-        - url: tutorials/first-mvc-app/start-mvc.md
-          itemType: tutorial
-          text: "SQL with ASP.NET Core"
-        - url: blazor/components/data-binding.md
-          itemType: concept
-          text: "Data binding in ASP.NET Core Blazor"
-        - url: tutorials/razor-pages/razor-pages-start.md
-          itemType: tutorial
-          text: "SQL Server Express and Razor Pages"
-        - url: data/ef-rp/intro.md
-          itemType: tutorial
-          text: "Entity Framework Core with Razor Pages"
-        - url: data/ef-mvc/intro.md
-          itemType: tutorial
-          text: "Entity Framework Core with ASP.NET Core MVC"
-        - url: /visualstudio/azure/vs-azure-tools-connected-services-storage?view=vs-2022
-          itemType: tutorial
-          text: "Azure Storage"
-        - url: /azure/storage/blobs/storage-quickstart-blobs-dotnet
-          itemType: tutorial
-          text: "Blob Storage"
-        - url: /azure/storage/tables/table-storage-overview?bc=%252faspnet%252fcore%252fbreadcrumb%252ftoc.json&toc=%252faspnet%252fcore%252ftoc.json&view=aspnetcore-6.0
-          itemType: concept
-          text: "Azure Table Storage"
-        - url: /training/paths/m365-msgraph-dotnet-core-scenarios
-          itemType: concept
-          text: "Microsoft Graph scenarios for ASP.NET Core"
       # Card
     - title: Previous ASP.NET framework versions
       summary: "Explore overviews, tutorials, fundamental concepts, architecture and API reference for previous ASP.NET framework versions"


### PR DESCRIPTION
[Internal review: Hub page for ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/?branch=pr-en-us-31913&view=aspnetcore-9.0)

Fixes #31578 

The ASP.NET Core hub page was specified as one of the Hub pages that could use some changes per hub OKR.  It had some high traffic links below the fold that needed to move up, some low traffic links above the fold where we provided too many doc choices per app type, and too many duplicate links.


- I reviewed traffic, clickthrough, exit rate, bounce, heatmap, and general report data available.
- Verified what should move above the fold per that data.
- Reviewed current published HUB with OKR stakeholders for suggestions per site wide initiative for Hub pages.
- Removed some duplicate links where it made sense.

**Top section:**
Summary: We can move the overall choices here to a more reasonable 6 by removing a low traffic card and high bounce/somewhat low traffic duplicate link.

**Remove Give feedback on ASP.NET Docs**
Why: It was receiving low relative traffic, and we have a feedback link on every single doc.

**Remove ASP.NET 4.x Documentation card.**
Why:  
- It had high bounce. 
  - We suspect folks are going there expecting the whole doc set or latest then bouncing out when they don't find that.  Being at the top as one of the first cards that indicates "Documentation" may be causing some confusion.
- It is a duplicate.  We have that link in a clear context on the "Previous ASP.NET framework versions" card.

Follow up:
- Watch the bounce rate for this after this PR change for the month of March, if it goes down significantly then the problem is the context it is presented in.  If the bounce rate stays high, we may have a different issue.

**2nd Section: Develop ASP.NET Core apps**

**Move HTTP API apps to the first position and move Interactive client-side Blazor apps to the 2nd postion**
Why:  _API_ has 3 times as much traffic than the _Blazor_ apps card which was in the first position and _API_ is about a 3rd more than _Create your first web UI_ which has its own top section card.

**Remove long tail sub-subject's links from each app card** 
Why: Specifically where they are around 0.15% of link traffic where we have more than 4 links to fit more towards the top of the fold and to avoid overwhelming with too many choices for lower interest topics.

**3rd Section:**
I left this last section alone.  It is all below the fold. It didn't have any high traffic interest areas that needed to move up to be faster to find.  It also doesn't hurt anything to leave those topics there and discoverable even though overall they are low traffic links.
