### PR TITLE
Update logindisplay-component.md

### DIFF
--- a/aspnetcore/blazor/security/includes/logindisplay-component.md
+++ b/aspnetcore/blazor/security/includes/logindisplay-component.md
@@ -1,4 +1,4 @@
-The `LoginDisplay` component (`Layout/LoginDisplay.razor`) is rendered in the `MainLayout` component (`Layout/MainLayout.razor`) and manages the following behaviors:
+The `LoginDisplay` component (`LoginDisplay.razor`) is rendered in the `MainLayout` component (`MainLayout.razor`) and manages the following behaviors:
 
 * For authenticated users:
   * Displays the current user name.
@@ -11,6 +11,6 @@ The `LoginDisplay` component (`Layout/LoginDisplay.razor`) is rendered in the `M
 Due to changes in the framework across releases of ASP.NET Core, Razor markup for the `LoginDisplay` component isn't shown in this section. To inspect the markup of the component for a given release, use ***either*** of the following approaches:
 
 * Create an app provisioned for authentication from the default Blazor WebAssembly project template for the version of ASP.NET Core that you intend to use. Inspect the `LoginDisplay` component in the generated app.
-* Inspect the `LoginDisplay` component in [reference source](https://github.com/dotnet/aspnetcore/blob/release/7.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/Shared/LoginDisplay.IndividualLocalAuth.razor). The templated content for `Hosted` equal to `true` is used.
+* Inspect the `LoginDisplay` component in [reference source](https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp). The location of the component changed over time, so use GitHub search tools to locate the component. The templated content for `Hosted` equal to `true` is used.
 
   [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]

--- a/aspnetcore/blazor/security/includes/logindisplay-component.md
+++ b/aspnetcore/blazor/security/includes/logindisplay-component.md
@@ -1,4 +1,4 @@
-The `LoginDisplay` component (`Shared/LoginDisplay.razor`) is rendered in the `MainLayout` component (`Shared/MainLayout.razor`) and manages the following behaviors:
+The `LoginDisplay` component (`Layout/LoginDisplay.razor`) is rendered in the `MainLayout` component (`Layout/MainLayout.razor`) and manages the following behaviors:
 
 * For authenticated users:
   * Displays the current user name.


### PR DESCRIPTION
It is inside "Layout" folder and not "Shared". I have checked it in .NET 8.0 version of blazor wasm project.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->