### PR TITLE
Blazor - layouts.md - _Imports.razor file

### DIFF
--- a/aspnetcore/blazor/components/layouts.md
+++ b/aspnetcore/blazor/components/layouts.md
@@ -181,7 +181,7 @@ The following rendered HTML markup is produced by the preceding `DoctorWhoLayout
 
 Specifying the layout directly in a component overrides a *default layout*:
 
-* Set by an `@layout` directive imported from an `_Imports` component (`_Imports.razor`), as described in the following [Apply a layout to a folder of components](#apply-a-layout-to-a-folder-of-components) section.
+* Set by an `@layout` directive imported from an `_Imports.razor` file, as described in the following [Apply a layout to a folder of components](#apply-a-layout-to-a-folder-of-components) section.
 * Set as the app's default layout, as described in the [Apply a default layout to an app](#apply-a-default-layout-to-an-app) section later in this article.
 
 ### Apply a layout to a folder of components


### PR DESCRIPTION
`_Imports.razor` is not a component.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/layouts.md](https://github.com/dotnet/AspNetCore.Docs/blob/d9a4ed1561514b2832ab022fab04fe9c322ea2f4/aspnetcore/blazor/components/layouts.md) | [ASP.NET Core Blazor layouts](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/layouts?branch=pr-en-us-31930) |

<!-- PREVIEW-TABLE-END -->