### PR TITLE
[Blazor] Performance - Too many parameters timing calculations correction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,5 +31,8 @@
         "MD025": {
             "front_matter_title": ""
         }
-    }
+    },
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,8 +31,5 @@
         "MD025": {
             "front_matter_title": ""
         }
-    },
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "main"
-    ]
+    }
 }

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -210,7 +210,7 @@ protected RenderFragment DisplayTitle =>
 
 If a component repeats extremely often, for example, hundreds or thousands of times, the overhead of passing and receiving each parameter builds up.
 
-It's rare that too many parameters severely restricts performance, but it can be a factor. For a `TableCell` component that renders 4,000 times within a grid, each parameter passed to the component adds around 15 ms to the total rendering cost. Parameter passing for ten parameters would take around 150 ms in total and cause a UI rendering lag.
+It's rare that too many parameters severely restricts performance, but it can be a factor. For a `TableCell` component that renders 4,000 times within a grid, each parameter passed to the component adds around 15 ms to the total rendering cost. Passing ten parameters requires around 150 ms and causes a UI rendering lag.
 
 To reduce parameter load, bundle multiple parameters in a custom class. For example, a table cell component might accept a common object. In the following example, `Data` is different for every cell, but `Options` is common across all cell instances:
 

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -210,7 +210,7 @@ protected RenderFragment DisplayTitle =>
 
 If a component repeats extremely often, for example, hundreds or thousands of times, the overhead of passing and receiving each parameter builds up.
 
-It's rare that too many parameters severely restricts performance, but it can be a factor. For a `TableCell` component that renders 1,000 times within a grid, each extra parameter passed to the component could add around 15 ms to the total rendering cost. If each cell accepted 10 parameters, parameter passing would take around 150 ms per component for a total rendering cost of 150,000 ms (150 seconds) and cause a UI rendering lag.
+It's rare that too many parameters severely restricts performance, but it can be a factor. For a `TableCell` component that renders 1,000 times within a grid, each extra parameter passed to the component could add around 15 ms to the total rendering cost. If each cell accepted 10 parameters, parameter passing would take around 150 ms in total and cause a UI rendering lag.
 
 To reduce parameter load, bundle multiple parameters in a custom class. For example, a table cell component might accept a common object. In the following example, `Data` is different for every cell, but `Options` is common across all cell instances:
 

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -210,7 +210,7 @@ protected RenderFragment DisplayTitle =>
 
 If a component repeats extremely often, for example, hundreds or thousands of times, the overhead of passing and receiving each parameter builds up.
 
-It's rare that too many parameters severely restricts performance, but it can be a factor. For a `TableCell` component that renders 1,000 times within a grid, each extra parameter passed to the component could add around 15 ms to the total rendering cost. If each cell accepted 10 parameters, parameter passing would take around 150 ms in total and cause a UI rendering lag.
+It's rare that too many parameters severely restricts performance, but it can be a factor. For a `TableCell` component that renders 4,000 times within a grid, each parameter passed to the component adds around 15 ms to the total rendering cost. Parameter passing for ten parameters would take around 150 ms in total and cause a UI rendering lag.
 
 To reduce parameter load, bundle multiple parameters in a custom class. For example, a table cell component might accept a common object. In the following example, `Data` is different for every cell, but `Options` is common across all cell instances:
 


### PR DESCRIPTION
> It's rare that too many parameters severely restricts performance, but it can be a factor. For a `TableCell` component that renders 1,000 times within a grid, each extra parameter passed to the component could add around 15 ms to the total rendering cost. If each cell accepted 10 parameters, parameter passing would take around 150 ms per component for a total rendering cost of 150 ms (0.15 seconds) and cause a UI rendering lag.

I believe the original information from benchmarks was "when rendering 1,000 `TableCells`, adding one more parameter adds 15 ms to the total rendering cost". With 10 parameters, it's 150 ms in total (still with the original 1,000 `TableCells` involved), not 150,000 ms (150 sec). The 150-sec number is too high to believe. ;-)

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/performance.md](https://github.com/dotnet/AspNetCore.Docs/blob/18f8a9dbe887f472d27a84aa1fdf6f70cef945c7/aspnetcore/blazor/performance.md) | [ASP.NET Core Blazor performance best practices](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/performance?branch=pr-en-us-31959) |


<!-- PREVIEW-TABLE-END -->