### PR TITLE
Refine the log category convention

### DIFF
--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -222,11 +222,11 @@ Logs that begin with "Microsoft" categories are from ASP.NET Core framework code
 
 ## Log category
 
-When an `ILogger` object is created, a *category* is specified. That category is included with each log message created by that instance of `ILogger`. The category string is arbitrary, but the convention is to use the class name. For example, in a controller the name might be `"TodoApi.Controllers.TodoController"`. The ASP.NET Core web apps use `ILogger<T>` to automatically get an `ILogger` instance that uses the fully qualified type name of `T` as the category:
+When an `ILogger` object is created, a *category* is specified. That category is included with each log message created by that instance of `ILogger`. The category string is arbitrary, but the convention is to use the fully qualified class name. For example, in a controller the name might be `"TodoApi.Controllers.TodoController"`. The ASP.NET Core web apps use `ILogger<T>` to automatically get an `ILogger` instance that uses the fully qualified type name of `T` as the category:
 
 [!code-csharp[](~/fundamentals/logging/index/samples/3.x/TodoApiDTO/Pages/Privacy.cshtml.cs?name=snippet)]
 
-To explicitly specify the category, call `ILoggerFactory.CreateLogger`:
+If further categorization is desired, the convention is to use a hierarchical name by appending a subcategory to the fully qualified class name, and explicitly specify the category using `ILoggerFactory.CreateLogger`:
 
 [!code-csharp[](~/fundamentals/logging/index/samples/3.x/TodoApiDTO/Pages/Contact.cshtml.cs?name=snippet)]
 

--- a/aspnetcore/fundamentals/logging/index/samples/3.x/TodoApiDTO/Pages/Contact.cshtml.cs
+++ b/aspnetcore/fundamentals/logging/index/samples/3.x/TodoApiDTO/Pages/Contact.cshtml.cs
@@ -10,7 +10,7 @@ namespace TodoApi.Pages
 
         public ContactModel(ILoggerFactory logger)
         {
-            _logger = logger.CreateLogger("MyCategory");
+            _logger = logger.CreateLogger("TodoApi.Pages.ContactModel.MyCategory");
         }
 
         public void OnGet()


### PR DESCRIPTION
This is a follow up to https://github.com/open-telemetry/opentelemetry-dotnet/pull/5405#discussion_r1508527541 based on discussion with @noahfalk and @tarekgh.

Related to https://github.com/dotnet/docs/pull/39777.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/logging/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/1a402ddca98bb99fa2fb6a6046d2016001f3e0d1/aspnetcore/fundamentals/logging/index.md) | [Logging in .NET Core and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/logging/index?branch=pr-en-us-31963) |

<!-- PREVIEW-TABLE-END -->