### PR TITLE
Add Bootstrap to Blazor Hybrid tutorials

### DIFF
--- a/aspnetcore/blazor/hybrid/tutorials/windows-forms.md
+++ b/aspnetcore/blazor/hybrid/tutorials/windows-forms.md
@@ -89,6 +89,7 @@ Add an `index.html` file to the `wwwroot` folder with the following markup.
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WinFormsBlazor</title>
     <base href="/" />
+    <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet" />
     <link href="css/app.css" rel="stylesheet" />
     <link href="WinFormsBlazor.styles.css" rel="stylesheet" />
 </head>
@@ -166,6 +167,8 @@ a, .btn-link {
         top: 0.5rem;
     }
 ```
+
+Inside the `wwwroot/css` folder, create a `bootstrap` folder. Inside the `bootstrap` folder, place a copy of `bootstrap.min.css`. You can obtain the latest version of `bootstrap.min.css` from the [Bootstrap website](https://getbootstrap.com/). Follow navigation bar links to **Docs** > **Download**. A direct link can't be provided here because all of the content at the site is versioned in the URL.
 
 Add the following `Counter` component to the root of the project, which is the default `Counter` component found in Blazor project templates.
 

--- a/aspnetcore/blazor/hybrid/tutorials/wpf.md
+++ b/aspnetcore/blazor/hybrid/tutorials/wpf.md
@@ -181,6 +181,8 @@ a, .btn-link {
     }
 ```
 
+Inside the `wwwroot/css` folder, create a `bootstrap` folder. Inside the `bootstrap` folder, place a copy of `bootstrap.min.css`. You can obtain the latest version of `bootstrap.min.css` from the [Bootstrap website](https://getbootstrap.com/). Follow navigation bar links to **Docs** > **Download**. A direct link can't be provided here because all of the content at the site is versioned in the URL.
+
 Add the following `Counter` component to the root of the project, which is the default `Counter` component found in Blazor project templates.
 
 `Counter.razor`:


### PR DESCRIPTION
Fixes #31995

Thanks @alvinashcraft! 🚀 ... I added it to the WinForms tutorial as well. I don't have time to test it there, but I'm sure a reader will come after me if it fails 💀😨😄. One sad thing in this ... Bootstrap versions ***ALL*** of their content at their website, including their download page, so I can't add a direct link here. I must tell readers in the text how to navigate at their site. They might have a permalink system, but IDK if they have it or how to get a hard (versionless) link to their download page. I think that's kind'a silly, but whatever ... anyway ... we have the coverage now. Thanks for the issue! 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/tutorials/windows-forms.md](https://github.com/dotnet/AspNetCore.Docs/blob/25f727474f954242ce27e91afc3ca3ae5dbf054c/aspnetcore/blazor/hybrid/tutorials/windows-forms.md) | [Build a Windows Forms Blazor app](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/tutorials/windows-forms?branch=pr-en-us-32005) |
| [aspnetcore/blazor/hybrid/tutorials/wpf.md](https://github.com/dotnet/AspNetCore.Docs/blob/25f727474f954242ce27e91afc3ca3ae5dbf054c/aspnetcore/blazor/hybrid/tutorials/wpf.md) | [Build a Windows Presentation Foundation (WPF) Blazor app](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/tutorials/wpf?branch=pr-en-us-32005) |

<!-- PREVIEW-TABLE-END -->