### PR TITLE
[Blazor] Data binding - @bind-Value:set - EventCallback<T> support

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -211,7 +211,7 @@ Components support two-way data binding by defining a pair of parameters:
 
 The `@bind:get` and `@bind:set` modifiers are always used together.
 
-Using an event callback parameter with `@bind:set` (`[Parameter] public EventCallback<string> ValueChanged { get; set; }`) isn't supported. Instead, pass a method that returns an <xref:System.Action> or <xref:System.Threading.Tasks.Task> to `@bind:set`.
+Using appropriate event callback parameter (such as `[Parameter] public EventCallback<string> ValueChanged { get; set; }`) with `@bind:set` is supported.
 
 Examples
 

--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -211,8 +211,6 @@ Components support two-way data binding by defining a pair of parameters:
 
 The `@bind:get` and `@bind:set` modifiers are always used together.
 
-Using appropriate event callback parameter (such as `[Parameter] public EventCallback<string> ValueChanged { get; set; }`) with `@bind:set` is supported.
-
 Examples
 
 `BindGetSet.razor`:


### PR DESCRIPTION
>Using an event callback parameter with `@bind:set` (`[Parameter] public EventCallback<string> ValueChanged { get; set; }`) isn't supported. Instead, pass a method that returns an [Action](https://learn.microsoft.com/en-us/dotnet/api/system.action) or [Task](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task) to `@bind:set`.

I think the `@bind-Value:set` actually supports the `EventCallback<T>`.

The paragraph probably clones the similar statement which is correct:

>Using an [event callback parameter (`EventCallback/EventCallback<T>`)](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?view=aspnetcore-8.0#eventcallback) with `@bind:after` isn't supported. Instead, pass a method that returns an [Action](https://learn.microsoft.com/en-us/dotnet/api/system.action) or [Task](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task) to `@bind:after`.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/data-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/78535ded5a0b0c5612158019f167d4bb1b696fda/aspnetcore/blazor/components/data-binding.md) | [ASP.NET Core Blazor data binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?branch=pr-en-us-32023) |


<!-- PREVIEW-TABLE-END -->