### PR TITLE
Blazor Server script fallback policy authorization

### DIFF
--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -91,6 +91,7 @@ The following migration scenarios are covered:
 * [*New article*: New article on class libraries with static server-side rendering (static SSR)](#new-article-on-class-libraries-with-static-server-side-rendering-static-ssr)
 * [Discover components from additional assemblies](#discover-components-from-additional-assemblies)
 * [Drop `[Parameter]` attribute when the parameter is supplied from a query string](#drop-parameter-attribute-when-the-parameter-is-supplied-from-a-query-string)
+* [Blazor Server script fallback policy authorization](#blazor-server-script-fallback-policy-authorization)
 
 For guidance on adding Blazor support to an ASP.NET Core app, see <xref:blazor/components/integration#add-blazor-support-to-an-aspnet-core-app>.
 
@@ -564,6 +565,43 @@ The `[Parameter]` attribute is no longer required when supplying a parameter fro
 - [Parameter]
   [SupplyParameterFromQuery]
 ```
+
+### Blazor Server script fallback policy authorization
+
+In .NET 7, the Blazor Server script (`blazor.server.js`) is [served by Static Files Middleware](https://github.com/dotnet/aspnetcore/blob/v7.0.16/src/Components/Server/src/DependencyInjection/ConfigureStaticFilesOptions.cs). Placing the call for Static Files Middleware (`UseStaticFiles`) in the request processing pipeline before the call to Authorization Middleware (`UseAuthorization`) is sufficient in .NET 7 apps to serve the Blazor script to anonymous users.
+
+In .NET 8, the Blazor Server script is served [by its own endpoint](https://github.com/search?q=repo%3Adotnet%2Faspnetcore%20GetBlazorEndpoint&type=code), using endpoint routing. This change is introduced by [Fixed bug - Passing options to UseStaticFiles breaks Blazor Server (`dotnet/aspnetcore` #45897)](https://github.com/dotnet/aspnetcore/pull/45897).
+
+Consider a multi-tenant scenario where:
+
+* Both the default and fallback policies are set identically.
+* The tenant is resolved using the first segment in the request path (for example, `tld.com/tenant-name/...`).
+* The requests to tenant endpoints are authenticated by an additional authentication scheme, which adds an additional identity to the request principal.
+* The fallback authorization policy has requirements that check claims via the additional identity.
+
+Requests for the Blazor script file (`blazor.server.js`) are served at `/_framework/blazor.server.js`, which is hardcoded in the framework. Requests for the file aren't authenticated by the additional authentication scheme for tenants ***but are still challenged by the fallback policy***, which results in returning an unauthorized result.
+
+This problem is under evaluation for a new framework feature in [MapRazorComponents broken with FallbackPolicy RequireAuthenticatedUser (`dotnet/aspnetcore` 51836)](https://github.com/dotnet/aspnetcore/issues/51836), which is currently scheduled for .NET 9's release in November, 2024. Until then, you can work around this problem using any of the following three approaches:
+
+* Don't use a fallback policy. Apply the `[Authorize]` attribute in the `_Imports.razor` file to apply it to all of the components of the app. For non-blazor endpoints, explicitly use `[Authorize]` or `RequireAuthorization`.
+
+* Add `[AllowAnonymous]` to the `/_framework/blazor.server.js` endpoint in the `Program` file:
+
+  ```csharp
+  app.MapBlazorHub().Add(endpointBuilder =>
+  {
+      if (endpointBuilder is 
+          RouteEndpointBuilder
+          { 
+              RoutePattern: { RawText: "/_framework/blazor.server.js" }
+          })
+      {
+          endpointBuilder.Metadata.Add(new AllowAnonymousAttribute());
+      }
+  });
+  ```
+
+* Register a custom `AuthorizationHandler` that [checks the `HttpContext`](xref:security/authorization/policies#access-mvc-request-context-in-handlers) to allow the `/_framework/blazor.server.js` file through.
 
 ## Docker
 


### PR DESCRIPTION
Fixes #31931

Thank you @CoskunSunali for that great write-up 🥇. I've combined your remarks with Stephen's response to address this subject in the *Migration* article. It's here for review if you would like to provide feedback 👂.

Stephen said on the issue ...

> It looks like the documentation at https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/blazor/fundamentals/static-files.md ought to be updated to reflect that Blazor static files no longer rely on UseStaticFiles and instead are mapped using endpoint routing.

... but I think I need a more specific change set to update the article. I'm also not generally clear what "Blazor static files" means ... I don't think he meant that Static File Middleware no-ops in BWAs. I think he means that static assets managed by Blazor (the framework) are now (8.0+) mapped via endpoint routing. Anyway, a specific change set for the article would be helpful. I'd like to knock it out 🤜😵 on this PR if possible. If not tho ... I can open a new issue to address it later.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/70-80.md](https://github.com/dotnet/AspNetCore.Docs/blob/8fcca80588eebdbf3d5ca31e2702eedb97fb056d/aspnetcore/migration/70-80.md) | [Migrate from ASP.NET Core in .NET 7 to .NET 8](https://review.learn.microsoft.com/en-us/aspnet/core/migration/70-80?branch=pr-en-us-32035) |

<!-- PREVIEW-TABLE-END -->