### PR TITLE
Server-side behaviors during static SSR

### DIFF
--- a/aspnetcore/blazor/components/layouts.md
+++ b/aspnetcore/blazor/components/layouts.md
@@ -219,13 +219,6 @@ Specifying the layout as a default layout in the <xref:Microsoft.AspNetCore.Comp
 
 To set a layout for arbitrary Razor template content, specify the layout with a <xref:Microsoft.AspNetCore.Components.LayoutView> component. You can use a <xref:Microsoft.AspNetCore.Components.LayoutView> in any Razor component. The following example sets a layout component named `ErrorLayout` for the `MainLayout` component's <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> template (`<NotFound>...</NotFound>`).
 
-:::moniker range=">= aspnetcore-8.0"
-
-> [!NOTE]
-> The following example is specifically for a Blazor WebAssembly app because Blazor Web Apps don't use the <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> template (`<NotFound>...</NotFound>`). However, the template is supported for backward compatibility to avoid a breaking change in the framework. Blazor Web Apps typically process bad URL requests by either displaying the browser's built-in 404 UI or returning a custom 404 page from the ASP.NET Core server via ASP.NET Core middleware (for example, [`UseStatusCodePagesWithRedirects`](xref:fundamentals/error-handling#usestatuscodepageswithredirects) / [API documentation](xref:Microsoft.AspNetCore.Builder.StatusCodePagesExtensions.UseStatusCodePagesWithRedirects%2A)).
-
-:::moniker-end
-
 ```razor
 <Router ...>
     <Found ...>
@@ -240,7 +233,14 @@ To set a layout for arbitrary Razor template content, specify the layout with a 
 </Router>
 ```
 
-You may need to idenfity the layout's namespace depending on the .NET version and type of Blazor app. For more information, see the [Make the layout namespace available](#make-the-layout-namespace-available) section.
+You may need to identity the layout's namespace depending on the .NET version and type of Blazor app. For more information, see the [Make the layout namespace available](#make-the-layout-namespace-available) section.
+
+:::moniker range=">= aspnetcore-8.0"
+
+> [!IMPORTANT]
+> Blazor Web Apps don't use the <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> parameter (`<NotFound>...</NotFound>` markup), but the parameter is supported for backward compatibility to avoid a breaking change in the framework. The server-side ASP.NET Core middleware pipeline processes requests on the server. Use server-side techniques to handle bad requests. For more information, see <xref:blazor/components/render-modes#static-server-side-rendering-static-ssr>.
+
+:::moniker-end
 
 :::moniker range="= aspnetcore-5.0"
 

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -259,7 +259,7 @@ Making a root component, such as the `App` component, interactive with the `@ren
 
 By default, components use static server-side rendering (static SSR). The component renders to the response stream and interactivity isn't enabled.
 
-In the following example, there's no designation for the component's render mode, so the component inherits its render mode from its parent. The parent is the `Routes` component, which doesn't set a render mode for this example, so static SSR is passed down from the root component, which is the `App` component. Therefore, the following component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't rerendered in response to UI events.
+In the following example, there's no designation for the component's render mode, so the component inherits its render mode from its parent. Since no ancestor component specifies a render mode, the following component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't rerendered in response to UI events.
 
 `RenderMode1.razor`:
 
@@ -286,7 +286,7 @@ During static SSR, Razor component page requests behave like Razor Pages and par
 
 * [Not found content (`<NotFound>...</NotFound>`)](xref:blazor/fundamentals/routing#provide-custom-content-when-content-isnt-found) (<xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound>): Blazor Web Apps typically process bad URL requests on the server by either displaying the browser's built-in 404 UI or returning a custom 404 page (or other response) via ASP.NET Core middleware (for example, [`UseStatusCodePagesWithRedirects`](xref:fundamentals/error-handling#usestatuscodepageswithredirects) / [API documentation](xref:Microsoft.AspNetCore.Builder.StatusCodePagesExtensions.UseStatusCodePagesWithRedirects%2A)).
 
-If the app becomes interactive for either interactive SSR or CSR components after static SSR, the server-side ASP.NET Core request processing is no longer acting on requests, which means that the preceding Blazor features work as expected.
+If the app exhibits root-level interactivity, server-side ASP.NET Core request processing isn't involved after the initial static SSR, which means that the preceding Blazor features work as expected.
 
 [Enhanced navigation](xref:blazor/fundamentals/routing#enhanced-navigation-and-form-handling) with static SSR requires special attention when loading JavaScript. For more information, see <xref:blazor/js-interop/ssr>.
 

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -280,7 +280,7 @@ In the following example, there's no designation for the component's render mode
 
 If using the preceding component locally in a Blazor Web App, place the component in the server project's `Components/Pages` folder. The server project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-1` in the browser's address bar.
 
-During static SSR, Razor component page requests behave like Razor Pages and participate in server-side ASP.NET Core middleware pipeline request processing for routing and authorization. Dedicated Blazor features for routing and authorization aren't operational because Razor components aren't rendered during server-side request processing. Blazor router features in the `Routes` component that aren't available during static SSR include displaying:
+During static SSR, Razor component page requests are processed by server-side ASP.NET Core middleware pipeline request processing for routing and authorization. Dedicated Blazor features for routing and authorization aren't operational because Razor components aren't rendered during server-side request processing. Blazor router features in the `Routes` component that aren't available during static SSR include displaying:
 
 * [Not authorized content (`<NotAuthorized>...</NotAuthorized>`)](xref:blazor/security/index#authorizeview-component) (<xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized>): Blazor Web Apps typically process unauthorized requests on the server by [customizing the behavior of Authorization Middleware](xref:security/authorization/authorizationmiddlewareresulthandler).
 

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -257,9 +257,9 @@ Making a root component, such as the `App` component, interactive with the `@ren
 
 ## Static server-side rendering (static SSR)
 
-By default, components use the static server-side rendering (static SSR). The component renders to the response stream and interactivity isn't enabled.
+By default, components use static server-side rendering (static SSR). The component renders to the response stream and interactivity isn't enabled.
 
-In the following example, there's no designation for the component's render mode, and the component inherits the default render mode from its parent. Therefore, the component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't rerendered in response to UI events.
+In the following example, there's no designation for the component's render mode, so the component inherits its render mode from its parent. The parent is the `Routes` component, which doesn't set a render mode for this example, so static SSR is passed down from the root component, which is the `App` component. Therefore, the following component is *statically rendered* on the server. The button isn't interactive and doesn't call the `UpdateMessage` method when selected. The value of `message` doesn't change, and the component isn't rerendered in response to UI events.
 
 `RenderMode1.razor`:
 
@@ -279,6 +279,14 @@ In the following example, there's no designation for the component's render mode
 ```
 
 If using the preceding component locally in a Blazor Web App, place the component in the server project's `Components/Pages` folder. The server project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-1` in the browser's address bar.
+
+During static SSR, Razor component page requests behave like Razor Pages and participate in server-side ASP.NET Core middleware pipeline request processing for routing and authorization. Dedicated Blazor features for routing and authorization aren't operational because Razor components aren't rendered during server-side request processing. Blazor router features in the `Routes` component that aren't available during static SSR include displaying:
+
+* [Not authorized content (`<NotAuthorized>...</NotAuthorized>`)](xref:blazor/security/index#authorizeview-component) (<xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized>): Blazor Web Apps typically process unauthorized requests on the server by [customizing the behavior of Authorization Middleware](xref:security/authorization/authorizationmiddlewareresulthandler).
+
+* [Not found content (`<NotFound>...</NotFound>`)](xref:blazor/fundamentals/routing#provide-custom-content-when-content-isnt-found) (<xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound>): Blazor Web Apps typically process bad URL requests on the server by either displaying the browser's built-in 404 UI or returning a custom 404 page (or other response) via ASP.NET Core middleware (for example, [`UseStatusCodePagesWithRedirects`](xref:fundamentals/error-handling#usestatuscodepageswithredirects) / [API documentation](xref:Microsoft.AspNetCore.Builder.StatusCodePagesExtensions.UseStatusCodePagesWithRedirects%2A)).
+
+If the app becomes interactive for either interactive SSR or CSR components after static SSR, the server-side ASP.NET Core request processing is no longer acting on requests, which means that the preceding Blazor features work as expected.
 
 [Enhanced navigation](xref:blazor/fundamentals/routing#enhanced-navigation-and-form-handling) with static SSR requires special attention when loading JavaScript. For more information, see <xref:blazor/js-interop/ssr>.
 
@@ -666,13 +674,13 @@ Each component that must adopt static SSR sets the custom layout and does ***not
 >
 > A `null` render mode is effectively the same as not specifying a render mode, which results in the component inheriting its parent's render mode. In this case, the `App` component is rendered using static SSR, so a `null` render mode results in the `Routes` component inheriting static SSR from the `App` component. If a null render mode is specified for a child component whose parent uses an interactive render mode, the child inherits the same interactive render mode.
 
-Nothing further must be done for the components to enforce static SSR than applying the custom layout:
+Nothing further must be done for the components to enforce static SSR than applying the custom layout ***without setting an interactive render mode***:
 
 ```razor
 @layout BlazorSample.Components.Layout.StaticSsrLayout
 ```
 
-Other components around the app set an appropriate interactive render mode, which upon reflection in the `App` component is applied to the `Routes` component. Interactive components ***avoid*** applying the custom static SSR layout:
+Interactive components around the app ***avoid*** applying the custom static SSR layout and ***only set an appropriate interactive render mode***, which upon reflection in the `App` component is applied to the `Routes` component:
 
 ```razor
 @rendermode {INTERACTIVE RENDER MODE}

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -132,12 +132,6 @@ When the <xref:Microsoft.AspNetCore.Components.Routing.Router> component navigat
 
 ## Provide custom content when content isn't found
 
-:::moniker range=">= aspnetcore-8.0"
-
-*This section only applies to Blazor WebAssembly apps.* Blazor Web Apps don't use the <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> parameter (`<NotFound>...</NotFound>` markup), but the parameter is supported for backward compatibility to avoid a breaking change in the framework. Blazor Web Apps typically process bad URL requests by either displaying the browser's built-in 404 UI or returning a custom 404 page from the ASP.NET Core server via ASP.NET Core middleware (for example, [`UseStatusCodePagesWithRedirects`](xref:fundamentals/error-handling#usestatuscodepageswithredirects) / [API documentation](xref:Microsoft.AspNetCore.Builder.StatusCodePagesExtensions.UseStatusCodePagesWithRedirects%2A)).
-
-:::moniker-end
-
 The <xref:Microsoft.AspNetCore.Components.Routing.Router> component allows the app to specify custom content if content isn't found for the requested route.
 
 Set custom content for the <xref:Microsoft.AspNetCore.Components.Routing.Router> component's <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> parameter:
@@ -152,6 +146,13 @@ Set custom content for the <xref:Microsoft.AspNetCore.Components.Routing.Router>
 ```
 
 Arbitrary items are supported as content of the <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> parameter, such as other interactive components. To apply a default layout to <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> content, see <xref:blazor/components/layouts#apply-a-layout-to-arbitrary-content-layoutview-component>.
+
+:::moniker range=">= aspnetcore-8.0"
+
+> [!IMPORTANT]
+> Blazor Web Apps don't use the <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound> parameter (`<NotFound>...</NotFound>` markup), but the parameter is supported for backward compatibility to avoid a breaking change in the framework. The server-side ASP.NET Core middleware pipeline processes requests on the server. Use server-side techniques to handle bad requests. For more information, see <xref:blazor/components/render-modes#static-server-side-rendering-static-ssr>.
+
+:::moniker-end
 
 ## Route to components from multiple assemblies
 

--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -409,6 +409,12 @@ You can also supply different content for display if the user isn't authorized w
 
 A default event handler for an authorized element, such as the `SecureMethod` method for the `<button>` element in the preceding example, can only be invoked by an authorized user.
 
+:::moniker range=">= aspnetcore-8.0"
+
+Razor components of Blazor Web Apps never display `<NotAuthorized>` content when authorization fails server-side during static server-side rendering (static SSR). The server-side ASP.NET Core pipeline processes authorization on the server. Use server-side techniques to handle unauthorized requests. For more information, see <xref:blazor/components/render-modes#static-server-side-rendering-static-ssr>.
+
+:::moniker-end
+
 > [!WARNING]
 > Client-side markup and methods associated with an <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> are only protected from view and execution in the ***rendered UI*** in client-side Blazor apps. In order to protect authorized content and secure methods in client-side Blazor, the content is usually supplied by a secure, authorized web API call to a server API and never stored in the app. For more information, see <xref:blazor/call-web-api> and <xref:blazor/security/webassembly/additional-scenarios>.
 
@@ -655,6 +661,13 @@ The <xref:Microsoft.AspNetCore.Components.Routing.Router> component, in conjunct
 
 * The user fails an [`[Authorize]`](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) condition applied to the component. The markup of the [`<NotAuthorized>`](xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.NotAuthorized?displayProperty=nameWithType) element is displayed. The [`[Authorize]`](xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute) attribute is covered in the [`[Authorize]` attribute](#authorize-attribute) section.
 * Asynchronous authorization is in progress, which usually means that the process of authenticating the user is in progress. The markup of the [`<Authorizing>`](xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeRouteView.Authorizing?displayProperty=nameWithType) element is displayed.
+
+:::moniker range=">= aspnetcore-8.0"
+
+> [!IMPORTANT]
+> Blazor router features that display `<NotAuthorized>` and `<NotFound>` content aren't operational during static server-side rendering (static SSR) because request processing is entirely handled by ASP.NET Core middleware pipeline request processing and Razor components aren't rendered at all for unauthorized or bad requests. Use server-side techniques to handle unauthorized and bad requests during static SSR. For more information, see <xref:blazor/components/render-modes#static-server-side-rendering-static-ssr>.
+
+:::moniker-end
 
 :::moniker range=">= aspnetcore-8.0"
 


### PR DESCRIPTION
Fixes #31402

Thanks @FengRuikai! 🚀

I'm mostly going off of Javier's sentiment expressed here ...

https://github.com/dotnet/aspnetcore/issues/52176#issuecomment-1825677291

... and I'm cleaning up the approach for how we can convey this information:

* Add the guidance to the static SSR section of the *Render Modes* article. Include how devs should deal with these scenarios server-side.
* Clean up and cross-link that from the `<NotAuthorized>` content in the *Security* article.
* Clean up and cross-link that from the `<NotFound>` content in the *Routing* and *Layouts* articles.

Also, are there any other scenarios that fall into this bucket outside of `<NotFound>` and `<NotAuthorized>` content that we should add to the list here (and cross-link from outside the article)?

... and btw ... you'll see a few other small wording changes ...

* At the start of the *Static server-side rendering (static SSR)* section.
* In the *Static SSR components spread out across the app* section.

Those updates are just things that I thought I could improve in passing. They don't pertain to the PR or the issue, but I recommend looking 👀 at those additional updates given the general complexity of the coverage.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/layouts.md](https://github.com/dotnet/AspNetCore.Docs/blob/fb27a123b0177473329412f44d58949be789746d/aspnetcore/blazor/components/layouts.md) | [ASP.NET Core Blazor layouts](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/layouts?branch=pr-en-us-32048) |
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/fb27a123b0177473329412f44d58949be789746d/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-32048) |
| [aspnetcore/blazor/fundamentals/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/fb27a123b0177473329412f44d58949be789746d/aspnetcore/blazor/fundamentals/routing.md) | [ASP.NET Core Blazor routing and navigation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?branch=pr-en-us-32048) |
| [aspnetcore/blazor/security/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/fb27a123b0177473329412f44d58949be789746d/aspnetcore/blazor/security/index.md) | [aspnetcore/blazor/security/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/index?branch=pr-en-us-32048) |


<!-- PREVIEW-TABLE-END -->