### PR TITLE
Fix flagged Download Center links for Web Deploy

### DIFF
--- a/aspnetcore/host-and-deploy/iis/advanced.md
+++ b/aspnetcore/host-and-deploy/iis/advanced.md
@@ -388,7 +388,7 @@ The files can be found by searching for `aspnetcore` in the `applicationHost.con
 
 ## Install Web Deploy when publishing with Visual Studio
 
-When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, use the [Web Platform Installer (WebPI)](https://www.microsoft.com/web/downloads/platform.aspx), which is the preferred installation procedure. WebPI offers a standalone setup and a configuration for hosting providers.
+When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server.
 
 ## Create the IIS site
 

--- a/aspnetcore/host-and-deploy/iis/advanced.md
+++ b/aspnetcore/host-and-deploy/iis/advanced.md
@@ -388,7 +388,7 @@ The files can be found by searching for `aspnetcore` in the `applicationHost.con
 
 ## Install Web Deploy when publishing with Visual Studio
 
-When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, obtain an installer from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=43717).
+When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, use the [Web Platform Installer (WebPI)](https://www.microsoft.com/web/downloads/platform.aspx), which is the preferred installation procedure. WebPI offers a standalone setup and a configuration for hosting providers.
 
 ## Create the IIS site
 

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -362,7 +362,7 @@ net start w3svc
 
 ## Install Web Deploy when publishing with Visual Studio
 
-When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, use the [Web Platform Installer (WebPI)](https://www.microsoft.com/web/downloads/platform.aspx) or obtain an installer directly from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=43717). The preferred method is to use WebPI. WebPI offers a standalone setup and a configuration for hosting providers.
+When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, use the [Web Platform Installer (WebPI)](https://www.microsoft.com/web/downloads/platform.aspx), which is the preferred installation procedure. WebPI offers a standalone setup and a configuration for hosting providers.
 
 ## Create the IIS site
 
@@ -931,7 +931,7 @@ ASP.NET Core adopts roll-forward behavior for patch releases of shared framework
 
 ## Install Web Deploy when publishing with Visual Studio
 
-When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, use the [Web Platform Installer (WebPI)](https://www.microsoft.com/web/downloads/platform.aspx) or obtain an installer directly from the [Microsoft Download Center](https://www.microsoft.com/download/details.aspx?id=43717). The preferred method is to use WebPI. WebPI offers a standalone setup and a configuration for hosting providers.
+When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, use the [Web Platform Installer (WebPI)](https://www.microsoft.com/web/downloads/platform.aspx), which is the preferred installation procedure. WebPI offers a standalone setup and a configuration for hosting providers.
 
 ## Create the IIS site
 

--- a/aspnetcore/host-and-deploy/iis/index.md
+++ b/aspnetcore/host-and-deploy/iis/index.md
@@ -362,7 +362,7 @@ net start w3svc
 
 ## Install Web Deploy when publishing with Visual Studio
 
-When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, use the [Web Platform Installer (WebPI)](https://www.microsoft.com/web/downloads/platform.aspx), which is the preferred installation procedure. WebPI offers a standalone setup and a configuration for hosting providers.
+When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server.
 
 ## Create the IIS site
 
@@ -931,7 +931,7 @@ ASP.NET Core adopts roll-forward behavior for patch releases of shared framework
 
 ## Install Web Deploy when publishing with Visual Studio
 
-When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server. To install Web Deploy, use the [Web Platform Installer (WebPI)](https://www.microsoft.com/web/downloads/platform.aspx), which is the preferred installation procedure. WebPI offers a standalone setup and a configuration for hosting providers.
+When deploying apps to servers with [Web Deploy](/iis/install/installing-publishing-technologies/installing-and-configuring-web-deploy-on-iis-80-or-later), install the latest version of Web Deploy on the server.
 
 ## Create the IIS site
 


### PR DESCRIPTION
The Download Center link cropped up on PR build report as being a broken link ...

> Link 'https://www.microsoft.com/download/details.aspx?id=43717' points to a page that doesn't exist. Check the path or URL and update the link.

It's not actually broken, but the landing page does throw a 302 and some 304s for some resources, which might be tricking the build system into thinking the link is bad. I'm updating the guidance where the link appears to just go with Web PI.

I'll merge as soon as any of you agree that this is the best way to go.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/iis/advanced.md](https://github.com/dotnet/AspNetCore.Docs/blob/9b46c2e98df99eb9bf884da6d5597e819274ad11/aspnetcore/host-and-deploy/iis/advanced.md) | [Advanced configuration of the ASP.NET Core Module and IIS](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/advanced?branch=pr-en-us-32050) |
| [aspnetcore/host-and-deploy/iis/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/9b46c2e98df99eb9bf884da6d5597e819274ad11/aspnetcore/host-and-deploy/iis/index.md) | [Host ASP.NET Core on Windows with IIS](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/index?branch=pr-en-us-32050) |


<!-- PREVIEW-TABLE-END -->