### PR TITLE
First MVC: Correct macOS command

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to get started with ASP.NET Core MVC.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 02/15/2024
+ms.date: 03/13/2024
 uid: tutorials/first-mvc-app/start-mvc
 ms.custom: engagement-fy23
 ---
@@ -141,7 +141,7 @@ The following image shows the app:
 
 [!INCLUDE[](~/includes/trustCertVSC.md)]
 
-* In Visual Studio Code, press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows)/<kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the app without debugging.
+* In Visual Studio Code, press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows)/<kbd>^</kbd>+<kbd>F5</kbd> (macOS) to run the app without debugging.
 
   Visual Studio Code:
 

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc7.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc7.md
@@ -124,7 +124,7 @@ The following image shows the app:
 
 [!INCLUDE[](~/includes/trustCertVSC.md)]
 
-* In Visual Studio Code, press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows)/<kbd>⌘</kbd>+<kbd>F5</kbd> (macOS) to run the app without debugging.
+* In Visual Studio Code, press <kbd>Ctrl</kbd>+<kbd>F5</kbd> (Windows)/<kbd>^</kbd>+<kbd>F5</kbd> (macOS) to run the app without debugging.
 
   Visual Studio Code:
 


### PR DESCRIPTION
Fixes #32045 

Should have been Control (^) key for macOS not Command to run without debugging.  Fixed.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mvc-app/start-mvc.md](https://github.com/dotnet/AspNetCore.Docs/blob/cbb7b72592898d4043fa2017ccb6e300054fea66/aspnetcore/tutorials/first-mvc-app/start-mvc.md) | [Get started with ASP.NET Core MVC](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/start-mvc?branch=pr-en-us-32052) |

<!-- PREVIEW-TABLE-END -->