### PR TITLE
Patch button class in example

### DIFF
--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -250,7 +250,7 @@ Similar to a regular component parameter, components accepting a cascading param
     
     private void ChangeToDarkTheme()
     {
-        theme = new() { ButtonClass = "btn-darkmode-success" };
+        theme = new() { ButtonClass = "btn-secondary" };
     }
 }
 ```


### PR DESCRIPTION
Noticed in passing that using a custom class isn't the best example (at least not without showing the class in the explanation), so I'm changing it to use a built-in Bootstrap class that will work well for a "dark" UI theme example, which is `btn-secondary`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/cascading-values-and-parameters.md](https://github.com/dotnet/AspNetCore.Docs/blob/ce2c5a28949e7961f98df9980c7e9e4330f0c72e/aspnetcore/blazor/components/cascading-values-and-parameters.md) | [ASP.NET Core Blazor cascading values and parameters](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/cascading-values-and-parameters?branch=pr-en-us-32058) |

<!-- PREVIEW-TABLE-END -->