### PR TITLE
ShutdownTimeout default value in documentation

### DIFF
--- a/aspnetcore/fundamentals/host/generic-host.md
+++ b/aspnetcore/fundamentals/host/generic-host.md
@@ -196,7 +196,7 @@ If the timeout period expires before all of the hosted services stop, any remain
 
 **Key**: `shutdownTimeoutSeconds`  
 **Type**: `int`  
-**Default**: 5 seconds  
+**Default**: 30 seconds  
 **Environment variable**: `{PREFIX_}SHUTDOWNTIMEOUTSECONDS`
 
 To set this value, use the environment variable or configure `HostOptions`. The following example sets the timeout to 20 seconds:


### PR DESCRIPTION
Fixes #32069

Update the default value for ShutdownTimeout according to https://github.com/dotnet/runtime/blob/v8.0.3/src/libraries/Microsoft.Extensions.Hosting/src/HostOptions.cs#L24

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/host/generic-host.md](https://github.com/dotnet/AspNetCore.Docs/blob/9f42265f7cdc28686e7871ab20ec53c8a6b23ac0/aspnetcore/fundamentals/host/generic-host.md) | [.NET Generic Host in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?branch=pr-en-us-32070) |

<!-- PREVIEW-TABLE-END -->