### PR TITLE
[Blazor] Event handling - button "select" => button "click"

### DIFF
--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -29,7 +29,7 @@ For event handling:
 
 The following code:
 
-* Calls the `UpdateHeading` method when the button is selected in the UI.
+* Calls the `UpdateHeading` method when the button is clicked in the UI.
 * Calls the `CheckChanged` method when the checkbox is changed in the UI.
 
 :::moniker range=">= aspnetcore-8.0"
@@ -74,7 +74,7 @@ The following code:
 
 In the following example, `UpdateHeading`:
 
-* Is called asynchronously when the button is selected.
+* Is called asynchronously when the button is clicked.
 * Waits two seconds before updating the heading.
 
 :::moniker range=">= aspnetcore-8.0"
@@ -119,7 +119,7 @@ In the following example, `UpdateHeading`:
 
 ## Built-in event arguments
 
-For events that support an event argument type, specifying an event parameter in the event method definition is only necessary if the event type is used in the method. In the following example, <xref:Microsoft.AspNetCore.Components.Web.MouseEventArgs> is used in the `ReportPointerLocation` method to set message text that reports the mouse coordinates when the user selects a button in the UI.
+For events that support an event argument type, specifying an event parameter in the event method definition is only necessary if the event type is used in the method. In the following example, <xref:Microsoft.AspNetCore.Components.Web.MouseEventArgs> is used in the `ReportPointerLocation` method to set message text that reports the mouse coordinates when the user clicks a button in the UI.
 
 :::moniker range=">= aspnetcore-8.0"
 
@@ -209,7 +209,7 @@ function eventArgsCreator(event) {
 
 The `event` parameter is a [DOM Event (MDN documentation)](https://developer.mozilla.org/docs/Web/API/Event).
 
-Register the custom event with the preceding handler in a [JavaScript initializer](xref:blazor/fundamentals/startup#javascript-initializers). Provide the appropriate browser event name to `browserEventName`, which for the example shown in this section is `click` for a button selection in the UI.
+Register the custom event with the preceding handler in a [JavaScript initializer](xref:blazor/fundamentals/startup#javascript-initializers). Provide the appropriate browser event name to `browserEventName`, which for the example shown in this section is `click` for a button action in the UI.
 
 `wwwroot/{PACKAGE ID/ASSEMBLY NAME}.lib.module.js` (the `{PACKAGE ID/ASSEMBLY NAME}` placeholder is the package ID or assembly name of the app):
 
@@ -621,7 +621,7 @@ The `Parent` component sets the child's <xref:Microsoft.AspNetCore.Components.Ev
 
 :::moniker-end
 
-When the button is selected in the `ChildComponent`:
+When the button is clicked in the `ChildComponent`:
 
 * The `Parent` component's `ShowMessage` method is called. `message` is updated and displayed in the `Parent` component.
 * A call to [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes-statehaschanged) isn't required in the callback's method (`ShowMessage`). <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> is called automatically to rerender the `Parent` component, just as child events trigger component rerendering in event handlers that execute within the child. For more information, see <xref:blazor/components/rendering>.
@@ -678,7 +678,7 @@ The following parent-child example demonstrates the technique.
 
 Use the [`@on{DOM EVENT}:preventDefault`](xref:mvc/views/razor#oneventpreventdefault) directive attribute to prevent the default action for an event, where the `{DOM EVENT}` placeholder is a [DOM event](https://developer.mozilla.org/docs/Web/Events).
 
-When a key is selected on an input device and the element focus is on a text box, a browser normally displays the key's character in the text box. In the following example, the default behavior is prevented by specifying the `@onkeydown:preventDefault` directive attribute. When the focus is on the `<input>` element, the counter increments with the key sequence <kbd>Shift</kbd>+<kbd>+</kbd>. The `+` character isn't assigned to the `<input>` element's value. For more information on `keydown`, see [`MDN Web Docs: Document: keydown` event](https://developer.mozilla.org/docs/Web/API/Document/keydown_event).
+When a key is pressed on an input device and the element focus is on a text box, a browser normally displays the key's character in the text box. In the following example, the default behavior is prevented by specifying the `@onkeydown:preventDefault` directive attribute. When the focus is on the `<input>` element, the counter increments with the key sequence <kbd>Shift</kbd>+<kbd>+</kbd>. The `+` character isn't assigned to the `<input>` element's value. For more information on `keydown`, see [`MDN Web Docs: Document: keydown` event](https://developer.mozilla.org/docs/Web/API/Document/keydown_event).
 
 :::moniker range=">= aspnetcore-8.0"
 
@@ -789,7 +789,7 @@ In the following example, selecting the checkbox prevents click events from the 
 
 ## Focus an element
 
-Call <xref:Microsoft.AspNetCore.Components.ElementReferenceExtensions.FocusAsync%2A> on an [element reference](xref:blazor/js-interop/call-javascript-from-dotnet#capture-references-to-elements) to focus an element in code. In the following example, select the button to focus the `<input>` element.
+Call <xref:Microsoft.AspNetCore.Components.ElementReferenceExtensions.FocusAsync%2A> on an [element reference](xref:blazor/js-interop/call-javascript-from-dotnet#capture-references-to-elements) to focus an element in code. In the following example, click the button to focus the `<input>` element.
 
 :::moniker-end
 


### PR DESCRIPTION
"Selecting" the button to mean triggering the `click` event might seem unusual. The term "clicking" is more commonly used and understood.

@guardrex If you agree, I will change the corresponding comments in sample code.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/event-handling.md](https://github.com/dotnet/AspNetCore.Docs/blob/ae53b94808116f89454c4af0f9e393d4f23ff827/aspnetcore/blazor/components/event-handling.md) | [ASP.NET Core Blazor event handling](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?branch=pr-en-us-32078) |

<!-- PREVIEW-TABLE-END -->