### PR TITLE
[Blazor] Event handling - first InvokeAsync example with args

### DIFF
--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -635,7 +635,7 @@ Prefer the strongly typed <xref:Microsoft.AspNetCore.Components.EventCallback%60
 Invoke an <xref:Microsoft.AspNetCore.Components.EventCallback> or <xref:Microsoft.AspNetCore.Components.EventCallback%601> with <xref:Microsoft.AspNetCore.Components.EventCallback.InvokeAsync%2A> and await the <xref:System.Threading.Tasks.Task>:
 
 ```csharp
-await OnClickCallback.InvokeAsync();
+await OnClickCallback.InvokeAsync(arg);
 ```
 
 The following parent-child example demonstrates the technique.

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -635,8 +635,10 @@ Prefer the strongly typed <xref:Microsoft.AspNetCore.Components.EventCallback%60
 Invoke an <xref:Microsoft.AspNetCore.Components.EventCallback> or <xref:Microsoft.AspNetCore.Components.EventCallback%601> with <xref:Microsoft.AspNetCore.Components.EventCallback.InvokeAsync%2A> and await the <xref:System.Threading.Tasks.Task>:
 
 ```csharp
-await OnClickCallback.InvokeAsync(arg);
+await OnClickCallback.InvokeAsync({ARGUMENT});
 ```
+
+In the preceding example, the `{ARGUMENT}` placeholder is an optional argument.
 
 The following parent-child example demonstrates the technique.
 


### PR DESCRIPTION
This is the very first example for `eventCallback.InvokeAsync()` in the whole article and I think we should show that the `InvokeAsync` method accepts the argument to be passed within the callback.

We might also use a placeholder:
```csharp
await OnClickCallback.InvokeAsync({ARG});
```
where we descibe the `{ARG}` as optional argument.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/event-handling.md](https://github.com/dotnet/AspNetCore.Docs/blob/c99e7904feae7eda85db7b50bc21632ed69bf811/aspnetcore/blazor/components/event-handling.md) | [ASP.NET Core Blazor event handling](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?branch=pr-en-us-32085) |


<!-- PREVIEW-TABLE-END -->