### PR TITLE
[Blazor] Event handling - ParentChild2.razor without Task.Yield()

### DIFF
--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -681,7 +681,8 @@ The following parent-child example demonstrates the technique.
 @code {
     private string message1 = string.Empty;
     private string message2 = string.Empty;
-}```
+}
+```
 
 The second occurrence of `Child2` component demonstrates an asynchronous callback and the new `message2` value will be assigned and rendered with a delay of two seconds.
 

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -663,16 +663,27 @@ The following parent-child example demonstrates the technique.
 ```razor
 @page "/parent-child-2"
 
-<Child2 OnClickCallback="@((value) => { messageText = value; })" />
+<PageTitle>Parent Child 2</PageTitle>
 
-<p>
-    @messageText
-</p>
+<h1>Parent Child 2 Example</h1>
+
+<div>
+    <Child2 OnClickCallback="(value) => { message1 = value; }" />
+    @message1
+</div>
+
+<div>
+    <Child2 OnClickCallback=
+        "async (value) => { await Task.Delay(2000); message2 = value; }" /> 
+    @message2
+</div>
 
 @code {
-    private string messageText = string.Empty;
-}
-```
+    private string message1 = string.Empty;
+    private string message2 = string.Empty;
+}```
+
+The second occurrence of `Child2` component demonstrates an asynchronous callback and the new `message2` value will be assigned and rendered with a delay of two seconds.
 
 ## Prevent default actions
 

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -684,7 +684,7 @@ The following parent-child example demonstrates the technique.
 }
 ```
 
-The second occurrence of `Child2` component demonstrates an asynchronous callback and the new `message2` value will be assigned and rendered with a delay of two seconds.
+The second occurrence of the `Child2` component demonstrates an asynchronous callback, and the new `message2` value is assigned and rendered with a delay of two seconds.
 
 ## Prevent default actions
 

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -663,7 +663,7 @@ The following parent-child example demonstrates the technique.
 ```razor
 @page "/parent-child-2"
 
-<Child2 OnClickCallback="@(async (value) => { await Task.Yield(); messageText = value; })" />
+<Child2 OnClickCallback="@((value) => { messageText = value; })" />
 
 <p>
     @messageText


### PR DESCRIPTION
I believe the `await Task.Yield()` in the `ParentChild2.razor` example no longer makes sense. It probably remained from an earlier era of Blazor when these in-line lambdas had to be asynchronous.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/event-handling.md](https://github.com/dotnet/AspNetCore.Docs/blob/e692389396709bbe8bee0398aa98ac0dcc7ae3c3/aspnetcore/blazor/components/event-handling.md) | [ASP.NET Core Blazor event handling](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?branch=pr-en-us-32086) |


<!-- PREVIEW-TABLE-END -->