### PR TITLE
[Blazor] Lifecycle - remove breaking-changes notice

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -18,7 +18,7 @@ This article explains the ASP.NET Core Razor component lifecycle and how to use 
 
 The Razor component processes Razor component lifecycle events in a set of synchronous and asynchronous lifecycle methods. The lifecycle methods can be overridden to perform additional operations in components during component initialization and rendering.
 
-This article simplifies component lifecycle event processing in order to clarify complex framework logic. You may need to access the [`ComponentBase` reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ComponentBase.cs) to integrate custom event processing with Blazor's lifecycle event processing. Code comments in the reference source include additional remarks on lifecycle event processing that don't appear in this article or in the [API documentation](/dotnet/api/).
+This article simplifies component lifecycle event processing in order to clarify complex framework logic and doesn't cover every change that was made over the years. You may need to access the [`ComponentBase` reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ComponentBase.cs) to integrate custom event processing with Blazor's lifecycle event processing. Code comments in the reference source include additional remarks on lifecycle event processing that don't appear in this article or in the [API documentation](/dotnet/api/).
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -18,7 +18,7 @@ This article explains the ASP.NET Core Razor component lifecycle and how to use 
 
 The Razor component processes Razor component lifecycle events in a set of synchronous and asynchronous lifecycle methods. The lifecycle methods can be overridden to perform additional operations in components during component initialization and rendering.
 
-This article simplifies component lifecycle event processing in order to clarify complex framework logic. You may need to access the [`ComponentBase` reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ComponentBase.cs) to integrate custom event processing with Blazor's lifecycle event processing. Code comments in the reference source include additional remarks on lifecycle event processing that don't appear in this article or in the [API documentation](/dotnet/api/). Blazor's lifecycle event processing has changed over time and is subject to change without notice each release.
+This article simplifies component lifecycle event processing in order to clarify complex framework logic. You may need to access the [`ComponentBase` reference source](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ComponentBase.cs) to integrate custom event processing with Blazor's lifecycle event processing. Code comments in the reference source include additional remarks on lifecycle event processing that don't appear in this article or in the [API documentation](/dotnet/api/).
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 


### PR DESCRIPTION
Such changes, typically breaking, are now uncommon, and the potential for these changes is inherent in the definition of a "major release." I believe there's no need to intimidate developers in the documentation by explicitly mentioning this.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/lifecycle.md](https://github.com/dotnet/AspNetCore.Docs/blob/2bf246e565d58cc4c207d9bc5222e3322f0253d3/aspnetcore/blazor/components/lifecycle.md) | [ASP.NET Core Razor component lifecycle](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?branch=pr-en-us-32090) |


<!-- PREVIEW-TABLE-END -->