### PR TITLE
Surface warning on compression for interactive SSR

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1112,6 +1112,8 @@ For more information, see the *Route parameters* section of <xref:blazor/fundame
 
 :::moniker-end
 
+[!INCLUDE[](~/includes/compression-with-untrusted-data.md)]
+
 ## Child content render fragments
 
 Components can set the content of another component. The assigning component provides the content between the child component's opening and closing tags.

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1010,6 +1010,8 @@ Supported types include:
 * Nullable variants of the preceding types.
 * Arrays of the preceding types, whether they're nullable or not nullable.
 
+[!INCLUDE[](~/includes/compression-with-untrusted-data.md)]
+
 ### Replace a query parameter value when the parameter exists
 
 ```csharp

--- a/aspnetcore/blazor/includes/compression-with-untrusted-data.md
+++ b/aspnetcore/blazor/includes/compression-with-untrusted-data.md
@@ -1,0 +1,6 @@
+:::moniker range=">= aspnetcore-9.0"
+
+> [!WARNING>]
+> When compression is enabled, avoid creating secure (authenticated/authorized) interactive server-side rendered components that render data from untrusted sources. Untrusted sources include route parameters, query strings, data from JS interop, and any other source of data that a third-party user can control (databases, external services). For more information, see <xref:blazor/fundamentals/signalr#websocket-compression-for-interactive-server-components> and <xref:blazor/security/server/interactive-server-side-rendering?view=aspnetcore-9.0#interactive-server-components-with-websocket-compression-enabled>.
+
+:::moniker-end

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -28,6 +28,14 @@ Further JS interop guidance is provided in the following articles:
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-9.0"
+
+## Compression for interactive server components with untrusted data
+
+:::moniker-end
+
+[!INCLUDE[](~/includes/compression-with-untrusted-data.md)]
+
 ## JavaScript interop abstractions and features package
 
 The [`@microsoft/dotnet-js-interop` package (`npmjs.com`)](https://www.npmjs.com/package/@microsoft/dotnet-js-interop) ([`Microsoft.JSInterop` NuGet package](https://www.nuget.org/packages/Microsoft.JSInterop)) provides abstractions and features for interop between .NET and JavaScript (JS) code. Reference source is available in the [`dotnet/aspnetcore` GitHub repository (`/src/JSInterop` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/JSInterop). For more information, see the GitHub repository's `README.md` file.

--- a/aspnetcore/blazor/security/server/interactive-server-side-rendering.md
+++ b/aspnetcore/blazor/security/server/interactive-server-side-rendering.md
@@ -29,7 +29,7 @@ In constrained environments, such as inside corporate networks or intranets, som
 
 ## Interactive Server Components with WebSocket compression enabled
 
-Compression can expose the app to side-channel attacks against the TLS encryption of the connection, such as [CRIME](https://wikipedia.org/wiki/CRIME_(security_exploit)) and [BREACH](https://wikipedia.org/wiki/BREACH_(security_exploit)) attacks. These types of attacks require that the attacker:
+[Compression](xref:blazor/fundamentals/signalr#websocket-compression-for-interactive-server-components) can expose the app to side-channel attacks against the TLS encryption of the connection, such as [CRIME](https://wikipedia.org/wiki/CRIME_(security_exploit)) and [BREACH](https://wikipedia.org/wiki/BREACH_(security_exploit)) attacks. These types of attacks require that the attacker:
 
 * Force a browser to issue requests with a payload the attacker controls to a vulnerable site via cross-site form posting or by embedding the site inside an iframe of another site.
 * Observe the length of the compressed and encrypted response over the network.
@@ -52,7 +52,7 @@ Generally speaking, Blazor apps can enable compression over the WebSocket connec
 
   * Rendering PII information on to the page at the same time as data coming from another user via JS interop or a local singleton service on the server.
 
-In general, we recommend that you avoid rendering components that contain sensitive information alongside components that can render data from untrusted sources as part of the same render batch.
+In general, we recommend that you avoid rendering components that contain sensitive information alongside components that can render data from untrusted sources as part of the same render batch. Untrusted sources include route parameters, query strings, data from JS interop, and any other source of data that a third-party user can control (databases, external services).
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #31916

I picked up on a potential opportunity to raise awareness in a couple of spots on CRIME/BREACH for compression with interactive SSR and authn/z components. This PR ...

* Sets up an INCLUDE (with >=9.0 versioning) with a quick WARNING note and cross-links.
* Places the INCLUDE in three spots ...
  * Route params section
  * Query strings section
  * JS interop overview (with an added >=9.0 heading)