### PR TITLE
[Blazor] Lifecycle - remove if (firstRender) from OnAfterRenderAsync sample

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -349,10 +349,7 @@ Asynchronous work immediately after rendering must occur during the <xref:Micros
 ```csharp
 protected override async Task OnAfterRenderAsync(bool firstRender)
 {
-    if (firstRender)
-    {
-        await ...
-    }
+    await ...
 }
 ```
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -349,7 +349,7 @@ Asynchronous work immediately after rendering must occur during the <xref:Micros
 ```csharp
 protected override async Task OnAfterRenderAsync(bool firstRender)
 {
-    await ...
+    ...
 }
 ```
 


### PR DESCRIPTION
The `if (firstRender)` is demonstrated in the `AfterRender.razor` sample. It seems unnecessary to complicate the `OnAfterRenderAsync` sample, which is meant to illustrate asynchronous usage, by making users wonder why `await` is used inside `if (firstRender)`.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/lifecycle.md](https://github.com/dotnet/AspNetCore.Docs/blob/f97d6fd0ad07181317ce2fec0664f8a94dd0693d/aspnetcore/blazor/components/lifecycle.md) | [ASP.NET Core Razor component lifecycle](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?branch=pr-en-us-32121) |


<!-- PREVIEW-TABLE-END -->