### PR TITLE
[Blazor] include/prerendering.md - JS element => HTML DOM element

### DIFF
--- a/aspnetcore/blazor/includes/prerendering.md
+++ b/aspnetcore/blazor/includes/prerendering.md
@@ -63,7 +63,7 @@ For the following example, the `setElementText2` function is called with <xref:M
 > [!WARNING]
 > **The preceding example modifies the DOM directly for demonstration purposes only.** Directly modifying the DOM with JS isn't recommended in most scenarios because JS can interfere with Blazor's change tracking. For more information, see <xref:blazor/js-interop/index#interaction-with-the-document-object-model-dom>.
 
-Where <xref:Microsoft.JSInterop.JSRuntime.InvokeAsync%2A?displayProperty=nameWithType> is called, the <xref:Microsoft.AspNetCore.Components.ElementReference> is only used in <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync%2A> and not in any earlier lifecycle method because there's no JS element until after the component is rendered.
+Where <xref:Microsoft.JSInterop.JSRuntime.InvokeAsync%2A?displayProperty=nameWithType> is called, the <xref:Microsoft.AspNetCore.Components.ElementReference> is only used in <xref:Microsoft.AspNetCore.Components.ComponentBase.OnAfterRenderAsync%2A> and not in any earlier lifecycle method because there's no HTML DOM element until after the component is rendered.
 
 [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes-statehaschanged) is called to rerender the component with the new state obtained from the JS interop call (for more information, see <xref:blazor/components/rendering>). The code doesn't create an infinite loop because `StateHasChanged` is only called when `data` is `null`.
 


### PR DESCRIPTION
There's no such thing as a "JS element" (in this context).
I believe the term intended here is "HTML DOM element" (which can be abbreviated to "HTML element," but we can retain "HTML DOM element" to emphasize the meaning).

cc @guardrex 