### PR TITLE
[Blazor] - Lifecycle - Incorrect usage of "unmanaged" term

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -565,7 +565,7 @@ Although the content in this section focuses on Blazor Server and stateful Signa
 
 ## Component disposal with `IDisposable` and `IAsyncDisposable`
 
-If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for unmanaged resource disposal when the component is removed from the UI. Disposal can occur at any time, including during [component initialization](#component-initialization-oninitializedasync).
+If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for resource disposal when the component is removed from the UI. Disposal can occur at any time, including during [component initialization](#component-initialization-oninitializedasync).
 
 Components shouldn't need to implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable> simultaneously. If both are implemented, the framework only executes the asynchronous overload.
 
@@ -596,7 +596,7 @@ For synchronous disposal tasks, use <xref:System.IDisposable.Dispose%2A?displayP
 The following component:
 
 * Implements <xref:System.IDisposable> with the [`@implements`](xref:mvc/views/razor#implements) Razor directive.
-* Disposes of `obj`, which is an unmanaged type that implements <xref:System.IDisposable>.
+* Disposes of `obj`, which is a type that implements <xref:System.IDisposable>.
 * A null check is performed because `obj` is created in a lifecycle method (not shown).
 
 ```razor


### PR DESCRIPTION
In the context of Blazor, `IDisposable` and `IAsyncDisposable` enable components to perform cleanup logic. However, it's important to note that this still involves managed logic. Components are generally not designed to directly use unmanaged resources, like file handles, which would necessitate the use of finalizers (destructors).

Therefore, we should avoid using the term _unmanaged_ in the context of Blazor.

(I'll propose adding an explanation about why we don't use destructors in Blazor in a separate issue.)

cc @guardrex

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/lifecycle.md](https://github.com/dotnet/AspNetCore.Docs/blob/d625fce4a143322515385fcad264e7964d4fd178/aspnetcore/blazor/components/lifecycle.md) | [ASP.NET Core Razor component lifecycle](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?branch=pr-en-us-32125) |

<!-- PREVIEW-TABLE-END -->