### PR TITLE
Improved Project Structure article WASM headings

### DIFF
--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -277,13 +277,13 @@ Additional files and folders may appear in an app produced from a Blazor Server 
 
 :::moniker-end
 
-## Blazor WebAssembly
-
 :::moniker range=">= aspnetcore-8.0"
 
-Blazor WebAssembly project templates: `blazorwasm`
+## Standalone Blazor WebAssembly
 
-The Blazor WebAssembly templates create the initial files and directory structure for a standalone Blazor WebAssembly app:
+Standalone Blazor WebAssembly project template: `blazorwasm`
+
+The Blazor WebAssembly template creates the initial files and directory structure for a standalone Blazor WebAssembly app:
 
 * If the `blazorwasm` template is used, the app is populated with the following:
   * Demonstration code for a `Weather` component that loads data from a static asset (`weather.json`) and user interaction with a `Counter` component.
@@ -326,6 +326,8 @@ Additional files and folders may appear in an app produced from a Blazor WebAsse
 :::moniker-end
 
 :::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
+
+## Blazor WebAssembly
 
 Blazor WebAssembly project templates: `blazorwasm`, `blazorwasm-empty`
 
@@ -388,6 +390,8 @@ The project structure of the client-side app in a hosted Blazor Webassembly solu
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
 
+## Blazor WebAssembly
+
 Blazor WebAssembly project template: `blazorwasm`
 
 The Blazor WebAssembly template creates the initial files and directory structure for a Blazor WebAssembly app. The app is populated with demonstration code for a `FetchData` component that loads data from a static asset, `weather.json`, and user interaction with a `Counter` component.
@@ -438,6 +442,8 @@ The project structure of the client-side app in a hosted Blazor Webassembly solu
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
+## Blazor WebAssembly
+
 Blazor WebAssembly project template: `blazorwasm`
 
 The Blazor WebAssembly template creates the initial files and directory structure for a Blazor WebAssembly app. The app is populated with demonstration code for a `FetchData` component that loads data from a static asset, `weather.json`, and user interaction with a `Counter` component.
@@ -487,6 +493,8 @@ The project structure of the client-side app in a hosted Blazor Webassembly solu
 :::moniker-end
 
 :::moniker range="< aspnetcore-5.0"
+
+## Blazor WebAssembly
 
 Blazor WebAssembly project template: `blazorwasm`
 


### PR DESCRIPTION
Fixes #32133

Thanks @Maintenance-Partnership-Systems! 🚀 ... This should clarify that the Blazor WASM section, named *Standalone Blazor WebAssembly* going forward, isn't part of the *Blazor Web App* section. WRT MudBlazor (or any other external docs that we don't control), you'd need to let them know that their guidance for BWAs is incorrect. I assume that they'd update their docs to indicate that the HTML markup they're seeking to have you add to a BWA would be for the `App` component of the server project.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/project-structure.md](https://github.com/dotnet/AspNetCore.Docs/blob/bceb991593577f5f2d6ac75448838035dfdfb20f/aspnetcore/blazor/project-structure.md) | [ASP.NET Core Blazor project structure](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/project-structure?branch=pr-en-us-32134) |

<!-- PREVIEW-TABLE-END -->