### PR TITLE
Control <head> content and migration updates

### DIFF
--- a/aspnetcore/blazor/components/control-head-content.md
+++ b/aspnetcore/blazor/components/control-head-content.md
@@ -66,6 +66,36 @@ In a **required**, shared `_Layout.cshtml` file of a prerendered hosted Blazor W
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-8.0"
+
+## Set a default page title in a Blazor Web App
+
+Set the page title in the `App` component (`App.razor`):
+
+```razor
+<head>
+    ...
+    <HeadOutlet />
+    <PageTitle>Page Title</PageTitle>
+</head>
+```
+
+:::moniker-end
+
+## Set a page title for components via a layout
+
+Set the page title in a [layout component](xref:blazor/components/layouts):
+
+```razor
+@inherits LayoutComponentBase
+
+<PageTitle>Page Title</PageTitle>
+
+<div class="page">
+    ...  
+</div>
+```
+
 ## `HeadOutlet` component
 
 The <xref:Microsoft.AspNetCore.Components.Web.HeadOutlet> component renders content provided by <xref:Microsoft.AspNetCore.Components.Web.PageTitle> and <xref:Microsoft.AspNetCore.Components.Web.HeadContent> components.
@@ -117,11 +147,9 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 When the [`::after` pseudo-selector](https://developer.mozilla.org/docs/Web/CSS/::after) is specified, the contents of the root component are appended to the existing head contents instead of replacing the content. This allows the app to retain static head content in `wwwroot/index.html` without having to repeat the content in the app's Razor components.
 
-## Not found page title
+## Not found page title in a Blazor WebAssembly app
 
 :::moniker range=">= aspnetcore-8.0"
-
-*This section only applies to Blazor WebAssembly apps.*
 
 In Blazor apps created from the Blazor WebAssembly Standalone App project template, the `NotFound` component template in the `App` component (`App.razor`) sets the page title to `Not found`.
 
@@ -136,7 +164,10 @@ In Blazor apps created from a Blazor project template, the `NotFound` component 
 `App.razor`:
 
 ```razor
-<PageTitle>Not found</PageTitle>
+<NotFound>
+    <PageTitle>Not found</PageTitle>
+    ...
+</NotFound>
 ```
 
 ## Additional resources

--- a/aspnetcore/blazor/components/control-head-content.md
+++ b/aspnetcore/blazor/components/control-head-content.md
@@ -66,22 +66,6 @@ In a **required**, shared `_Layout.cshtml` file of a prerendered hosted Blazor W
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-8.0"
-
-## Set a default page title in a Blazor Web App
-
-Set the page title in the `App` component (`App.razor`):
-
-```razor
-<head>
-    ...
-    <HeadOutlet />
-    <PageTitle>Page Title</PageTitle>
-</head>
-```
-
-:::moniker-end
-
 ## Set a page title for components via a layout
 
 Set the page title in a [layout component](xref:blazor/components/layouts):
@@ -146,6 +130,22 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 ```
 
 When the [`::after` pseudo-selector](https://developer.mozilla.org/docs/Web/CSS/::after) is specified, the contents of the root component are appended to the existing head contents instead of replacing the content. This allows the app to retain static head content in `wwwroot/index.html` without having to repeat the content in the app's Razor components.
+
+:::moniker range=">= aspnetcore-8.0"
+
+## Set a default page title in a Blazor Web App
+
+Set the page title in the `App` component (`App.razor`):
+
+```razor
+<head>
+    ...
+    <HeadOutlet />
+    <PageTitle>Page Title</PageTitle>
+</head>
+```
+
+:::moniker-end
 
 ## Not found page title in a Blazor WebAssembly app
 

--- a/aspnetcore/migration/70-80.md
+++ b/aspnetcore/migration/70-80.md
@@ -351,7 +351,7 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
 
 1. Make the following changes to the `App.razor` file:
 
-   Replace the `<title>` tag with the `HeadOutlet` component. Start by removing the `<title>` tag: 
+   Replace the `<title>` tag with `HeadOutlet` and `PageTitle` components. Start by removing the `<title>` tag. Note the title for use later before removing the tag: 
 
    ```diff
    - <title>...</title>
@@ -369,11 +369,14 @@ Blazor WebAssembly apps are supported in .NET 8 without any code changes. Use th
    * `{CLIENT PROJECT ASSEMBLY NAME}`: Client project assembly name. Example: `BlazorSample.Client`
    * `{SERVER PROJECT ASSEMBLY NAME}`: Server project assembly name. Example: `BlazorSample`
 
-   Add the `HeadOutlet` component at the end of the `<head>` content with the Interactive WebAssembly render mode (prerendering disabled):
+   Add the `HeadOutlet` component at the end of the `<head>` content with the Interactive WebAssembly render mode (prerendering disabled). Also, add the `PageTitle` component with the app's title:
 
    ```razor
    <HeadOutlet @rendermode="new InteractiveWebAssemblyRenderMode(prerender: false)" />
+   <PageTitle>...</PageTitle>
    ```
+
+   For more information, see <xref:blazor/components/control-head-content>.
 
    Locate following `<div>...</div>` HTML markup:
    


### PR DESCRIPTION
Addresses #32138

This just resolves the page title aspects of the issue. An upcoming PR will address the security aspects.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/control-head-content.md](https://github.com/dotnet/AspNetCore.Docs/blob/b804297c61df806f4425ca3a641b2335c43b819a/aspnetcore/blazor/components/control-head-content.md) | [Control `<head>` content in ASP.NET Core Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/control-head-content?branch=pr-en-us-32144) |
| [aspnetcore/migration/70-80.md](https://github.com/dotnet/AspNetCore.Docs/blob/b804297c61df806f4425ca3a641b2335c43b819a/aspnetcore/migration/70-80.md) | [[Visual Studio Code](#tab/visual-studio-code)](https://review.learn.microsoft.com/en-us/aspnet/core/migration/70-80?branch=pr-en-us-32144) |


<!-- PREVIEW-TABLE-END -->