### PR TITLE
Fix url pointing to Configuration-binding source generator

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -947,7 +947,7 @@ An <xref:Microsoft.AspNetCore.Hosting.IHostingStartup> implementation allows add
 
 ## Configuration-binding source generator
 
-The [Configuration-binding source generator](/dotnet/core/whats-new/dotnet-8#configuration-binding-source-generator) provides AOT and trim-friendly configuration. For more information, see [Configuration-binding source generator](/dotnet/core/whats-new/dotnet-8#configuration-binding-source-generator).
+The [Configuration-binding source generator](/dotnet/core/whats-new/dotnet-8/runtime#configuration-binding-source-generator) provides AOT and trim-friendly configuration. For more information, see [Configuration-binding source generator](/dotnet/core/whats-new/dotnet-8/runtime#configuration-binding-source-generator).
 
 ## Additional resources
 


### PR DESCRIPTION
Fixes #32114 

Url corrected

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/configuration/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/676a418463deabb38761fa4c0a73dbfffbc466d6/aspnetcore/fundamentals/configuration/index.md) | [Configuration in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/index?branch=pr-en-us-32178) |

<!-- PREVIEW-TABLE-END -->