### PR TITLE
[Blazor] Rendering - ShouldRender explanation

### DIFF
--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -33,7 +33,7 @@ Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> s
   
   [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-* The component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false`.
+* The override of component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false` (default `ComponentBase` implementation returns always `true`).
 
 ## Control the rendering flow
 

--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -33,7 +33,7 @@ Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> s
   
   [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-* The override of component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false` (default `ComponentBase` implementation returns always `true`).
+* The override of component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false` (default `ComponentBase` implementation always returns `true`).
 
 ## Control the rendering flow
 

--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -33,7 +33,7 @@ Components inherited from <xref:Microsoft.AspNetCore.Components.ComponentBase> s
   
   [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-* The override of component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false` (default `ComponentBase` implementation always returns `true`).
+* The override of the component's [`ShouldRender` method](#suppress-ui-refreshing-shouldrender) returns `false` (the default `ComponentBase` implementation always returns `true`).
 
 ## Control the rendering flow
 


### PR DESCRIPTION
Minor adjustment to the `ShouldRender`-related condition on when rendering is skipped (to improve clarity).

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/rendering.md](https://github.com/dotnet/AspNetCore.Docs/blob/a7b94c6ff001964d2147df6434e479807aec7547/aspnetcore/blazor/components/rendering.md) | [ASP.NET Core Razor component rendering](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/rendering?branch=pr-en-us-32226) |


<!-- PREVIEW-TABLE-END -->