### PR TITLE
[Blazor] Rendering - order of approaches to manage state

### DIFF
--- a/aspnetcore/blazor/components/rendering.md
+++ b/aspnetcore/blazor/components/rendering.md
@@ -256,9 +256,9 @@ One way to deal with this scenario is to provide a *state management* class, oft
 
 For approaches to manage state, see the following resources:
 
-* [Server-side in-memory state container service](xref:blazor/state-management?pivots=server#in-memory-state-container-service-server) ([client-side equivalent](xref:blazor/state-management?pivots=webassembly#in-memory-state-container-service-wasm)) section of the *State management* article.
-* [Pass data across a component hierarchy](xref:blazor/components/cascading-values-and-parameters#pass-data-across-a-component-hierarchy) using cascading values and parameters.
 * [Bind across more than two components](xref:blazor/components/data-binding#bind-across-more-than-two-components) using data bindings.
+* [Pass data across a component hierarchy](xref:blazor/components/cascading-values-and-parameters#pass-data-across-a-component-hierarchy) using cascading values and parameters.
+* [Server-side in-memory state container service](xref:blazor/state-management?pivots=server#in-memory-state-container-service-server) ([client-side equivalent](xref:blazor/state-management?pivots=webassembly#in-memory-state-container-service-wasm)) section of the *State management* article.
 
 For the state manager approach, C# events are outside the Blazor rendering pipeline. Call <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> on other components you wish to rerender in response to the state manager's events.
 


### PR DESCRIPTION
I believe that when presenting a bullet list of approaches to manage state in Blazor, we should list the built-in approaches first.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/rendering.md](https://github.com/dotnet/AspNetCore.Docs/blob/69a2851358882494c3abee9a18cbcc7a161e33d0/aspnetcore/blazor/components/rendering.md) | [ASP.NET Core Razor component rendering](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/rendering?branch=pr-en-us-32227) |

<!-- PREVIEW-TABLE-END -->