### PR TITLE
Update @HostEnvironment to @Env

### DIFF
--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -186,7 +186,7 @@ Obtain the app's environment in a component by injecting <xref:Microsoft.AspNetC
 
 <h1>Environment example</h1>
 
-<p>Environment: @HostEnvironment.Environment</p>
+<p>Environment: @Env.Environment</p>
 ```
 
 :::moniker range=">= aspnetcore-8.0"


### PR DESCRIPTION
In the example, IWebAssemblyHostEnvironment is injected as `Env`, but referenced in the code as `@HostEnvironment`. Modified the `@HostEnvironment` to be `@Env`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/environments.md](https://github.com/dotnet/AspNetCore.Docs/blob/6c83b6129bbc3ad14a2264fc20a8307d790b84d0/aspnetcore/blazor/fundamentals/environments.md) | [ASP.NET Core Blazor environments](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/environments?branch=pr-en-us-32256) |

<!-- PREVIEW-TABLE-END -->