### PR TITLE
WASM runtime max heap size

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -136,13 +136,13 @@ Disable the trimming property if it prevents your app from running normally:
 
 :::moniker range=">= aspnetcore-8.0"
 
-When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` may be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-8.0"
 
-When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` may be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -136,13 +136,13 @@ Disable the trimming property if it prevents your app from running normally:
 
 :::moniker range=">= aspnetcore-8.0"
 
-When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes, which might be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-8.0"
 
-When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes, which might be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -136,7 +136,7 @@ Disable the trimming property if it prevents your app from running normally:
 
 :::moniker range=">= aspnetcore-8.0"
 
-When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, increasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes or size of the app's DLLs, whichever is larger. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes or size of the app's DLLs, whichever is larger. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -136,13 +136,13 @@ Disable the trimming property if it prevents your app from running normally:
 
 :::moniker range=">= aspnetcore-8.0"
 
-When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` may be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` may be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app crashing if the app attempts to allocate more memory with the browser failing to grant it. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-8.0"
 
-When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` may be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` may be required. The default value is 2,147,483,648 bytes, which may be too large and result in the app crashing if the app attempts to allocate more memory with the browser failing to grant it. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -132,17 +132,17 @@ Disable the trimming property if it prevents your app from running normally:
 
 :::moniker-end
 
-## Increase maximum heap size for some mobile device browsers
+## Decrease maximum heap size for some mobile device browsers
 
 :::moniker range=">= aspnetcore-8.0"
 
-When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes or size of the app's DLLs, whichever is larger. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes, which might be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-8.0"
 
-When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, increasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes or size of the app's DLLs, whichever is larger. The following example sets the value to 268,435,456 bytes in the `Program` file:
+When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, decreasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes, which might be too large and result in the app failing to run. The following example sets the value to 268,435,456 bytes in the `Program` file:
 
 :::moniker-end
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -132,6 +132,26 @@ Disable the trimming property if it prevents your app from running normally:
 
 :::moniker-end
 
+## Increase maximum heap size for some mobile device browsers
+
+:::moniker range=">= aspnetcore-8.0"
+
+When building a Blazor app that runs on the client (`.Client` project of a Blazor Web App or standalone Blazor WebAssembly app) and targets mobile device browsers, especially Safari on iOS, increasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes or size of the app's DLLs, whichever is larger. The following example sets the value to 268,435,456 bytes in the `Program` file:
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
+When building a Blazor WebAssembly app that targets mobile device browsers, especially Safari on iOS, increasing the maximum memory for the app with the MSBuild property `EmccMaximumHeapSize` might be required. The default value is 2,147,483,648 bytes or size of the app's DLLs, whichever is larger. The following example sets the value to 268,435,456 bytes in the `Program` file:
+
+:::moniker-end
+
+```xml
+<EmccMaximumHeapSize>268435456</EmccMaximumHeapSize>
+```
+
+For more information on [Mono](https://github.com/mono/mono)/WebAssembly MSBuild properties and targets, see [`WasmApp.Common.targets` (`dotnet/runtime` GitHub repository)](https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.Common.targets).
+
 :::moniker range=">= aspnetcore-6.0"
 
 ## Runtime relinking


### PR DESCRIPTION
Fixes #30278

Marek ... I'm confused on the setting you provided ... 256 MiB (BTW, they won't allow us to use MiB, so I'm just going to show bytes and write "bytes" for this guidance) ... anyway ... 256 MiB ... or 268,435,456 bytes.

According to https://github.com/dotnet/runtime/blob/main/src/mono/wasm/build/WasmApp.Common.targets, the default is listed a lot higher ...

> - $(EmccMaximumHeapSize) - Maximum heap size specified with `emcc`. Default value: 2147483648 or size of the DLLs, whichever is larger. Corresponds to `-s MAXIMUM_MEMORY=...` emcc arg.

... **2,147,483,648** bytes ... 2 gigs.

So ... is the remark in that file incorrect on the default? If so, what's the actual default value?

Otherwise, the PR is ready for review.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/f73b380558e9c31d7fb8cd48aaeb97d8d6092538/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-32257) |


<!-- PREVIEW-TABLE-END -->