### PR TITLE
Clarify use of IHttpContextAccessor/HttpContext

### DIFF
--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -48,6 +48,9 @@ The `BlazorWebAppOidc` project is the server-side project of the Blazor Web App.
 
 The `BlazorWebAppOidc.http` file can be used for testing the weather data request. Note that the `BlazorWebAppOidc` project must be running to test the endpoint, and the endpoint is hardcoded into the file. For more information, see <xref:test/http-files>.
 
+> [!NOTE]
+> The server project uses <xref:Microsoft.AspNetCore.Http.IHttpContextAccessor>/<xref:Microsoft.AspNetCore.Http.HttpContext>, but never for interactively-rendered components. For more information, see <xref:blazor/security/server/interactive-server-side-rendering#ihttpcontextaccessorhttpcontext-in-razor-components>.
+
 ### Configuration
 
 This section explains how to configure the sample app.
@@ -280,6 +283,9 @@ Confirm that you've met the prerequisites for .NET Aspire. For more information,
 The `BlazorWebAppOidc` project is the server-side project of the Blazor Web App. The project uses [YARP](https://microsoft.github.io/reverse-proxy/) to proxy requests to a weather forecast endpoint in the backend web API project (`MinimalApiJwt`) with the `access_token` stored in the authentication cookie.
 
 The `BlazorWebAppOidc.http` file can be used for testing the weather data request. Note that the `BlazorWebAppOidc` project must be running to test the endpoint, and the endpoint is hardcoded into the file. For more information, see <xref:test/http-files>.
+
+> [!NOTE]
+> The server project uses <xref:Microsoft.AspNetCore.Http.IHttpContextAccessor>/<xref:Microsoft.AspNetCore.Http.HttpContext>, but never for interactively-rendered components. For more information, see <xref:blazor/security/server/interactive-server-side-rendering#ihttpcontextaccessorhttpcontext-in-razor-components>.
 
 ### Configuration
 


### PR DESCRIPTION
Fixes #32243

Thanks @nwoolls! 🚀 ... I'm adding a NOTE to clarify that `IHttpContextAccessor`/`HttpContext` isn't used for interactively-rendered components with a cross-link to that guidance.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/blazor-web-app-with-oidc.md](https://github.com/dotnet/AspNetCore.Docs/blob/c2138cbc1c9acd3d6bc8186200bb836d645c329c/aspnetcore/blazor/security/blazor-web-app-with-oidc.md) | [Secure an ASP.NET Core Blazor Web App with OpenID Connect (OIDC)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-oidc?branch=pr-en-us-32260) |

<!-- PREVIEW-TABLE-END -->