### PR TITLE
SignalR: Clarify groups

### DIFF
--- a/aspnetcore/signalr/groups.md
+++ b/aspnetcore/signalr/groups.md
@@ -44,7 +44,7 @@ It's safe to add a user to a group multiple times, no exception is thrown in the
 
 Group membership isn't preserved when a connection reconnects. The connection needs to rejoin the group when it's re-established. It's not possible to count the members of a group, since this information isn't available if the application is scaled to multiple servers. 
 
-Groups are kept in-memory, so they won't persist through a server restart. Consider the Azure SignalR service for scenarios requiring group membership to be persisted. For more information, see [Azure SignalR](https://learn.microsoft.com/azure/azure-signalr/signalr-overview)
+Groups are kept in memory, so they won't persist through a server restart. Consider the Azure SignalR service for scenarios requiring group membership to be persisted. For more information, see [Azure SignalR](/azure/azure-signalr/signalr-overview)
 
 To protect access to resources while using groups, use [authentication and authorization](xref:signalr/authn-and-authz) functionality in ASP.NET Core. If a user is added to a group only when the credentials are valid for that group. This way, messages dispatched to the group are guaranteed to reach only those users who are authorized. However, groups aren't a security feature. Authentication claims have features that groups don't, such as expiry and revocation. If a user's permission to access the group is revoked, the app must remove the user from the group explicitly.
 

--- a/aspnetcore/signalr/groups.md
+++ b/aspnetcore/signalr/groups.md
@@ -5,7 +5,7 @@ description: Overview of ASP.NET Core SignalR User and Group management.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 05/17/2020
+ms.date: 04/04/2024
 uid: signalr/groups
 ---
 
@@ -13,7 +13,7 @@ uid: signalr/groups
 
 By [Brennan Conroy](https://github.com/BrennanConroy)
 
-SignalR allows messages to be sent to all connections associated with a specific user, as well as to named groups of connections.
+SignalR allows messages to be sent to all connections associated with a specific user and to named groups of connections.
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/signalr/groups/sample/) [(how to download)](xref:index#how-to-download-a-sample)
 
@@ -32,11 +32,21 @@ Send a message to a specific user by passing the user identifier to the `User` f
 
 ## Groups in SignalR
 
-A group is a collection of connections associated with a name. Messages can be sent to all connections in a group. Groups are the recommended way to send to a connection or multiple connections because the groups are managed by the application. A connection can be a member of multiple groups. Groups are ideal for something like a chat application, where each room can be represented as a group. Connections are added to or removed from groups via the `AddToGroupAsync` and `RemoveFromGroupAsync` methods.
+### What are groups in SignalR and why use them
+
+A group is a collection of connections associated with a name. Messages can be sent to all connections in a group. Groups are the recommended way to send to a connection or multiple connections because the groups are managed by the application. A connection can be a member of multiple groups. Groups are ideal for something like a chat application, where each room can be represented as a group. 
+
+### Add or remove connections from a group
+
+Connections are added to or removed from groups via the `AddToGroupAsync` and `RemoveFromGroupAsync` methods:
 
 [!code-csharp[Hub methods](groups/sample/Hubs/ChatHub.cs?range=15-27)]
 
+It's safe to add a user to a group multiple times, no exception is thrown in the case that the user already exists in the group.
+
 Group membership isn't preserved when a connection reconnects. The connection needs to rejoin the group when it's re-established. It's not possible to count the members of a group, since this information is not available if the application is scaled to multiple servers.
+
+Groups are kept in-memory, so they will not persist through a server restart.  Consider the Azure SignalR service for scenarios requiring group membership to be persisted.  For more inforamtion see [Azure SignalR](https://learn.microsoft.com/en-us/azure/azure-signalr/signalr-overview)
 
 To protect access to resources while using groups, use [authentication and authorization](xref:signalr/authn-and-authz) functionality in ASP.NET Core. If a user is added to a group only when the credentials are valid for that group, messages sent to that group will only go to authorized users. However, groups are not a security feature. Authentication claims have features that groups do not, such as expiry and revocation. If a user's permission to access the group is revoked, the app must remove the user from the group explicitly.
 

--- a/aspnetcore/signalr/groups.md
+++ b/aspnetcore/signalr/groups.md
@@ -32,8 +32,6 @@ Send a message to a specific user by passing the user identifier to the `User` f
 
 ## Groups in SignalR
 
-### What are groups in SignalR and why use them
-
 A group is a collection of connections associated with a name. Messages can be sent to all connections in a group. Groups are the recommended way to send to a connection or multiple connections because the groups are managed by the application. A connection can be a member of multiple groups. Groups are ideal for something like a chat application, where each room can be represented as a group. 
 
 ### Add or remove connections from a group
@@ -44,11 +42,11 @@ Connections are added to or removed from groups via the `AddToGroupAsync` and `R
 
 It's safe to add a user to a group multiple times, no exception is thrown in the case that the user already exists in the group.
 
-Group membership isn't preserved when a connection reconnects. The connection needs to rejoin the group when it's re-established. It's not possible to count the members of a group, since this information is not available if the application is scaled to multiple servers.
+Group membership isn't preserved when a connection reconnects. The connection needs to rejoin the group when it's re-established. It's not possible to count the members of a group, since this information isn't available if the application is scaled to multiple servers. 
 
-Groups are kept in-memory, so they will not persist through a server restart.  Consider the Azure SignalR service for scenarios requiring group membership to be persisted.  For more inforamtion see [Azure SignalR](https://learn.microsoft.com/en-us/azure/azure-signalr/signalr-overview)
+Groups are kept in-memory, so they won't persist through a server restart. Consider the Azure SignalR service for scenarios requiring group membership to be persisted. For more information, see [Azure SignalR](https://learn.microsoft.com/azure/azure-signalr/signalr-overview)
 
-To protect access to resources while using groups, use [authentication and authorization](xref:signalr/authn-and-authz) functionality in ASP.NET Core. If a user is added to a group only when the credentials are valid for that group, messages sent to that group will only go to authorized users. However, groups are not a security feature. Authentication claims have features that groups do not, such as expiry and revocation. If a user's permission to access the group is revoked, the app must remove the user from the group explicitly.
+To protect access to resources while using groups, use [authentication and authorization](xref:signalr/authn-and-authz) functionality in ASP.NET Core. If a user is added to a group only when the credentials are valid for that group. This way, messages dispatched to the group are guaranteed to reach only those users who are authorized. However, groups aren't a security feature. Authentication claims have features that groups don't, such as expiry and revocation. If a user's permission to access the group is revoked, the app must remove the user from the group explicitly.
 
 > [!NOTE]
 > Group names are case-sensitive.

--- a/aspnetcore/signalr/groups.md
+++ b/aspnetcore/signalr/groups.md
@@ -46,7 +46,7 @@ Group membership isn't preserved when a connection reconnects. The connection ne
 
 Groups are kept in memory, so they won't persist through a server restart. Consider the Azure SignalR service for scenarios requiring group membership to be persisted. For more information, see [Azure SignalR](/azure/azure-signalr/signalr-overview)
 
-To protect access to resources while using groups, use [authentication and authorization](xref:signalr/authn-and-authz) functionality in ASP.NET Core. If a user is added to a group only when the credentials are valid for that group. This way, messages dispatched to the group are guaranteed to reach only those users who are authorized. However, groups aren't a security feature. Authentication claims have features that groups don't, such as expiry and revocation. If a user's permission to access the group is revoked, the app must remove the user from the group explicitly.
+To protect access to resources while using groups, use [authentication and authorization](xref:signalr/authn-and-authz) functionality in ASP.NET Core. If a user is added to a group only when the credentials are valid for that group, messages sent to that group will only go to authorized users. However, groups are not a security feature. Authentication claims have features that groups don't, such as expiry and revocation. If a user's permission to access the group is revoked, the app must remove the user from the group explicitly.
 
 > [!NOTE]
 > Group names are case-sensitive.


### PR DESCRIPTION
Fixes: #29736

Clarifying:

- Group data is kept in-memory and do not persist.
- You are allowed to add users multiple times to a group, it will not throw an exception.

Also a little bit of cleanup.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/signalr/groups.md](https://github.com/dotnet/AspNetCore.Docs/blob/faf6cffea9e0b97634a63aa3027efa0b69194eb1/aspnetcore/signalr/groups.md) | [Manage users and groups in SignalR](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/groups?branch=pr-en-us-32261) |


<!-- PREVIEW-TABLE-END -->