### PR TITLE
Link update

### DIFF
--- a/aspnetcore/blazor/components/dynamiccomponent.md
+++ b/aspnetcore/blazor/components/dynamiccomponent.md
@@ -145,8 +145,7 @@ In the preceding example:
 
 * An <xref:System.Collections.Generic.Dictionary%602> is used to manage components to be displayed.
 * Names serve as the dictionary keys and are provided as selection options.
-* Component types are stored as dictionary values using the [`typeof` operator](/dotnet/csharp/language-reference/operators/typeof).
-
+* Component types are stored as dictionary values using the [`typeof` operator](/dotnet/csharp/language-reference/operators/type-testing-and-cast#typeof-operator).
 
 ## Pass parameters
 


### PR DESCRIPTION
Looks like they moved the 🧀 on this one!

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/dynamiccomponent.md](https://github.com/dotnet/AspNetCore.Docs/blob/76c37f7742ebb7dbd6b316f156577b66ec578cf2/aspnetcore/blazor/components/dynamiccomponent.md) | [Dynamically-rendered ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/dynamiccomponent?branch=pr-en-us-32267) |

<!-- PREVIEW-TABLE-END -->