### PR TITLE
Remove sneaky component reference

### DIFF
--- a/aspnetcore/blazor/components/js-spa-frameworks.md
+++ b/aspnetcore/blazor/components/js-spa-frameworks.md
@@ -357,7 +357,7 @@ For a complete example of how to create custom elements with Blazor, see the [`C
 
 ### Pass parameters
 
-Pass parameters to your Blazor component either as HTML attributes or as JavaScript properties on the DOM element.
+Pass parameters to your Razor component either as HTML attributes or as JavaScript properties on the DOM element.
 
 The following `Counter` component uses an `IncrementAmount` parameter to set the increment amount of the **:::no-loc text="Click me":::** button.
 


### PR DESCRIPTION
# 😈 

***Arrrrrgh!*** 😡 Looks like one of these snuck in here from content that arrived for the article. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/js-spa-frameworks.md](https://github.com/dotnet/AspNetCore.Docs/blob/25748d51eefa433102701f1dddc59bb5a65f3e76/aspnetcore/blazor/components/js-spa-frameworks.md) | [Use Razor components in JavaScript apps and SPA frameworks](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/js-spa-frameworks?branch=pr-en-us-32275) |

<!-- PREVIEW-TABLE-END -->