### PR TITLE
Improve guidance on security config with app settings files

### DIFF
--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -61,7 +61,7 @@ Other configuration providers registered by the app can also provide configurati
 For more information on configuration providers, see <xref:fundamentals/configuration/index>.
 
 > [!WARNING]
-> Configuration and settings files in the web root (`wwwroot` folder) are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in the app's configuration or files.**
+> Configuration and settings files in the web root (`wwwroot` folder) are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in any web root file.**
 
 ## App settings configuration
 
@@ -112,7 +112,7 @@ Inject an <xref:Microsoft.Extensions.Configuration.IConfiguration> instance into
 Client security restrictions prevent direct access to files via user code, including settings files for app configuration. To read configuration files in addition to `appsettings.json`/`appsettings.{ENVIRONMENT}.json` from the `wwwroot` folder into configuration, use an <xref:System.Net.Http.HttpClient>.
 
 > [!WARNING]
-> Configuration and settings files are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in the app's configuration or files.**
+> Configuration and settings files in the web root (`wwwroot` folder) are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in any web root file.**
 
 The following example reads a configuration file (`cars.json`) into the app's configuration.
 
@@ -246,7 +246,7 @@ builder.Services.AddOidcAuthentication(options =>
 ```
 
 > [!WARNING]
-> Configuration and settings files in the web root (`wwwroot` folder) are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in the app's configuration or files.**
+> Configuration and settings files in the web root (`wwwroot` folder) are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in any web root file.**
 
 ## Logging configuration
 

--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -61,7 +61,7 @@ Other configuration providers registered by the app can also provide configurati
 For more information on configuration providers, see <xref:fundamentals/configuration/index>.
 
 > [!WARNING]
-> Configuration and settings files are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in the app's configuration or files.**
+> Configuration and settings files in the web root (`wwwroot` folder) are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in the app's configuration or files.**
 
 ## App settings configuration
 
@@ -246,7 +246,7 @@ builder.Services.AddOidcAuthentication(options =>
 ```
 
 > [!WARNING]
-> Configuration and settings files are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in the app's configuration or files.**
+> Configuration and settings files in the web root (`wwwroot` folder) are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in the app's configuration or files.**
 
 ## Logging configuration
 

--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -225,7 +225,7 @@ Obtain a section of the configuration in C# code with <xref:Microsoft.Extensions
 
 ## Authentication configuration
 
-Provide authentication configuration in an app settings file.
+Provide ***public*** authentication configuration in an app settings file.
 
 `wwwroot/appsettings.json`:
 
@@ -244,6 +244,9 @@ Load the configuration for an Identity provider with <xref:Microsoft.Extensions.
 builder.Services.AddOidcAuthentication(options =>
     builder.Configuration.Bind("Local", options.ProviderOptions));
 ```
+
+> [!WARNING]
+> Configuration and settings files are visible to users on the client, and users can tamper with the data. **Don't store app secrets, credentials, or any other sensitive data in the app's configuration or files.**
 
 ## Logging configuration
 


### PR DESCRIPTION
Fixes #31152

Thanks @HaraldSchmitt! 🚀 ... I'm resolving this by ...

* Noting that it's ***PUBLIC*** security config that goes into the file ... public data that's required for the security implementation to work properly by-design. I both **bold** and *italicize* the word "public" in the security section to highlight that fact.
* Further, I place a copy of that warning in that section with a modification to clarify that it's the web root-served (`wwwroot` folder) app settings file that's of concern. A server-side app settings fine remains secure on the server, so that's not a concern here.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/configuration.md](https://github.com/dotnet/AspNetCore.Docs/blob/0a81bbe98963f46054af9aa1858d9c9a12114d38/aspnetcore/blazor/fundamentals/configuration.md) | [ASP.NET Core Blazor configuration](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/configuration?branch=pr-en-us-32277) |


<!-- PREVIEW-TABLE-END -->