### PR TITLE
Add additional scope guidance

### DIFF
--- a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
@@ -70,8 +70,8 @@ When testing with the Graph SDK locally, we recommend using a new in-private/inc
 
 To permit [Microsoft Graph API](/graph/use-the-api) calls for user profile, role assignment, and group membership data:
 
-* A **CLIENT** app is configured with the delegated `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal because access is determined by the scopes granted to individual users.
-* A **SERVER** app is configured with the application `GroupMember.Read.All` scope (`https://graph.microsoft.com/GroupMember.Read.All`) in the Azure portal because access is for the app to obtain information about group membership, not based on individual user authorization to access data about group members.
+* A **CLIENT** app is configured with the ***delegated*** `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal because access is determined by the scopes granted to individual users.
+* A **SERVER** app is configured with the ***application*** `GroupMember.Read.All` scope (`https://graph.microsoft.com/GroupMember.Read.All`) in the Azure portal because access is for the app to obtain information about group membership, not based on individual user authorization to access data about group members.
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
@@ -70,8 +70,8 @@ When testing with the Graph SDK locally, we recommend using a new in-private/inc
 
 To permit [Microsoft Graph API](/graph/use-the-api) calls for user profile, role assignment, and group membership data:
 
-* A **CLIENT** app is configured with the `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal.
-* A **SERVER** app is configured with the `GroupMember.Read.All` scope (`https://graph.microsoft.com/GroupMember.Read.All`) in the Azure portal.
+* A **CLIENT** app is configured with the delegated `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal.
+* A **SERVER** app is configured with the application `GroupMember.Read.All` scope (`https://graph.microsoft.com/GroupMember.Read.All`) in the Azure portal.
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
@@ -70,8 +70,8 @@ When testing with the Graph SDK locally, we recommend using a new in-private/inc
 
 To permit [Microsoft Graph API](/graph/use-the-api) calls for user profile, role assignment, and group membership data:
 
-* A **CLIENT** app is configured with the delegated `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal.
-* A **SERVER** app is configured with the application `GroupMember.Read.All` scope (`https://graph.microsoft.com/GroupMember.Read.All`) in the Azure portal.
+* A **CLIENT** app is configured with the delegated `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal because access is determined by the scopes granted to individual users.
+* A **SERVER** app is configured with the application `GroupMember.Read.All` scope (`https://graph.microsoft.com/GroupMember.Read.All`) in the Azure portal because access is for the app to obtain information about group membership, not based on individual user authorization to access data about group members.
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
@@ -70,7 +70,7 @@ When testing with the Graph SDK locally, we recommend using a new in-private/inc
 
 To permit [Microsoft Graph API](/graph/use-the-api) calls for user profile, role assignment, and group membership data:
 
-* A **CLIENT** app is configured with the ***delegated*** `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal because access is determined by the scopes granted to individual users.
+* A **CLIENT** app is configured with the ***delegated*** `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal because access is determined by the scopes granted (delegated) to individual users.
 * A **SERVER** app is configured with the ***application*** `GroupMember.Read.All` scope (`https://graph.microsoft.com/GroupMember.Read.All`) in the Azure portal because access is for the app to obtain information about group membership, not based on individual user authorization to access data about group members.
 
 :::moniker range=">= aspnetcore-8.0"

--- a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
@@ -70,7 +70,7 @@ When testing with the Graph SDK locally, we recommend using a new in-private/inc
 
 To permit [Microsoft Graph API](/graph/use-the-api) calls for user profile, role assignment, and group membership data:
 
-* A **CLIENT** app is configured with the ***delegated*** `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal because access is determined by the scopes granted (delegated) to individual users.
+* A **CLIENT** app is configured with the ***delegated*** `User.Read` scope (`https://graph.microsoft.com/User.Read`) in the Azure portal because access to read user data is determined by the scopes granted (delegated) to individual users.
 * A **SERVER** app is configured with the ***application*** `GroupMember.Read.All` scope (`https://graph.microsoft.com/GroupMember.Read.All`) in the Azure portal because access is for the app to obtain information about group membership, not based on individual user authorization to access data about group members.
 
 :::moniker range=">= aspnetcore-8.0"

--- a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
@@ -85,7 +85,7 @@ The preceding scopes are required in addition to the scopes required in ME-ID de
 
 :::moniker-end
 
-For more information, see the [Microsoft Graph permissions reference](/graph/permissions-reference).
+For more information, see [Overview of permissions and consent in the Microsoft identity platform](/entra/identity-platform/permissions-consent-overview) and [Overview of Microsoft Graph permissions](/graph/permissions-overview).
 
 > [!NOTE]
 > The words "permission" and "scope" are used interchangeably in the Azure portal and in various Microsoft and external documentation sets. This article uses the word "scope" throughout for the permissions assigned to an app in the Azure portal.


### PR DESCRIPTION
Fixes #30788

Thanks @philip-reed! 🚀 ... This is an important improvement to the coverage.

Since we discussed this, there was a considerable overhaul to the Graph API article, which included updates to the remarks on scopes. Those updates also ensure that devs can get over to the Azure docs for more info.

Here, I think the article should merely indicate delegated scope(s) for the client and application scope(s) for the server app with a bit of explanation on why one is delegated and the other is for the application. Beyond that, devs should access the Identity platform/Azure docs for more info, as they have extensive coverage. I'm improving the cross-linking by adding a second cross-link to helpful information over there.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md](https://github.com/dotnet/AspNetCore.Docs/blob/397b310823eb6447f2ae3b127c3387e308231893/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md) | [Microsoft Entra (ME-ID) groups, Administrator Roles, and App Roles](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/microsoft-entra-id-groups-and-roles?branch=pr-en-us-32286) |


<!-- PREVIEW-TABLE-END -->