### PR TITLE
Add Debugger support section

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -341,6 +341,24 @@ Breakpoints are **not** hit during app startup before the debug proxy is running
 
 ---
 
+:::moniker range=">= aspnetcore-8.0"
+
+## Debugger support
+
+Debugging is enabled for the runtime when debugger support is enabled with `<DebuggerSupport>{VALUE}</DebuggerSupport>`, where the `{VALUE}` place holder is either `true` or `false`.
+
+By default, the Blazor framework *disables* debugger support for all non-Debug configurations. To enable debugger support for a non-Debug configuration, add a `<DebuggerSupport>` property to the app's project file.
+
+In the following example, debugger support is enabled for the custom "`DebugCustom`" configuration:
+
+```xml
+<DebuggerSupport Condition="'$(Configuration)' == 'DebugCustom'">true</DebuggerSupport>
+```
+
+For more information, see [Blazor WebAssembly custom debugger configuration (`dotnet/runtime` #96239)](https://github.com/dotnet/runtime/issues/96239).
+
+:::moniker-end
+
 :::moniker range="< aspnetcore-8.0"
 
 ## Debug a hosted Blazor WebAssembly app in an IDE

--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -341,6 +341,9 @@ Breakpoints are **not** hit during app startup before the debug proxy is running
 
 ---
 
+<!-- UPDATE 9.0 Remove the following versioning on the Debugger
+                support section at 9.0 GA -->
+
 :::moniker range=">= aspnetcore-8.0"
 
 ## Debugger support


### PR DESCRIPTION
Fixes #31281

Thanks @Bradtus! 🚀 ... Let me know when you get the title of the `dotnet/runtime` PU issue changed.

@maraf ... Given how hard it is to understand the <8.0 behavior and the fact that use of <8.0 will recede in coming years, I think we should only document this for >=8.0. Let me know if you disagree and please suggest text. What you said on the PU issue is very challenging to comprehend for <8.0. The cross-link is here, so devs can get into the weeds of your complete answer if they want to. At this point, I don't think the article has to cover that level of detail.

BTW @maraf ... In case @Bradtus doesn't see this, could you change the name of that PU issue at https://github.com/dotnet/runtime/issues/96239?

Go from its current title of ...

> Blazor WASM Custom debug configs need \<DebuggerSupport Condition="''$(Configuration)' == 'DebugCustom'">true\</DebuggerSupport>

... TO ...

> Blazor WebAssembly custom debugger configuration

... which is what I have for the link text for the cross-link on this PR.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/debug.md](https://github.com/dotnet/AspNetCore.Docs/blob/cb620e0615867959e0828a24daddda6da5c0db63/aspnetcore/blazor/debug.md) | [Debug ASP.NET Core apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/debug?branch=pr-en-us-32287) |

<!-- PREVIEW-TABLE-END -->