### PR TITLE
Generic type article improvements

### DIFF
--- a/aspnetcore/blazor/components/generic-type-support.md
+++ b/aspnetcore/blazor/components/generic-type-support.md
@@ -5,7 +5,7 @@ description: Learn about generic type support in ASP.NET Core Razor components.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 02/09/2024
+ms.date: 04/10/2024
 uid: blazor/components/generic-type-support
 ---
 # ASP.NET Core Razor component generic type support
@@ -13,6 +13,10 @@ uid: blazor/components/generic-type-support
 [!INCLUDE[](~/includes/not-latest-version.md)]
 
 This article describes generic type support in Razor components.
+
+If you're new to generic types, see [Generic classes and methods (C# Guide)](/dotnet/csharp/fundamentals/types/generics) for general guidance on the use of generics before reading this article.
+
+The example code in this article is only available for the latest .NET release in the [Blazor sample apps](xref:blazor/fundamentals/index#sample-apps).
 
 ## Generic type parameter support
 
@@ -28,84 +32,20 @@ C# syntax with [`where`](/dotnet/csharp/language-reference/keywords/where-generi
 @typeparam TEntity where TEntity : IEntity
 ```
 
-In the following example, the `ListGenericTypeItems1` component is generically typed as `TExample`.
+In the following example, the `ListItems1` component is generically typed as `TExample`, which represents the type of the `ExampleList` collection.
 
-`ListGenericTypeItems1.razor`:
+`ListItems1.razor`:
 
-:::moniker range=">= aspnetcore-8.0"
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/ListItems1.razor":::
 
-:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/ListGenericTypeItems1.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
-
-:::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Shared/generic-type-support/ListGenericTypeItems1.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Shared/generic-type-support/ListGenericTypeItems1.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-:::code language="razor" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/Shared/generic-type-support/ListGenericTypeItems1.razor":::
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-5.0"
-
-:::code language="razor" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/Shared/generic-type-support/ListGenericTypeItems1.razor":::
-
-:::moniker-end
-
-The following component renders two `ListGenericTypeItems1` components:
+The following component renders two `ListItems1` components:
 
 * String or integer data is assigned to the `ExampleList` parameter of each component.
 * Type `string` or `int` that matches the type of the assigned data is set for the type parameter (`TExample`) of each component.
 
-:::moniker range=">= aspnetcore-8.0"
+`Generics1.razor`:
 
-`GenericType1.razor`:
-
-:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/Pages/GenericType1.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
-
-`GenericTypeExample1.razor`:
-
-:::code language="razor" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/Pages/generic-type-support/GenericTypeExample1.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
-
-`GenericTypeExample1.razor`:
-
-:::code language="razor" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/Pages/generic-type-support/GenericTypeExample1.razor":::
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
-
-`GenericTypeExample1.razor`:
-
-:::code language="razor" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/Pages/generic-type-support/GenericTypeExample1.razor":::
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-5.0"
-
-`GenericTypeExample1.razor`:
-
-:::code language="razor" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/Pages/generic-type-support/GenericTypeExample1.razor":::
-
-:::moniker-end
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/Pages/Generics1.razor":::
 
 For more information, see <xref:mvc/views/razor#typeparam>. For an example of generic typing with templated components, see <xref:blazor/components/templated-components>.
 
@@ -125,205 +65,51 @@ When receiving a cascaded type parameter, components obtain the parameter value 
 
 Matching is only performed by name. Therefore, we recommend avoiding a cascaded generic type parameter with a generic name, for example `T` or `TItem`. If a developer opts into cascading a type parameter, they're implicitly promising that its name is unique enough not to clash with other cascaded type parameters from unrelated components.
 
-Generic types can be cascaded to child components in either of the following approaches with ancestor (parent) components, which are demonstrated in the following two sub-sections:
+Generic types can be cascaded to child components with either of the following approaches for ancestor (parent) components, which are demonstrated in the following two sub-sections:
 
 * Explicitly set the cascaded generic type.
 * Infer the cascaded generic type.
 
-The following subsections provide examples of the preceding approaches using the following two `ListDisplay` components. The components receive and render list data and are generically typed as `TExample`. These components are for demonstration purposes and only differ in the color of text that the list is rendered. If you wish to experiment with the components in the following sub-sections in a local test app, add the following two components to the app first.
+The following subsections provide examples of the preceding approaches using the following `ListDisplay1` component. The component receives and renders list data generically typed as `TExample`. To make each instance of `ListDisplay1` stand out, an additional component parameter controls the color of the list.
 
 `ListDisplay1.razor`:
 
-```razor
-@typeparam TExample
-
-@if (ExampleList is not null)
-{
-    <ul style="color:blue">
-        @foreach (var item in ExampleList)
-        {
-            <li>@item</li>
-        }
-    </ul>
-}
-
-@code {
-    [Parameter]
-    public IEnumerable<TExample>? ExampleList { get; set; }
-}
-```
-
-`ListDisplay2.razor`:
-
-```razor
-@typeparam TExample
-
-@if (ExampleList is not null)
-{
-    <ul style="color:red">
-        @foreach (var item in ExampleList)
-        {
-            <li>@item</li>
-        }
-    </ul>
-}
-
-@code {
-    [Parameter]
-    public IEnumerable<TExample>? ExampleList { get; set; }
-}
-```
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/ListDisplay1.razor":::
 
 ### Explicit generic types based on ancestor components
 
 The demonstration in this section cascades a type explicitly for `TExample`.
 
 > [!NOTE]
-> This section uses the two `ListDisplay` components in the [Cascaded generic type support](#cascaded-generic-type-support) section.
+> This section uses the preceding `ListDisplay1` component in the [Cascaded generic type support](#cascaded-generic-type-support) section.
 
-The following `ListGenericTypeItems2` component receives data and cascades a generic type parameter named `TExample` to its descendent components. In the upcoming parent component, the `ListGenericTypeItems2` component is used to display list data with the preceding `ListDisplay` component.
+The following `ListItems2` component receives data and cascades a generic type parameter named `TExample` to its descendent components. In the upcoming parent component, the `ListItems2` component is used to display list data with the preceding `ListDisplay1` component.
 
-`ListGenericTypeItems2.razor`:
+`ListItems2.razor`:
 
-```razor
-@attribute [CascadingTypeParameter(nameof(TExample))]
-@typeparam TExample
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/ListItems2.razor":::
 
-<h2>List Generic Type Items 2</h2>
+The following parent component sets the child content (<xref:Microsoft.AspNetCore.Components.RenderFragment>) of two `ListItems2` components specifying the `ListItems2` types (`TExample`), which are cascaded to child components. `ListDisplay1` components are rendered with the list item data shown in the example. String data is used with the first `ListItems2` component, and integer data is used with the second `ListItems2` component.
 
-@ChildContent
+`Generics2.razor`:
 
-@code {
-    [Parameter]
-    public RenderFragment? ChildContent { get; set; }
-}
-```
-
-The following parent component sets the child content (<xref:Microsoft.AspNetCore.Components.RenderFragment>) of two `ListGenericTypeItems2` components specifying the `ListGenericTypeItems2` types (`TExample`), which are cascaded to child components. `ListDisplay` components are rendered with the list item data shown in the example. String data is used with the first `ListGenericTypeItems2` component, and integer data is used with the second `ListGenericTypeItems2` component.
-
-`GenericType2.razor`:
-
-```razor
-@page "/generic-type-2"
-
-<h1>Generic Type Example 2</h1>
-
-<ListGenericTypeItems2 TExample="string">
-    <ListDisplay1 ExampleList="@(new List<string> { "Item 1", "Item 2" })" />
-    <ListDisplay2 ExampleList="@(new List<string> { "Item 3", "Item 4" })" />
-</ListGenericTypeItems2>
-
-<ListGenericTypeItems2 TExample="int">
-    <ListDisplay1 ExampleList="@(new List<int> { 1, 2, 3 })" />
-    <ListDisplay2 ExampleList="@(new List<int> { 4, 5, 6 })" />
-</ListGenericTypeItems2>
-```
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/Pages/Generics2.razor":::
 
 Specifying the type explicitly also allows the use of [cascading values and parameters](xref:blazor/components/cascading-values-and-parameters) to provide data to child components, as the following demonstration shows.
 
-`ListDisplay3.razor`:
+`ListDisplay2.razor`:
 
-```razor
-@typeparam TExample
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/ListDisplay2.razor":::
 
-@if (ExampleList is not null)
-{
-    <ul style="color:blue">
-        @foreach (var item in ExampleList)
-        {
-            <li>@item</li>
-        }
-    </ul>
-}
+`ListItems3.razor`:
 
-@code {
-    [CascadingParameter]
-    protected IEnumerable<TExample>? ExampleList { get; set; }
-}
-```
-
-`ListDisplay4.razor`:
-
-```razor
-@typeparam TExample
-
-@if (ExampleList is not null)
-{
-    <ul style="color:red">
-        @foreach (var item in ExampleList)
-        {
-            <li>@item</li>
-        }
-    </ul>
-}
-
-@code {
-    [CascadingParameter]
-    protected IEnumerable<TExample>? ExampleList { get; set; }
-}
-```
-
-`ListGenericTypeItems3.razor`:
-
-```razor
-@attribute [CascadingTypeParameter(nameof(TExample))]
-@typeparam TExample
-
-<h2>List Generic Type Items 3</h2>
-
-@ChildContent
-
-@if (ExampleList is not null)
-{
-    <ul style="color:green">
-        @foreach(var item in ExampleList)
-        {
-            <li>@item</li>
-        }
-    </ul>
-
-    <p>
-        Type of <code>TExample</code>: @typeof(TExample)
-    </p>
-}
-
-@code {
-    [CascadingParameter]
-    protected IEnumerable<TExample>? ExampleList { get; set; }
-
-    [Parameter]
-    public RenderFragment? ChildContent { get; set; }
-}
-```
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/ListItems3.razor":::
 
 When cascading the data in the following example, the type must be provided to the component.
 
-`GenericType3.razor`:
+`Generics3.razor`:
 
-```razor
-@page "/generic-type-3"
-
-<h1>Generic Type Example 3</h1>
-
-<CascadingValue Value="stringData">
-    <ListGenericTypeItems3 TExample="string">
-        <ListDisplay3 />
-        <ListDisplay4 />
-    </ListGenericTypeItems3>
-</CascadingValue>
-
-<CascadingValue Value="integerData">
-    <ListGenericTypeItems3 TExample="int">
-        <ListDisplay3 />
-        <ListDisplay4 />
-    </ListGenericTypeItems3>
-</CascadingValue>
-
-@code {
-    private List<string> stringData = new() { "Item 1", "Item 2" };
-    private List<int> integerData = new() { 1, 2, 3 };
-}
-```
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/Pages/Generics3.razor":::
 
 When multiple generic types are cascaded, values for all generic types in the set must be passed. In the following example, `TItem`, `TValue`, and `TEdit` are `GridColumn` generic types, but the parent component that places `GridColumn` doesn't specify the `TItem` type:
 
@@ -342,84 +128,22 @@ The preceding example generates a compile-time error that the `GridColumn` compo
 The demonstration in this section cascades a type inferred for `TExample`.
 
 > [!NOTE]
-> This section uses the two `ListDisplay` components in the [Cascaded generic type support](#cascaded-generic-type-support) section.
+> This section uses the `ListDisplay` component in the [Cascaded generic type support](#cascaded-generic-type-support) section.
 
-`ListGenericTypeItems4.razor`:
+`ListItems4.razor`:
 
-```razor
-@attribute [CascadingTypeParameter(nameof(TExample))]
-@typeparam TExample
-
-<h2>List Generic Type Items 4</h2>
-
-@ChildContent
-
-@if (ExampleList is not null)
-{
-    <ul style="color:green">
-        @foreach(var item in ExampleList)
-        {
-            <li>@item</li>
-        }
-    </ul>
-
-    <p>
-        Type of <code>TExample</code>: @typeof(TExample)
-    </p>
-}
-
-@code {
-    [Parameter]
-    public IEnumerable<TExample>? ExampleList { get; set; }
-
-    [Parameter]
-    public RenderFragment? ChildContent { get; set; }
-}
-```
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/ListItems4.razor":::
 
 The following component with inferred cascaded types provides different data for display.
 
-`GenericType4.razor`:
+`Generics4.razor`:
 
-```razor
-@page "/generic-type-4"
-
-<h1>Generic Type Example 4</h1>
-
-<ListGenericTypeItems4 ExampleList="@(new List<string> { "Item 5", "Item 6" })">
-    <ListDisplay1 ExampleList="@(new List<string> { "Item 1", "Item 2" })" />
-    <ListDisplay2 ExampleList="@(new List<string> { "Item 3", "Item 4" })" />
-</ListGenericTypeItems4>
-
-<ListGenericTypeItems4 ExampleList="@(new List<int> { 7, 8, 9 })">
-    <ListDisplay1 ExampleList="@(new List<int> { 1, 2, 3 })" />
-    <ListDisplay2 ExampleList="@(new List<int> { 4, 5, 6 })" />
-</ListGenericTypeItems4>
-```
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/Pages/Generics4.razor":::
 
 The following component with inferred cascaded types provides the same data for display. The following example directly assigns the data to the components.
 
-`GenericType5.razor`:
+`Generics5.razor`:
 
-```razor
-@page "/generic-type-5"
-
-<h1>Generic Type Example 5</h1>
-
-<ListGenericTypeItems4 ExampleList="stringData">
-    <ListDisplay1 ExampleList="stringData" />
-    <ListDisplay2 ExampleList="stringData" />
-</ListGenericTypeItems4>
-
-<ListGenericTypeItems4 ExampleList="integerData">
-    <ListDisplay1 ExampleList="integerData" />
-    <ListDisplay2 ExampleList="integerData" />
-</ListGenericTypeItems4>
-
-@code {
-    private List<string> stringData = new() { "Item 1", "Item 2" };
-    private List<int> integerData = new() { 1, 2, 3 };
-}
-```
+:::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/Pages/Generics5.razor":::
 
 :::moniker-end


### PR DESCRIPTION
Fixes #31905

Thanks @hakenr! 🎸 ... This won't address all of your suggestions, but it will improve the state of the doc with the following updates ...

* `ListDisplay1` and `ListDisplay2`/`ListDisplay3` and `ListDisplay4` component pairs, which only distinguished by color as an additional helpful way to see the different collections in rendered output, are condensed into a single component each, passing the color as a param. This helps a little ... just a little bit ... with your concern about simplifying the guidance.
* Makes some component name changes, but it doesn't go as far as you suggest because numbering helps me maintain the examples and lists the components together in a sample app for devs to find them easily.
* Moves all examples into the sample apps. However, these are only added to the latest release sample apps for BWA/WASM. We won't carry these examples in prior release sample apps.
* WRT your remarks on the pedagogical methods:
  * This is only demonstrating generic type patterns with components. It should link to the C# Guide for the generics basics. However, I made a mistake on the cross-linking. I linked to their generic type param doc, which is fine because it did further link to their generics article. However, that's silly of me to rely on a *cross-link to a* ***cross-link*** 🙈. Therefore, I'm going to tell devs in the opening remarks to discover general info on generic types in the C# Guide and give them the best (direct) link to their content. If the educational content of their article is poor, then I recommend opening for them to improve that article. I'd like to keep this content focused only on the patterns. More on the examples next ...
  * Contrived/practical examples ...
    * ***Yep!*** This is by-design. These are the simplest, plainest patterns using components/params that I could think of. They're contrived on purpose to be easy to understand. They perhaps do favor visual learners with a reduced amount of explanatory text in some spots, but that's not uncommon around here when the examples are so simple.
    * Practical examples aren't necessary to get folks started with a subject, but I'll certainly consider this further. These simple examples with strings and ints are at least nice ***starters***. If a community member wanted to ***add*** some more advanced (or just different) real world, practical examples, I think that would be great. Personally, I don't have time to address it now, but I'll take a look the next time I reach this article for an overhaul ... in ... mmmmmm 🤔 ... 2037 ... yeah ... *I'll be free in 2037* 🛸😆. It will very likely need to be a community contributor that takes on adding additional practical examples. If the practical examples are to replace these introductory ... I'll call them "pattern-based" ... pattern-based examples, then I'd like to see them in an issue first. If you want to proceed to float some ideas, please open a new issue with component code for me to put an 👁️ on. I'm going to close out your existing issue with this. Again tho, I'm more inclined to ***add*** examples than replace the existing ones.

You have time to look :eyes:. I'm going to 🛌💤💤 sleep on this and not merge it until tomorrow morning. The samples PR is at https://github.com/dotnet/blazor-samples/pull/262. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/generic-type-support.md](https://github.com/dotnet/AspNetCore.Docs/blob/eb824c678dff794cdf88bb1dee00bdbff88073a3/aspnetcore/blazor/components/generic-type-support.md) | [ASP.NET Core Razor component generic type support](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/generic-type-support?branch=pr-en-us-32290) |

<!-- PREVIEW-TABLE-END -->