### PR TITLE
[Blazor] Integration - Autor render mode explanation

### DIFF
--- a/aspnetcore/blazor/components/integration.md
+++ b/aspnetcore/blazor/components/integration.md
@@ -223,7 +223,7 @@ When the app is run, the `Counter` component is accessed at `/counter`.
 
 Follow the guidance in the [Add static server-side rendering (static SSR)](#add-static-server-side-rendering-static-ssr) section.
 
-Components using the Interactive Auto render mode initially use interactive SSR, but then switch to render on the client after the Blazor bundle has been downloaded and the Blazor runtime activates. Components using the Interactive WebAssembly render mode only render interactively on the client after the Blazor bundle is downloaded and the Blazor runtime activates. Keep in mind that when using the Interactive Auto or Interactive WebAssembly render modes, component code downloaded to the client is ***not*** private. For more information, see <xref:blazor/components/render-modes>.
+Components using the Interactive Auto render mode initially use interactive SSR, the .NET runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits. Components using the Interactive WebAssembly render mode only render interactively on the client after the Blazor bundle is downloaded and the Blazor runtime activates. Keep in mind that when using the Interactive Auto or Interactive WebAssembly render modes, component code downloaded to the client is ***not*** private. For more information, see <xref:blazor/components/render-modes>.
 
 After deciding which render mode to adopt:
 

--- a/aspnetcore/blazor/components/integration.md
+++ b/aspnetcore/blazor/components/integration.md
@@ -223,7 +223,7 @@ When the app is run, the `Counter` component is accessed at `/counter`.
 
 Follow the guidance in the [Add static server-side rendering (static SSR)](#add-static-server-side-rendering-static-ssr) section.
 
-Components using the Interactive Auto render mode initially use interactive SSR, the .NET runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits. Components using the Interactive WebAssembly render mode only render interactively on the client after the Blazor bundle is downloaded and the Blazor runtime activates. Keep in mind that when using the Interactive Auto or Interactive WebAssembly render modes, component code downloaded to the client is ***not*** private. For more information, see <xref:blazor/components/render-modes>.
+Components using the Interactive Auto render mode initially use interactive SSR. The .NET runtime and app bundle are downloaded to the client in the background and cached so that they can be used on future visits. Components using the Interactive WebAssembly render mode only render interactively on the client after the Blazor bundle is downloaded and the Blazor runtime activates. Keep in mind that when using the Interactive Auto or Interactive WebAssembly render modes, component code downloaded to the client is ***not*** private. For more information, see <xref:blazor/components/render-modes>.
 
 After deciding which render mode to adopt:
 


### PR DESCRIPTION
The original text could be misinterpreted in a way that Blazor switches from interactive-SSR to WASM immediately after the  Blazor bundle has been downloaded (within first visit).

I reused the wording from https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?view=aspnetcore-8.0#automatic-auto-rendering

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/integration.md](https://github.com/dotnet/AspNetCore.Docs/blob/f008fc35632a018cf11f590afa5493c12cb56a93/aspnetcore/blazor/components/integration.md) | [Integrate ASP.NET Core Razor components into ASP.NET Core apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/integration?branch=pr-en-us-32313) |


<!-- PREVIEW-TABLE-END -->