### PR TITLE
First Web API: Test PostTodoItem section: GET rather than POST used in return

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -361,7 +361,7 @@ The <xref:Microsoft.AspNetCore.Mvc.ControllerBase.CreatedAtAction%2A> method:
 
 * Returns an [HTTP 201 status code](https://developer.mozilla.org/docs/Web/HTTP/Status/201) if successful. `HTTP 201` is the standard response for an `HTTP POST` method that creates a new resource on the server.
 * Adds a [Location](https://developer.mozilla.org/docs/Web/HTTP/Headers/Location) header to the response. The `Location` header specifies the [URI](https://developer.mozilla.org/docs/Glossary/URI) of the newly created to-do item. For more information, see [10.2.2 201 Created](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2).
-* References the `GetTodoItem` action to create the `Location` header's URI. The C# `nameof` keyword is used to avoid hard-coding the action name in the `CreatedAtAction` call.
+* References the `PostTodoItem` action to create the `Location` header's URI. The C# `nameof` keyword is used to avoid hard-coding the action name in the `CreatedAtAction` call.
 
 <a name="post7"></a>
 

--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to build a web API with ASP.NET Core.
 ms.author: wpickett
 ms.custom: mvc, engagement-fy24
-ms.date: 01/03/2024
+ms.date: 4/3/2024
 uid: tutorials/first-web-api
 ---
 

--- a/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
+++ b/aspnetcore/tutorials/first-web-api/includes/first-web-api3-7.md
@@ -344,7 +344,7 @@ The <xref:Microsoft.AspNetCore.Mvc.ControllerBase.CreatedAtAction%2A> method:
 
 * Returns an [HTTP 201 status code](https://developer.mozilla.org/docs/Web/HTTP/Status/201) if successful. `HTTP 201` is the standard response for an `HTTP POST` method that creates a new resource on the server.
 * Adds a [Location](https://developer.mozilla.org/docs/Web/HTTP/Headers/Location) header to the response. The `Location` header specifies the [URI](https://developer.mozilla.org/docs/Glossary/URI) of the newly created to-do item. For more information, see [10.2.2 201 Created](https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.2).
-* References the `GetTodoItem` action to create the `Location` header's URI. The C# `nameof` keyword is used to avoid hard-coding the action name in the `CreatedAtAction` call.
+* References the `PostTodoItem` action to create the `Location` header's URI. The C# `nameof` keyword is used to avoid hard-coding the action name in the `CreatedAtAction` call.
 
 <a name="post7"></a>
 

--- a/aspnetcore/tutorials/first-web-api/samples/2.2/TodoApi/Controllers/TodoController.cs
+++ b/aspnetcore/tutorials/first-web-api/samples/2.2/TodoApi/Controllers/TodoController.cs
@@ -63,7 +63,7 @@ namespace TodoApi.Controllers
             _context.TodoItems.Add(item);
             await _context.SaveChangesAsync();
 
-            return CreatedAtAction(nameof(GetTodoItem), new { id = item.Id }, item);
+            return CreatedAtAction(nameof(PostTodoItem), new { id = item.Id }, item);
         }
         #endregion
 

--- a/aspnetcore/tutorials/first-web-api/samples/3.0/TodoApi/Controllers/TodoItemsController.cs
+++ b/aspnetcore/tutorials/first-web-api/samples/3.0/TodoApi/Controllers/TodoItemsController.cs
@@ -85,8 +85,8 @@ namespace TodoApi.Controllers
             _context.TodoItems.Add(todoItem);
             await _context.SaveChangesAsync();
 
-            //return CreatedAtAction("GetTodoItem", new { id = todoItem.Id }, todoItem);
-            return CreatedAtAction(nameof(GetTodoItem), new { id = todoItem.Id }, todoItem);
+            //return CreatedAtAction("PostTodoItem", new { id = todoItem.Id }, todoItem);
+            return CreatedAtAction(nameof(PostTodoItem), new { id = todoItem.Id }, todoItem);
         }
         #endregion
 

--- a/aspnetcore/tutorials/first-web-api/samples/5.x/TodoApi/Controllers/TodoItemsController.cs
+++ b/aspnetcore/tutorials/first-web-api/samples/5.x/TodoApi/Controllers/TodoItemsController.cs
@@ -85,8 +85,8 @@ namespace TodoApi.Controllers
             _context.TodoItems.Add(todoItem);
             await _context.SaveChangesAsync();
 
-            //return CreatedAtAction("GetTodoItem", new { id = todoItem.Id }, todoItem);
-            return CreatedAtAction(nameof(GetTodoItem), new { id = todoItem.Id }, todoItem);
+            //return CreatedAtAction("PostTodoItem", new { id = todoItem.Id }, todoItem);
+            return CreatedAtAction(nameof(PostTodoItem), new { id = todoItem.Id }, todoItem);
         }
         #endregion
 

--- a/aspnetcore/tutorials/first-web-api/samples/6.0/TodoApi/Controllers/TodoItemsController.cs
+++ b/aspnetcore/tutorials/first-web-api/samples/6.0/TodoApi/Controllers/TodoItemsController.cs
@@ -87,8 +87,8 @@ namespace TodoApi.Controllers
             _context.TodoItems.Add(todoItem);
             await _context.SaveChangesAsync();
 
-            //return CreatedAtAction("GetTodoItem", new { id = todoItem.Id }, todoItem);
-            return CreatedAtAction(nameof(GetTodoItem), new { id = todoItem.Id }, todoItem);
+            //return CreatedAtAction("PostTodoItem", new { id = todoItem.Id }, todoItem);
+            return CreatedAtAction(nameof(PostTodoItem), new { id = todoItem.Id }, todoItem);
         }
         #endregion
 

--- a/aspnetcore/tutorials/first-web-api/samples/7.0/TodoApi/Controllers/TodoItemsController.cs
+++ b/aspnetcore/tutorials/first-web-api/samples/7.0/TodoApi/Controllers/TodoItemsController.cs
@@ -80,8 +80,8 @@ namespace TodoApi.Controllers
             _context.TodoItems.Add(todoItem);
             await _context.SaveChangesAsync();
 
-            //    return CreatedAtAction("GetTodoItem", new { id = todoItem.Id }, todoItem);
-            return CreatedAtAction(nameof(GetTodoItem), new { id = todoItem.Id }, todoItem);
+            //    return CreatedAtAction("PostTodoItem", new { id = todoItem.Id }, todoItem);
+            return CreatedAtAction(nameof(PostTodoItem), new { id = todoItem.Id }, todoItem);
         }
         // </snippet_Create>
 


### PR DESCRIPTION
Adjust places where GetTodosItem is referenced wrong, when needed to be PostTodosItem

Fixes #32326
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #32326

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/ee66486fc50403721c3973cb3102a49fd22e6d03/aspnetcore/tutorials/first-web-api.md) | [Tutorial: Create a web API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?branch=pr-en-us-32328) |

<!-- PREVIEW-TABLE-END -->