### PR TITLE
Optional (but not recommened) Razor directive attribute syntax

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -88,6 +88,8 @@ Components use [Razor syntax](xref:mvc/views/razor). Two Razor features are exte
   <input @bind="episodeId" />
   ```
 
+  You can prefix directive attribute values with the at symbol (`@`) for non-explicit Razor expressions (`@bind="@episodeId"`), but we don't recommend it, and the docs don't adopt the approach in examples. 
+
 Directives and directive attributes used in components are explained further in this article and other articles of the Blazor documentation set. For general information on Razor syntax, see <xref:mvc/views/razor>.
 
 ### Component name, class name, and namespace


### PR DESCRIPTION
Fixes #31042

We'll call this out because it's valid, but we'll recommend not adopting the approach.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/aef92c6bf106c33cdd31344ba937131291e4df4b/aspnetcore/blazor/components/index.md) | [ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/index?branch=pr-en-us-32333) |

<!-- PREVIEW-TABLE-END -->