### PR TITLE
[Blazor] render-components-outside-of-aspnetcore - Proper DI usage

### DIFF
--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -59,7 +59,7 @@ Add the following `RenderMessage` component to the project.
 Update the `Program` file:
 
 * Set up dependency injection (<xref:Microsoft.Extensions.DependencyInjection.IServiceCollection>/<xref:Microsoft.Extensions.DependencyInjection.ServiceCollectionContainerBuilderExtensions.BuildServiceProvider%2A>) and logging (<xref:Microsoft.Extensions.DependencyInjection.LoggingServiceCollectionExtensions.AddLogging%2A>/<xref:Microsoft.Extensions.Logging.ILoggerFactory>).
-* Create an <xref:Microsoft.AspNetCore.Components.Web.HtmlRenderer> and render the `RenderMessage` component by calling <xref:Microsoft.AspNetCore.Components.Web.HtmlRenderer.RenderComponentAsync%2A>.
+* Get a <xref:Microsoft.AspNetCore.Components.Web.HtmlRenderer> and render the `RenderMessage` component by calling <xref:Microsoft.AspNetCore.Components.Web.HtmlRenderer.RenderComponentAsync%2A>.
 
 Any calls to <xref:Microsoft.AspNetCore.Components.Web.HtmlRenderer.RenderComponentAsync%2A> must be made in the context of calling `InvokeAsync` on a component dispatcher. A component dispatcher is available from the <xref:Microsoft.AspNetCore.Components.Web.HtmlRenderer.Dispatcher?displayProperty=nameWithType> property.
 
@@ -72,11 +72,10 @@ using ConsoleApp1;
 
 IServiceCollection services = new ServiceCollection();
 services.AddLogging();
+services.AddTransient<HtmlRenderer, HtmlRenderer>();
 
 IServiceProvider serviceProvider = services.BuildServiceProvider();
-ILoggerFactory loggerFactory = serviceProvider.GetRequiredService<ILoggerFactory>();
-
-await using var htmlRenderer = new HtmlRenderer(serviceProvider, loggerFactory);
+await using var htmlRenderer = serviceProvider.GetRequiredService<HtmlRenderer>();
 
 var html = await htmlRenderer.Dispatcher.InvokeAsync(async () =>
 {


### PR DESCRIPTION
When using dependency injection, the `HtmlRenderer` should not be composed directly (with `new`), but using a service provider.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md](https://github.com/dotnet/AspNetCore.Docs/blob/2cde1fdc63f2707d6cb236b2c49657bd4fc8ee9d/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md) | [Render Razor components outside of ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-components-outside-of-aspnetcore?branch=pr-en-us-32364) |

<!-- PREVIEW-TABLE-END -->