### PR TITLE
Swagger Update: web-api-help-pages: Sample fix

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -96,7 +96,7 @@ The Swagger UI can be found at `https://localhost:<port>/swagger`. Explore the A
 > [!TIP]
 > To serve the Swagger UI at the app's root (`https://localhost:<port>/`), set the `RoutePrefix` property to an empty string:
 >
-> :::code language="csharp" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs" id="snippet_MiddlewareRoutePrefix" highlight="4":::
+> :::code language="csharp" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs" id="snippet_MiddlewareRoutePrefix" highlight="6":::
 
 If using directories with IIS or a reverse proxy, set the Swagger endpoint to a relative path using the `./` prefix. For example, `./swagger/v1/swagger.json`. Using `/swagger/v1/swagger.json` instructs the app to look for the JSON file at the true root of the URL (plus the route prefix, if used). For example, use `https://localhost:<port>/<route_prefix>/swagger/v1/swagger.json` instead of `https://localhost:<port>/<virtual_directory>/<route_prefix>/swagger/v1/swagger.json`.
 
@@ -261,7 +261,7 @@ Enable Static File Middleware:
 
 To inject additional CSS stylesheets, add them to the project's *wwwroot* folder and specify the relative path in the middleware options:
 
-:::code language="csharp" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs" id="snippet_MiddlewareInjectStylesheet" highlight="3":::
+:::code language="csharp" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs" id="snippet_MiddlewareInjectStylesheet" highlight="5":::
 
 ## Additional resources
 

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -5,7 +5,7 @@ description: Learn how to add Swashbuckle to your ASP.NET Core web API project t
 ms.author: scaddie
 monikerRange: '>= aspnetcore-3.1'
 ms.custom: mvc
-ms.date: 04/15/2024
+ms.date: 04/25/2024
 uid: tutorials/get-started-with-swashbuckle
 ---
 # Get started with Swashbuckle and ASP.NET Core

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -257,11 +257,11 @@ The default UI is both functional and presentable. However, API documentation pa
 
 Enable Static File Middleware:
 
-:::code language="csharp" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs" id="snippet_MiddlewareStaticFiles" highlight="2":::
+[!code-csharp[](~/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs?name=snippet_MiddlewareStaticFiles&highlight=2)]
 
 To inject additional CSS stylesheets, add them to the project's *wwwroot* folder and specify the relative path in the middleware options:
 
-:::code language="csharp" source="web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs" id="snippet_MiddlewareInjectStylesheet" highlight="5":::
+[!code-csharp[](~/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs?name=snippet_MiddlewareInjectStylesheet&highlight=5)]
 
 ## Additional resources
 

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs
@@ -76,5 +76,6 @@ public static class Program
         app.UseHttpsRedirection();
         app.UseStaticFiles();
         app.MapControllers();
+        // </snippet_MiddlewareStaticFiles>
     }
 }

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs
@@ -62,17 +62,19 @@ public static class Program
 
     private static void Snippet3(WebApplication app)
     {
-        // <snippet_MiddlewareInjectStylesheet>
-        app.UseSwaggerUI(options =>
+        if (builder.Environment.IsDevelopment())
         {
-            options.InjectStylesheet("/swagger-ui/custom.css");
-        });
-        // </snippet_MiddlewareInjectStylesheet>
+            // <snippet_MiddlewareInjectStylesheet>
+            app.UseSwaggerUI(options =>
+            {
+                options.InjectStylesheet("/swagger-ui/custom.css");
+            });
+            // </snippet_MiddlewareInjectStylesheet>
 
-        // <snippet_MiddlewareStaticFiles>
-        app.UseHttpsRedirection();
-        app.UseStaticFiles();
-        app.MapControllers();
-        // </snippet_MiddlewareStaticFiles>
+            // <snippet_MiddlewareStaticFiles>
+            app.UseHttpsRedirection();
+            app.UseStaticFiles();
+            app.MapControllers();
+        }
     }
 }

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs
@@ -62,19 +62,19 @@ public static class Program
 
     private static void Snippet3(WebApplication app)
     {
+        // <snippet_MiddlewareInjectStylesheet>
         if (builder.Environment.IsDevelopment())
         {
-            // <snippet_MiddlewareInjectStylesheet>
             app.UseSwaggerUI(options =>
             {
                 options.InjectStylesheet("/swagger-ui/custom.css");
             });
-            // </snippet_MiddlewareInjectStylesheet>
-
-            // <snippet_MiddlewareStaticFiles>
-            app.UseHttpsRedirection();
-            app.UseStaticFiles();
-            app.MapControllers();
         }
+        // </snippet_MiddlewareInjectStylesheet>
+
+        // <snippet_MiddlewareStaticFiles>
+        app.UseHttpsRedirection();
+        app.UseStaticFiles();
+        app.MapControllers();
     }
 }

--- a/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs
+++ b/aspnetcore/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs
@@ -63,7 +63,7 @@ public static class Program
     private static void Snippet3(WebApplication app)
     {
         // <snippet_MiddlewareInjectStylesheet>
-        if (builder.Environment.IsDevelopment())
+        if (app.Environment.IsDevelopment())
         {
             app.UseSwaggerUI(options =>
             {


### PR DESCRIPTION
Fixes #32414

UseSwaggerUI() moved to within dev env only.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/getting-started-with-swashbuckle.md](https://github.com/dotnet/AspNetCore.Docs/blob/5bb9e5d5e5b354f3bea55690143c74768b420da0/aspnetcore/tutorials/getting-started-with-swashbuckle.md) | [Get started with Swashbuckle and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?branch=pr-en-us-32416) |


<!-- PREVIEW-TABLE-END -->