### PR TITLE
Fix potential github action smells

### DIFF
--- a/.github/workflows/merge-live.yml
+++ b/.github/workflows/merge-live.yml
@@ -9,6 +9,10 @@ permissions:
 env:
   DOTNET_DOCS_HEAD: main
   DOTNET_DOCS_BASE: live
+# Prevent merging merging at the same time
+concurrency: 
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
 jobs:
   default:
     runs-on: ubuntu-latest

--- a/.github/workflows/whats-new.yml
+++ b/.github/workflows/whats-new.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    if: ${{ github.repository == 'dotnet/AspNetCore.Docs' }}
+    if: ${{ github.repository_owner == 'dotnet' }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/whats-new.yml
+++ b/.github/workflows/whats-new.yml
@@ -23,13 +23,14 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    if: ${{ github.repository == 'dotnet/AspNetCore.Docs' }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
 
       - name: "Print manual run reason"
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: github.event_name == 'workflow_dispatch'
         run: |
           echo "Reason: ${{ github.event.inputs.reason }}"
 


### PR DESCRIPTION
Hey! 🙂
I want to contribute the following changes to your workflow:

- Avoid executing  scheduled workflows on forks
- Stop running workflows when there is a newer commit in branch

(These changes are part of a research Study at TU Delft looking at GitHub Action Smells. [Find out more](https://ceddy4395.github.io/research/gha-smells.html))

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->