### PR TITLE
Fix typo in logging.md

### DIFF
--- a/aspnetcore/blazor/fundamentals/logging.md
+++ b/aspnetcore/blazor/fundamentals/logging.md
@@ -704,7 +704,7 @@ Blazor Web App:
   Blazor.start({
     circuit: {
       configureSignalR: function (builder) {
-        builder.configureLogging("information");
+        builder.configureLogging(2);
       }
     }
   });


### PR DESCRIPTION
Log level string replaced with its corresponding integer value (as Example2 is about integers)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/logging.md](https://github.com/dotnet/AspNetCore.Docs/blob/ac456a3d40504ea54e3bb2fdbcecd7465d14c413/aspnetcore/blazor/fundamentals/logging.md) | [ASP.NET Core Blazor logging](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/logging?branch=pr-en-us-32429) |

<!-- PREVIEW-TABLE-END -->