### PR TITLE
[Blazor] Logging - comments for "magic numbers"

### DIFF
--- a/aspnetcore/blazor/fundamentals/logging.md
+++ b/aspnetcore/blazor/fundamentals/logging.md
@@ -704,7 +704,7 @@ Blazor Web App:
   Blazor.start({
     circuit: {
       configureSignalR: function (builder) {
-        builder.configureLogging(2);
+        builder.configureLogging(2); // LogLevel.Information
       }
     }
   });
@@ -720,7 +720,7 @@ Blazor Server:
 <script>
   Blazor.start({
     configureSignalR: function (builder) {
-      builder.configureLogging(2);
+      builder.configureLogging(2); // LogLevel.Information
     }
   });
 </script>

--- a/aspnetcore/blazor/fundamentals/logging.md
+++ b/aspnetcore/blazor/fundamentals/logging.md
@@ -728,6 +728,9 @@ Blazor Server:
 
 In the preceding example, the `{BLAZOR SCRIPT}` placeholder is the Blazor script path and file name. For the location of the script, see <xref:blazor/project-structure#location-of-the-blazor-script>.
 
+> [!NOTE]
+> Using an integer to specify the logging level in Example 2, often referred to as a *magic number* or *magic constant*, is considered a poor coding practice because the integer doesn't clearly identify the logging level when viewing the source code. If minimizing the bytes transferred to the browser is a priority, using an integer might be justified (consider removing the comment in such cases).
+
 For more information on Blazor startup (`Blazor.start()`), see <xref:blazor/fundamentals/startup>.
 
 ## SignalR client logging with app configuration


### PR DESCRIPTION
The code, although intended to demonstrate function calls using integers, should avoid containing magic numbers. I've added a comment typical for such cases, similar to what you can find here:
https://github.com/dotnet/aspnetcore/blob/333629e6c3d4ee301bb5985f0de66f447f6226ba/src/Components/test/testassets/ComponentsApp.Server/Pages/_Host.cshtml#L20-L24

(In production code, we might want to minify the script, but here in the demo code, including a comment seems appropriate.)

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/logging.md](https://github.com/dotnet/AspNetCore.Docs/blob/de488369d2ae03544ca18b62fbcb32027ed23e2b/aspnetcore/blazor/fundamentals/logging.md) | [ASP.NET Core Blazor logging](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/logging?branch=pr-en-us-32455) |


<!-- PREVIEW-TABLE-END -->