### PR TITLE
Add named and typed clients section

### DIFF
--- a/aspnetcore/fundamentals/http-requests/samples/6.x/HttpRequestsSample/Pages/Consumption/Index.cshtml
+++ b/aspnetcore/fundamentals/http-requests/samples/6.x/HttpRequestsSample/Pages/Consumption/Index.cshtml
@@ -9,4 +9,5 @@
 	<li><a asp-page="./Basic">Basic usage</a></li>
 	<li><a asp-page="./NamedClient">Named client</a></li>
 	<li><a asp-page="./TypedClient">Typed client</a></li>
+	<li><a asp-page="./NamedAndTypedClient">Named and typed client</a></li>
 </ul>

--- a/aspnetcore/fundamentals/http-requests/samples/6.x/HttpRequestsSample/Pages/Consumption/NamedAndTypedClient.cshtml
+++ b/aspnetcore/fundamentals/http-requests/samples/6.x/HttpRequestsSample/Pages/Consumption/NamedAndTypedClient.cshtml
@@ -1,0 +1,10 @@
+@page
+@model HttpRequestsSample.Pages.TypedClientModel
+
+@{
+	ViewData["Title"] = "Consumption - Named and typed";
+}
+
+<h1>Consumption patterns - Named and typed client</h1>
+
+@await Component.InvokeAsync("GitHubBranches", new { gitHubBranches = Model.GitHubBranches })

--- a/aspnetcore/fundamentals/http-requests/samples/6.x/HttpRequestsSample/Pages/Consumption/NamedAndTypedClient.cshtml.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/6.x/HttpRequestsSample/Pages/Consumption/NamedAndTypedClient.cshtml.cs
@@ -1,0 +1,38 @@
+using HttpRequestsSample.GitHub;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Http;
+
+namespace HttpRequestsSample.Pages;
+
+// <snippet_Class>
+public class NamedAndTypedClientModel : PageModel
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ITypedHttpClientFactory<GitHubService> _gitHubServiceFactory;
+
+    public NamedAndTypedClientModel(IHttpClientFactory httpClientFactory, 
+        ITypedHttpClientFactory<GitHubService> gitHubServiceFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+        _gitHubServiceFactory = gitHubServiceFactory;
+    }
+
+    public IEnumerable<GitHubBranch>? GitHubBranches { get; set; }
+
+    public async Task OnGet()
+    {
+        try
+        {
+            var quickClient = _httpClientFactory.CreateClient("Quick");
+            var gitHubService = _gitHubServiceFactory.CreateClient(quickClient);
+            GitHubBranches = await gitHubService.GetAspNetCoreDocsBranchesAsync();
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            var tolerantClient = _httpClientFactory.CreateClient("LatencyTolerant");
+            var gitHubService = _gitHubServiceFactory.CreateClient(tolerantClient);
+            GitHubBranches = await gitHubService.GetAspNetCoreDocsBranchesAsync();
+        }
+    }
+}
+// </snippet_Class>

--- a/aspnetcore/fundamentals/http-requests/samples/6.x/HttpRequestsSample/Program.cs
+++ b/aspnetcore/fundamentals/http-requests/samples/6.x/HttpRequestsSample/Program.cs
@@ -75,6 +75,17 @@ builder.Services.AddHttpClient("Operation")
 builder.Services.AddHttpClient<GitHubService>();
 // </snippet_AddHttpClientTyped>
 
+// <snippet_AddHttpClientNamedAndTyped>
+builder.Services.AddHttpClient<GitHubService>("Quick", httpClient =>
+{
+    httpClient.Timeout = TimeSpan.FromSeconds(1);
+});
+builder.Services.AddHttpClient<GitHubService>("LatencyTolerant", httpClient =>
+{
+    httpClient.Timeout = TimeSpan.FromSeconds(10);
+});
+// </snippet_AddHttpClientNamedAndTyped>
+
 // <snippet_AddHttpClientPollyWaitAndRetry>
 builder.Services.AddHttpClient("PollyWaitAndRetry")
     .AddTransientHttpErrorPolicy(policyBuilder =>


### PR DESCRIPTION
This PR is basically a follow up of my other PR against the [dotnet/docs](https://github.com/dotnet/docs/pull/40359) repository.

It extends the [Make HTTP requests using IHttpClientFactory in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests) page with named and typed client capability.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/http-requests.md](https://github.com/dotnet/AspNetCore.Docs/blob/325da1b054601408ffb04b991d6f5e9fec6635e9/aspnetcore/fundamentals/http-requests.md) | [Make HTTP requests using IHttpClientFactory in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?branch=pr-en-us-32456) |

<!-- PREVIEW-TABLE-END -->