### PR TITLE
Improve remark on component disposal code

### DIFF
--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -583,7 +583,7 @@ Although the content in this section focuses on Blazor Server and stateful Signa
 
 ## Component disposal with `IDisposable` and `IAsyncDisposable`
 
-If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for resource disposal when the component is removed from the UI. Don't rely on the exact timing of when <xref:System.IDisposable>/<xref:System.IAsyncDisposable> are executed when you implement either of these methods, nor should your object disposal code assume that objects created during initialization or other lifecycle methods exist.
+If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for resource disposal when the component is removed from the UI. Don't rely on the exact timing of when <xref:System.IDisposable>/<xref:System.IAsyncDisposable> are executed when you implement either of these methods. For example, <xref:System.IAsyncDisposable> can be triggered before or after an asychronous <xref:System.Threading.Tasks.Task> awaited in [`OnInitalizedAsync`](#component-initialization-oninitializedasync) is called or completes. Also, object disposal code shouldn't assume that objects created during initialization or other lifecycle methods exist.
 
 Components shouldn't need to implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable> simultaneously. If both are implemented, the framework only executes the asynchronous overload.
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -583,7 +583,7 @@ Although the content in this section focuses on Blazor Server and stateful Signa
 
 ## Component disposal with `IDisposable` and `IAsyncDisposable`
 
-If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for resource disposal when the component is removed from the UI. Disposal can occur at any time, including during [component initialization](#component-initialization-oninitializedasync).
+If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for resource disposal when the component is removed from the UI. Don't rely on the exact timing of when <xref:System.IDisposable>/<xref:System.IAsyncDisposable> are executed when you implement either of these methods, nor should your object disposal code assume that objects created during initialization or other lifecycle methods exist.
 
 Components shouldn't need to implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable> simultaneously. If both are implemented, the framework only executes the asynchronous overload.
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -583,7 +583,7 @@ Although the content in this section focuses on Blazor Server and stateful Signa
 
 ## Component disposal with `IDisposable` and `IAsyncDisposable`
 
-If a component implements <xref:System.IDisposable>, <xref:System.IAsyncDisposable>, or both, the framework calls for resource disposal when the component is removed from the UI. Don't rely on the exact timing of when <xref:System.IDisposable>/<xref:System.IAsyncDisposable> are executed when you implement either of these methods. For example, <xref:System.IAsyncDisposable> can be triggered before or after an asychronous <xref:System.Threading.Tasks.Task> awaited in [`OnInitalizedAsync`](#component-initialization-oninitializedasync) is called or completes. Also, object disposal code shouldn't assume that objects created during initialization or other lifecycle methods exist.
+If a component implements <xref:System.IDisposable> or <xref:System.IAsyncDisposable>, the framework calls for resource disposal when the component is removed from the UI. Don't rely on the exact timing of when these methods are executed. For example, <xref:System.IAsyncDisposable> can be triggered before or after an asychronous <xref:System.Threading.Tasks.Task> awaited in [`OnInitalizedAsync`](#component-initialization-oninitializedasync) is called or completes. Also, object disposal code shouldn't assume that objects created during initialization or other lifecycle methods exist.
 
 Components shouldn't need to implement <xref:System.IDisposable> and <xref:System.IAsyncDisposable> simultaneously. If both are implemented, the framework only executes the asynchronous overload.
 


### PR DESCRIPTION
Addresses #32209

Thanks @kjkrum! 🚀 ... This only "addresses" part of your issue, and your issue will remain ***open***. The product unit is swamped with .NET 9 work at the moment, so I'm just going to fix up the one line to reflect a more specific statement about implementing the disposal methods ...

* Don't count on when they'll execute. Clarify with the example that Javier and imtrobin were discussing.
* Don't count on the existence of objects when disposing.

WRT the text that you provided in the issue ... I'll ask one of the engineers in a few months to look at that and see if we can place it into the guidance, perhaps with some modifications to their liking.

I'll leave this open for a few hours for you to look and merge it later today.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/lifecycle.md](https://github.com/dotnet/AspNetCore.Docs/blob/6813e89139dc83260bb38259e368eed1c51025d9/aspnetcore/blazor/components/lifecycle.md) | [ASP.NET Core Razor component lifecycle](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?branch=pr-en-us-32457) |


<!-- PREVIEW-TABLE-END -->