### PR TITLE
RCLs for Blazor apps that support pages+views

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -47,13 +47,36 @@ If the **Support pages and views** checkbox is selected to support pages and vie
   @using Microsoft.AspNetCore.Components.Web
   ```
 
-* Add the following `SupportedPlatform` item to the project file (`.csproj`):
+* Add the following `SupportedPlatform` item and package reference for [`Microsoft.AspNetCore.Components.Web`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.Web) to the project file (`.csproj`):
 
   ```xml
   <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="{VERSION}" />
+  </ItemGroup>
   ```
+
+  In the preceding example, the `{VERSION}` placeholder is the package version.
+
+  > [!IMPORTANT]
+  > When a Razor class library is added to a solution with the **Support pages and views** checkbox selected, the library also references the [`Microsoft.AspNetCore.App` ASP.NET Core shared framework](xref:fundamentals/metapackage-app):
+  >
+  > ```xml
+  > <ItemGroup>
+  >   <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  > </ItemGroup>
+  > ```
+  >
+  > The shared framework isn't supported on Blazor WebAssembly, so libraries that target client-side apps should remove the framework reference. When the library targets both server-side and client-side apps, control the dependency with an [MSBuild condition](/visualstudio/msbuild/msbuild-conditions):
+  >
+  > ```xml
+  > <ItemGroup Condition="'$(IsWasmProject)' != 'true'">
+  >   <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  > </ItemGroup>
+  > ```
 
   For more information on the `SupportedPlatform` item, see the [client-side browser compatibility analyzer](#client-side-browser-compatibility-analyzer) section.
 
@@ -93,13 +116,36 @@ If the `-s|--support-pages-and-views` option is used to support pages and views 
   @using Microsoft.AspNetCore.Components.Web
   ```
 
-* Add the following `SupportedPlatform` item to the project file (`.csproj`):
+* Add the following `SupportedPlatform` item and package reference for [`Microsoft.AspNetCore.Components.Web`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.Web) to the project file (`.csproj`):
 
   ```xml
   <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="{VERSION}" />
+  </ItemGroup>
   ```
+
+  In the preceding example, the `{VERSION}` placeholder is the package version.
+
+  > [!IMPORTANT]
+  > When a Razor class library is added to a solution with the **Support pages and views** checkbox selected, the library also references the [`Microsoft.AspNetCore.App` ASP.NET Core shared framework](xref:fundamentals/metapackage-app):
+  >
+  > ```xml
+  > <ItemGroup>
+  >   <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  > </ItemGroup>
+  > ```
+  >
+  > The shared framework isn't supported on Blazor WebAssembly, so libraries that target client-side apps should remove the framework reference. When the library targets both server-side and client-side apps, control the dependency with an [MSBuild condition](/visualstudio/msbuild/msbuild-conditions):
+  >
+  > ```xml
+  > <ItemGroup Condition="'$(IsWasmProject)' != 'true'">
+  >   <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  > </ItemGroup>
+  > ```
 
   For more information on the `SupportedPlatform` item, see the [client-side browser compatibility analyzer](#client-side-browser-compatibility-analyzer) section.
 


### PR DESCRIPTION
Fixes #32453

Thanks @ghhv! 🚀 ... Let's see where this goes.

Dan, Artak ... It was several years ago that I had an RCL working in a Blazor Server app with pages/views and components. This PR updates the guidance on using the **Support pages and views** checkbox for those who do so. We instruct to **deselect** for pages and views but say that if you do that you also need to make changes to support components and explain those changes.

Also note that @ghhv said on the [PU issue](https://github.com/dotnet/aspnetcore/issues/53671#issuecomment-2081461812) that `<AddRazorSupportForMvc>true</AddRazorSupportForMvc>` no-oped in a Blazor WASM app, so I didn't remark on it here.

~Versioning-wise, I'm a bit concerned. It looks like to me based on what I had here from several years ago that the 🧀 moved (at least once) over the years, and I'm not sure how (or even if) to version these revisions. I'll go look at the RCL template over releases and see if I can spot deltas in the project file as a clue for when changes occurred.~ 🏃‍♂️ **UPDATE**: I checked all versions of the project template, and the updates on PR apply to all versions. 👍 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/class-libraries.md](https://github.com/dotnet/AspNetCore.Docs/blob/42c248277492e610fbffc0e8a7ed98cc843fb9b0/aspnetcore/blazor/components/class-libraries.md) | [Consume ASP.NET Core Razor components from a Razor class library (RCL)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries?branch=pr-en-us-32458) |

<!-- PREVIEW-TABLE-END -->