### PR TITLE
Location override using the "Sensors" pane

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -1638,6 +1638,12 @@ To create localization shared resources, adopt the following approach.
 
 For additional guidance, see <xref:fundamentals/localization>.
 
+## Location override using "Sensors" pane in developer tools
+
+When using the location override using the **Sensors** pane in Google Chrome or Microsoft Edge developer tools, the fallback language is reset after prerendering. Avoid setting the language using the **Sensors** pane when testing. Set the language using the browser's language settings.
+
+For more information, see [Blazor Localization does not work with InteractiveServer (`dotnet/aspnetcore` #53707)](https://github.com/dotnet/aspnetcore/issues/53707).
+
 ## Additional resources
 
 * [Set the app base path](xref:blazor/host-and-deploy/index#app-base-path)
@@ -1647,3 +1653,4 @@ For additional guidance, see <xref:fundamentals/localization>.
 * [Microsoft Multilingual App Toolkit](https://marketplace.visualstudio.com/items?itemName=MultilingualAppToolkit.MultilingualAppToolkit-18308)
 * [Localization & Generics](http://hishambinateya.com/localization-and-generics)
 * [Calling `InvokeAsync(StateHasChanged)` causes page to fallback to default culture (dotnet/aspnetcore #28521)](https://github.com/dotnet/aspnetcore/issues/28521)
+* [Blazor Localization does not work with InteractiveServer (`dotnet/aspnetcore` #53707)](https://github.com/dotnet/aspnetcore/issues/53707) ([Location override using "Sensors" pane](#location-override-using-sensors-pane-in-developer-tools))

--- a/aspnetcore/fundamentals/troubleshoot-aspnet-core-localization.md
+++ b/aspnetcore/fundamentals/troubleshoot-aspnet-core-localization.md
@@ -1,12 +1,12 @@
 ---
-title: Troubleshoot ASP.NET Core Localization
+title: Troubleshoot ASP.NET Core localization
 author: hishamco
 description: Learn how to diagnose problems with localization in ASP.NET Core apps.
 ms.author: riande
 ms.date: 01/24/2019
 uid: fundamentals/troubleshoot-aspnet-core-localization
 ---
-# Troubleshoot ASP.NET Core Localization
+# Troubleshoot ASP.NET Core localization
 
 By [Hisham Bin Ateya](https://github.com/hishamco)
 
@@ -30,78 +30,95 @@ public void ConfigureServices(IServiceCollection services)
 
 **Localization resources path not found**
 
-**Supported Cultures in RequestCultureProvider don't match with registered once**  
+**Supported Cultures in RequestCultureProvider don't match with registered once**
 
 ## Resource file naming issues
 
-ASP.NET Core has predefined rules and guidelines for localization resources file naming, which are described in detail [here](xref:fundamentals/localization#resource-file-naming).
+ASP.NET Core has predefined rules and guidelines for localization resources file naming, which are described in <xref:fundamentals/localization#resource-file-naming>.
 
 ## Missing resources
 
 Common causes of resources not being found include:
 
-- Resource names are misspelled in either the `resx` file or the localizer request.
-- The resource is missing from the `resx` for some languages, but exists in others.
-- If you're still having trouble, check the localization log messages (which are at `Debug` log level) for more details about the missing resources.
+* Resource names are misspelled in either the .NET XML resource file (`.resx`) or the localizer request.
+* The resource is missing from the resource file for some languages, but exists in others.
+* If you're still having trouble, check the localization log messages (logged at the `Debug` log level) for more details about the missing resources.
 
-_**Hint:** When using `CookieRequestCultureProvider`, verify single quotes are not used with the cultures inside the localization cookie value. For example, `c='en-UK'|uic='en-US'` is an invalid cookie value, while `c=en-UK|uic=en-US` is a valid._
+> [!TIP]
+> When using <xref:Microsoft.AspNetCore.Localization.CookieRequestCultureProvider>, verify single quotes aren't used with the cultures inside the localization cookie value. For example, `c='en-UK'|uic='en-US'` is an invalid cookie value, while `c=en-UK|uic=en-US` is valid.
 
-## Resources & Class Libraries issues
+## Resources and class libraries issues
 
 ASP.NET Core by default provides a way to allow the class libraries to find their resource files via <xref:Microsoft.Extensions.Localization.ResourceLocationAttribute>.
 
 Common issues with class libraries include:
-- Missing the `ResourceLocationAttribute` in a class library will prevent `ResourceManagerStringLocalizerFactory` from discovering the resources.
-- Resource file naming. For more information, see [Resource file naming issues](#resource-file-naming-issues) section.
-- Changing the root namespace of the class library. For more information, see [Root Namespace issues](#root-namespace-issues) section.
 
-## CustomRequestCultureProvider doesn't work as expected
+* Missing the <xref:Microsoft.Extensions.Localization.ResourceLocationAttribute> in a class library prevents <xref:Microsoft.Extensions.Localization.ResourceManagerStringLocalizerFactory> from discovering the resources.
+* Resource file naming. For more information, see the [Resource file naming issues](#resource-file-naming-issues) section.
+* Changing the root namespace of the class library. For more information, see the [Root namespace issues](#root-namespace-issues) section.
 
-The `RequestLocalizationOptions` class has three default providers:
+## `CustomRequestCultureProvider` doesn't work as expected
 
-1. `QueryStringRequestCultureProvider`
-2. `CookieRequestCultureProvider`
-3. `AcceptLanguageHeaderRequestCultureProvider`
+The <xref:Microsoft.AspNetCore.Builder.RequestLocalizationOptions> class has three default providers:
 
-The <xref:Microsoft.AspNetCore.Localization.CustomRequestCultureProvider> allows you to customize how the localization culture is provided in your app. The `CustomRequestCultureProvider` is used when the default providers don't meet your requirements.
+* <xref:Microsoft.AspNetCore.Localization.QueryStringRequestCultureProvider>
+* <xref:Microsoft.AspNetCore.Localization.CookieRequestCultureProvider>
+* <xref:Microsoft.AspNetCore.Localization.AcceptLanguageHeaderRequestCultureProvider>
 
-- A common reason custom provider don't work properly is that it isn't the first provider in the `RequestCultureProviders` list. To resolve this issue:
+The <xref:Microsoft.AspNetCore.Localization.CustomRequestCultureProvider> allows you to customize how the localization culture is provided. The <xref:Microsoft.AspNetCore.Localization.CustomRequestCultureProvider> is used when the default providers don't meet your requirements.
 
-- Insert the custom provider at the position 0 in the `RequestCultureProviders` list as the following:
-
-:::moniker range="< aspnetcore-3.0"
-```csharp
-options.RequestCultureProviders.Insert(0, new CustomRequestCultureProvider(async context =>
-    {
-        // My custom request culture logic
-        return new ProviderCultureResult("en");
-    }));
-```
-:::moniker-end
+A common reason for a custom provider not working properly is that it isn't the first provider in the <xref:Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestCultureProviders> list. To resolve this issue:
 
 :::moniker range=">= aspnetcore-3.0"
-```csharp
-options.AddInitialRequestCultureProvider(new CustomRequestCultureProvider(async context =>
-    {
-        // My custom request culture logic
-        return new ProviderCultureResult("en");
-    }));
-```
+
+* Insert the custom provider at position zero in the <xref:Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestCultureProviders> list:
+
+  ```csharp
+  options.AddInitialRequestCultureProvider(
+      new CustomRequestCultureProvider(async context =>
+      {
+          // My custom request culture logic
+          return new ProviderCultureResult("en");
+      }));
+  ```
+
 :::moniker-end
 
-- Use `AddInitialRequestCultureProvider` extension method to set the custom provider as initial provider.
+:::moniker range="< aspnetcore-3.0"
 
-## Root Namespace issues
+* Insert the custom provider at position zero in the <xref:Microsoft.AspNetCore.Builder.RequestLocalizationOptions.RequestCultureProviders> list:
 
-When the root namespace of an assembly is different than the assembly name, localization doesn't work by default. To avoid this issue use [RootNamespace](xref:Microsoft.Extensions.Localization.RootNamespaceAttribute), which is described in detail [here](xref:fundamentals/localization#resource-file-naming)
+  ```csharp
+  options.RequestCultureProviders.Insert(0, 
+      new CustomRequestCultureProvider(async context =>
+      {
+          // My custom request culture logic
+          return new ProviderCultureResult("en");
+      }));
+  ```
+
+:::moniker-end
+
+* Use the <xref:Microsoft.AspNetCore.Builder.RequestLocalizationOptionsExtensions.AddInitialRequestCultureProvider%2A> extension method to set the custom provider as the initial provider.
+
+## Root namespace issues
+
+When the root namespace of an assembly is different than the assembly name, localization doesn't work by default. To avoid this issue use the [`RootNamespace` attribute](xref:Microsoft.Extensions.Localization.RootNamespaceAttribute), which is described in <xref:fundamentals/localization#resource-file-naming>.
 
 > [!WARNING]
-> This can occur when a project's name is not a valid .NET identifier. For instance `my-project-name.csproj` will use the root namespace `my_project_name` and the assembly name `my-project-name` leading to this error. 
+> A root namespace issue can occur when a project's name isn't a valid .NET identifier. For instance, `my-project-name.csproj` uses the root namespace `my_project_name` and the assembly name `my-project-name`, which results in this error. 
 
-## Resources & Build Action
+## Resources and build action
 
-If you use resource files for localization, it's important that they have an appropriate build action. They should be **Embedded Resource**, otherwise the `ResourceStringLocalizer` is not able to find these resources.
+If you use resource files for localization, it's important that they have an appropriate build action. Use **Embedded Resource**; otherwise, the `ResourceStringLocalizer` isn't able to find these resources.
+
+## Location override using "Sensors" pane in developer tools
+
+When using the location override using the **Sensors** pane in Google Chrome or Microsoft Edge developer tools, the fallback language is reset after prerendering. Avoid setting the language using the **Sensors** pane when testing. Set the language using the browser's language settings.
+
+For more information, see [Blazor Localization does not work with InteractiveServer (`dotnet/aspnetcore` #53707)](https://github.com/dotnet/aspnetcore/issues/53707).
 
 ## GitHub issues with helpful problem solving tips
 
-* [AspNetCore.Docs/issues/28674](https://github.com/dotnet/AspNetCore.Docs/issues/28674)
+* [Please add more info about shared files (`dotnet/AspNetCore.Docs` #28674](https://github.com/dotnet/AspNetCore.Docs/issues/28674)
+* [Blazor Localization does not work with InteractiveServer (`dotnet/aspnetcore` #53707)](https://github.com/dotnet/aspnetcore/issues/53707) ([Location override using "Sensors" pane](#location-override-using-sensors-pane-in-developer-tools))


### PR DESCRIPTION
Fixes #32463

@hishamco ... I performed a NIT 😈 edit pass on the article, mostly just hitting styles that we use today in articles and per the MS Style Manual. Indeed! It is old. I see some versioning for <3.0 here! 😄

I ended up adding a short section on it at the end of each article, and I cross-link to the PU issue. If you think we shouldn't bother with the PU issue cross-link, that's fine with me ... I'll 🔪 it out if you think that's best and just leave the new sections in place.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/globalization-localization.md](https://github.com/dotnet/AspNetCore.Docs/blob/e52239c2b242ef75c5803c64e27c4ce60bcc2716/aspnetcore/blazor/globalization-localization.md) | [ASP.NET Core Blazor globalization and localization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?branch=pr-en-us-32464) |
| [aspnetcore/fundamentals/troubleshoot-aspnet-core-localization.md](https://github.com/dotnet/AspNetCore.Docs/blob/e52239c2b242ef75c5803c64e27c4ce60bcc2716/aspnetcore/fundamentals/troubleshoot-aspnet-core-localization.md) | [Troubleshoot ASP.NET Core Localization](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/troubleshoot-aspnet-core-localization?branch=pr-en-us-32464) |

<!-- PREVIEW-TABLE-END -->