### PR TITLE
[Blazor] Binding - class name fix

### DIFF
--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -293,7 +293,7 @@ public class ComponentEnums
 }
 ```
 
-Make the `enums` class accessible to the:
+Make the `ComponentEnums` class accessible to the:
 
 * `Starship` model in `Starship.cs` (for example, `using static ComponentEnums;`).
 * `Starfleet Starship Database` form (`Starship3.razor`) (for example, `@using static ComponentEnums`).


### PR DESCRIPTION
The referred class name is `ComponentEnums` not `enums`.

cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/bae10315e901485399e22d11c60788b9b3661481/aspnetcore/blazor/forms/binding.md) | [ASP.NET Core Blazor forms binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?branch=pr-en-us-32496) |

<!-- PREVIEW-TABLE-END -->