### PR TITLE
SignalR Hubs: Clarify hub essential part of client-to-client communication

### DIFF
--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -15,7 +15,7 @@ uid: signalr/hubs
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -15,7 +15,7 @@ uid: signalr/hubs
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -5,7 +5,7 @@ description: Learn how to use hubs in ASP.NET Core SignalR.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: bradyg
 ms.custom: mvc
-ms.date: 02/14/2023
+ms.date: 05/03/2024
 uid: signalr/hubs
 ---
 
@@ -15,7 +15,7 @@ uid: signalr/hubs
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs.md
+++ b/aspnetcore/signalr/hubs.md
@@ -15,7 +15,7 @@ uid: signalr/hubs
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that are called by the client, and the client defines methods that are called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-2.1.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-2.1.md
@@ -7,7 +7,7 @@ By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://t
 
 ## What is a SignalR hub
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-2.1.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-2.1.md
@@ -7,7 +7,7 @@ By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://t
 
 ## What is a SignalR hub
 
-The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that are called by the client, and the client defines methods that are called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-2.1.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-2.1.md
@@ -7,7 +7,7 @@ By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://t
 
 ## What is a SignalR hub
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-2.1.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-2.1.md
@@ -7,7 +7,7 @@ By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://t
 
 ## What is a SignalR hub
 
-The SignalR Hubs API enables you to call methods on connected clients from the server. In the server code, you define methods that are called by client. In the client code, you define methods that are called from the server. SignalR takes care of everything behind the scenes that makes real-time client-to-server and server-to-client communications possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-3-5.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-3-5.md
@@ -7,7 +7,7 @@ By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://t
 
 ## What is a SignalR hub
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-3-5.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-3-5.md
@@ -7,7 +7,7 @@ By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://t
 
 ## What is a SignalR hub
 
-The SignalR Hubs API enables you to call methods on connected clients from the server. In the server code, you define methods that are called by client. In the client code, you define methods that are called from the server. SignalR takes care of everything behind the scenes that makes real-time client-to-server and server-to-client communications possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-3-5.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-3-5.md
@@ -7,7 +7,7 @@ By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://t
 
 ## What is a SignalR hub
 
-The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that are called by the client, and the client defines methods that are called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-3-5.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-3-5.md
@@ -7,7 +7,7 @@ By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://t
 
 ## What is a SignalR hub
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-6.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-6.md
@@ -2,7 +2,7 @@
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-6.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-6.md
@@ -2,7 +2,7 @@
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-6.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-6.md
@@ -2,7 +2,7 @@
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that are called by the client, and the client defines methods that are called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-6.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-6.md
@@ -2,7 +2,7 @@
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-7.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-7.md
@@ -3,7 +3,7 @@
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-7.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-7.md
@@ -3,7 +3,7 @@
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-7.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-7.md
@@ -3,7 +3,7 @@
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communcation between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client and client-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server and facilitates real-time communication between clients. The server defines methods that are called from the client and the client defines methods that are called from the server. SignalR takes care of everything required to make real-time client-to-server, server-to-client, and client-to-client communication possible.
 
 ## Configure SignalR hubs
 

--- a/aspnetcore/signalr/hubs/includes/hubs-7.md
+++ b/aspnetcore/signalr/hubs/includes/hubs-7.md
@@ -3,7 +3,7 @@
 
 By [Rachel Appel](https://twitter.com/rachelappel) and [Kevin Griffin](https://twitter.com/1kevgriff)
 
-The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that can be called by the client, and the client defines methods that can be called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
+The SignalR Hubs API enables connected clients to call methods on the server, facilitating real-time communication. The server defines methods that are called by the client, and the client defines methods that are called by the server. SignalR also enables indirect client-to-client communication, always mediated by the SignalR Hub, allowing messages to be sent between individual clients, groups, or to all connected clients. SignalR takes care of everything required to make real-time client-to-server and server-to-client communication possible.
 
 ## Configure SignalR hubs
 


### PR DESCRIPTION
Fixes #32066 

The intro to the hubs topic emphasizes that a SignalR Hub API enables communication between client and server and does not really give the impression that a hub is also essential to facilitate client-to-client communication. Making that role a little more explicit here in the intro since it was causing some confusion.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/signalr/hubs.md](https://github.com/dotnet/AspNetCore.Docs/blob/336495fc1edd438519cee868fa79dc75d71b3e91/aspnetcore/signalr/hubs.md) | [Use hubs in SignalR for ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/hubs?branch=pr-en-us-32516) |


<!-- PREVIEW-TABLE-END -->