### PR TITLE
Add cross-link to new guidance

### DIFF
--- a/aspnetcore/blazor/hybrid/reuse-razor-components.md
+++ b/aspnetcore/blazor/hybrid/reuse-razor-components.md
@@ -69,7 +69,11 @@ The following example demonstrates the concepts for images in an app that organi
 
 ![A .NET MAUI Blazor Hybrid app uses InputPhoto from a Razor class library (RCL) that it references. The .NET MAUI app also references a .NET MAUI class library. InputPhoto in the RCL injects an ICameraService interface defined in the RCL. CameraService partial class implementations for ICameraService are in the .NET MAUI class library (CameraService.Windows.cs, CameraService.iOS.cs, CameraService.Android.cs), which references the RCL.](~/blazor/hybrid/reuse-razor-components/_static/diagram4.png)
 
-For more information and an example for .NET 8 or later with a Blazor Web App, see <xref:blazor/hybrid/tutorials/maui-blazor-web-app?view=aspnetcore-8.0#using-interfaces-to-support-different-device-implementations>.
+:::moniker range=">= aspnetcore-8.0"
+
+For an example, see <xref:blazor/hybrid/tutorials/maui-blazor-web-app#using-interfaces-to-support-different-device-implementations>.
+
+:::moniker-end
 
 ## Additional resources
 

--- a/aspnetcore/blazor/hybrid/reuse-razor-components.md
+++ b/aspnetcore/blazor/hybrid/reuse-razor-components.md
@@ -69,7 +69,7 @@ The following example demonstrates the concepts for images in an app that organi
 
 ![A .NET MAUI Blazor Hybrid app uses InputPhoto from a Razor class library (RCL) that it references. The .NET MAUI app also references a .NET MAUI class library. InputPhoto in the RCL injects an ICameraService interface defined in the RCL. CameraService partial class implementations for ICameraService are in the .NET MAUI class library (CameraService.Windows.cs, CameraService.iOS.cs, CameraService.Android.cs), which references the RCL.](~/blazor/hybrid/reuse-razor-components/_static/diagram4.png)
 
-For more informaiton and an example for .NET 8 or later with a Blazor Web App, see <xref:blazor/hybrid/tutorials/maui-blazor-web-app?view=aspnetcore-8.0#using-interfaces-to-support-different-device-implementations>.
+For more information and an example for .NET 8 or later with a Blazor Web App, see <xref:blazor/hybrid/tutorials/maui-blazor-web-app?view=aspnetcore-8.0#using-interfaces-to-support-different-device-implementations>.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/hybrid/reuse-razor-components.md
+++ b/aspnetcore/blazor/hybrid/reuse-razor-components.md
@@ -69,6 +69,8 @@ The following example demonstrates the concepts for images in an app that organi
 
 ![A .NET MAUI Blazor Hybrid app uses InputPhoto from a Razor class library (RCL) that it references. The .NET MAUI app also references a .NET MAUI class library. InputPhoto in the RCL injects an ICameraService interface defined in the RCL. CameraService partial class implementations for ICameraService are in the .NET MAUI class library (CameraService.Windows.cs, CameraService.iOS.cs, CameraService.Android.cs), which references the RCL.](~/blazor/hybrid/reuse-razor-components/_static/diagram4.png)
 
+For more informaiton and an example for .NET 8 or later with a Blazor Web App, see <xref:blazor/hybrid/tutorials/maui-blazor-web-app?view=aspnetcore-8.0#using-interfaces-to-support-different-device-implementations>.
+
 ## Additional resources
 
 * .NET MAUI Blazor podcast sample app


### PR DESCRIPTION
Fixes #32518

cc: @BethMassi - Let me know if this requires a patch. To avoid any problems confusing devs working in 6.0/7.0, I originally had a remark in the sentence that the cross-linked content is for .NET 8 or later with a BWA. However, that approach will kind'a break over the years because I had to peg the destination at the 8.0 article. We don't really want to do that. It's best to just version the whole remark for 8.0 or later to harden this cross-link. ***Future generations of doc authors will thank us!*** 😆

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/reuse-razor-components.md](https://github.com/dotnet/AspNetCore.Docs/blob/b047bcc0d99fb278f191992da24246fff6d580d0/aspnetcore/blazor/hybrid/reuse-razor-components.md) | [Reuse Razor components in ASP.NET Core Blazor Hybrid](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/reuse-razor-components?branch=pr-en-us-32522) |

<!-- PREVIEW-TABLE-END -->