### PR TITLE
Update aspnetcore-7.0.md

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-7.0.md
+++ b/aspnetcore/release-notes/aspnetcore-7.0.md
@@ -187,7 +187,7 @@ There is no built-in support for [antiforgery](/aspnet/core/security/anti-reques
 
 ### `[AsParameters]` attribute enables parameter binding for argument lists
 
-The [`[AsParameters]` attribute](xref:Microsoft.AspNetCore.Http.AsParametersAttribute) enables parameter binding for argument lists. For more information, see [Parameter binding for argument lists with `[AsParameters]`](xref:fundamentals/minimal-apis?view=aspnetcore-7.0&preserve-view=true#asparam7).
+The [`[AsParameters]` attribute](xref:Microsoft.AspNetCore.Http.AsParametersAttribute) enables parameter binding for argument lists. For more information, see [Parameter binding for argument lists with `[AsParameters]`](xref:fundamentals/minimal-apis?view=aspnetcore-7.0&preserve-view=true#parameter-binding-for-argument-lists-with-asparameters).
 
 ## Minimal APIs and API controllers
 


### PR DESCRIPTION
Fix link to `[AsParameters]` binding information in Fundamentals/Minimal-APIs


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-7.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/266772a3f1ebf38485e1e9aa4f994a6c65aa6968/aspnetcore/release-notes/aspnetcore-7.0.md) | [What's new in ASP.NET Core 7.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-7.0?branch=pr-en-us-32534) |

<!-- PREVIEW-TABLE-END -->