### PR TITLE
[Blazor] Data binding - "Expressions" - alternative intro proposal

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -894,7 +894,7 @@ For an alternative approach suited to sharing data in memory and across componen
 
 ## Bound field or property expression tree
 
-A bound field or property's [expression tree](/dotnet/csharp/advanced-topics/expression-trees/) is obtained by adding a property named for the field or property (`{PARAMETER OR FIELD NAME}Expression`).
+To facilitate deeper interactions with the bindings, Blazor allows the capture of the [expression tree](/dotnet/csharp/advanced-topics/expression-trees/) of a bound field or property. This is achieved by defining a property named in accordance with the field or property it relates to, suffixed by `Expression`. Thus, for any given parameter or field named `{PARAMETER OR FIELD NAME}`, the corresponding expression tree property should be named `{PARAMETER OR FIELD NAME}Expression`.
 
 The following `ChildParameterExpression` component identifies the `Year` expression's model and field name. A <xref:Microsoft.AspNetCore.Components.Forms.FieldIdentifier>, which is used to obtain the model and field name, uniquely identifies a single field that can be edited. This may correspond to a property on a model object or can be any other named value. Use of a parameter's expression is useful when creating custom validation components, which isn't covered by the Microsoft Blazor documentation but is addressed by numerous third-party resources.
 

--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -894,7 +894,7 @@ For an alternative approach suited to sharing data in memory and across componen
 
 ## Bound field or property expression tree
 
-To facilitate deeper interactions with the bindings, Blazor allows the capture of the [expression tree](/dotnet/csharp/advanced-topics/expression-trees/) of a bound field or property. This is achieved by defining a property named in accordance with the field or property it relates to, suffixed by `Expression`. Thus, for any given parameter or field named `{PARAMETER OR FIELD NAME}`, the corresponding expression tree property should be named `{PARAMETER OR FIELD NAME}Expression`.
+To facilitate deeper interactions with a binding, Blazor allows you to capture of the [expression tree](/dotnet/csharp/advanced-topics/expression-trees/) of a bound field or property. This is achieved by defining a property with the field or property name suffixed with `Expression`. For any given field or property named `{FIELD OR PROPERTY NAME}`, the corresponding expression tree property is named `{FIELD OR PROPERTY NAME}Expression`.
 
 The following `ChildParameterExpression` component identifies the `Year` expression's model and field name. A <xref:Microsoft.AspNetCore.Components.Forms.FieldIdentifier>, which is used to obtain the model and field name, uniquely identifies a single field that can be edited. This may correspond to a property on a model object or can be any other named value. Use of a parameter's expression is useful when creating custom validation components, which isn't covered by the Microsoft Blazor documentation but is addressed by numerous third-party resources.
 


### PR DESCRIPTION
@guardrex 
Feel free to reject this, just trying to propose an alternative intro to the `ValueExpression` aspect.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/data-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/e78ef4c341eef3dbc95299162a861f3045ac6764/aspnetcore/blazor/components/data-binding.md) | [ASP.NET Core Blazor data binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?branch=pr-en-us-32535) |


<!-- PREVIEW-TABLE-END -->