### PR TITLE
Update quest.yml to match quest.yml in dotnet/docs

### DIFF
--- a/.github/workflows/quest.yml
+++ b/.github/workflows/quest.yml
@@ -76,4 +76,4 @@ jobs:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
           issue: ${{ github.event.issue.number }}
-          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || 5 }}
+


### PR DESCRIPTION
See https://github.com/dotnet/docs/blob/9293ff9d4430de1b1aa3a40312707f7eb7575876/.github/workflows/quest.yml#L72
Only Quest_bulk.yml has duration at the end of the file; Quest.yml doesn't