### PR TITLE
Skip workflow in forks

### DIFF
--- a/.github/workflows/merge-live.yml
+++ b/.github/workflows/merge-live.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   default:
     runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
     steps:
       - uses: actions/checkout@v2
       - run: |


### PR DESCRIPTION
Don't run the merge-live workflow in forks.

This should prevent PRs like this one: https://github.com/martincostello/AspNetCore.Docs/pull/1
