### PR TITLE
First MVC: Clarify project location has no restriction

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -59,7 +59,7 @@ See https://github.com/dotnet/AspNetCore.Docs/issues/21193
 * In the **Create a new project** dialog, select **ASP.NET Core Web App (Model-View-Controller)** > **Next**.
 * In the **Configure your new project** dialog:
   * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
-  * Enter a directory for the project in **Location**. The project can be located anywhere.
+  * The **Location** for the project can be set to anywhere.
 * Select **Next**.
 * In the **Additional information** dialog:
   * Select **.NET 8.0 (Long Term Support)**.
@@ -103,7 +103,7 @@ The tutorial assumes familiarity with VS Code. For more information, see [Gettin
   * Verify that **Do not use top-level statements** is unchecked.
 * Select **Continue**.
 * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
-* Enter a directory for the project in **Location**. The project can be located anywhere.
+* The **Location** for the project can be set to anywhere.
 * Select **Create**.
 
 ---

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to get started with ASP.NET Core MVC.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 03/13/2024
+ms.date: 05/14/2024
 uid: tutorials/first-mvc-app/start-mvc
 ms.custom: engagement-fy23
 ---
@@ -57,7 +57,9 @@ See https://github.com/dotnet/AspNetCore.Docs/issues/21193
 
 * Start Visual Studio and select **Create a new project**.
 * In the **Create a new project** dialog, select **ASP.NET Core Web App (Model-View-Controller)** > **Next**.
-* In the **Configure your new project** dialog, enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
+* In the **Configure your new project** dialog:
+  * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
+  * Enter a directory for the project in **Location**. The project can be located anywhere.
 * Select **Next**.
 * In the **Additional information** dialog:
   * Select **.NET 8.0 (Long Term Support)**.
@@ -78,7 +80,7 @@ Visual Studio uses the default project template for the created MVC project. The
 The tutorial assumes familiarity with VS Code. For more information, see [Getting started with VS Code](https://code.visualstudio.com/docs) and [Visual Studio Code help](#visual-studio-code-help).
 
 * Select **New Terminal** from the **Terminal** menu to open the [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal).
-* Change to the directory (`cd`) that will contain the project.
+* Change to the directory (`cd`) that will contain the project. The project can be located anywhere.
 * Run the following commands:
 
    ```dotnetcli
@@ -101,6 +103,7 @@ The tutorial assumes familiarity with VS Code. For more information, see [Gettin
   * Verify that **Do not use top-level statements** is unchecked.
 * Select **Continue**.
 * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
+* Enter a directory for the project in **Location**. The project can be located anywhere.
 * Select **Create**.
 
 ---

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc7.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc7.md
@@ -41,7 +41,9 @@ See https://github.com/dotnet/AspNetCore.Docs/issues/21193
 
 * Start Visual Studio and select **Create a new project**.
 * In the **Create a new project** dialog, select **ASP.NET Core Web App (Model-View-Controller)** > **Next**.
-* In the **Configure your new project** dialog, enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
+* In the **Configure your new project** dialog:
+  * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
+  * Enter a directory for the project in **Location**. The project can be located anywhere.
 * Select **Next**.
 * In the **Additional information** dialog:
   * Select **.NET 7.0**.
@@ -62,7 +64,7 @@ Visual Studio uses the default project template for the created MVC project. The
 The tutorial assumes familiarity with VS Code. For more information, see [Getting started with VS Code](https://code.visualstudio.com/docs).
 
 * Select **New Terminal** from the **Terminal** menu to open the [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal).
-* Change to the directory (`cd`) that will contain the project.
+* Change to the directory (`cd`) that will contain the project. The project can be located anywhere.
 * Run the following commands:
 
    ```dotnetcli
@@ -85,6 +87,7 @@ The tutorial assumes familiarity with VS Code. For more information, see [Gettin
   * Verify that **Do not use top-level statements** is unchecked.
 * Select **Continue**.
 * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
+* Enter a directory for the project in **Location**. The project can be located anywhere.
 * Select **Create**.
 
 ---

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc7.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc7.md
@@ -43,7 +43,7 @@ See https://github.com/dotnet/AspNetCore.Docs/issues/21193
 * In the **Create a new project** dialog, select **ASP.NET Core Web App (Model-View-Controller)** > **Next**.
 * In the **Configure your new project** dialog:
   * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
-  * Enter a directory for the project in **Location**. The project can be located anywhere.
+  * The **Location** for the project can be set to anywhere.
 * Select **Next**.
 * In the **Additional information** dialog:
   * Select **.NET 7.0**.
@@ -87,7 +87,7 @@ The tutorial assumes familiarity with VS Code. For more information, see [Gettin
   * Verify that **Do not use top-level statements** is unchecked.
 * Select **Continue**.
 * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
-* Enter a directory for the project in **Location**. The project can be located anywhere.
+* The **Location** for the project can be set to anywhere.
 * Select **Create**.
 
 ---


### PR DESCRIPTION
Fixes #32039 

It was not clear that the project is not required to be in any particular place expected by .NET and can be put anywhere.  Clarifying it can be put anywhere for VS/VSCode/Mac, version 7 and up.  Not touching the older versions of this tutorial.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mvc-app/start-mvc.md](https://github.com/dotnet/AspNetCore.Docs/blob/c03948e47158e0f888fff2318fb60dcb3efa9b81/aspnetcore/tutorials/first-mvc-app/start-mvc.md) | [Get started with ASP.NET Core MVC](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/start-mvc?branch=pr-en-us-32580) |


<!-- PREVIEW-TABLE-END -->