### PR TITLE
Update order of operations in ConfigureKestrel in interprocess.md

### DIFF
--- a/aspnetcore/grpc/interprocess.md
+++ b/aspnetcore/grpc/interprocess.md
@@ -49,6 +49,11 @@ Depending on the OS, cross-platform apps may choose different IPC transports. An
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.ConfigureKestrel(serverOptions =>
 {
+    serverOptions.ConfigureEndpointDefaults(listenOptions =>
+    {
+        listenOptions.Protocols = HttpProtocols.Http2;
+    });
+
     if (OperatingSystem.IsWindows())
     {
         serverOptions.ListenNamedPipe("MyPipeName");
@@ -58,11 +63,6 @@ builder.WebHost.ConfigureKestrel(serverOptions =>
         var socketPath = Path.Combine(Path.GetTempPath(), "socket.tmp");
         serverOptions.ListenUnixSocket(socketPath);
     }
-
-    serverOptions.ConfigureEndpointDefaults(listenOptions =>
-    {
-        listenOptions.Protocols = HttpProtocols.Http2;
-    });
 });
 ```
 


### PR DESCRIPTION
If the ListenUnixSocket method is called before ConfigureEndpointsDefault with Http2 as Protocols in ConfigureKestrel, the following Exception is thrown by a client trying to communicate over that socket:

Call failed with gRPC error status. Status code: 'Internal', Message: '"Error starting gRPC call. HttpRequestException: The HTTP/2 server closed the connection. HTTP/2 error code 'HTTP_1_1_REQUIRED' (0xd). (HttpProtocolError) HttpProtocolException: The HTT P/2 server closed the connection. HTTP/2 error code 'HTTP_1_1_REQUIRED' (0xd). (HttpProtocolError)"'.

This can be solved by adding EndpointDefaults with Http2 as Protocols to your appsettings, or by changing the order in which the methods are called.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/interprocess.md](https://github.com/dotnet/AspNetCore.Docs/blob/7129b14670847f8512601668dc54256409aab732/aspnetcore/grpc/interprocess.md) | [Inter-process communication with gRPC](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/interprocess?branch=pr-en-us-32590) |

<!-- PREVIEW-TABLE-END -->