### PR TITLE
Azure Container Apps updates

### DIFF
--- a/aspnetcore/blazor/fundamentals/logging.md
+++ b/aspnetcore/blazor/fundamentals/logging.md
@@ -775,7 +775,7 @@ Provide a `Logging:LogLevel:HubConnection` app setting in the default `appsettin
 
 At the top of the Razor component file (`.razor`):
 
-* Inject an <xref:Microsoft.Extensions.Logging.ILoggerProvider> to add a `WebAssemblyConsoleLogger` to the logging providers passed to <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder>. Unlike a traditional <xref:Microsoft.Extensions.Logging.Console.ConsoleLogger>, `WebAssemblyConsoleLogger` is a wrapper around browser-specific logging APIs (for example, `console.log`). Use of `WebAssemblyConsoleLogger` makes logging possible within Mono inside a browser context.
+* Inject an <xref:Microsoft.Extensions.Logging.ILoggerProvider> to add a `WebAssemblyConsoleLogger` to the logging providers passed to <xref:Microsoft.AspNetCore.SignalR.Client.HubConnectionBuilder>. Unlike a <xref:Microsoft.Extensions.Logging.Console.ConsoleLoggerProvider>, `WebAssemblyConsoleLogger` is a wrapper around browser-specific logging APIs (for example, `console.log`). Use of `WebAssemblyConsoleLogger` makes logging possible within Mono inside a browser context.
 * Inject an `IConfiguration` to read the `Logging:LogLevel:HubConnection` app setting.
 
 > [!NOTE]

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -129,7 +129,7 @@ To provision the Azure SignalR Service for an app in Visual Studio:
 
 Provisioning the Azure SignalR Service in Visual Studio automatically adds the SignalR connection string to the app service's configuration.
 
-## Azure App Service without the Azure SignalR Service
+## Azure App Service
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -125,31 +125,6 @@ Hosting a Blazor Server app on Azure App Service requires configuration for Appl
 
 :::moniker-end
 
-1. Configure the app for session affinity by setting the Azure SignalR `ServerStickyMode` option to `Required`. Typically, an app creates the configuration using **one** of the following approaches:
-
-   * Set the option in `Program.cs`:
-
-     ```csharp
-     builder.Services.AddSignalR().AddAzureSignalR(options =>
-     {
-         options.ServerStickyMode = 
-             Microsoft.Azure.SignalR.ServerStickyMode.Required;
-     });
-     ```
-
-   * Configure the option in `appsettings.json`:
-
-       ```json
-       "Azure:SignalR:ServerStickyMode": "Required"
-       ```
-
-   * Configure the option with an application setting in the Azure portal (**Configuration** > **Application settings**: **Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`).
-  
-  > [!NOTE]
-  > The following error is thrown by an app that hasn't enabled session affinity:
-  >
-  > > :::no-loc text="blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.":::
-
 1. Use the following guidance to configure the service:
 
   * [Configure the app in Azure App Service](xref:signalr/publish-to-azure-web-app#configure-the-app-in-azure-app-service).
@@ -160,26 +135,6 @@ Hosting a Blazor Server app on Azure App Service requires configuration for Appl
 ## Azure Container Apps
 
 For a deeper exploration of scaling server-side Blazor apps on the Azure Container Apps service, see <xref:host-and-deploy/scaling-aspnet-apps/scaling-aspnet-apps>. The tutorial explains how to create and integrate the services required to host apps on Azure Container Apps. Basic steps are also provided in this section.
-
-1. Configure *session affinity*, also known as *sticky sessions*, where clients are redirected back to the same server. Session affinity is configured by setting the Azure SignalR `ServerStickyMode` option to `Required`. Typically, an app creates the configuration using **one** of the following approaches:
-
-   * Set the option in `Program.cs`:
-
-     ```csharp
-     builder.Services.AddSignalR().AddAzureSignalR(options =>
-     {
-         options.ServerStickyMode = 
-             Microsoft.Azure.SignalR.ServerStickyMode.Required;
-     });
-     ```
-
-   * Configure the option in `appsettings.json`:
-
-       ```json
-       "Azure:SignalR:ServerStickyMode": "Required"
-       ```
-
-   * Configure the option with an application setting in the Azure portal (**Configuration** > **Application settings**: **Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`).
 
 1. Configure Azure Container Apps service for session affinity by following the guidance in [Session Affinity in Azure Container Apps (Azure documentation)](/azure/container-apps/sticky-sessions).
 

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -98,6 +98,24 @@ Consider using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-serv
 
 The app must support *session affinity*, also called *sticky sessions*, where clients are redirected back to the same server. To support session affinity, an application setting in the Azure portal is automatically configured (**Configuration** > **Application settings**: **Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`). Therefore, you don't need to manually configure the app for session affinity.
 
+If you prefer not to use the app setting in Azure (and delete it in the Azure portal), two other approaches for configuring session affinity are (**use either approach, not both**):
+
+* Set the option in `Program.cs`:
+
+  ```csharp
+  builder.Services.AddSignalR().AddAzureSignalR(options =>
+  {
+      options.ServerStickyMode = 
+          Microsoft.Azure.SignalR.ServerStickyMode.Required;
+  });
+  ```
+
+* Configure the option in `appsettings.json`:
+
+  ```json
+  "Azure:SignalR:ServerStickyMode": "Required"
+  ```
+
 > [!NOTE]
 > The following error is thrown by an app that hasn't enabled session affinity:
 >

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -96,32 +96,12 @@ Consider using the [Azure SignalR Service](xref:signalr/scale#azure-signalr-serv
 > * [Performance guide for Azure SignalR Service](/azure/azure-signalr/signalr-concept-performance#performance-factors)
 > * <xref:signalr/publish-to-azure-web-app>
 
-To configure an app for the Azure SignalR Service, the app must support *sticky sessions*, where clients are redirected back to the same server. The `ServerStickyMode` option or configuration value is set to `Required`. Typically, an app creates the configuration using **one** of the following approaches:
-
-* `Program.cs`:
-
-  ```csharp
-  builder.Services.AddSignalR().AddAzureSignalR(options =>
-  {
-      options.ServerStickyMode = 
-          Microsoft.Azure.SignalR.ServerStickyMode.Required;
-  });
-  ```
-
-* Configuration (use **one** of the following approaches):
-
-  * In `appsettings.json`:
-
-    ```json
-    "Azure:SignalR:ServerStickyMode": "Required"
-    ```
-
-  * The app service's **Configuration** > **Application settings** in the Azure portal (**Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`). This approach is adopted for the app automatically if you [provision the Azure SignalR Service](#provision-the-azure-signalr-service).
+The app must support *session affinity*, also called *sticky sessions*, where clients are redirected back to the same server. To support session affinity, an application setting in the Azure portal is automatically configured (**Configuration** > **Application settings**: **Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`). Therefore, you don't need to manually configure the app for session affinity.
 
 > [!NOTE]
-> The following error is thrown by an app that hasn't enabled sticky sessions for Azure SignalR Service:
+> The following error is thrown by an app that hasn't enabled session affinity:
 >
-> > blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.
+> > :::no-loc text="blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.":::
 
 To provision the Azure SignalR Service for an app in Visual Studio:
 
@@ -129,7 +109,7 @@ To provision the Azure SignalR Service for an app in Visual Studio:
 1. Add the **Azure SignalR Service** dependency to the profile. If the Azure subscription doesn't have a pre-existing Azure SignalR Service instance to assign to the app, select **Create a new Azure SignalR Service instance** to provision a new service instance.
 1. Publish the app to Azure.
 
-Provisioning the Azure SignalR Service in Visual Studio automatically [enables *sticky sessions*](#configuration) and adds the SignalR connection string to the app service's configuration.
+Provisioning the Azure SignalR Service in Visual Studio automatically adds the SignalR connection string to the app service's configuration.
 
 ## Azure App Service without the Azure SignalR Service
 
@@ -145,24 +125,43 @@ Hosting a Blazor Server app on Azure App Service requires configuration for Appl
 
 :::moniker-end
 
-Use the following guidance to configure the app:
+1. Configure the app for session affinity by setting the Azure SignalR `ServerStickyMode` option to `Required`. Typically, an app creates the configuration using **one** of the following approaches:
 
-* [Configure the app in Azure App Service](xref:signalr/publish-to-azure-web-app#configure-the-app-in-azure-app-service).
-* [App Service Plan Limits](xref:signalr/publish-to-azure-web-app#app-service-plan-limits).
+   * Set the option in `Program.cs`:
+
+     ```csharp
+     builder.Services.AddSignalR().AddAzureSignalR(options =>
+     {
+         options.ServerStickyMode = 
+             Microsoft.Azure.SignalR.ServerStickyMode.Required;
+     });
+     ```
+
+   * Configure the option in `appsettings.json`:
+
+       ```json
+       "Azure:SignalR:ServerStickyMode": "Required"
+       ```
+
+   * Configure the option with an application setting in the Azure portal (**Configuration** > **Application settings**: **Name**: `Azure__SignalR__ServerStickyMode`, **Value**: `Required`).
+  
+  > [!NOTE]
+  > The following error is thrown by an app that hasn't enabled session affinity:
+  >
+  > > :::no-loc text="blazor.server.js:1 Uncaught (in promise) Error: Invocation canceled due to the underlying connection being closed.":::
+
+1. Use the following guidance to configure the service:
+
+  * [Configure the app in Azure App Service](xref:signalr/publish-to-azure-web-app#configure-the-app-in-azure-app-service).
+  * [App Service Plan Limits](xref:signalr/publish-to-azure-web-app#app-service-plan-limits).
 
 :::moniker range=">= aspnetcore-6.0"
 
 ## Azure Container Apps
 
-Scaling server-side Blazor apps on Azure Container Apps requires the following:
+For a deeper exploration of scaling server-side Blazor apps on the Azure Container Apps service, see <xref:host-and-deploy/scaling-aspnet-apps/scaling-aspnet-apps>. The tutorial explains how to create and integrate the services required to host apps on Azure Container Apps. Basic steps are also provided in this section.
 
-* Configure *session affinity*, also known as *sticky sessions*, where clients are redirected back to the same server.
-* Due to the way request routing is handled, the ASP.NET Core Data Protection service must be configured to persist keys in a centralized location that all container instances can access. The keys can be stored in Azure Blob Storage and protected with Azure Key Vault. The data protection service uses the keys to deserialize Razor components.
-
-> [!NOTE]
-> For a deeper exploration of this scenario and scaling container apps, see <xref:host-and-deploy/scaling-aspnet-apps/scaling-aspnet-apps>. The tutorial explains how to create and integrate the services required to host apps on Azure Container Apps. Basic steps are also provided in this section.
-
-1. Configure the app for session affinity by setting the Azure SignalR `ServerStickyMode` option to `Required`. Typically, an app creates the configuration using **one** of the following approaches:
+1. Configure *session affinity*, also known as *sticky sessions*, where clients are redirected back to the same server. Session affinity is configured by setting the Azure SignalR `ServerStickyMode` option to `Required`. Typically, an app creates the configuration using **one** of the following approaches:
 
    * Set the option in `Program.cs`:
 
@@ -184,7 +183,7 @@ Scaling server-side Blazor apps on Azure Container Apps requires the following:
 
 1. Configure Azure Container Apps service for session affinity by following the guidance in [Session Affinity in Azure Container Apps (Azure documentation)](/azure/container-apps/sticky-sessions).
 
-1. To configure the data protection service to use Azure Blob Storage and Azure Key Vault, reference the following NuGet packages:
+1. The ASP.NET Core Data Protection service must be configured to persist keys in a centralized location that all container instances can access. The keys can be stored in Azure Blob Storage and protected with Azure Key Vault. The data protection service uses the keys to deserialize Razor components. To configure the data protection service to use Azure Blob Storage and Azure Key Vault, reference the following NuGet packages:
 
    * [`Azure.Identity`](https://www.nuget.org/packages/Azure.Identity): Provides classes to work with the Azure identity and access management services.
    * [`Microsoft.Extensions.Azure`](https://www.nuget.org/packages/Microsoft.Extensions.Azure): Provides helpful extension methods to perform core Azure configurations.

--- a/aspnetcore/blazor/host-and-deploy/server.md
+++ b/aspnetcore/blazor/host-and-deploy/server.md
@@ -154,7 +154,7 @@ Use the following guidance to configure the app:
 
 ## Azure Container Apps
 
-Scaling server-side Blazor apps on Azure Container Apps requires specific considerations:
+Scaling server-side Blazor apps on Azure Container Apps requires the following:
 
 * Configure *session affinity*, also known as *sticky sessions*, where clients are redirected back to the same server.
 * Due to the way request routing is handled, the ASP.NET Core Data Protection service must be configured to persist keys in a centralized location that all container instances can access. The keys can be stored in Azure Blob Storage and protected with Azure Key Vault. The data protection service uses the keys to deserialize Razor components.


### PR DESCRIPTION
Fixes #32591

I ended up having to rework the entire presentation, and it might take a little more time.

The PR tries to address the problems by ...

* Divorcing the Azure Container Apps guidance into its own section.
  * Removing mention of the Azure SignalR Service from Azure Container Apps guidance.
  * Placing the session affinity guidance (app-side config) in the new section.
  * Cross-link their article for the Azure Container Apps service configuration.
* Rework the Azure SignalR Service guidance for App Service to focus only on its configuration.
* Rework the non-Azure SignalR Service guidance for App Service to focus only on its configuration.

I'll need to take another look at this over the weekend.

Additional notes ...

* I have a separate tracking item to adopt "session affinity" as the primary termonology with "sticky sessions" mentioned in passing. A few sections across the doc set will require attention, which I'll take care of later on a different PR.
* I have a separate tracking item to use a proper noun for "data protection" when referring to the ASP.NET Core feature (i.e., "ASP.NET Core Data Protection"). There are just a few spots that don't already do it. I'll fix a few 😈 on a different PR later.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/logging.md](https://github.com/dotnet/AspNetCore.Docs/blob/bb9755db0b1a752c7f84489fd0b272045ef8c53e/aspnetcore/blazor/fundamentals/logging.md) | [ASP.NET Core Blazor logging](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/logging?branch=pr-en-us-32592) |
| [aspnetcore/blazor/host-and-deploy/server.md](https://github.com/dotnet/AspNetCore.Docs/blob/bb9755db0b1a752c7f84489fd0b272045ef8c53e/aspnetcore/blazor/host-and-deploy/server.md) | [Host and deploy ASP.NET Core server-side Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/server?branch=pr-en-us-32592) |


<!-- PREVIEW-TABLE-END -->