### PR TITLE
Correct iard.md

### DIFF
--- a/aspnetcore/security/authorization/iard.md
+++ b/aspnetcore/security/authorization/iard.md
@@ -13,32 +13,13 @@ Consider the following sample that implements a custom `MinimumAgeAuthorizationH
 
 :::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Program.cs" highlight="9":::
 
-The `MinimumAgeAuthorizationHandler` class:
+The `MinimumAgeAuthorizationHandler` class handles the single IAuthorizationRequirement provided by the MinimumAgeAuthorizeAttribute implementation of IAuthorizationRequirementData, as specified by the generic parameter MinimumAgeAuthorizeAttribute.
 
 :::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Authorization/MinimumAgeAuthorizationHandler.cs" highlight="7,19":::
 
-The custom `MinimumAgePolicyProvider`:
-
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Authorization/MinimumAgePolicyProvider.cs" id="snippet_all":::
-
-ASP.NET Core only uses one authorization policy provider. If the custom implementation
-doesn't handle all policies, including default policies, etc., it should fall back to an
-alternate provider. In the preceding sample, a default authorization policy provider is:
-
-* Constructed with options from the [dependency injection container](xref:fundamentals/dependency-injection).
-* Used if this custom provider isn't able to handle a given policy name.
-
-If a custom policy provider is able to handle all expected policy names, setting the fallback policy with <xref:Microsoft.AspNetCore.Authorization.IAuthorizationPolicyProvider.GetFallbackPolicyAsync> isn't required.
-
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Authorization/MinimumAgePolicyProvider.cs" id="snippet_1":::
-
-Policies are looked up by string name, therefore parameters, for example, `age`, are embedded in the policy names. This is abstracted away from developers by the more strongly-typed attributes derived from <xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute>. For example, the `[MinimumAgeAuthorize()]` attribute in this sample looks up policies by string name.
-
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Authorization/MinimumAgePolicyProvider.cs" id="snippet_2":::
-
 The `MinimumAgeAuthorizeAttribute` uses the <xref:Microsoft.AspNetCore.Authorization.IAuthorizationRequirementData> interface that allows the attribute definition to specify the requirements associated with the authorization policy:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Authorization/MinimumAgeAuthorizeAttribute.cs" highlight="6":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Authorization/MinimumAgeAuthorizeAttribute.cs" highlight="6,11":::
 
 The `GreetingsController` displays the user's name when they satisfy the minimum age policy:
 

--- a/aspnetcore/security/authorization/iard.md
+++ b/aspnetcore/security/authorization/iard.md
@@ -13,7 +13,7 @@ Consider the following sample that implements a custom `MinimumAgeAuthorizationH
 
 :::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Program.cs" highlight="9":::
 
-The `MinimumAgeAuthorizationHandler` class handles the single <xref:Microsoft.AspNetCore.Authorization.IAuthorizationRequirement> provided by the MinimumAgeAuthorizeAttribute implementation of <xref:Microsoft.AspNetCore.Authorization.IAuthorizationRequirementData>, as specified by the generic parameter MinimumAgeAuthorizeAttribute.
+The `MinimumAgeAuthorizationHandler` class handles the single <xref:Microsoft.AspNetCore.Authorization.IAuthorizationRequirement> provided by the `MinimumAgeAuthorizeAttribute` implementation of <xref:Microsoft.AspNetCore.Authorization.IAuthorizationRequirementData>, as specified by the generic parameter `MinimumAgeAuthorizeAttribute`.
 
 :::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Authorization/MinimumAgeAuthorizationHandler.cs" highlight="7,19":::
 

--- a/aspnetcore/security/authorization/iard.md
+++ b/aspnetcore/security/authorization/iard.md
@@ -7,13 +7,13 @@ monikerRange: '>= aspnetcore-8.0'
 ms.date: 6/4/2023
 uid: security/authorization/iard
 ---
-# Custom authorization policies with IAuthorizationRequirementData
+# Custom authorization policies with `IAuthorizationRequirementData`
 
 Consider the following sample that implements a custom `MinimumAgeAuthorizationHandler`:
 
 :::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Program.cs" highlight="9":::
 
-The `MinimumAgeAuthorizationHandler` class handles the single IAuthorizationRequirement provided by the MinimumAgeAuthorizeAttribute implementation of IAuthorizationRequirementData, as specified by the generic parameter MinimumAgeAuthorizeAttribute.
+The `MinimumAgeAuthorizationHandler` class handles the single <xref:Microsoft.AspNetCore.Authorization.IAuthorizationRequirement> provided by the MinimumAgeAuthorizeAttribute implementation of <xref:Microsoft.AspNetCore.Authorization.IAuthorizationRequirementData>, as specified by the generic parameter MinimumAgeAuthorizeAttribute.
 
 :::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Authorization/MinimumAgeAuthorizationHandler.cs" highlight="7,19":::
 
@@ -25,7 +25,7 @@ The `GreetingsController` displays the user's name when they satisfy the minimum
 
 :::code language="csharp" source="~/../AspNetCore.Docs.Samples/security/authorization/AuthRequirementsData/Controllers/GreetingsController.cs" highlight="10":::
 
-The complete sample can be found in the [AuthRequirementsData](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/security/authorization/AuthRequirementsData) folder of the [AspNetCore.Docs.Samples](https://github.com/dotnet/AspNetCore.Docs.Samples) repository.
+The complete sample can be found in the [`AuthRequirementsData` folder](https://github.com/dotnet/AspNetCore.Docs.Samples/tree/main/security/authorization/AuthRequirementsData) of the [ASP.NET Core documentation samples GitHub repository](https://github.com/dotnet/AspNetCore.Docs.Samples).
 
 The sample can be tested with [`dotnet user-jwts`](xref:security/authentication/jwt) and curl:
 


### PR DESCRIPTION
Remove all references to the MinimumAgePolicyProvider that is not used when using IAuthorizationRequirementData.

The middleware constructs a policy adding the requirements from IAuthorizationRequirementData.GetRequirements

https://github.com/dotnet/aspnetcore/blob/82b0fc9f43ae2bd50fb95f427116efc2f6f094df/src/Security/Authorization/Policy/src/AuthorizationMiddleware.cs#L130



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authorization/iard.md](https://github.com/dotnet/AspNetCore.Docs/blob/2eebbf54664ebc3b36ff9fba20faee22c7115225/aspnetcore/security/authorization/iard.md) | [aspnetcore/security/authorization/iard](https://review.learn.microsoft.com/en-us/aspnet/core/security/authorization/iard?branch=pr-en-us-32595) |


<!-- PREVIEW-TABLE-END -->