### PR TITLE
Static SSR pages in a globally-interactive app

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -181,7 +181,7 @@ For more information, see <xref:blazor/tooling>.
 
 Properties and fields can assign a render mode.
 
-The second approach described in this section, setting the render mode by component instance, is especially useful when your app specification calls for one or more components to adopt static SSR in a globally-interactive app. This scenario is covered in the [Static SSR pages in a globally-interactive app](#static-ssr-pages-in-a-globally-interactive-app) section later in this article. The following two subsections focus on basic approaches for setting the render mode.
+The second approach described in this section, setting the render mode by component instance, is especially useful when your app specification calls for one or more components to adopt static SSR in a globally-interactive app. This scenario is covered in the [Static SSR pages in a globally-interactive app](#static-ssr-pages-in-a-globally-interactive-app) section later in this article.
 
 ### Set the render mode by component definition
 
@@ -525,20 +525,20 @@ Mark any Razor component page with the `[ExcludeFromInteractiveRouting]` attribu
 @attribute [ExcludeFromInteractiveRouting]
 ```
 
-Applying the attribute causes navigation to the page to exit from interactive routing. That is, inbound navigation is forced to perform a full-page reload instead resolving the page via SPA-style interactive routing. This means that your top-level root component, typically the `App` component (`App.razor`), re-runs, allowing you to switch to a different top-level render mode.
+This approach is only useful when you have specific pages that can't work with interactive Server or WebAssembly rendering. For example, adopt this approach for pages that include code that depends on reading/writing HTTP cookies and can only work in a request/response cycle instead of interactive rendering.
 
-In your `App` component, you can use the following pattern, where all pages default to the `InteractiveServer` render mode, retaining global interactivity, except for pages annotated with `[ExcludeFromInteractiveRouting]`, which only render with static SSR. Of course, you can replace `InteractiveServer` with `InteractiveWebAssembly` or `InteractiveAuto` to specify a different default global mode.
+In the `App` component, use the following pattern, where all pages default to the `InteractiveServer` render mode, retaining global interactivity, except for pages annotated with `[ExcludeFromInteractiveRouting]`, which only render with static SSR. You can replace `InteractiveServer` with `InteractiveWebAssembly` or `InteractiveAuto` to specify a different default global render mode.
 
 ```razor
 <!DOCTYPE html>
 <html>
 <head>
-    ... other head content here ...
+    ...
     <HeadOutlet @rendermode="@PageRenderMode" />
 </head>
 <body>
     <Routes @rendermode="@PageRenderMode" />
-    <script src="_framework/blazor.web.js"></script>
+    ...
 </body>
 </html>
 
@@ -553,9 +553,9 @@ In your `App` component, you can use the following pattern, where all pages defa
 
 The `HttpContext.AcceptsInteractiveRouting` extension method allows the component to detect whether `[ExcludeFromInteractiveRouting]` is applied to the current page. Alternatively, you can read endpoint metadata manually using `HttpContext.GetEndpoint()?.Metadata`.
 
-This approach is useful only if you have certain pages that can't work with interactive Server or WebAssembly rendering. For example, adopt this approach for pages that include code that depends on reading/writing HTTP cookies and can only work in a request/response cycle. Forcing those pages to use static SSR mode forces them into this traditional request/response cycle instead of interactive SPA-style rendering.
+This approach is useful only if you have specific pages that can't work with interactive Server or WebAssembly rendering. For example, adopt this approach for pages that include code that depends on reading/writing HTTP cookies and can only work in a request/response cycle. Forcing those pages to use static SSR mode forces them into this traditional request/response cycle instead of interactive rendering.
 
-For pages that work with interactive SPA-style rendering, you shouldn't force them to use static SSR rendering, as it's less efficient and less responsive for the end user.
+For pages that work with interactive rendering, you shouldn't force them to use static SSR rendering, as it's less efficient and less responsive for the end user.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/security/server/index.md
+++ b/aspnetcore/blazor/security/server/index.md
@@ -769,7 +769,7 @@ To avoid showing unauthorized content, for example content in an [`AuthorizeView
   <HeadOutlet @rendermode="new InteractiveServerRenderMode(prerender: false)" />
   ```
 
-  You can also selectively disable prerendering with fine control of the render mode applied to the `Routes` component instance. For more information, see <xref:blazor/components/render-modes#fine-control-of-render-modes>.
+  You can also selectively disable prerendering with fine control of the render mode applied to the `Routes` component instance. For more information, see <xref:blazor/components/render-modes#static-ssr-pages-in-a-globally-interactive-app>.
 
 :::moniker-end
 

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -1,3 +1,50 @@
+<!-- ENABLE at Pre4 release ...
+
+### Add static server-side rendering (SSR) pages to a globally-interactive Blazor Web App
+
+The Blazor Web App template includes an option to enable *global interactivity*, which means that all pages run on Server, WebAssembly, or Auto (Server and WebAssembly) interactivity mode. Until the release of .NET 9, it wasn't possible to add static SSR pages to apps that adopt global interactivity.
+
+Now, you can mark any Razor component page with the new `[ExcludeFromInteractiveRouting]` attribute assigned with the `@attribute` Razor directive:
+
+```razor
+@attribute [ExcludeFromInteractiveRouting]
+```
+
+Applying the attribute causes navigation to the page to exit from interactive routing. That is, inbound navigation is forced to perform a full-page reload instead resolving the page via SPA-style interactive routing. This means that your top-level root component, typically the `App` component (`App.razor`), re-runs, allowing you to switch to a different top-level render mode.
+
+In your `App` component, you can use the following pattern, where all pages default to the `InteractiveServer` render mode, retaining global interactivity, except for pages annotated with `[ExcludeFromInteractiveRouting]`, which only render with static SSR. Of course, you can replace `InteractiveServer` with `InteractiveWebAssembly` or `InteractiveAuto` to specify a different default global mode.
+
+```razor
+<!DOCTYPE html>
+<html>
+<head>
+    ... other head content here ...
+    <HeadOutlet @rendermode="@PageRenderMode" />
+</head>
+<body>
+    <Routes @rendermode="@PageRenderMode" />
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>
+
+@code {
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    private IComponentRenderMode? PageRenderMode
+        => HttpContext.AcceptsInteractiveRouting() ? InteractiveServer : null;
+}
+```
+
+The new `HttpContext.AcceptsInteractiveRouting` extension method is a helper that makes it easy to detect whether `[ExcludeFromInteractiveRouting]` is applied to the current page. Alternatively, you can read endpoint metadata manually using `HttpContext.GetEndpoint()?.Metadata`.
+
+This approach is useful only if you have certain pages that can't work with interactive Server or WebAssembly rendering. For example, adopt this approach for pages that include code that depends on reading/writing HTTP cookies and can only work in a request/response cycle. Forcing those pages to use static SSR mode forces them into this traditional request/response cycle instead of interactive SPA-style rendering.
+
+For pages that work with interactive SPA-style rendering, you shouldn't force them to use static SSR rendering, as it's less efficient and less responsive for the end user.
+
+This feature is covered by the reference documentation in <xref:blazor/components/render-modes#static-ssr-pages-in-a-globally-interactive-app>.
+-->
+
 ### Constructor injection
 
 Razor components support constructor injection.

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -1,5 +1,3 @@
-<!-- ENABLE at Pre4 release ...
-
 ### Add static server-side rendering (SSR) pages to a globally-interactive Blazor Web App
 
 The Blazor Web App template includes an option to enable *global interactivity*, which means that all pages run on Server, WebAssembly, or Auto (Server and WebAssembly) interactivity mode. Until the release of .NET 9, it wasn't possible to add static SSR pages to apps that adopt global interactivity.
@@ -10,20 +8,20 @@ Now, you can mark any Razor component page with the new `[ExcludeFromInteractive
 @attribute [ExcludeFromInteractiveRouting]
 ```
 
-Applying the attribute causes navigation to the page to exit from interactive routing. That is, inbound navigation is forced to perform a full-page reload instead resolving the page via SPA-style interactive routing. This means that your top-level root component, typically the `App` component (`App.razor`), re-runs, allowing you to switch to a different top-level render mode.
+Applying the attribute causes navigation to the page to exit from interactive routing. That is, inbound navigation is forced to perform a full-page reload instead resolving the page via interactive routing. The full-page reload forces the top-level root component, typically the `App` component (`App.razor`), to rerender from the server, allowing you to switch to a different top-level render mode.
 
-In your `App` component, you can use the following pattern, where all pages default to the `InteractiveServer` render mode, retaining global interactivity, except for pages annotated with `[ExcludeFromInteractiveRouting]`, which only render with static SSR. Of course, you can replace `InteractiveServer` with `InteractiveWebAssembly` or `InteractiveAuto` to specify a different default global mode.
+In the `App` component, use the following pattern, where all pages default to the `InteractiveServer` render mode, retaining global interactivity, except for pages annotated with `[ExcludeFromInteractiveRouting]`, which only render with static SSR. You can replace `InteractiveServer` with `InteractiveWebAssembly` or `InteractiveAuto` to specify a different default global render mode.
 
 ```razor
 <!DOCTYPE html>
 <html>
 <head>
-    ... other head content here ...
+    ...
     <HeadOutlet @rendermode="@PageRenderMode" />
 </head>
 <body>
     <Routes @rendermode="@PageRenderMode" />
-    <script src="_framework/blazor.web.js"></script>
+    ...
 </body>
 </html>
 
@@ -38,12 +36,11 @@ In your `App` component, you can use the following pattern, where all pages defa
 
 The new `HttpContext.AcceptsInteractiveRouting` extension method is a helper that makes it easy to detect whether `[ExcludeFromInteractiveRouting]` is applied to the current page. Alternatively, you can read endpoint metadata manually using `HttpContext.GetEndpoint()?.Metadata`.
 
-This approach is useful only if you have certain pages that can't work with interactive Server or WebAssembly rendering. For example, adopt this approach for pages that include code that depends on reading/writing HTTP cookies and can only work in a request/response cycle. Forcing those pages to use static SSR mode forces them into this traditional request/response cycle instead of interactive SPA-style rendering.
+This approach is only useful when you have specific pages that can't work with interactive Server or WebAssembly rendering. For example, adopt this approach for pages that include code that depends on reading/writing HTTP cookies and can only work in a request/response cycle instead of interactive rendering.
 
-For pages that work with interactive SPA-style rendering, you shouldn't force them to use static SSR rendering, as it's less efficient and less responsive for the end user.
+For pages that work with interactive rendering, you shouldn't force them to use static SSR rendering, as it's less efficient and less responsive for the end user.
 
 This feature is covered by the reference documentation in <xref:blazor/components/render-modes#static-ssr-pages-in-a-globally-interactive-app>.
--->
 
 ### Constructor injection
 

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -1,16 +1,23 @@
 ### Add static server-side rendering (SSR) pages to a globally-interactive Blazor Web App
 
-The Blazor Web App template includes an option to enable *global interactivity*, which means that all pages run on Server, WebAssembly, or Auto (Server and WebAssembly) interactivity mode. Until the release of .NET 9, it wasn't possible to add static SSR pages to apps that adopt global interactivity.
+With the release of .NET 9, it's now simpler to add static SSR pages to apps that adopt global interactivity.
 
-Now, you can mark any Razor component page with the new `[ExcludeFromInteractiveRouting]` attribute assigned with the `@attribute` Razor directive:
+This approach is only useful when the app has specific pages that can't work with interactive Server or WebAssembly rendering. For example, adopt this approach for pages that depend on reading/writing HTTP cookies and can only work in a request/response cycle instead of interactive rendering. For pages that work with interactive rendering, you shouldn't force them to use static SSR rendering, as it's less efficient and less responsive for the end user.
+
+Mark any Razor component page with the new `[ExcludeFromInteractiveRouting]` attribute assigned with the `@attribute` Razor directive:
 
 ```razor
 @attribute [ExcludeFromInteractiveRouting]
 ```
 
-Applying the attribute causes navigation to the page to exit from interactive routing. That is, inbound navigation is forced to perform a full-page reload instead resolving the page via interactive routing. The full-page reload forces the top-level root component, typically the `App` component (`App.razor`), to rerender from the server, allowing you to switch to a different top-level render mode.
+Applying the attribute causes navigation to the page to exit from interactive routing. That is, inbound navigation is forced to perform a full-page reload instead resolving the page via interactive routing. The full-page reload forces the top-level root component, typically the `App` component (`App.razor`), to rerender from the server, allowing the to switch to a different top-level render mode.
 
-In the `App` component, use the following pattern, where all pages default to the `InteractiveServer` render mode, retaining global interactivity, except for pages annotated with `[ExcludeFromInteractiveRouting]`, which only render with static SSR. You can replace `InteractiveServer` with `InteractiveWebAssembly` or `InteractiveAuto` to specify a different default global render mode.
+The `HttpContext.AcceptsInteractiveRouting` extension method allows the component to detect whether `[ExcludeFromInteractiveRouting]` is applied to the current page.
+
+In the `App` component, use the pattern in the following example:
+
+* Pages that aren't annotated with `[ExcludeFromInteractiveRouting]` default to the `InteractiveServer` render mode with global interactivity. You can replace `InteractiveServer` with `InteractiveWebAssembly` or `InteractiveAuto` to specify a different default global render mode.
+* Pages annotated with `[ExcludeFromInteractiveRouting]` adopt static SSR (`PageRenderMode` is `null`).
 
 ```razor
 <!DOCTYPE html>
@@ -34,11 +41,7 @@ In the `App` component, use the following pattern, where all pages default to th
 }
 ```
 
-The new `HttpContext.AcceptsInteractiveRouting` extension method is a helper that makes it easy to detect whether `[ExcludeFromInteractiveRouting]` is applied to the current page. Alternatively, you can read endpoint metadata manually using `HttpContext.GetEndpoint()?.Metadata`.
-
-This approach is only useful when you have specific pages that can't work with interactive Server or WebAssembly rendering. For example, adopt this approach for pages that include code that depends on reading/writing HTTP cookies and can only work in a request/response cycle instead of interactive rendering.
-
-For pages that work with interactive rendering, you shouldn't force them to use static SSR rendering, as it's less efficient and less responsive for the end user.
+An alternative to using the `HttpContext.AcceptsInteractiveRouting` extension method is to read endpoint metadata manually using `HttpContext.GetEndpoint()?.Metadata`.
 
 This feature is covered by the reference documentation in <xref:blazor/components/render-modes#static-ssr-pages-in-a-globally-interactive-app>.
 


### PR DESCRIPTION
Addresses #32361
Addresses #31909

There will be a separate PR for the BWA+OIDC article+sample later, as I think we'll be implementing this new tech for that sample. I've made a separate tracking entry for it on the Blazor .NET 9 tracking issue.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/d293d296a5a5ec8f08a9d6f8195f6c85a9b8b94f/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-32599) |
| [aspnetcore/blazor/security/server/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/d293d296a5a5ec8f08a9d6f8195f6c85a9b8b94f/aspnetcore/blazor/security/server/index.md) | [[Visual Studio](#tab/visual-studio)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/server/index?branch=pr-en-us-32599) |


<!-- PREVIEW-TABLE-END -->