### PR TITLE
Update unauthorized content display while prerendering section

### DIFF
--- a/aspnetcore/blazor/security/server/index.md
+++ b/aspnetcore/blazor/security/server/index.md
@@ -769,7 +769,7 @@ To avoid showing unauthorized content, for example content in an [`AuthorizeView
   <HeadOutlet @rendermode="new InteractiveServerRenderMode(prerender: false)" />
   ```
 
-  You can also selectively disable prerendering with fine control of the render mode applied to the `Routes` component instance. For more information, see <xref:blazor/components/render-modes#static-ssr-pages-in-a-globally-interactive-app>.
+  You can also selectively control the render mode applied to the `Routes` component instance. For example, see <xref:blazor/components/render-modes#static-ssr-pages-in-a-globally-interactive-app>.
 
 :::moniker-end
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/AspNetCore.Docs/pull/32599#discussion_r1607416286

cc: @danroth27 ... Applying your suggestion here. I was OOF when your review came in. BTW, "fine control of the render mode" merely referred to the name of the section before that other PR was merged. It has a better section name now, and your suggestion is spot on 👍.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/server/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/af081a8b4ad90d4839a85ff8b439fa0c823df859/aspnetcore/blazor/security/server/index.md) | [Secure ASP.NET Core server-side Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/server/index?branch=pr-en-us-32613) |

<!-- PREVIEW-TABLE-END -->