### PR TITLE
Bump Swashbuckle versions

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
@@ -225,7 +225,7 @@ The `Swashbuckle.AspNetCore.SwaggerUi` package provides a bundle of Swagger UI's
   * Execute the following command:
 
     ```powershell
-    Install-Package Swashbuckle.AspNetCore.SwaggerUi -v 6.6.1
+    Install-Package Swashbuckle.AspNetCore.SwaggerUi -v 6.6.2
     ```
 
 * From the **Manage NuGet Packages** dialog:
@@ -240,7 +240,7 @@ The `Swashbuckle.AspNetCore.SwaggerUi` package provides a bundle of Swagger UI's
 Run the following command from the **Integrated Terminal**:
 
 ```dotnetcli
-dotnet add package Swashbuckle.AspNetCore.SwaggerUi -v 6.6.1
+dotnet add package Swashbuckle.AspNetCore.SwaggerUi -v 6.6.2
 ```
 
 ### [.NET Core CLI](#tab/netcore-cli)
@@ -248,7 +248,7 @@ dotnet add package Swashbuckle.AspNetCore.SwaggerUi -v 6.6.1
 Run the following command:
 
 ```dotnetcli
-dotnet add package Swashbuckle.AspNetCore.SwaggerUi -v 6.6.1
+dotnet add package Swashbuckle.AspNetCore.SwaggerUi -v 6.6.2
 ```
 
 ---

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -32,7 +32,7 @@ Swashbuckle can be added with the following approaches:
   * Execute the following command:
 
     ```powershell
-    Install-Package Swashbuckle.AspNetCore -Version 6.6.1
+    Install-Package Swashbuckle.AspNetCore -Version 6.6.2
     ```
 
 * From the **Manage NuGet Packages** dialog:
@@ -55,7 +55,7 @@ Swashbuckle can be added with the following approaches:
 Run the following command from the **Integrated Terminal**:
 
 ```dotnetcli
-dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 6.6.1
+dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 6.6.2
 ```
 
 ### [.NET Core CLI](#tab/netcore-cli)
@@ -63,7 +63,7 @@ dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 6.6.1
 Run the following command:
 
 ```dotnetcli
-dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 6.6.1
+dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 6.6.2
 ```
 
 ---


### PR DESCRIPTION
Bump Swashbuckle.AspNetCore version to the latest release.

We shipped a [new release today](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/releases/tag/v6.6.2) that fixed a number of user-reported issues.

/cc @captainsafia


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/eb2f8e6dad319b537bfa41af14fd859208e022ed/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md) | [Get started with Microsoft.AspNetCore.OpenApi](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/aspnetcore-openapi?branch=pr-en-us-32622) |
| [aspnetcore/tutorials/getting-started-with-swashbuckle.md](https://github.com/dotnet/AspNetCore.Docs/blob/eb2f8e6dad319b537bfa41af14fd859208e022ed/aspnetcore/tutorials/getting-started-with-swashbuckle.md) | [Get started with Swashbuckle and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?branch=pr-en-us-32622) |

<!-- PREVIEW-TABLE-END -->