### PR TITLE
Fix broken nginx link in response-compression.md

### DIFF
--- a/aspnetcore/performance/response-compression.md
+++ b/aspnetcore/performance/response-compression.md
@@ -32,7 +32,7 @@ Use Response Compression Middleware when the app is:
 * Unable to use the following server-based compression technologies:
   * [IIS Dynamic Compression module](https://www.iis.net/overview/reliability/dynamiccachingandcompression)
   * [Apache mod_deflate module](https://httpd.apache.org/docs/current/mod/mod_deflate.html)
-  * [Nginx Compression and Decompression](https://www.nginx.com/resources/admin-guide/compression-and-decompression/)
+  * [Nginx Compression and Decompression](https://docs.nginx.com/nginx/admin-guide/web-server/compression/)
 * Hosting directly on:
   * [HTTP.sys server](xref:fundamentals/servers/httpsys)
   * [Kestrel server](xref:fundamentals/servers/kestrel)


### PR DESCRIPTION
NGINX Docs has its own subdomain.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/response-compression.md](https://github.com/dotnet/AspNetCore.Docs/blob/af3f7c8e07c0b785eb43e50ac4f0c223033d00d3/aspnetcore/performance/response-compression.md) | [Response compression in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/response-compression?branch=pr-en-us-32673) |

<!-- PREVIEW-TABLE-END -->