### PR TITLE
gRPC Health Checks: Add client factory example

### DIFF
--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -49,10 +49,6 @@ When health checks is set up:
 By default, the gRPC health checks service uses all registered health checks to determine health status. gRPC health checks can be customized when registered to use a subset of health checks. The `MapService` method is used to map health results to service names, along with a predicate for filtering health results:
 
 [!code-csharp[](~/grpc/health-checks/samples-6/GrpcServiceHC/Program.cs?name=snippet2&highlight=4-7)]
-<<<<<<< HEAD
-
-=======
->>>>>>> 131f00f636883b00cdc6ae2c97b40114624e91b7
 The preceding code overrides the default service (`""`) to only use health results with the "public" tag.
 
 gRPC health checks supports the client specifying a service name argument when checking health. Multiple services are supported by providing a service name to `MapService`:

--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -88,7 +88,7 @@ builder.Services
         o.Address = new Uri("https://localhost:5001");
     });
 ```
-In the previous example, a client factory for Health.HealthClient instances is registered with the dependency injection system. Then, these instances are injected into services for executing health check calls.
+In the previous example, a client factory for `Health.HealthClient` instances is registered with the dependency injection system. Then, these instances are injected into services for executing health check calls.
 
 There are two methods on the `Health` service:
 

--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -49,7 +49,7 @@ When health checks is set up:
 By default, the gRPC health checks service uses all registered health checks to determine health status. gRPC health checks can be customized when registered to use a subset of health checks. The `MapService` method is used to map health results to service names, along with a predicate for filtering health results:
 
 [!code-csharp[](~/grpc/health-checks/samples-6/GrpcServiceHC/Program.cs?name=snippet2&highlight=4-7)]
-
+bui
 The preceding code overrides the default service (`""`) to only use health results with the "public" tag.
 
 gRPC health checks supports the client specifying a service name argument when checking health. Multiple services are supported by providing a service name to `MapService`:
@@ -95,7 +95,7 @@ There are two methods on the `Health` service:
 * `Check` is a unary method for getting the current health status. Health checks are executed immediately when `Check` is called. The server returns a `NOT_FOUND` error response if the client requests an unknown service name. This can happen at app startup if health results haven't been published yet.
 * `Watch` is a streaming method that reports changes in health status over time. <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> is periodically executed to gather health results. The server returns an `Unknown` status if the client requests an unknown service name.
 
-The following in an example of how to call the `Check` method:
+The following is an example of how to call the `Check` method:
 
 ```csharp
 var channel = GrpcChannel.ForAddress("https://localhost:5001");

--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -91,7 +91,7 @@ There are two methods on the `Health` service:
 * `Check` is a unary method for getting the current health status. Health checks are executed immediately when `Check` is called. The server returns a `NOT_FOUND` error response if the client requests an unknown service name. This can happen at app startup if health results haven't been published yet.
 * `Watch` is a streaming method that reports changes in health status over time. <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> is periodically executed to gather health results. The server returns an `Unknown` status if the client requests an unknown service name.
 
-The `Grpc.HealthCheck` client can be used in a client factory approach.
+The `Grpc.HealthCheck` client can be used in a client factory approach:
 
 ```csharp
 builder.Services

--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: Learn how to use gRPC health checks in ASP.NET Core.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: jamesnk
-ms.date: 01/16/2022
+ms.date: 05/27/2024
 uid: grpc/health-checks
 ---
 # gRPC health checks in ASP.NET Core
@@ -15,7 +15,7 @@ By [James Newton-King](https://twitter.com/jamesnk)
 
 The [gRPC health checking protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) is a standard for reporting the health of gRPC server apps.
 
-Health checks are exposed by an app as a gRPC service. They are typically used with an external monitoring service to check the status of an app. The service can be configured for various real-time monitoring scenarios:
+Health checks are exposed by an app as a gRPC service. They're typically used with an external monitoring service to check the status of an app. The service can be configured for various real-time monitoring scenarios:
 
 * Health probes can be used by container orchestrators and load balancers to check an app's status. For example, Kubernetes supports [gRPC liveness, readiness and startup probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-grpc-liveness-probe). Kubernetes can be configured to reroute traffic or restart unhealthy containers based on gRPC health check results.
 * Use of memory, disk, and other physical server resources can be monitored for healthy status.
@@ -38,7 +38,7 @@ To set up gRPC health checks in an app:
 When health checks is set up:
 
 * The health checks service is added to the server app.
-* .NET health checks registered with the app are periodically executed for health results. By default, there is a 5 second delay after app startup, and then health checks are executed every 30 seconds. Health check execution interval [can be customized with `HealthCheckPublisherOptions`](#configure-health-checks-execution-interval).
+* .NET health checks registered with the app are periodically executed for health results. By default, there's a 5-second delay after app startup, and then health checks are executed every 30 seconds. Health check execution interval [can be customized with `HealthCheckPublisherOptions`](#configure-health-checks-execution-interval).
 * Health results determine what the gRPC service reports:
   * `Unknown` is reported when there are no health results.
   * `NotServing` is reported when there are any health results of <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType>.
@@ -77,7 +77,25 @@ builder.Services.Configure<HealthCheckPublisherOptions>(options =>
 
 ## Call gRPC health checks service
 
-The [`Grpc.HealthCheck`](https://www.nuget.org/packages/Grpc.HealthCheck) package includes a client for gRPC health checks:
+The [`Grpc.HealthCheck`](https://www.nuget.org/packages/Grpc.HealthCheck) package includes a client for gRPC health checks. The client factory approach can be utilized to configure the client and make health check calls.
+
+The client factory is configured in the `Program.cs` file:
+
+```csharp
+builder.Services
+    .AddGrpcClient<Health.HealthClient>(o =>
+    {
+        o.Address = new Uri("https://localhost:5001");
+    });
+```
+In the previous example, a client factory for Health.HealthClient instances is registered with the dependency injection system. Then, these instances are injected into services for executing health check calls.
+
+There are two methods on the `Health` service:
+
+* `Check` is a unary method for getting the current health status. Health checks are executed immediately when `Check` is called. The server returns a `NOT_FOUND` error response if the client requests an unknown service name. This can happen at app startup if health results haven't been published yet.
+* `Watch` is a streaming method that reports changes in health status over time. <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> is periodically executed to gather health results. The server returns an `Unknown` status if the client requests an unknown service name.
+
+The following in an example of how to call the `Check` method:
 
 ```csharp
 var channel = GrpcChannel.ForAddress("https://localhost:5001");
@@ -86,11 +104,6 @@ var client = new Health.HealthClient(channel);
 var response = await client.CheckAsync(new HealthCheckRequest());
 var status = response.Status;
 ```
-
-There are two methods on the `Health` service:
-
-* `Check` is a unary method for getting the current health status. Health checks are executed immediately when `Check` is called. The server returns a `NOT_FOUND` error response if the client requests an unknown service name. This can happen at app startup if health results haven't been published yet.
-* `Watch` is a streaming method that reports changes in health status over time. <xref:Microsoft.Extensions.Diagnostics.HealthChecks.IHealthCheckPublisher> is periodically executed to gather health results. The server returns an `Unknown` status if the client requests an unknown service name.
 
 ## Additional resources
 

--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -102,6 +102,8 @@ builder.Services
 ```
 In the previous example, a client factory for `Health.HealthClient` instances is registered with the dependency injection system. Then, these instances are injected into services for executing health check calls.
 
+For more information, see <xref:grpc/clientfactory>.
+
 ## Additional resources
 
 * <xref:host-and-deploy/health-checks>


### PR DESCRIPTION
Fixes: #31828

[Internal Preview to edited section here](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/health-checks?view=aspnetcore-8.0&branch=pr-en-us-32675#call-grpc-health-checks-service)

Added configure the client factory steps for the Health Checks Service section.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/health-checks.md](https://github.com/dotnet/AspNetCore.Docs/blob/88dc5743c02971b9e1dca4999e77823c3c426aa5/aspnetcore/grpc/health-checks.md) | [gRPC health checks in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/health-checks?branch=pr-en-us-32675) |


<!-- PREVIEW-TABLE-END -->