### PR TITLE
Fix ReDoc link in OpenAPI docs

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
@@ -185,7 +185,7 @@ OpenAPI documents can plug into a wide ecosystem of existing tools for testing, 
 
 ### Using Swagger UI for local ad-hoc testing
 
-By default, the `Microsoft.AspNetCore.OpenApi` package doesn't ship with built-in support for visualizing or interacting with the OpenAPI document. Popular tools for visualizing or interacting with the OpenAPI document include [Swagger UI](https://swagger.io/tools/swaggerhub/) and [ReDoc](https://appsumo.com/products/redoc/). Swagger UI and ReDoc can be integrated in an app in several ways. Editors such as Visual Studio and VS Code offer extensions and built-in experiences for testing against an OpenAPI document.
+By default, the `Microsoft.AspNetCore.OpenApi` package doesn't ship with built-in support for visualizing or interacting with the OpenAPI document. Popular tools for visualizing or interacting with the OpenAPI document include [Swagger UI](https://swagger.io/tools/swaggerhub/) and [ReDoc](https://github.com/Redocly/redoc). Swagger UI and ReDoc can be integrated in an app in several ways. Editors such as Visual Studio and VS Code offer extensions and built-in experiences for testing against an OpenAPI document.
 
 The `Swashbuckle.AspNetCore.SwaggerUi` package provides a bundle of Swagger UI's web assets for use in apps. This package can be used to render a UI for the generated document. To configure this, install the `Swashbuckle.AspNetCore.SwaggerUi` package.
 


### PR DESCRIPTION
Closes https://github.com/dotnet/AspNetCore.Docs/issues/32687.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/2ff73e7d595267af86eaa788ab03cd35ae4dad62/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md) | [Get started with Microsoft.AspNetCore.OpenApi](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/aspnetcore-openapi?branch=pr-en-us-32688) |

<!-- PREVIEW-TABLE-END -->