### PR TITLE
Update install package instructions.

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
@@ -25,9 +25,8 @@ Install the `Microsoft.AspNetCore.OpenApi` package:
 
 Run the following command from the **Package Manager Console**:
 
-    ```powershell
-    Install-Package Microsoft.AspNetCore.OpenApi -IncludePrerelease
-    ```
+ ```powershell
+ Install-Package Microsoft.AspNetCore.OpenApi -IncludePrerelease
 ### [Visual Studio Code](#tab/visual-studio-code)
 
 Run the following command from the **Integrated Terminal**:

--- a/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
@@ -19,26 +19,15 @@ The [`Microsoft.AspNetCore.OpenApi`](https://www.nuget.org/packages/Microsoft.As
 
 ## Package installation
 
-The `Microsoft.AspNetCore.OpenApi` package can be added with the following approaches:
+Install the `Microsoft.AspNetCore.OpenApi` package:
 
 ### [Visual Studio](#tab/visual-studio)
 
-* From the **Package Manager Console** window:
-  * Go to **View** > **Other Windows** > **Package Manager Console**
-  * Navigate to the directory in which the `.csproj` file exists
-  * Execute the following command:
+Run the following command from the **Package Manager Console**:
 
     ```powershell
     Install-Package Microsoft.AspNetCore.OpenApi -IncludePrerelease
     ```
-
-* From the **Manage NuGet Packages** dialog:
-  * Right-click the project in **Solution Explorer** > **Manage NuGet Packages**
-  * Set the **Package source** to "nuget.org"
-  * Ensure the "Include prerelease" option is enabled
-  * Enter "Microsoft.AspNetCore.OpenApi" in the search box
-  * Select the latest "Microsoft.AspNetCore.OpenApi" package from the **Browse** tab and click **Install**
-
 ### [Visual Studio Code](#tab/visual-studio-code)
 
 Run the following command from the **Integrated Terminal**:
@@ -54,7 +43,6 @@ Run the following command:
 ```dotnetcli
 dotnet add package Microsoft.AspNetCore.OpenApi --prerelease
 ```
-
 ---
 
 ## Configure OpenAPI document generation

--- a/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md
@@ -27,6 +27,8 @@ Run the following command from the **Package Manager Console**:
 
  ```powershell
  Install-Package Microsoft.AspNetCore.OpenApi -IncludePrerelease
+```
+
 ### [Visual Studio Code](#tab/visual-studio-code)
 
 Run the following command from the **Integrated Terminal**:


### PR DESCRIPTION
From [this comment](https://github.com/dotnet/AspNetCore.Docs/pull/32634#issuecomment-2137681858)

> @Rick-Anderson @tdykstra This PR removed the install instructions from the `Microsoft.AspNetCore.OpenApi` package from the documentation. It's an important part of the setup. Can we revert this change?

@captainsafia  we don't add these instructions to anything but onboarding tutorials. 
Per the style guide, we don't have two different approaches to install the package. As it was, it wasn't clear you had to chose one approach.

I'd prefer to remove these instructions and just have:

`Install the `Microsoft.AspNetCore.OpenApi` package.`
But we can keep these if you like.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/2367642b0c4789f57a313653a6c83ced31056569/aspnetcore/fundamentals/minimal-apis/aspnetcore-openapi.md) | [Get started with Microsoft.AspNetCore.OpenApi](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/aspnetcore-openapi?branch=pr-en-us-32697) |


<!-- PREVIEW-TABLE-END -->