### PR TITLE
Maximum parallel invocations per client remark

### DIFF
--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -857,6 +857,16 @@ When uploading files, reaching the message size limit on the first message is ra
 
 For more information on SignalR configuration and how to set <xref:Microsoft.AspNetCore.SignalR.HubOptions.MaximumReceiveMessageSize>, see <xref:blazor/fundamentals/signalr#server-side-circuit-handler-options>.
 
+## Maximum parallel invocations per client hub setting
+
+<!-- UPDATE 9.0 Check on a fix for this per
+                https://github.com/dotnet/aspnetcore/issues/53951 
+                and version if fixed. -->
+
+Blazor relies on <xref:Microsoft.AspNetCore.SignalR.HubOptions.MaximumParallelInvocationsPerClient%2A> set to 1, which is the default value.
+
+Increasing the value leads to a high probability that `CopyTo` operations throw `System.InvalidOperationException: 'Reading is not allowed after reader was completed.'`. For more information, see [MaximumParallelInvocationsPerClient > 1 breaks file upload in Blazor Server mode (`dotnet/aspnetcore` #53951)](https://github.com/dotnet/aspnetcore/issues/53951).
+
 ## Additional resources
 
 :::moniker range=">= aspnetcore-6.0"

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -288,8 +288,15 @@ services.AddServerSideBlazor().AddHubOptions(options =>
 
 :::moniker-end
 
+<!-- UPDATE 9.0 Check on a fix for the added 
+                MaximumParallelInvocationsPerClient warning
+                per https://github.com/dotnet/aspnetcore/issues/53951 
+                and version if fixed. -->
+
 > [!WARNING]
 > The default value of <xref:Microsoft.AspNetCore.SignalR.HubOptions.MaximumReceiveMessageSize> is 32 KB. Increasing the value may increase the risk of [Denial of Service (DoS) attacks](xref:blazor/security/server/interactive-server-side-rendering#denial-of-service-dos-attacks).
+>
+> Blazor relies on <xref:Microsoft.AspNetCore.SignalR.HubOptions.MaximumParallelInvocationsPerClient%2A> set to 1, which is the default value. For more information, see [MaximumParallelInvocationsPerClient > 1 breaks file upload in Blazor Server mode (`dotnet/aspnetcore` #53951)](https://github.com/dotnet/aspnetcore/issues/53951).
 
 For information on memory management, see <xref:blazor/host-and-deploy/server#memory-management>.
 


### PR DESCRIPTION
Fixes #32696

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/file-uploads.md](https://github.com/dotnet/AspNetCore.Docs/blob/b7962d7e2576257dc024bd44052bf2a6c62adc4f/aspnetcore/blazor/file-uploads.md) | [ASP.NET Core Blazor file uploads](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/file-uploads?branch=pr-en-us-32702) |
| [aspnetcore/blazor/fundamentals/signalr.md](https://github.com/dotnet/AspNetCore.Docs/blob/b7962d7e2576257dc024bd44052bf2a6c62adc4f/aspnetcore/blazor/fundamentals/signalr.md) | [ASP.NET Core Blazor SignalR guidance](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/signalr?branch=pr-en-us-32702) |

<!-- PREVIEW-TABLE-END -->