### PR TITLE
Add a link

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/test-min-api.md
+++ b/aspnetcore/fundamentals/minimal-apis/test-min-api.md
@@ -3,7 +3,7 @@ title: Test Minimal API apps
 author: rick-anderson
 description: Unit and integration tests in Minimal API apps
 ms.author: riande
-ms.date: 9/30/2022
+ms.date: 05/31/2024
 monikerRange: '>= aspnetcore-7.0'
 uid: fundamentals/minimal-apis/test-min-api
 ---

--- a/aspnetcore/includes/integrationTests.md
+++ b/aspnetcore/includes/integrationTests.md
@@ -9,7 +9,7 @@ These broader tests are used to test the app's infrastructure and whole framewor
 * Network appliances
 * Request-response pipeline
 
-Unit tests use fabricated components, known as *fakes* or *mock objects*, in place of infrastructure components.
+Unit tests use fabricated components, known as [*fakes* or *mock objects*](/dotnet/core/testing/unit-testing-best-practices#lets-speak-the-same-language), in place of infrastructure components.
 
 In contrast to unit tests, integration tests:
 


### PR DESCRIPTION
Fixes #32158 

This is not the right article for an introduction to unit testing and mocking. It assumes you have basic knowledge about unit testing because it provides a link for those who don't, but the article it links to doesn't talk about mocking. We don't have on the site a better unit testing intro that does talk about mocking, but I did the next best thing, adding a link to the unit testing best practices section on mock and fake terminology. As far as MockDb in particular is concerned, it's a class that's defined in the project, so anyone who opens the project will see what it is.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/test-min-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/7740b0c97c388d1986552429d7af1559b660d228/aspnetcore/fundamentals/minimal-apis/test-min-api.md) | [Unit and integration tests in Minimal API apps](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/test-min-api?branch=pr-en-us-32714) |

<!-- PREVIEW-TABLE-END -->