### PR TITLE
First MVC: Validation: Clear old null values

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/validation.md
+++ b/aspnetcore/tutorials/first-mvc-app/validation.md
@@ -28,6 +28,10 @@ One of the design tenets of MVC is [DRY](https://wikipedia.org/wiki/Don%27t_repe
 
 The validation support provided by MVC and Entity Framework Core Code First is a good example of the DRY principle in action. You can declaratively specify validation rules in one place (in the model class) and the rules are enforced everywhere in the app.
 
+## Delete any previous movie data items to re-seed the data.
+
+In the next step validation rules are added that will no longer allow null values. Run the app, navigate to `/Movies/Index` and delete all listed movies and stop the app.  The app will use the seed data the next time it is run.
+
 [!INCLUDE[](~/includes/RP-MVC/validation-net7.md)]
 
 ## Validation Error UI


### PR DESCRIPTION
Fixes #32661 

There is a problem that can occur if the developer happens to enter a null value for one of the movie items.  When we move on to add validation to the model, any entries that are null will cause an error to be thrown: 
SqlNullValueException: Data is Null. This method or property cannot be called on Null values.

To get around this, I added a line of instruction to delete the movie data entries just before we add validation in the next step so it will re-seed with clean data.