### PR TITLE
Update aspnetcore-9.0.md

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-9.0.md
+++ b/aspnetcore/release-notes/aspnetcore-9.0.md
@@ -19,6 +19,8 @@ This article has been updated for .NET 9 Preview 5.
 
 This section describes new features for Blazor.
 
+[!INCLUDE[](~/release-notes/aspnetcore-9/includes/blazor.md)]
+
 [!INCLUDE[](~/release-notes/aspnetcore-9/includes/blazor-reconnection.md)]
 
 [!INCLUDE[](~/release-notes/aspnetcore-9/includes/blazor-maui-web-template.md)]


### PR DESCRIPTION
Restore accidentally dropped `include` reference.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-9.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/3f124a465829dab3bad64dbd1e055902eb9d9e13/aspnetcore/release-notes/aspnetcore-9.0.md) | [What's new in ASP.NET Core 9.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-9.0?branch=pr-en-us-32786) |

<!-- PREVIEW-TABLE-END -->