### PR TITLE
Blazor Server reconnection coverage

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1127,6 +1127,31 @@ Blazor Server:
 
 **In the preceding example, the `{BLAZOR SCRIPT}` placeholder is the Blazor script path and file name.** For the location of the script and the path to use, see <xref:blazor/project-structure#location-of-the-blazor-script>.
 
+:::moniker range=">= aspnetcore-9.0"
+
+When the user navigates back to an app with a disconnected circuit, reconnection is attempted immediately rather than waiting for the duration of the next reconnect interval. This improves the user experience when navigating to an app in a browser tab that has gone to sleep.
+
+When a reconnection attempt reaches the server but the server has already released the circuit, a page refresh occurs automatically. This prevents the user from having to manually refresh the page if it's likely going to result in a successful reconnection.
+
+Reconnect timing uses a computed backoff strategy. The first several reconnection attempts occur in rapid succession without a retry interval before computed delays are introduced between attempts. The default logic for computing the retry interval is an implementation detail subject to change without notice, but you can find the default logic that the Blazor framework uses [in the `computeDefaultRetryInterval` function (reference source)](https://github.com/search?q=repo%3Adotnet%2Faspnetcore%20computeDefaultRetryInterval&type=code).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+Customize the retry interval behavior by specifying a function to compute the retry interval. In the following exponential backoff example, the number of previous reconnection attempts is multiplied by 1,000 ms to calculate the retry interval. When the count of previous attempts to reconnect (`previousAttempts`) is greater than the maximum retry limit (`maxRetries`), `null` is assigned to the retry interval (`retryIntervalMilliseconds`) to cease further reconnection attempts:
+
+```javascript
+Blazor.start({
+  circuit: {
+    reconnectionOptions: {
+      retryIntervalMilliseconds: (previousAttempts, maxRetries) => 
+        previousAttempts >= maxRetries ? null : previousAttempts * 1000
+    },
+  },
+});
+```
+
+:::moniker-end
+
 For more information on Blazor startup, see <xref:blazor/fundamentals/startup>.
 
 :::moniker range=">= aspnetcore-6.0"

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1133,7 +1133,7 @@ When the user navigates back to an app with a disconnected circuit, reconnection
 
 When a reconnection attempt reaches the server but the server has already released the circuit, a page refresh occurs automatically. This prevents the user from having to manually refresh the page if it's likely going to result in a successful reconnection.
 
-Reconnect timing uses a computed backoff strategy. The first several reconnection attempts occur in rapid succession without a retry interval before computed delays are introduced between attempts. The default logic for computing the retry interval is an implementation detail subject to change without notice, but you can find the default logic that the Blazor framework uses [in the `computeDefaultRetryInterval` function (reference source)](https://github.com/search?q=repo%3Adotnet%2Faspnetcore%20computeDefaultRetryInterval&type=code).
+The default reconnect timing uses a computed backoff strategy. The first several reconnection attempts occur in rapid succession before computed delays are introduced between attempts. The default logic for computing the retry interval is an implementation detail subject to change without notice, but you can find the default logic that the Blazor framework uses [in the `computeDefaultRetryInterval` function (reference source)](https://github.com/search?q=repo%3Adotnet%2Faspnetcore%20computeDefaultRetryInterval&type=code).
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1129,9 +1129,7 @@ Blazor Server:
 
 :::moniker range=">= aspnetcore-9.0"
 
-When the user navigates back to an app with a disconnected circuit, reconnection is attempted immediately rather than waiting for the duration of the next reconnect interval. This improves the user experience when navigating to an app in a browser tab that has gone to sleep.
-
-When a reconnection attempt reaches the server but the server has already released the circuit, a page refresh occurs automatically. This prevents the user from having to manually refresh the page if it's likely going to result in a successful reconnection.
+When the user navigates back to an app with a disconnected circuit, reconnection is attempted immediately rather than waiting for the duration of the next reconnect interval to resume  the connection as quickly as possible for the user.
 
 The default reconnect timing uses a computed backoff strategy. The first several reconnection attempts occur in rapid succession before computed delays are introduced between attempts. The default logic for computing the retry interval is an implementation detail subject to change without notice, but you can find the default logic that the Blazor framework uses [in the `computeDefaultRetryInterval` function (reference source)](https://github.com/search?q=repo%3Adotnet%2Faspnetcore%20computeDefaultRetryInterval&type=code).
 
@@ -1145,6 +1143,18 @@ Blazor.start({
     reconnectionOptions: {
       retryIntervalMilliseconds: (previousAttempts, maxRetries) => 
         previousAttempts >= maxRetries ? null : previousAttempts * 1000
+    },
+  },
+});
+```
+
+Specify the exact milliseconds of each interval for precise retry interval control. After the last specified retry interval, retries stop because the function returns `undefined`:
+
+```javascript
+Blazor.start({
+  circuit: {
+    reconnectionOptions: {
+      retryIntervalMilliseconds: Array.prototype.at.bind([0, 1000, 2000, 5000, 10000, 15000, 30000]),
     },
   },
 });

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1154,7 +1154,8 @@ An alternative is to specify the exact sequence of retry intervals. After the la
 Blazor.start({
   circuit: {
     reconnectionOptions: {
-      retryIntervalMilliseconds: Array.prototype.at.bind([0, 1000, 2000, 5000, 10000, 15000, 30000]),
+      retryIntervalMilliseconds: 
+        Array.prototype.at.bind([0, 1000, 2000, 5000, 10000, 15000, 30000]),
     },
   },
 });

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1148,7 +1148,7 @@ Blazor.start({
 });
 ```
 
-Specify the exact milliseconds of each interval for precise retry interval control. After the last specified retry interval, retries stop because the function returns `undefined`:
+An alternative is to specify the exact sequence of retry intervals. After the last specified retry interval, retries stop because the `retryIntervalMilliseconds` function returns `undefined`:
 
 ```javascript
 Blazor.start({

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1129,7 +1129,7 @@ Blazor Server:
 
 :::moniker range=">= aspnetcore-9.0"
 
-When the user navigates back to an app with a disconnected circuit, reconnection is attempted immediately rather than waiting for the duration of the next reconnect interval to resume  the connection as quickly as possible for the user.
+When the user navigates back to an app with a disconnected circuit, reconnection is attempted immediately rather than waiting for the duration of the next reconnect interval. This behavior seeks to resume the connection as quickly as possible for the user.
 
 The default reconnect timing uses a computed backoff strategy. The first several reconnection attempts occur in rapid succession before computed delays are introduced between attempts. The default logic for computing the retry interval is an implementation detail subject to change without notice, but you can find the default logic that the Blazor framework uses [in the `computeDefaultRetryInterval` function (reference source)](https://github.com/search?q=repo%3Adotnet%2Faspnetcore%20computeDefaultRetryInterval&type=code).
 


### PR DESCRIPTION
Fixes #32789
Addresses #32692
Addresses #31909

Mackinnon, ~I'm blocked at the moment on working on the *What's New* side of this until another PR merges, but I'll have the *What's New* part for this updated (some coverage was placed that I'll be touching up) by EOD on a separate PR.~ 

**UPDATE: Not blocked any longer on What's New. I'll take care of it after the four reference article PRs are merged.**

WRT this coverage: It seems like we'd call the default logic "a computed backoff strategy" instead of "an exponential backoff strategy." However, your custom example is exponential, so I retain that language for the example.

I was curious about the default logic, and I think devs will be curious, too. The link goes here ...

https://github.com/search?q=repo%3Adotnet%2Faspnetcore%20computeDefaultRetryInterval&type=code

... and that's probably a decent approach for avoiding a hard link with a specific set of line numbers. It will work well as long as the FN name `computeDefaultRetryInterval` is stable. I like the way that it finds the exact line in the file for them when they click on the search result, and I like the way that it would find this FN if it moved to a different file in the future. However, we can pull that link and those remarks if you don't want to risk it breaking at some point.

As usual, the INCLUDE that explains what the link loads follows the link, and the content of that INCLUDE can be seen here ...

https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/includes/aspnetcore-repo-ref-source-links.md

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/signalr.md](https://github.com/dotnet/AspNetCore.Docs/blob/491ec9b718c2073baca0de381245f67282cf2635/aspnetcore/blazor/fundamentals/signalr.md) | [ASP.NET Core Blazor SignalR guidance](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/signalr?branch=pr-en-us-32790) |


<!-- PREVIEW-TABLE-END -->