### PR TITLE
New .NET MAUI Blazor Hybrid template

### DIFF
--- a/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md
+++ b/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md
@@ -53,6 +53,23 @@ Instead of [using the sample app](#net-maui-blazor-web-app-sample-app), you can 
 
 Add new project to the solution with the **Blazor Web App** project template. Select the following options:
 
+:::moniker range=">= aspnetcore-9.0"
+
+* **Project name**: Use the solution's name with `.Web` appended. The examples in this article assume the following naming:
+  * Solution: `MauiBlazorWeb`
+  * MAUI project: `MauiBlazorWeb`
+  * Blazor Web App: `MauiBlazorWeb.Web`
+  * Razor class library (RCL) (added in a later step): `MauiBlazorWeb.Shared`
+* **Authentication type**: **None**
+* **Configure for HTTPS**: Selected (enabled)
+* **Interactive render mode**: **Server**
+* **Interactivity location**: **Global**
+* **Sample pages**: Unselected (disabled)
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
+
 * **Project name**: Use the solution's name with `.Web` appended. The examples in this article assume the following naming:
   * Solution: `MauiBlazorWeb`
   * MAUI project: `MauiBlazorWeb.Maui`
@@ -63,6 +80,8 @@ Add new project to the solution with the **Blazor Web App** project template. Se
 * **Interactive render mode**: **Server**
 * **Interactivity location**: **Global**
 * **Sample pages**: Unselected (disabled)
+
+:::moniker-end
 
 <!-- UPDATE 9.0 Check on PU issue mentioned below and 
                 revise accordingly. -->
@@ -190,6 +209,21 @@ Render mode and interactivity specification subsections:
 
 ### Global Server interactivity
 
+:::moniker range=">= aspnetcore-9.0"
+
+* Interactive render mode: **Server**
+* Interactivity location: **Global**
+* Solution projects
+  * MAUI (`MauiBlazorWeb`)
+  * Blazor Web App (`MauiBlazorWeb.Web`)
+  * RCL (`MauiBlazorWeb.Shared`): Contains the shared Razor components without setting render modes in each component.
+
+Project references: `MauiBlazorWeb` and `MauiBlazorWeb.Web` have a project reference to `MauiBlazorWeb.Shared`.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
+
 * Interactive render mode: **Server**
 * Interactivity location: **Global**
 * Solution projects
@@ -199,7 +233,29 @@ Render mode and interactivity specification subsections:
 
 Project references: `MauiBlazorWeb.Maui` and `MauiBlazorWeb.Web` have a project reference to `MauiBlazorWeb.Shared`.
 
+:::moniker-end
+
 ### Global Auto or WebAssembly interactivity
+
+:::moniker range=">= aspnetcore-9.0"
+
+* Interactive render mode: **Auto** or **WebAssembly**
+* Interactivity location: **Global**
+* Solution projects
+  * MAUI (`MauiBlazorWeb`)
+  * Blazor Web App
+    * Server project: `MauiBlazorWeb.Web`
+    * Client project: `MauiBlazorWeb.Web.Client`
+  * RCL (`MauiBlazorWeb.Shared`): Contains the shared Razor components without setting render modes in each component.
+
+Project references:
+
+* `MauiBlazorWeb`, `MauiBlazorWeb.Web`, and `MauiBlazorWeb.Web.Client` projects have a project reference to `MauiBlazorWeb.Shared`.
+* `MauiBlazorWeb.Web` has a project reference to `MauiBlazorWeb.Web.Client`.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
 
 * Interactive render mode: **Auto** or **WebAssembly**
 * Interactivity location: **Global**
@@ -215,7 +271,24 @@ Project references:
 * `MauiBlazorWeb.Maui`, `MauiBlazorWeb.Web`, and `MauiBlazorWeb.Web.Client` projects have a project reference to `MauiBlazorWeb.Shared`.
 * `MauiBlazorWeb.Web` has a project reference to `MauiBlazorWeb.Web.Client`.
 
+:::moniker-end
+
 ### Per-page/component Server interactivity
+
+:::moniker range=">= aspnetcore-9.0"
+
+* Interactive render mode: **Server**
+* Interactivity location: **Per-page/component**
+* Solution projects
+  * MAUI (`MauiBlazorWeb`): Calls `InteractiveRenderSettings.ConfigureBlazorHybridRenderModes` in `MauiProgram.cs`.
+  * Blazor Web App (`MauiBlazorWeb.Web`): Doesn't set an `@rendermode` directive attribute on the `HeadOutlet` and `Routes` components of the `App` component (`Components/App.razor`).
+  * RCL (`MauiBlazorWeb.Shared`): Contains the shared Razor components that set the `InteractiveServer` render mode in each component.
+
+`MauiBlazorWeb` and `MauiBlazorWeb.Web` have a project reference to `MauiBlazorWeb.Shared`.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
 
 * Interactive render mode: **Server**
 * Interactivity location: **Per-page/component**
@@ -225,6 +298,8 @@ Project references:
   * RCL (`MauiBlazorWeb.Shared`): Contains the shared Razor components that set the `InteractiveServer` render mode in each component.
 
 `MauiBlazorWeb.Maui` and `MauiBlazorWeb.Web` have a project reference to `MauiBlazorWeb.Shared`.
+
+:::moniker-end
 
 Add the following `InteractiveRenderSettings` class to the RCL. The class properties are used to set component render modes.
 
@@ -253,6 +328,26 @@ In the RCL's `_Imports.razor` file, add the following global static `@using` dir
 
 ### Per-page/component Auto interactivity
 
+:::moniker range=">= aspnetcore-9.0"
+
+* Interactive render mode: **Auto**
+* Interactivity location: **Per-page/component**
+* Solution projects
+  * MAUI (`MauiBlazorWeb`): Calls `InteractiveRenderSettings.ConfigureBlazorHybridRenderModes` in `MauiProgram.cs`.
+  * Blazor Web App
+    * Server project: `MauiBlazorWeb.Web`: Doesn't set an `@rendermode` directive attribute on the `HeadOutlet` and `Routes` components of the `App` component (`Components/App.razor`).
+    * Client project: `MauiBlazorWeb.Web.Client`
+  * RCL (`MauiBlazorWeb.Shared`): Contains the shared Razor components that set the `InteractiveAuto` render mode in each component.
+
+Project references:
+
+* `MauiBlazorWeb`, `MauiBlazorWeb.Web`, and `MauiBlazorWeb.Web.Client` have a project reference to `MauiBlazorWeb.Shared`.
+* `MauiBlazorWeb.Web` has a project reference to `MauiBlazorWeb.Web.Client`.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
+
 * Interactive render mode: **Auto**
 * Interactivity location: **Per-page/component**
 * Solution projects
@@ -266,6 +361,8 @@ Project references:
 
 * `MauiBlazorWeb.Maui`, `MauiBlazorWeb.Web`, and `MauiBlazorWeb.Web.Client` have a project reference to `MauiBlazorWeb.Shared`.
 * `MauiBlazorWeb.Web` has a project reference to `MauiBlazorWeb.Web.Client`.
+
+:::moniker-end
 
 Add the following `InteractiveRenderSettings` class is added to the RCL. The class properties are used to set component render modes.
 
@@ -294,6 +391,29 @@ In the RCL's `_Imports.razor` file, add the following global static `@using` dir
 
 ### Per-page/component WebAssembly interactivity
 
+:::moniker range=">= aspnetcore-9.0"
+
+* Interactive render mode: **WebAssembly**
+* Interactivity location: **Per-page/component**
+* Solution projects
+  * MAUI (`MauiBlazorWeb`)
+  * Blazor Web App
+    * Server project: `MauiBlazorWeb.Web`: Doesn't set an `@rendermode` directive attribute on the `HeadOutlet` and `Routes` components of the `App` component (`Components/App.razor`).
+    * Client project: `MauiBlazorWeb.Web.Client`
+  * RCLs
+    * `MauiBlazorWeb.Shared`
+    * `MauiBlazorWeb.Shared.Client`: Contains the shared Razor components that set the `InteractiveWebAssembly` render mode in each component. The `.Shared.Client` RCL is maintained separately from the `.Shared` RCL because the app should maintain the components that are required to run on WebAssembly separately from the components that run on server and that stay on the server.
+
+Project references:
+
+* `MauiBlazorWeb` and `MauiBlazorWeb.Web` have project references to `MauiBlazorWeb.Shared`.
+* `MauiBlazorWeb.Web` has a project reference to `MauiBlazorWeb.Web.Client`.
+* `MauiBlazorWeb.Web.Client` and `MauiBlazorWeb.Shared` have a project reference to `MauiBlazorWeb.Shared.Client`.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
+
 * Interactive render mode: **WebAssembly**
 * Interactivity location: **Per-page/component**
 * Solution projects
@@ -310,6 +430,8 @@ Project references:
 * `MauiBlazorWeb.Maui` and `MauiBlazorWeb.Web` have project references to `MauiBlazorWeb.Shared`.
 * `MauiBlazorWeb.Web` has a project reference to `MauiBlazorWeb.Web.Client`.
 * `MauiBlazorWeb.Web.Client` and `MauiBlazorWeb.Shared` have a project reference to `MauiBlazorWeb.Shared.Client`.
+
+:::moniker-end
 
 Add the following <xref:Microsoft.AspNetCore.Components.Routing.Router.AdditionalAssemblies%2A> parameter to the `Router` component instance for the `MauiBlazorWeb.Shared.Client` project assembly (via its `_Imports` file) in the `MauiBlazorWeb.Shared` project's `Routes.razor` file:
 
@@ -398,7 +520,34 @@ In the Razor class library (RCL), an `Interfaces` folder contains an `IFormFacto
 
 :::code language="csharp" source="~/../blazor-samples/8.0/MauiBlazorWeb/MauiBlazorWeb.Shared/Interfaces/IFormFactor.cs":::
 
-The following `DeviceFormFactor` component is present in the RCL's `Components` folder:
+:::moniker range=">= aspnetcore-9.0"
+
+The `Home` component (`Components/Pages/Home.razor`) of the RCL displays the form factor and platform.
+
+`Components/Pages/Home.razor`:
+
+```razor
+@page "/"
+@using MyApp.Shared.Services
+@inject IFormFactor FormFactor
+
+<PageTitle>Home</PageTitle>
+
+<h1>Hello, world!</h1>
+
+Welcome to your new app running on <em>@factor</em> using <em>@platform</em>.
+
+@code {
+    private string factor => FormFactor.GetFormFactor();
+    private string platform => FormFactor.GetPlatform();
+}
+```
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
+
+The following `DeviceFormFactor` component is present in the RCL's `Components` folder.
 
 `Components/Pages/DeviceFormFactor.razor`:
 
@@ -416,6 +565,8 @@ In `Components/Layout/NavMenu.razor`:
 </div>
 ```
 
+:::moniker-end
+
 The web and native apps contain the implementations for `IFormFactor`.
 
 In the Blazor Web App, a folder named `Services` contains the following `FormFactor.cs` file with the `FormFactor` implementation for web app use.
@@ -427,7 +578,13 @@ In the Blazor Web App, a folder named `Services` contains the following `FormFac
 In the MAUI project, a folder named `Services` contains the following `FormFactor.cs` file with the `FormFactor` implementation for native use. The MAUI abstractions layer is used to write code that works on all native device platforms.
 
 `Services/FormFactor.cs` (MAUI project):
- 
+
+<!-- NOTE: The following link points to the 8.0 
+           sample but we don't need to update it 
+           for 9.0 or later coverage as long as
+           the code in the project template
+           doesn't change. -->
+
 :::code language="csharp" source="~/../blazor-samples/8.0/MauiBlazorWeb/MauiBlazorWeb.Maui/Services/FormFactor.cs":::
 
 Dependency injection is used to obtain the implementations of these services.

--- a/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md
+++ b/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md
@@ -18,9 +18,9 @@ For prerequisites and preliminary steps, see <xref:blazor/hybrid/tutorials/maui>
 
 :::moniker range=">= aspnetcore-9.0"
 
-## .NET MAUI Blazor Web App project template
+## .NET MAUI Blazor Hybrid and Web App solution template
 
-The .NET MAUI Blazor Web App project template allows you to choose a Blazor interactive render mode for the web app and creates the appropriate projects for the app, including a Blazor Web App and a .NET MAUI Blazor Hybrid app. A shared Razor class library (RCL) maintains the Razor components for the app's UI. The template also provides sample code to shows you how to use dependency injection to provide different interface implementations for the Blazor Hybrid and Blazor Web App, which is covered in the [Using interfaces to support different device implementations](#using-interfaces-to-support-different-device-implementations) section of this article.
+The .NET MAUI Blazor Hybrid and Web App solution template sets up a solution that targets Android, iOS, Mac, Windows and Web that reuses UI. You can choose a Blazor interactive render mode for the web app and it creates the appropriate projects for the app, including a Blazor Web App and a .NET MAUI Blazor Hybrid app. A shared Razor class library (RCL) maintains the Razor components for the app's UI. The template also provides sample code to show you how to use dependency injection to provide different interface implementations for the Blazor Hybrid and Blazor Web App, which is covered in the [Using interfaces to support different device implementations](#using-interfaces-to-support-different-device-implementations) section of this article.
 
 Create an app from the project template with the following .NET CLI command:
 
@@ -41,7 +41,7 @@ In the preceding command:
 
 :::moniker range="< aspnetcore-9.0"
 
-## .NET MAUI Blazor Web App sample app
+## .NET MAUI Blazor Hybrid and Web App sample app
 
 [Obtain the sample app](xref:blazor/fundamentals/index#sample-apps) named `MauiBlazorWeb` from the [Blazor samples GitHub repository (`dotnet/blazor-samples`)](https://github.com/dotnet/blazor-samples) (.NET 8 or later).
 
@@ -435,7 +435,7 @@ Dependency injection is used to obtain the implementations of these services.
 In the MAUI project, the `MauiProgram.cs` file has following `using` statements at the top of the file:
 
 ```csharp
-using MauiBlazorWeb.Maui.Services;
+using MauiBlazorWeb.Services;
 using MauiBlazorWeb.Shared.Interfaces;
 ```
 

--- a/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md
+++ b/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md
@@ -49,26 +49,9 @@ The sample app is a starter solution that contains a .NET MAUI Blazor Hybrid (na
 
 ## Migrating a .NET MAUI Blazor Hybrid solution
 
-Instead of [using the sample app](#net-maui-blazor-web-app-sample-app), you can migrate an existing .NET MAUI Blazor Hybrid app with the guidance in this section using Visual Studio.
+Instead of [using the sample app](#net-maui-blazor-hybrid-and-web-app-sample-app), you can migrate an existing .NET MAUI Blazor Hybrid app with the guidance in this section using Visual Studio.
 
 Add new project to the solution with the **Blazor Web App** project template. Select the following options:
-
-:::moniker range=">= aspnetcore-9.0"
-
-* **Project name**: Use the solution's name with `.Web` appended. The examples in this article assume the following naming:
-  * Solution: `MauiBlazorWeb`
-  * MAUI project: `MauiBlazorWeb`
-  * Blazor Web App: `MauiBlazorWeb.Web`
-  * Razor class library (RCL) (added in a later step): `MauiBlazorWeb.Shared`
-* **Authentication type**: **None**
-* **Configure for HTTPS**: Selected (enabled)
-* **Interactive render mode**: **Server**
-* **Interactivity location**: **Global**
-* **Sample pages**: Unselected (disabled)
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-9.0"
 
 * **Project name**: Use the solution's name with `.Web` appended. The examples in this article assume the following naming:
   * Solution: `MauiBlazorWeb`
@@ -80,8 +63,6 @@ Add new project to the solution with the **Blazor Web App** project template. Se
 * **Interactive render mode**: **Server**
 * **Interactivity location**: **Global**
 * **Sample pages**: Unselected (disabled)
-
-:::moniker-end
 
 <!-- UPDATE 9.0 Check on PU issue mentioned below and 
                 revise accordingly. -->

--- a/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md
+++ b/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md
@@ -5,7 +5,7 @@ description: Learn how to build a .NET MAUI Blazor Hybrid app with a Blazor Web 
 monikerRange: '>= aspnetcore-8.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 04/25/2024
+ms.date: 06/10/2024
 uid: blazor/hybrid/tutorials/maui-blazor-web-app
 ---
 # Build a .NET MAUI Blazor Hybrid app with a Blazor Web App
@@ -15,6 +15,31 @@ This article shows you how to build a .NET MAUI Blazor Hybrid app with a Blazor 
 ## Prerequisites and preliminary steps
 
 For prerequisites and preliminary steps, see <xref:blazor/hybrid/tutorials/maui>. We recommend using the .NET MAUI Blazor Hybrid tutorial to set up your local system for .NET MAUI development before using the guidance in this article.
+
+:::moniker range=">= aspnetcore-9.0"
+
+## .NET MAUI Blazor Web App project template
+
+The .NET MAUI Blazor Web App project template allows you to choose a Blazor interactive render mode for the web app and creates the appropriate projects for the app, including a Blazor Web App and a .NET MAUI Blazor Hybrid app. A shared Razor class library (RCL) maintains the Razor components for the app's UI. The template also provides sample code to shows you how to use dependency injection to provide different interface implementations for the Blazor Hybrid and Blazor Web App, which is covered in the [Using interfaces to support different device implementations](#using-interfaces-to-support-different-device-implementations) section of this article.
+
+Create an app from the project template with the following .NET CLI command:
+
+```dotnetcli
+dotnet new maui-blazor-web -o MauiBlazorWeb -int Server  -ai
+```
+
+In the preceding command:
+
+* The `-o|--output` option creates a new folder for the app named `MauiBlazorWeb`.
+* The `-int|--interactivity` option sets up the interactivity location to `Server`.
+* The `-ai|--all-interactive` option specifies global interactivity, which is important because MAUI apps always run interactively and throw errors on Razor component pages that explicitly specify a render mode. If you don't use a global render mode, you must implement the approach described in the [Use Blazor render modes](#use-blazor-render-modes) section. For more information, see [BlazorWebView needs a way to enable overriding ResolveComponentForRenderMode (`dotnet/aspnetcore` #51235)](https://github.com/dotnet/aspnetcore/issues/51235).
+
+<!-- UPDATE 9.0 Provide the project template's name here for VS, possibly
+                using a tooling pivot for the article. -->
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
 
 ## .NET MAUI Blazor Web App sample app
 
@@ -39,8 +64,8 @@ Add new project to the solution with the **Blazor Web App** project template. Se
 * **Interactivity location**: **Global**
 * **Sample pages**: Unselected (disabled)
 
-<!-- UPDATE 9.0 Check on PU issue and revise the following
-                for >=9.0 accordingly -->
+<!-- UPDATE 9.0 Check on PU issue mentioned below and 
+                revise accordingly. -->
 
 The **Interactivity location** setting to **Global** is important because MAUI apps always run interactively and throw errors on Razor component pages that explicitly specify a render mode. If you don't use a global render mode, you must implement the approach described in the [Use Blazor render modes](#use-blazor-render-modes) section after following the guidance in this section. For more information, see [BlazorWebView needs a way to enable overriding ResolveComponentForRenderMode (`dotnet/aspnetcore` #51235)](https://github.com/dotnet/aspnetcore/issues/51235).
 
@@ -148,6 +173,8 @@ Run the MAUI project by selecting the project in **Solution Explorer** and using
 Run the Blazor Web App project by selecting the Blazor Web App project in **Solution Explorer** and using Visual Studio's start button with the `https` build configuration.
 
 If you receive a build error that the RCL's assembly can't be resolved, build the RCL project first. If any MAUI project resource errors occur on build, rebuild the MAUI project to clear the errors.
+
+:::moniker-end
 
 ## Use Blazor render modes
 
@@ -365,19 +392,19 @@ In the `_Imports.razor` file of the `.Shared.Client` RCL, add `@using static Int
 
 The following example demonstrates how to use an interface to call into different implementations across the web app and the native (MAUI) app. The following example creates a component that displays the device form factor. Use the MAUI abstraction layer for native apps and provide an implementation for the web app.
 
-In the Razor class library (RCL), create an `Interfaces` folder and add file named `IFormFactor.cs` with the following code.
+In the Razor class library (RCL), an `Interfaces` folder contains an `IFormFactor` interface.
 
 `Interfaces/IFormFactor.cs`:
 
 :::code language="csharp" source="~/../blazor-samples/8.0/MauiBlazorWeb/MauiBlazorWeb.Shared/Interfaces/IFormFactor.cs":::
 
-In the RCL's `Components` folder, add the following `DeviceFormFactor` component.
+The following `DeviceFormFactor` component is present in the RCL's `Components` folder:
 
 `Components/Pages/DeviceFormFactor.razor`:
 
 :::code language="razor" source="~/../blazor-samples/8.0/MauiBlazorWeb/MauiBlazorWeb.Shared/Components/Pages/DeviceFormFactor.razor":::
 
-In the RCL, add an entry for the `DeviceFormFactor` component to the navigation menu.
+In the RCL, an entry for the `DeviceFormFactor` component is part of the navigation menu in the `NavMenu` component.
 
 In `Components/Layout/NavMenu.razor`:
 
@@ -389,43 +416,43 @@ In `Components/Layout/NavMenu.razor`:
 </div>
 ```
 
-Provide implementations in the web and native apps.
+The web and native apps contain the implementations for `IFormFactor`.
 
-In the Blazor Web App, add a folder named `Services`. Add a file to the `Services` folder named `FormFactor.cs` with the following code.
+In the Blazor Web App, a folder named `Services` contains the following `FormFactor.cs` file with the `FormFactor` implementation for web app use.
 
 `Services/FormFactor.cs` (Blazor Web App project):
 
 :::code language="csharp" source="~/../blazor-samples/8.0/MauiBlazorWeb/MauiBlazorWeb.Web/Services/FormFactor.cs":::
 
-In the MAUI project, add a folder named `Services` and add a file named `FormFactor.cs`. The MAUI abstractions layer is used to write code that works on all native device platforms.
+In the MAUI project, a folder named `Services` contains the following `FormFactor.cs` file with the `FormFactor` implementation for native use. The MAUI abstractions layer is used to write code that works on all native device platforms.
 
 `Services/FormFactor.cs` (MAUI project):
  
 :::code language="csharp" source="~/../blazor-samples/8.0/MauiBlazorWeb/MauiBlazorWeb.Maui/Services/FormFactor.cs":::
 
-Use dependency injection to obtain the implementations of these services.
+Dependency injection is used to obtain the implementations of these services.
 
-In the MAUI project, open the `MauiProgram.cs` file and add the following `using` statements to the top of the file:
+In the MAUI project, the `MauiProgram.cs` file has following `using` statements at the top of the file:
 
 ```csharp
 using MauiBlazorWeb.Maui.Services;
 using MauiBlazorWeb.Shared.Interfaces;
 ```
 
-Immediately before the call to `builder.Build()`, add the following code to add device-specific services used by the RCL:
+Immediately before the call to `builder.Build()`, `FormFactor` is registered to add device-specific services used by the RCL:
 
 ```csharp
 builder.Services.AddSingleton<IFormFactor, FormFactor>();
 ```
 
-In the Blazor Web App, open the `Program` file and add the following `using` statements to the top of the file:
+In the Blazor Web App, the `Program` file has the following `using` statements at the top of the file:
 
 ```csharp
 using MauiBlazorWeb.Shared.Interfaces;
 using MauiBlazorWeb.Web.Services;  
 ```
 
-Immediately before the call to `builder.Build()`, add the following code to add device-specific services used by the RCL:
+Immediately before the call to `builder.Build()`, `FormFactor` is registered to add device-specific services used by the Blazor Web App:
 
 ```csharp
 builder.Services.AddScoped<IFormFactor, FormFactor>();


### PR DESCRIPTION
Fixes #32792
Addresses #32692
Addresses #31909

Beth ... This should work ... *I think* 🤔🤞🍀. It should work ***IF*** the new project template *exactly matches* what we have in the article in terms of namespace suffixes, file locations and file names, code logic, etc. I still haven't created an app from the template (*YET*) just because I'm working full speed at the moment 🏃‍♂️🏃‍♂️🏃‍♂️ just to get everything covered in time for release tomorrow. I will create a local test app to compare; but if you can tell me about any deltas that exist between the article/sample app and the template, I hope I can work up the changes for this PR and put off creating a local project at the moment.

Here's what this PR is doing to the current coverage ...

* Version a new section to describe the .NET MAUI Blazor Web App project template. BTW ... The workload should already be installed if they follow our earlier guidance here to go work the .NET MAUI Blazor Hybrid tutorial first.
* Version OUT the coverage on *.NET MAUI Blazor Web App sample app* and *Migrating a .NET MAUI Blazor Hybrid solution* so that it only appears for 8.0.
* Keep the rest of the article in place for >=9.0.
* In the *Using interfaces to support different device implementations* section, refactor the language to describe the API in a way that should cover both 8.0 folks using it to manually build the app and 9.0 or later folks who are getting it generated from the project template ... as I mentioned, ***IF*** all of the naming and code was preserved exactly for the new template.

WRT the command, I included the interactivity and interactivity location options, but you might prefer that I strike them because they're probably the default ...

```dotnetcli
dotnet new maui-blazor-web -o MauiBlazorWeb -int Server -ai
```

If you confirm that they are the default, I'll change the text a bit and remove them from that command. I'll tell the reader the defaults in the text next to the command.

I'll retain the option for naming the folder/namespace (`-o|--output MauiBlazorWeb`).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md](https://github.com/dotnet/AspNetCore.Docs/blob/a377cd5a754f5257f7e844a44503c13a54977c6f/aspnetcore/blazor/hybrid/tutorials/maui-blazor-web-app.md) | [Build a .NET MAUI Blazor Hybrid app with a Blazor Web App](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/tutorials/maui-blazor-web-app?branch=pr-en-us-32793) |


<!-- PREVIEW-TABLE-END -->