### PR TITLE
Detect the current render mode at runtime

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -233,34 +233,10 @@ The `ComponentBase.Platform` and `ComponentBase.AssignedRenderMode` properties p
   * `InteractiveAuto` for Interactive Auto.
   * `InteractiveWebassembly` for Interactive WebAssembly.
 
-<!-- REVIEWER NOTE
-
-The preceding line based on the pre5 issue was ...
-
-`ComponentBase.AssignedRenderMode` exposes the render mode value defined in the component hierarchy (if any) via the `@rendermode` attribute on a root component or the `[RenderMode]` attribute.
-
-... but we never covered "the `[RenderMode]` attribute," 
-so that had to be removed at least temporarily until we
-document it. Also, it's more complicated to get into 
-the details on where/how the render mode is applied 
-(by definition or by inheritance). I phrased it more 
-generally as you see above until review can sort out 
-if it should say something more specific.
-
--->
-
 > [!NOTE]
 > `ComponentBase.Platform` will be renamed to `ComponentBase.RendererInfo` in a future preview release.
 
 Components use these properties to render content depending on their location or interactivity status. For example, a form can be disabled during prerendering and enabled when the component becomes interactive:
-
-<!-- REVIEWER NOTE
-
-     In the next example, I'm supplying just a bit of
-     "Movie" property context to make it clear why
-     the init is async.
-     
--->
 
 ```razor
 <EditForm Model="Movie" ...>

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -215,7 +215,7 @@ Additional information on render mode propagation is provided in the [Render mod
 
 :::moniker range=">= aspnetcore-9.0"
 
-## Detect the current render mode at runtime
+## Detect rendering location, interactivity, and assigned render mode at runtime
 
 <!-- UPDATE 9.0 Renaming of API for Pre6: 
                 Update the content and remove the NOTE -->


### PR DESCRIPTION
Fixes #32780
Addresses #32692
Addresses #31909

I hope I'm not making up my own 🦖 Blazor framework ... ***again!*** 🙈 

If either or both of my examples aren't best, give me your code for better examples. I figure we place two examples here, one for interactivity and one for assigned render mode.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/dce7ed7451bb781be1154c643386b92b4d83af1d/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-32794) |


<!-- PREVIEW-TABLE-END -->