### PR TITLE
Update Apache coverage (drop CentOS mentions)

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -14,12 +14,6 @@ uid: blazor/host-and-deploy/webassembly
 
 This article explains how to host and deploy Blazor WebAssembly using ASP.NET Core, Content Delivery Networks (CDN), file servers, and GitHub Pages.
 
-<!-- UPDATE 9.0 Remove CAUTION at 9.0 GA or
-                when we update CentOS guidance -->
-
-> [!CAUTION]
-> This article references CentOS, a Linux distribution that's nearing End Of Life (EOL) status. Please consider your use and plan accordingly. For more information, see the [CentOS](#centos) section of this article.
-
 With the [Blazor WebAssembly hosting model](xref:blazor/hosting-models#blazor-webassembly):
 
 * The Blazor app, its dependencies, and the .NET runtime are downloaded to the browser in parallel.
@@ -571,31 +565,14 @@ Increase the value if browser developer tools or a network traffic tool indicate
 
 For more information on production Nginx web server configuration, see [Creating NGINX Plus and NGINX Configuration Files](https://docs.nginx.com/nginx/admin-guide/basic-functionality/managing-configuration-files/).
 
-### CentOS
-
-<!-- UPDATE 9.0 Update future tense, and we'll 
-                need to completely update the 
-                following "Apache" section to use
-                a different Linux distribution. 
-                Currently, this is tracked by
-                the UE issue. -->
-
-On June 30, 2024, CentOS reaches End Of Life (EOL) status and will no longer be supported with web servers for Blazor WebAssembly hosting. For more information, see the following resources:
-
-* [CentOS Stream: Building an innovative future for enterprise Linux](https://www.redhat.com/blog/centos-stream-building-innovative-future-enterprise-linux)
-* [CentOS End Of Life guidance](/azure/virtual-machines/workloads/centos/centos-end-of-life)
-
-:::moniker range="< aspnetcore-9.0"
 
 ### Apache
 
-To deploy a Blazor WebAssembly app to CentOS 7 or later:
+To deploy a Blazor WebAssembly app to Apache:
+
+:::moniker range=">= aspnetcore-8.0"
 
 1. Create the Apache configuration file. The following example is a simplified configuration file (`blazorapp.config`):
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
 
    ```
    <VirtualHost *:80>
@@ -634,6 +611,8 @@ To deploy a Blazor WebAssembly app to CentOS 7 or later:
 
 :::moniker range="< aspnetcore-8.0"
 
+1. Create the Apache configuration file. The following example is a simplified configuration file (`blazorapp.config`):
+
    ```
    <VirtualHost *:80>
        ServerName www.example.com
@@ -670,17 +649,13 @@ To deploy a Blazor WebAssembly app to CentOS 7 or later:
 
 :::moniker-end
 
-:::moniker range="< aspnetcore-9.0"
+1. Place the Apache configuration file into the `/etc/httpd/conf.d/` directory.
 
-1. Place the Apache configuration file into the `/etc/httpd/conf.d/` directory, which is the default Apache configuration directory in CentOS 7.
-
-1. Place the app's files into the `/var/www/blazorapp` directory (the location specified to `DocumentRoot` in the configuration file).
+1. Place the app's published assets (`/bin/Release/{TARGET FRAMEWORK}/publish/wwwroot`, where the `{TARGET FRAMEWORK}` placeholder is the target framework) into the `/var/www/blazorapp` directory (the location specified to `DocumentRoot` in the configuration file).
 
 1. Restart the Apache service.
 
 For more information, see [`mod_mime`](https://httpd.apache.org/docs/2.4/mod/mod_mime.html) and [`mod_deflate`](https://httpd.apache.org/docs/current/mod/mod_deflate.html).
-
-:::moniker-end
 
 ### GitHub Pages
 


### PR DESCRIPTION
Fixes #32308

cc: @Rick-Anderson ... This does it for CentOS coverage. After this goes in, there are no references to CentOS on the entire repo, Blazor included.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/662cfde6c82313bb51f2c4fe6ca64e9b58ab6c85/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-32817) |

<!-- PREVIEW-TABLE-END -->