### PR TITLE
Use 'reconnection UI' for all references

### DIFF
--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -947,7 +947,7 @@ By initializing components with the same state used during prerendering, any exp
 A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
 
 * The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
-* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+* The reconnection UI on the client appears when the circuit fails. Recovery isn't possible.
 
 To resolve the problem, use ***either*** of the following approaches:
 
@@ -1890,7 +1890,7 @@ By initializing components with the same state used during prerendering, any exp
 A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
 
 * The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
-* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+* The reconnection UI on the client appears when the circuit fails. Recovery isn't possible.
 
 To resolve the problem, use ***either*** of the following approaches:
 
@@ -2596,7 +2596,7 @@ For more information, see <xref:blazor/components/index#class-name-and-namespace
 A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
 
 * The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
-* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+* The reconnection UI on the client appears when the circuit fails. Recovery isn't possible.
 
 To resolve the problem, use ***either*** of the following approaches:
 
@@ -3036,7 +3036,7 @@ For more information, see <xref:blazor/components/index#class-name-and-namespace
 A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
 
 * The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
-* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+* The reconnection UI on the client appears when the circuit fails. Recovery isn't possible.
 
 To resolve the problem, use ***either*** of the following approaches:
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -165,7 +165,7 @@ If prerendering is configured, prerendering occurs before the client connection 
 A large prerendered state size may exceed the SignalR circuit message size limit, which results in the following:
 
 * The SignalR circuit fails to initialize with an error on the client: :::no-loc text="Circuit host not initialized.":::
-* The reconnection dialog on the client appears when the circuit fails. Recovery isn't possible.
+* The reconnection UI on the client appears when the circuit fails. Recovery isn't possible.
 
 To resolve the problem, use ***either*** of the following approaches:
 
@@ -550,7 +550,7 @@ The following table describes the CSS classes applied to the `components-reconne
 
 :::moniker range=">= aspnetcore-5.0"
 
-Customize the delay before the reconnection display appears by setting the `transition-delay` property in the site's CSS for the modal element. The following example sets the transition delay from 500 ms (default) to 1,000 ms (1 second).
+Customize the delay before the reconnection UI appears by setting the `transition-delay` property in the site's CSS for the modal element. The following example sets the transition delay from 500 ms (default) to 1,000 ms (1 second).
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #32818

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/prerendering-and-integration.md](https://github.com/dotnet/AspNetCore.Docs/blob/438a13653eb785360cb425cdc99f6ba4832a5dd1/aspnetcore/blazor/components/prerendering-and-integration.md) | [Prerender and integrate ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/prerendering-and-integration?branch=pr-en-us-32820) |
| [aspnetcore/blazor/fundamentals/signalr.md](https://github.com/dotnet/AspNetCore.Docs/blob/438a13653eb785360cb425cdc99f6ba4832a5dd1/aspnetcore/blazor/fundamentals/signalr.md) | [ASP.NET Core Blazor SignalR guidance](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/signalr?branch=pr-en-us-32820) |

<!-- PREVIEW-TABLE-END -->