### PR TITLE
Interactive SSR RCs in global WASM/Auto projects

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -392,7 +392,13 @@ In the following example, the render mode is set interactive SSR by adding `@ren
 If using the preceding component in a Blazor Web App, place the component in the server project's `Components/Pages` folder&dagger;. The server project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
 
 > [!IMPORTANT]
-> &dagger;If the app adopts global WebAssembly or global Auto rendering via the `Routes` component, individual components that specify interactive SSR (`@rendermode InteractiveServer`) in their component definition file (`.razor`) are *placed in the `.Client` project's `Pages` folder*. This is counter-intuitive because such components are only rendered on the server. Placement in the `.Client` project is required. After the component is prerendered on the server and briefly displayed by the browser, the client-side router isn't able to find the component, which ultimately results in a *404 - Not Found* in the browser. Therefore, place interactive SSR components in the `.Client` project's `Pages` folder when the app adopts either global WebAssembly or Auto rendering.
+> &dagger;If the app adopts global WebAssembly or global Auto rendering via the `Routes` component, individual components that specify interactive SSR (`@rendermode InteractiveServer`) in their component definition file (`.razor`) are *placed in the `.Client` project's `Pages` folder*.
+>
+> Placing interactive SSR components in the `.Client` project is counter-intuitive because such components are only rendered on the server.
+>
+> If you place an interactive SSR component in the server project's `Components/Pages` folder of a global WebAssembly or Auto app, the component is prerendered normally and briefly displayed in the user's browser. However, the client-side router isn't able to find the component, ultimately resulting in a *404 - Not Found* in the browser.
+>
+> Therefore, place interactive SSR components in the `.Client` project's `Pages` folder if the app adopts global WebAssembly or global Auto rendering via the `Routes` component.
 
 ## Client-side rendering (CSR)
 

--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -389,7 +389,10 @@ In the following example, the render mode is set interactive SSR by adding `@ren
 }
 ```
 
-If using the preceding component locally in a Blazor Web App, place the component in the server project's `Components/Pages` folder. The server project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
+If using the preceding component in a Blazor Web App, place the component in the server project's `Components/Pages` folder&dagger;. The server project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
+
+> [!IMPORTANT]
+> &dagger;If the app adopts global WebAssembly or global Auto rendering via the `Routes` component, individual components that specify interactive SSR (`@rendermode InteractiveServer`) in their component definition file (`.razor`) are *placed in the `.Client` project's `Pages` folder*. This is counter-intuitive because such components are only rendered on the server. Placement in the `.Client` project is required. After the component is prerendered on the server and briefly displayed by the browser, the client-side router isn't able to find the component, which ultimately results in a *404 - Not Found* in the browser. Therefore, place interactive SSR components in the `.Client` project's `Pages` folder when the app adopts either global WebAssembly or Auto rendering.
 
 ## Client-side rendering (CSR)
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -581,9 +581,9 @@ The <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExt
 
 :::zone-end
 
-## Adding per-component interactive server-side rendered components
+## Adding components that adopt interactive server-side rendering
 
-Because the app adopts global Auto rendering via the `Routes` component, individual components that specify interactive SSR (`@rendermode InteractiveServer`) in their component definition file (`.razor`) are *placed in the `.Client` project's `Pages` folder*.
+Because the app uses global Interactive Auto rendering via the `Routes` component, individual components that specify interactive server-side rendering (interactive SSR, `@rendermode InteractiveServer`) in their component definition file (`.razor`) are *placed in the `.Client` project's `Pages` folder*.
 
 Placing interactive SSR components in the `.Client` project is counter-intuitive because such components are only rendered on the server.
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -581,6 +581,16 @@ The <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExt
 
 :::zone-end
 
+## Adding per-component interactive server-side rendered components
+
+Because the app adopts global Auto rendering via the `Routes` component, individual components that specify interactive SSR (`@rendermode InteractiveServer`) in their component definition file (`.razor`) are *placed in the `.Client` project's `Pages` folder*.
+
+Placing interactive SSR components in the `.Client` project is counter-intuitive because such components are only rendered on the server.
+
+If you place an interactive SSR component in the server project's `Components/Pages` folder, the component is prerendered normally and briefly displayed in the user's browser. However, the client-side router isn't able to find the component, ultimately resulting in a *404 - Not Found* in the browser.
+
+Therefore, place interactive SSR components in the `.Client` project's `Pages` folder.
+
 ## Redirect to the home page on signout
 
 When a user navigates around the app, the `LogInOrOut` component (`Layout/LogInOrOut.razor`) sets a hidden field for the return URL (`ReturnUrl`) to the value of the current URL (`currentURL`). When the user signs out of the app, the identity provider returns them to the page from which they signed out.


### PR DESCRIPTION
Fixes #32551

Mackinnion ... This PR arose because a dev, @Takhoffman, was using the BWA+OIDC sample app (it's global Auto) and hit a 💥 ***404*** trying to drop in a per-component-style interactive SSR component into the server project's `Components/Pages` folder. I told him that with that type of project ... global Auto ... that actually the component is placed (counter-intuitatively) into the `Pages` folder of the `.Client` project, which I think Steve told me about a while back IIRC 🤔.

Please confirm if that's correct. If so, see if the NOTE that I'm adding to the interactive SSR section of the *Render Modes* article and the new section in the BWA+OIDC article is explaining the scenario, the placement, and ***the reason*** for the 404 is all correct. I think the reason is due to the client-side router not being able to find/route to the component if it's in the server's `Components/Pages` folder, but that's a 🦖 guess based on my vague recollection of talking to Steve about it ... or maybe we discussed it.

Cross-ref @Takhoffman's original issue: https://github.com/dotnet/blazor-samples/issues/289

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/39309aeb7ace88d47a891398fdaf25c5830ea1cf/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-32844) |
| [aspnetcore/blazor/security/blazor-web-app-with-oidc.md](https://github.com/dotnet/AspNetCore.Docs/blob/39309aeb7ace88d47a891398fdaf25c5830ea1cf/aspnetcore/blazor/security/blazor-web-app-with-oidc.md) | [Secure an ASP.NET Core Blazor Web App with OpenID Connect (OIDC)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-oidc?branch=pr-en-us-32844) |


<!-- PREVIEW-TABLE-END -->