### PR TITLE
Lowercase the code name

### DIFF
--- a/aspnetcore/mobile/native-mobile-backend.md
+++ b/aspnetcore/mobile/native-mobile-backend.md
@@ -120,7 +120,7 @@ curl is installed with Windows 10, version 1802 or higher. For more information 
 
 Install jq with the following command in PowerShell or the Command Prompt:
 
-```PowerShell
+```powershell
 winget install jqlang.jq
 ```
 
@@ -154,7 +154,7 @@ In the terminal, call the following curl command:
 
 In PowerShell, call the following curl command:
 
-  ```PowerShell
+  ```powershell
   curl -v -X GET 'http://localhost:5000/api/todoitems/' | jq
   ```
 
@@ -223,7 +223,7 @@ curl -v -X POST 'http://localhost:5000/api/todoitems/' \
 
 # [Windows](#tab/windows)
 
-```PowerShell
+```powershell
 curl -v -X POST 'http://localhost:5000/api/todoitems/' `
 --header 'Content-Type: application/json' `
 --data '{
@@ -265,7 +265,7 @@ curl -v -X PUT 'http://localhost:5000/api/todoitems/' \
 ```
 # [Windows](#tab/windows)
 
-```PowerShell
+```powershell
 curl -v -X PUT 'http://localhost:5000/api/todoitems/' `
 --header 'Content-Type: application/json' `
 --data '{
@@ -294,7 +294,7 @@ curl -v -X DELETE 'http://localhost:5000/api/todoitems/6bb8b868-dba1-4f1a-93b7-2
 ```
 # [Windows](#tab/windows)
 
-```PowerShell
+```powershell
 curl -v -X DELETE 'http://localhost:5000/api/todoitems/6bb8b868-dba1-4f1a-93b7-24ebce87e243'
 ```
 


### PR DESCRIPTION
I found a handful to fix the other way.

cc: @Rick-Anderson ... Tom indicated that they get set into uppercase but should be lowercase in markdown. It threw me off. We have these tho that really are incorrect.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mobile/native-mobile-backend.md](https://github.com/dotnet/AspNetCore.Docs/blob/bd378097f6ab58afe148b320d6373725812e9fe1/aspnetcore/mobile/native-mobile-backend.md) | [Create backend services for native mobile apps with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/mobile/native-mobile-backend?branch=pr-en-us-32849) |

<!-- PREVIEW-TABLE-END -->