### PR TITLE
Import-Export interop: collocated JS with RCL

### DIFF
--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -144,7 +144,7 @@ export function showPrompt2(message) {
 }
 ```
 
-Use of scripts and modules for collocated JS in a Razor class library (RCL) is only supported for Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface. If you're implementing [JavaScript `[JSImport]`/`[JSExport]` interop](xref:blazor/js-interop/import-export-interop), see <xref:blazor/js-interop/import-export-interop#collocated-js-in-a-razor-class-library-rcl-is-unsupported>.
+Use of scripts and modules for collocated JS in a Razor class library (RCL) is only supported for Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface. If you're implementing [JavaScript `[JSImport]`/`[JSExport]` interop](xref:blazor/js-interop/import-export-interop), see <xref:blazor/js-interop/import-export-interop#razor-class-library-rcl-collocated-js-is-unsupported>.
 
 For scripts or modules provided by a Razor class library (RCL) using <xref:Microsoft.JSInterop.IJSRuntime>-based JS interop, the following path is used:
 

--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -144,7 +144,9 @@ export function showPrompt2(message) {
 }
 ```
 
-For scripts or modules provided by a Razor class library (RCL), the following path is used:
+Use of scripts and modules for collocated JS in a Razor class library (RCL) is only supported for Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface. If you're implementing [JavaScript `[JSImport]`/`[JSExport]` interop](xref:blazor/js-interop/import-export-interop), see <xref:xref:blazor/js-interop/import-export-interop#collocated-js-in-a-razor-class-library-rcl-is-unsupported>.
+
+For scripts or modules provided by a Razor class library (RCL) using <xref:Microsoft.JSInterop.IJSRuntime>-based JS interop, the following path is used:
 
 `_content/{PACKAGE ID}/{PATH}/{COMPONENT}.{EXTENSION}.js`
 

--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -144,7 +144,7 @@ export function showPrompt2(message) {
 }
 ```
 
-Use of scripts and modules for collocated JS in a Razor class library (RCL) is only supported for Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface. If you're implementing [JavaScript `[JSImport]`/`[JSExport]` interop](xref:blazor/js-interop/import-export-interop), see <xref:xref:blazor/js-interop/import-export-interop#collocated-js-in-a-razor-class-library-rcl-is-unsupported>.
+Use of scripts and modules for collocated JS in a Razor class library (RCL) is only supported for Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface. If you're implementing [JavaScript `[JSImport]`/`[JSExport]` interop](xref:blazor/js-interop/import-export-interop), see <xref:blazor/js-interop/import-export-interop#collocated-js-in-a-razor-class-library-rcl-is-unsupported>.
 
 For scripts or modules provided by a Razor class library (RCL) using <xref:Microsoft.JSInterop.IJSRuntime>-based JS interop, the following path is used:
 

--- a/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
+++ b/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
@@ -49,7 +49,7 @@ Enable the <xref:Microsoft.Build.Tasks.Csc.AllowUnsafeBlocks> property in app's 
 > [!WARNING]
 > The JS interop API requires enabling <xref:Microsoft.Build.Tasks.Csc.AllowUnsafeBlocks>. Be careful when implementing your own unsafe code in .NET apps, which can introduce security and stability risks. For more information, see [Unsafe code, pointer types, and function pointers](/dotnet/csharp/language-reference/unsafe-code).
 
-## Collocated JS in a Razor class library (RCL) is unsupported
+## Razor class library (RCL) collocated JS is unsupported
 
 Generally, the JS location support for <xref:Microsoft.JSInterop.IJSRuntime>-based JS interop (<xref:blazor/js-interop/javascript-location>) is also present for the `[JSImport]`/`[JSExport]` interop described by this article. The only unsupported JS location feature is for *collocated JS in a Razor class library (RCL)*.
 

--- a/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
+++ b/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
@@ -24,8 +24,6 @@ This article describes an alternative JS interop approach specific to client-sid
 > [!NOTE]
 > This article focuses on JS interop in client-side components. For guidance on calling .NET in JavaScript apps, see <xref:client-side/dotnet-interop>.
 
-
-
 ## Obsolete JavaScript interop API
 
 Unmarshalled JS interop using <xref:Microsoft.JSInterop.IJSUnmarshalledRuntime> API is obsolete in ASP.NET Core in .NET 7 or later. Follow the guidance in this article to replace the obsolete API.
@@ -36,7 +34,7 @@ Unmarshalled JS interop using <xref:Microsoft.JSInterop.IJSUnmarshalledRuntime> 
 
 ## Namespace
 
-The JS interop API described in this article is controlled by attributes in the <xref:System.Runtime.InteropServices.JavaScript?displayProperty=fullName> namespace.
+The JS interop API (<xref:System.Runtime.InteropServices.JavaScript.JSHost.ImportAsync%2A?displayProperty=nameWithType>) described in this article is controlled by attributes in the <xref:System.Runtime.InteropServices.JavaScript?displayProperty=fullName> namespace.
 
 ## Enable unsafe blocks
 
@@ -50,6 +48,23 @@ Enable the <xref:Microsoft.Build.Tasks.Csc.AllowUnsafeBlocks> property in app's 
 
 > [!WARNING]
 > The JS interop API requires enabling <xref:Microsoft.Build.Tasks.Csc.AllowUnsafeBlocks>. Be careful when implementing your own unsafe code in .NET apps, which can introduce security and stability risks. For more information, see [Unsafe code, pointer types, and function pointers](/dotnet/csharp/language-reference/unsafe-code).
+
+## Collocated JS in a Razor class library (RCL) is unsupported
+
+Generally, the JS location support for <xref:Microsoft.JSInterop.IJSRuntime>-based JS interop (<xref:blazor/js-interop/javascript-location>) is also present for the `[JSImport]`/`[JSExport]` interop described by this article. The only unsupported JS location feature is for *collocated JS in a Razor class library (RCL)*.
+
+Instead of using collocated JS in an RCL, place the JS file in the RCL's `wwwroot` folder and reference it using the usual path for RCL static assets:
+
+`_content/{PACKAGE ID}/{PATH}/{FILE NAME}.js`
+
+* The `{PACKAGE ID}` placeholder is the RCL's package identifier (or library name for a class library).
+* The `{PATH}` placeholder is the path to the file.
+* The `{FILE NAME}` placeholder is the file name.
+
+Although collocated JS in an RCL isn't supported, you can keep your JS files organized by taking either or both of the following approaches:
+
+* Name the JS file the same as the component where the JS is used. For a component in the RCL named `CallJavaScriptFromLib` (`CallJavaScriptFromLib.razor`), name the file `CallJavaScriptFromLib.js` in the `wwwroot` folder.
+* Place component-specific JS files in a `Components` folder inside the RCL's `wwwroot` folder and use "`Components`" in the path to the file: `_content/{PACKAGE ID}/Components/CallJavaScriptFromLib.js`.
 
 ## Call JavaScript from .NET
 

--- a/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
+++ b/aspnetcore/blazor/javascript-interoperability/import-export-interop.md
@@ -61,7 +61,7 @@ Instead of using collocated JS in an RCL, place the JS file in the RCL's `wwwroo
 * The `{PATH}` placeholder is the path to the file.
 * The `{FILE NAME}` placeholder is the file name.
 
-Although collocated JS in an RCL isn't supported, you can keep your JS files organized by taking either or both of the following approaches:
+Although collocated JS in an RCL isn't supported by `[JSImport]`/`[JSExport]` interop, you can keep your JS files organized by taking either or both of the following approaches:
 
 * Name the JS file the same as the component where the JS is used. For a component in the RCL named `CallJavaScriptFromLib` (`CallJavaScriptFromLib.razor`), name the file `CallJavaScriptFromLib.js` in the `wwwroot` folder.
 * Place component-specific JS files in a `Components` folder inside the RCL's `wwwroot` folder and use "`Components`" in the path to the file: `_content/{PACKAGE ID}/Components/CallJavaScriptFromLib.js`.


### PR DESCRIPTION
Fixes #32618

Marek ... The article that covers JS location ...

https://learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/location-of-javascript?view=aspnetcore-8.0

... is meant to cover all of the location scenarios, and it looks like it's just this ***one thing*** that isn't supported: Import-Export interop with collocated JS in an RCL.

If that's a correct interpretation, then I think a section should be added to the Import-Export article that just calls out that the collocation feature isn't supported, leaving the JS location article to continue to serve its purpose for both JS interop APIs. I'm adding that section here, and I'm cross-linking it from the JS location article where it talks about collocated JS from an RCL. 

Also, it seemed like a little advice can be offered to devs trying to keep their JS organized by component because that's the whole purpose of collocated JS in the first place: They can name the JS file to match the component, and they can place component-specific JS files into a `Components` folder in `wwwroot` of the RCL. We can strike that bit if it seems obvious or inappropriate for some reason.

Note that your remark on how "JSHost.ImportAsync always loads files relative to `wwwroot/_framework` directory" is an implementation detail that we don't cover, so dropping it into the coverage is going to be a little confusing. The only place in the entire Blazor doc set that we talk about that is for loading boot resources.

Also note that that JS collocation coverage is actually provided by an INCLUDE file. It's not only in the JS location article. It also gets sucked into the class libraries article, so the new cross-link will appear there as well after this merges ...

https://learn.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries?view=aspnetcore-8.0&tabs=visual-studio#create-an-rcl-with-javascript-files-collocated-with-components

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/import-export-interop.md](https://github.com/dotnet/AspNetCore.Docs/blob/5e3dd35037e00406b8c598eb115fdda00c59924b/aspnetcore/blazor/javascript-interoperability/import-export-interop.md) | [JavaScript `[JSImport]`/`[JSExport]` interop with ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/import-export-interop?branch=pr-en-us-32856) |


<!-- PREVIEW-TABLE-END -->