### PR TITLE
Mitigate overposting attacks

### DIFF
--- a/aspnetcore/blazor/forms/index.md
+++ b/aspnetcore/blazor/forms/index.md
@@ -286,6 +286,18 @@ For more information, see <xref:blazor/security/index#antiforgery-support>.
 
 :::moniker range=">= aspnetcore-8.0"
 
+## Mitigate overposting attacks
+
+Statically-rendered server-side forms, such as those typically used in components that create and edit records in a database with a form model, can be vulnerable to an *overposting* attack, also known as a *mass assignment* attack. An overposting attack occurs when a malicious user issues an HTML form POST to the server that processes data for properties that aren't part of the rendered form and that the developer doesn't wish to allow users to modify. The term "overposting" literally means that the malicious user has *over*-POSTed with the form.
+
+Overposting isn't a concern when the model doesn't include restricted properties for create and update operations. However, it's important to keep overposting in mind when working with static SSR-based Blazor forms that you maintain.
+
+To mitigate overposting, we recommend using a separate view model/data transfer object (DTO) for the form and database with create (insert) and update operations. When the form is submitted, only properties of the view model/DTO are used by the component and C# code to modify the database. Any extra data included by a malicious user is discarded, so the malicious user is prevented from conducting an overposting attack.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
+
 ## Enhanced form handling
 
 [Enhance navigation](xref:blazor/fundamentals/routing#enhanced-navigation-and-form-handling) for form POST requests with the <xref:Microsoft.AspNetCore.Components.Forms.EditForm.Enhance%2A> parameter for <xref:Microsoft.AspNetCore.Components.Forms.EditForm> forms or the `data-enhance` attribute for HTML forms (`<form>`):


### PR DESCRIPTION
Fixes #32733

Adding a section for ...

* General coverage on this subject.
* Inbound links from scaffolded `Create` and `Edit` component markup using the `blazor` generator. Today, these components point to the RP coverage ...

  ```razor
  // To protect from overposting attacks, see https://aka.ms/RazorPagesCRUD
  ```

  ... which isn't much help given the landing section is https://learn.microsoft.com/en-us/aspnet/core/data/ef-rp/crud?view=aspnetcore-8.0#update-the-create-page with API and an approach that isn't available in a Razor component scenario.

  Cross-refs:

  * https://github.com/dotnet/Scaffolding/blob/main/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Create.tt#L66
  * https://github.com/dotnet/Scaffolding/blob/main/src/Scaffolding/VS.Web.CG.Mvc/Templates/Blazor/Edit.tt#L92

  I'll signal the scaffolding folks that the links in the components should be updated to this new section after this merges.