### PR TITLE
Specify three Blazor subservice articles

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -67,7 +67,10 @@
         "**/web-api/**/**.md": "web-api",
         "whats-new/**/**.md": "whats-new",
         "**/blazor/**/**.md": "blazor",
-        "**/blazor/hybrid/**/**.md": "blazor-hybrid"
+        "**/blazor/hybrid/**/**.md": "blazor-hybrid",
+        "**/client-side/dotnet-interop.md": "blazor",
+        "**/mvc/views/tag-helpers/built-in/component-tag-helper.md": "blazor",
+        "**/mvc/views/tag-helpers/built-in/persist-component-state.md": "blazor"
       },
       "ms.topic": {
         "**/getting-started/**/**.md": "tutorial",


### PR DESCRIPTION
Fixes #32710

This will yield correct issue management for these three Blazor articles. This system works on a last-one-wins strategy, so adding them at the end will give them the correct subservice.