### PR TITLE
.NET JS interop article updates

### DIFF
--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -172,11 +172,11 @@ In the following example:
 
 * `setModuleImports` associates a name with a module of JS functions for import into .NET. The JS module contains a `dom.setInnerText` function, which accepts and element selector and time to display the current stopwatch time in the UI. The name of the module can be any string (it doesn't need to be a file name), but it must match the name used with the `JSImportAttribute` (explained later in this article). The `dom.setInnerText` function is imported into C# and called by the C# method `SetInnerText`. The `SetInnerText` method is shown later in this section.
 
-* `exports.StopwatchSample.Reset()` calls into .NET (`StopwatchSample.Reset`) from JS. The `Reset` C# method restarts the stopwatch if it's running or resets it if it isn't running.
+* `exports.StopwatchSample.Reset()` calls into .NET (`StopwatchSample.Reset`) from JS. The `Reset` C# method restarts the stopwatch if it's running or resets it if it isn't running. The `Reset` method is shown later in this section.
 
 * `exports.StopwatchSample.Toggle()` calls into .NET (`StopwatchSample.Toggle`) from JS. The `Toggle` C# method starts or stops the stopwatch depending on if it's currently running or not. The `Toggle` method is shown later in this section.
 
-* `runMain()` runs `Program.Main` and keeps the runtime process running and executing further API calls.
+* `runMain()` runs `Program.Main`.
 
 :::moniker-end
 
@@ -198,28 +198,29 @@ JS module:
 import { dotnet } from './_framework/dotnet.js'
 
 const { setModuleImports, getAssemblyExports, getConfig, runMain } = await dotnet
-    .withApplicationArguments("start")
-    .create();
+  .withApplicationArguments("start")
+  .create();
 
 setModuleImports('main.js', {
-    dom: {
-        setInnerText: (selector, time) => document.querySelector(selector).innerText = time
-    }
+  dom: {
+    setInnerText: (selector, time) => 
+      document.querySelector(selector).innerText = time
+  }
 });
 
 const config = getConfig();
 const exports = await getAssemblyExports(config.mainAssemblyName);
 
 document.getElementById('reset').addEventListener('click', e => {
-    exports.StopwatchSample.Reset();
-    e.preventDefault();
+  exports.StopwatchSample.Reset();
+  e.preventDefault();
 });
 
 const pauseButton = document.getElementById('pause');
 pauseButton.addEventListener('click', e => {
-    const isRunning = exports.StopwatchSample.Toggle();
-    pauseButton.innerText = isRunning ? 'Pause' : 'Start';
-    e.preventDefault();
+  const isRunning = exports.StopwatchSample.Toggle();
+  pauseButton.innerText = isRunning ? 'Pause' : 'Start';
+  e.preventDefault();
 });
 
 await runMain();
@@ -233,16 +234,16 @@ await runMain();
 import { dotnet } from './_framework/dotnet.js'
 
 const { setModuleImports, getAssemblyExports, getConfig } = await dotnet
-    .withDiagnosticTracing(false)
-    .withApplicationArgumentsFromQuery()
-    .create();
+  .withDiagnosticTracing(false)
+  .withApplicationArgumentsFromQuery()
+  .create();
 
 setModuleImports('main.js', {
-    window: {
-        location: {
-            href: () => globalThis.window.location.href
-        }
+  window: {
+    location: {
+      href: () => globalThis.window.location.href
     }
+  }
 });
 
 const config = getConfig();

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -5,7 +5,7 @@ description: Learn how to run .NET from JavaScript.
 monikerRange: '>= aspnetcore-7.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/10/2022
+ms.date: 06/18/2024
 uid: client-side/dotnet-interop
 ---
 # Run .NET from JavaScript
@@ -22,8 +22,6 @@ Existing JS apps can use the expanded client-side WebAssembly support in .NET 7 
 These approaches are appropriate when you only expect to run on WebAssembly (:::no-loc text="WASM":::). Libraries can make a runtime check to determine if the app is running on :::no-loc text="WASM"::: by calling <xref:System.OperatingSystem.IsBrowser%2A?displayProperty=nameWithType>.
 
 ## Prerequisites
-
-[!INCLUDE[](~/includes/7.0-SDK.md)]
 
 Install the latest version of the [.NET SDK](https://dotnet.microsoft.com/download/dotnet/).
 

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -287,11 +287,13 @@ dotnet new install Microsoft.NET.Runtime.WebAssembly.Templates
 
 ### Browser app
 
-You can create a browser app with the `wasmbrowser` template, which creates a web app that demonstrates using .NET and JS together in a browser:
+You can create a browser app with the `wasmbrowser` template from the command line, which creates a web app that demonstrates using .NET and JS together in a browser:
 
 ```dotnetcli
 dotnet new wasmbrowser
 ```
+
+Alternatively in Visual Studio, you can create the app using the **:::no-loc text="WebAssembly Browser App":::** project template.
 
 Build the app from Visual Studio or by using the .NET CLI:
 
@@ -331,6 +333,8 @@ You can create a console app with the `wasmconsole` template, which creates an a
 ```dotnetcli
 dotnet new wasmconsole
 ```
+
+Alternatively in Visual Studio, you can create the app using the **:::no-loc text="WebAssembly Console App":::** project template.
 
 Build the app from Visual Studio or by using the .NET CLI:
 

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -14,7 +14,7 @@ This article explains how to run .NET from JavaScript (JS) using JS `[JSImport]`
 
 For additional guidance, see the [Configuring and hosting .NET WebAssembly applications](https://github.com/dotnet/runtime/blob/main/src/mono/wasm/features.md) guidance in the .NET Runtime (`dotnet/runtime`) GitHub repository.
 
-Existing JS apps can use the expanded client-side WebAssembly support in .NET 7 or later to reuse .NET libraries from JS or to build novel .NET-based apps and frameworks.
+Existing JS apps can use the expanded client-side WebAssembly support to reuse .NET libraries from JS or to build novel .NET-based apps and frameworks.
 
 > [!NOTE]
 > This article focuses on running .NET from JS apps without any dependency on [Blazor](xref:blazor/index). For guidance on using `[JSImport]`/`[JSExport]` interop in Blazor WebAssembly apps, see <xref:blazor/js-interop/import-export-interop>.
@@ -47,10 +47,10 @@ The JS interop API described in this article is controlled by attributes in the 
 
 To configure a project (`.csproj`) to enable JS interop:
 
-* Target `net7.0` or later:
+* Target `net8.0` or later:
 
   ```xml
-  <TargetFramework>net7.0</TargetFramework>
+  <TargetFramework>net8.0</TargetFramework>
   ```
 
 * Specify `browser-wasm` for the runtime identifier:
@@ -85,10 +85,10 @@ To configure a project (`.csproj`) to enable JS interop:
 Example project file (`.csproj`) after configuration:
 
 ```xml
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -115,7 +115,7 @@ In the following example:
 
   > :::no-loc text="bin/{BUILD CONFIGURATION}/{TARGET FRAMEWORK}/browser-wasm/AppBundle":::
 
-  The `{BUILD CONFIGURATION}` placeholder is the build configuration (for example, `Debug`, `Release`), and the `{TARGET FRAMEWORK}` placeholder is the target framework (for example, `net7.0`).
+  The `{BUILD CONFIGURATION}` placeholder is the build configuration (for example, `Debug`, `Release`), and the `{TARGET FRAMEWORK}` placeholder is the [target framework moniker](/dotnet/standard/frameworks).
 
   > [!IMPORTANT]
   > To integrate with an existing app, copy the contents of the `AppBundle` folder so that it can be served along with the rest of the app. For production deployments, publish the app with the `dotnet publish -c Release` command in a command shell and deploy the `AppBundle` folder with the app.
@@ -199,7 +199,7 @@ To demonstrate the JS interop functionality and obtain JS interop project templa
 dotnet workload install wasm-experimental
 ```
 
-The `wasm-experimental` workload contains two project templates: `wasmbrowser` and `wasmconsole`. These templates are experimental at this time, which means the developer workflow for the templates is evolving. However, the .NET and JS APIs used in the templates are supported in .NET 7 and provide a foundation for using .NET on :::no-loc text="WASM"::: from JS.
+The `wasm-experimental` workload contains two project templates: `wasmbrowser` and `wasmconsole`. These templates are experimental at this time, which means the developer workflow for the templates is evolving. However, the .NET and JS APIs used in the templates are supported in .NET 8 and provide a foundation for using .NET on :::no-loc text="WASM"::: from JS.
 
 ### Browser app
 
@@ -215,7 +215,7 @@ Build the app from Visual Studio or by using the .NET CLI:
 dotnet build
 ```
 
-The built app is in the `bin/{BUILD CONFIGURATION}/{TARGET FRAMEWORK}/browser-wasm/AppBundle` directory. The `{BUILD CONFIGURATION}` placeholder is the build configuration (for example, `Debug`, `Release`). The `{TARGET FRAMEWORK}` placeholder is the target framework moniker (for example, `net7.0`).
+The built app is in the `bin/{BUILD CONFIGURATION}/{TARGET FRAMEWORK}/browser-wasm/AppBundle` directory. The `{BUILD CONFIGURATION}` placeholder is the build configuration (for example, `Debug`, `Release`). The `{TARGET FRAMEWORK}` placeholder is the [target framework moniker](/dotnet/standard/frameworks).
 
 Build and run the app from Visual Studio or by using the .NET CLI:
 
@@ -229,7 +229,7 @@ Alternatively, start any static file server from the `AppBundle` directory:
 dotnet serve -d:bin/$(Configuration)/{TARGET FRAMEWORK}/browser-wasm/AppBundle
 ```
 
-In the preceding example, the `{TARGET FRAMEWORK}` placeholder is the target framework moniker (for example, `net7.0`).
+In the preceding example, the `{TARGET FRAMEWORK}` placeholder is the [target framework moniker](/dotnet/standard/frameworks).
 
 ### Node.js console app
 
@@ -245,7 +245,7 @@ Build the app from Visual Studio or by using the .NET CLI:
 dotnet build
 ```
 
-The built app is in the `bin/{BUILD CONFIGURATION}/{TARGET FRAMEWORK}/browser-wasm/AppBundle` directory. The `{BUILD CONFIGURATION}` placeholder is the build configuration (for example, `Debug`, `Release`). The `{TARGET FRAMEWORK}` placeholder is the target framework moniker (for example, `net7.0`).
+The built app is in the `bin/{BUILD CONFIGURATION}/{TARGET FRAMEWORK}/browser-wasm/AppBundle` directory. The `{BUILD CONFIGURATION}` placeholder is the build configuration (for example, `Debug`, `Release`). The `{TARGET FRAMEWORK}` placeholder is the [target framework moniker](/dotnet/standard/frameworks).
 
 Build and run the app from Visual Studio or by using the .NET CLI:
 
@@ -259,7 +259,7 @@ Alternatively, start any static file server from the `AppBundle` directory:
 node bin/$(Configuration)/{TARGET FRAMEWORK}/browser-wasm/AppBundle/main.mjs
 ```
 
-In the preceding example, the `{TARGET FRAMEWORK}` placeholder is the target framework moniker (for example, `net7.0`).
+In the preceding example, the `{TARGET FRAMEWORK}` placeholder is the [target framework moniker](/dotnet/standard/frameworks).
 
 ## Additional resources
 

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -47,11 +47,13 @@ The JS interop API described in this article is controlled by attributes in the 
 
 To configure a project (`.csproj`) to enable JS interop:
 
-* Target `net8.0` or later:
+* Set the [target framework moniker](/dotnet/standard/frameworks) (`{TARGET FRAMEWORK}` placeholder):
 
   ```xml
-  <TargetFramework>net8.0</TargetFramework>
+  <TargetFramework>{TARGET FRAMEWORK}</TargetFramework>
   ```
+
+  .NET 7 (`net7.0`) or later is supported.
 
 * Specify `browser-wasm` for the runtime identifier:
 

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -5,7 +5,7 @@ description: Learn how to run .NET from JavaScript.
 monikerRange: '>= aspnetcore-7.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 06/18/2024
+ms.date: 06/21/2024
 uid: client-side/dotnet-interop
 ---
 # Run .NET from JavaScript
@@ -171,6 +171,8 @@ In the following example:
 :::moniker range=">= aspnetcore-9.0"
 
 * `setModuleImports` associates a name with a module of JS functions for import into .NET. The JS module contains a `dom.setInnerText` function, which accepts and element selector and time to display the current stopwatch time in the UI. The name of the module can be any string (it doesn't need to be a file name), but it must match the name used with the `JSImportAttribute` (explained later in this article). The `dom.setInnerText` function is imported into C# and called by the C# method `SetInnerText`. The `SetInnerText` method is shown later in this section.
+
+* `exports.StopwatchSample.Reset()` calls into .NET (`StopwatchSample.Reset`) from JS. The `Reset` C# method restarts the stopwatch if it's running or resets it if it isn't running.
 
 * `exports.StopwatchSample.Toggle()` calls into .NET (`StopwatchSample.Toggle`) from JS. The `Toggle` C# method starts or stops the stopwatch depending on if it's currently running or not. The `Toggle` method is shown later in this section.
 

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -164,7 +164,7 @@ In the following example:
   > [!IMPORTANT]
   > To integrate with an existing app, copy the contents of the publish output folder&dagger; to the existing app's deployment assets so that it can be served along with the rest of the app. For production deployments, publish the app with the `dotnet publish -c Release` command in a command shell and deploy the output folder's contents with the app.
   >
-  > &dagger;The publish output folder is the target location of your publish profile. The default for a **:::no-loc text="Release":::** profile for .NET 8 or later is `Release/{TARGET FRAMEWORK}/publish`, where the `{TARGET FRAMEWORK}` placeholder is the target framework (for example, `net8.0`).
+  > &dagger;The publish output folder is the target location of your publish profile. The default for a **:::no-loc text="Release":::** profile in .NET 8 or later is `bin/Release/{TARGET FRAMEWORK}/publish`, where the `{TARGET FRAMEWORK}` placeholder is the target framework (for example, `net8.0`).
 
 * `dotnet.create()` sets up the .NET WebAssembly runtime.
 


### PR DESCRIPTION
Fixes #32660

Marek ... ***UPDATE***: Making progress ...

* Version-specific language updates. Version new coverage for .NET 8+.
* Change from the `Microsoft.NET.Sdk` SDK to the `Microsoft.NET.Sdk.WebAssembly` SDK.
* Update code and language for .NET 8+.
* Update guidance for workload and template installation.  

See my latest comments on three items of concern :point_down:.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/client-side/dotnet-interop.md](https://github.com/dotnet/AspNetCore.Docs/blob/fca6875016950ab06398315fe2d1ec1f4a9e8ccf/aspnetcore/client-side/dotnet-interop.md) | [Run .NET from JavaScript](https://review.learn.microsoft.com/en-us/aspnet/core/client-side/dotnet-interop?branch=pr-en-us-32882) |


<!-- PREVIEW-TABLE-END -->