### PR TITLE
Add type to code example for route param.

### DIFF
--- a/aspnetcore/diagnostics/asp0018.md
+++ b/aspnetcore/diagnostics/asp0018.md
@@ -35,7 +35,7 @@ To fix a violation of this rule, remove the route parameter or add code that use
 ```csharp
 var app = WebApplication.Create();
 
-app.MapGet("/{id}", (id) => ...);
+app.MapGet("/{id}", (string id) => ...);
 ```
 
 ## When to suppress warnings


### PR DESCRIPTION
Updating the documentation for error ASP0018 "" to add a type (string) to the example. Afaik the default type is HttpContext but I think the most likely use case for a route parameter in the path is a string, especially given the name is `id`. Not sure if this is a best practice or not. Feel free to reject!

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/diagnostics/asp0018.md](https://github.com/dotnet/AspNetCore.Docs/blob/163bd51f54d17668f94ab0e164129ef989dcefcb/aspnetcore/diagnostics/asp0018.md) | [ASP0018: Unused route parameter](https://review.learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0018?branch=pr-en-us-32906) |

<!-- PREVIEW-TABLE-END -->