### PR TITLE
Blazor CLI commands moving to `dotnet watch`

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -397,7 +397,7 @@ Breakpoints are **not** hit during app startup before the debug proxy is running
 > [!NOTE]
 > Only browser debugging is supported.
 >
-> You can't automatically rebuild the backend **:::no-loc text="Server":::** project of a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln) during debugging, for example by running the app with [`dotnet watch run`](xref:tutorials/dotnet-watch).
+> You can't automatically rebuild the backend **:::no-loc text="Server":::** project of a hosted Blazor WebAssembly [solution](xref:blazor/tooling#visual-studio-solution-file-sln) during debugging, for example by running the app with [`dotnet watch`](xref:tutorials/dotnet-watch).
 
 To debug a **published**, hosted Blazor WebAssembly app, configure debugger support (`DebuggerSupport`) and copy output symbols to the `publish` directory (`CopyOutputSymbolsToPublishDirectory`) in the **:::no-loc text="Client":::** project's project file:
 
@@ -463,7 +463,7 @@ The additional options in the following table only apply to **hosted Blazor WebA
 * *Google Chrome running on Windows or macOS.*
 * *Microsoft Edge running on Windows.*
 
-1. Run the app in a command shell with `dotnet run`.
+1. Run the app in a command shell with `dotnet watch` (or `dotnet run`).
 1. Launch a browser and navigate to the app's URL.
 1. Start remote debugging by pressing:
 
@@ -506,7 +506,7 @@ To debug a Blazor WebAssembly app in Firefox during development:
    * Enable `devtools.chrome.enabled` by setting its value to `True`.
    * Disable `devtools.debugger.prompt-connection` by setting its value to `False`.
 1. Close all Firefox instances.
-1. Run the app in a command shell with `dotnet run`.
+1. Run the app in a command shell with `dotnet watch` (or `dotnet run`).
 1. Relaunch the Firefox browser and navigate to the app.
 1. Open `about:debugging` in a new browser tab. **Leave this tab open**.
 1. Go back to the tab where the app is running. Start remote debugging by pressing <kbd>Shift</kbd>+<kbd>Alt</kbd>+<kbd>d</kbd>.

--- a/aspnetcore/blazor/host-and-deploy/index.md
+++ b/aspnetcore/blazor/host-and-deploy/index.md
@@ -305,19 +305,19 @@ In typical configurations for Azure/IIS hosting, additional configuration usuall
 * To serve static files correctly (for example, `app.UseStaticFiles("/CoolApp");`).
 * To serve the Blazor script (`_framework/blazor.*.js`). For more information, see <xref:blazor/fundamentals/static-files>.
 
-For a Blazor WebAssembly app with a non-root relative URL path (for example, `<base href="/CoolApp/">`), the app fails to find its resources *when run locally*. To overcome this problem during local development and testing, you can supply a *path base* argument that matches the `href` value of the `<base>` tag at runtime. **Don't include a trailing slash.** To pass the path base argument when running the app locally, execute the `dotnet run` command from the app's directory with the `--pathbase` option:
+For a Blazor WebAssembly app with a non-root relative URL path (for example, `<base href="/CoolApp/">`), the app fails to find its resources *when run locally*. To overcome this problem during local development and testing, you can supply a *path base* argument that matches the `href` value of the `<base>` tag at runtime. **Don't include a trailing slash.** To pass the path base argument when running the app locally, execute the `dotnet watch` (or `dotnet run`) command from the app's directory with the `--pathbase` option:
 
 ```dotnetcli
-dotnet run --pathbase=/{RELATIVE URL PATH (no trailing slash)}
+dotnet watch --pathbase=/{RELATIVE URL PATH (no trailing slash)}
 ```
 
 For a Blazor WebAssembly app with a relative URL path of `/CoolApp/` (`<base href="/CoolApp/">`), the command is:
 
 ```dotnetcli
-dotnet run --pathbase=/CoolApp
+dotnet watch --pathbase=/CoolApp
 ```
 
-If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet run`, set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL (`launchUrl`):
+If you prefer to configure the app's launch profile to specify the `pathbase` automatically instead of manually with `dotnet watch` (or `dotnet run`), set the `commandLineArgs` property in `Properties/launchSettings.json`. The following also configures the launch URL (`launchUrl`):
 
 ```json
 "commandLineArgs": "--pathbase=/{RELATIVE URL PATH (no trailing slash)}",
@@ -331,7 +331,7 @@ Using `CoolApp` as the example:
 "launchUrl": "CoolApp",
 ```
 
-Using either `dotnet run` with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
+Using either `dotnet watch` (or `dotnet run`) with the `--pathbase` option or a launch profile configuration that sets the base path, the Blazor WebAssembly app responds locally at `http://localhost:port/CoolApp`.
 
 For more information on the `launchSettings.json` file, see <xref:fundamentals/environments#development-and-launchsettingsjson>. For additional information on Blazor app base paths and hosting, see [`<base href="/" />` or base-tag alternative for Blazor MVC integration (dotnet/aspnetcore #43191)](https://github.com/dotnet/aspnetcore/issues/43191#issuecomment-1212156106).
 

--- a/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md
@@ -504,7 +504,7 @@ In the preceding example URLs, the `{DEFAULT PORT}` placeholder is the default p
 :::zone-end
 
 > [!IMPORTANT]
-> When running the app with the `dotnet run` command (.NET CLI), confirm that the command shell is open in the `Server` folder of the solution.
+> When running the app with the `dotnet watch` (or `dotnet run`) command (.NET CLI), confirm that the command shell is open in the `Server` folder of the solution.
 >
 > When using Visual Studio's start button to run the app, confirm that the `MultipleBlazorApps.Server` project is set as the startup project (highlighted in Solution Explorer). 
 

--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -699,10 +699,10 @@ The `--contentroot` argument sets the absolute path to the directory that contai
 * Pass the argument when running the app locally at a command prompt. From the app's directory, execute:
 
   ```dotnetcli
-  dotnet run --contentroot=/content-root-path
+  dotnet watch --contentroot=/content-root-path
   ```
 
-* Add an entry to the app's `launchSettings.json` file in the **IIS Express** profile. This setting is used when the app is run with the Visual Studio Debugger and from a command prompt with `dotnet run`.
+* Add an entry to the app's `launchSettings.json` file in the **IIS Express** profile. This setting is used when the app is run with the Visual Studio Debugger and from a command prompt with `dotnet watch` (or `dotnet run`).
 
   ```json
   "commandLineArgs": "--contentroot=/content-root-path"
@@ -724,10 +724,10 @@ The `--pathbase` argument sets the app base path for an app run locally with a n
 * Pass the argument when running the app locally at a command prompt. From the app's directory, execute:
 
   ```dotnetcli
-  dotnet run --pathbase=/relative-URL-path
+  dotnet watch --pathbase=/relative-URL-path
   ```
 
-* Add an entry to the app's `launchSettings.json` file in the **IIS Express** profile. This setting is used when running the app with the Visual Studio Debugger and from a command prompt with `dotnet run`.
+* Add an entry to the app's `launchSettings.json` file in the **IIS Express** profile. This setting is used when running the app with the Visual Studio Debugger and from a command prompt with `dotnet watch` (or `dotnet run`).
 
   ```json
   "commandLineArgs": "--pathbase=/relative-URL-path"
@@ -746,10 +746,10 @@ The `--urls` argument sets the IP addresses or host addresses with ports and pro
 * Pass the argument when running the app locally at a command prompt. From the app's directory, execute:
 
   ```dotnetcli
-  dotnet run --urls=http://127.0.0.1:0
+  dotnet watch --urls=http://127.0.0.1:0
   ```
 
-* Add an entry to the app's `launchSettings.json` file in the **IIS Express** profile. This setting is used when running the app with the Visual Studio Debugger and from a command prompt with `dotnet run`.
+* Add an entry to the app's `launchSettings.json` file in the **IIS Express** profile. This setting is used when running the app with the Visual Studio Debugger and from a command prompt with `dotnet watch` (or `dotnet run`).
 
   ```json
   "commandLineArgs": "--urls=http://127.0.0.1:0"

--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -53,7 +53,7 @@ For more information, see <xref:blazor/components/render-modes>.
   * `Properties` folder: Holds [development environment configuration](xref:fundamentals/environments#development-and-launchsettingsjson) in the `launchSettings.json` file.
 
     > [!NOTE]
-    > The `http` profile precedes the `https` profile in the `launchSettings.json` file. When an app is run with the .NET CLI, the app runs at an HTTP endpoint because the first profile found is `http`. The profile order eases the transition of adopting HTTPS for Linux and macOS users. If you prefer to start the app with the .NET CLI without having to pass the `-lp https` or `--launch-profile https` option to the `dotnet run` command, simply place the `https` profile above the `http` profile in the file.
+    > The `http` profile precedes the `https` profile in the `launchSettings.json` file. When an app is run with the .NET CLI, the app runs at an HTTP endpoint because the first profile found is `http`. The profile order eases the transition of adopting HTTPS for Linux and macOS users. If you prefer to start the app with the .NET CLI without having to pass the `-lp https` or `--launch-profile https` option to the `dotnet watch` (or `dotnet run`) command, simply place the `https` profile above the `http` profile in the file.
 
   * `wwwroot` folder: The [Web Root](xref:fundamentals/index#web-root) folder for the server project containing the app's public static assets.
 
@@ -310,7 +310,7 @@ Project structure:
 * `Properties` folder: Holds [development environment configuration](xref:fundamentals/environments#development-and-launchsettingsjson) in the `launchSettings.json` file.
 
   > [!NOTE]
-  > The `http` profile precedes the `https` profile in the `launchSettings.json` file. When an app is run with the .NET CLI, the app runs at an HTTP endpoint because the first profile found is `http`. The profile order eases the transition of adopting HTTPS for Linux and macOS users. If you prefer to start the app with the .NET CLI without having to pass the `-lp https` or `--launch-profile https` option to the `dotnet run` command, simply place the `https` profile above the `http` profile in the file.
+  > The `http` profile precedes the `https` profile in the `launchSettings.json` file. When an app is run with the .NET CLI, the app runs at an HTTP endpoint because the first profile found is `http`. The profile order eases the transition of adopting HTTPS for Linux and macOS users. If you prefer to start the app with the .NET CLI without having to pass the `-lp https` or `--launch-profile https` option to the `dotnet watch` (or `dotnet run`) command, simply place the `https` profile above the `http` profile in the file.
 
 * `wwwroot` folder: The [Web Root](xref:fundamentals/index#web-root) folder for the app containing the app's public static assets, including `appsettings.json` and environmental app settings files for [configuration settings](xref:blazor/fundamentals/configuration) and sample weather data (`sample-data/weather.json`). The `index.html` webpage is the root page of the app implemented as an HTML page:
   * When any page of the app is initially requested, this page is rendered and returned in the response.

--- a/aspnetcore/blazor/security/includes/run-the-app.md
+++ b/aspnetcore/blazor/security/includes/run-the-app.md
@@ -8,4 +8,4 @@ Run the app from the **`Server`** project. When using Visual Studio, either:
   * Use **Debug** > **Start Debugging** from the menu.
   * Press <kbd>F5</kbd>.
 
-* In a command shell, navigate to the **`Server`** project folder of the solution. Execute the `dotnet run` command.
+* In a command shell, navigate to the **`Server`** project folder of the solution. Execute the `dotnet watch` (or `dotnet run`) command.

--- a/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md
@@ -121,7 +121,7 @@ Use one of the following approaches to run the app:
   * Select the **Run** button.
   * Use **Debug** > **Start Debugging** from the menu.
   * Press <kbd>F5</kbd>.
-* .NET CLI command shell: Execute the `dotnet run` command from the app's folder.
+* .NET CLI command shell: Execute the `dotnet watch` (or `dotnet run`) command from the app's folder.
 
 ## Parts of the app
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md
@@ -101,7 +101,7 @@ Use one of the following approaches to run the app:
   * Select the **Run** button.
   * Use **Debug** > **Start Debugging** from the menu.
   * Press <kbd>F5</kbd>.
-* .NET CLI command shell: Execute the `dotnet run` command from the app's folder.
+* .NET CLI command shell: Execute the `dotnet watch` (or `dotnet run`) command from the app's folder.
 
 ## Parts of the app
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-accounts.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-accounts.md
@@ -77,7 +77,7 @@ Use one of the following approaches to run the app:
   * Select the **Run** button.
   * Use **Debug** > **Start Debugging** from the menu.
   * Press <kbd>F5</kbd>.
-* .NET CLI command shell: Execute the `dotnet run` command from the app's folder.
+* .NET CLI command shell: Execute the `dotnet watch` (or `dotnet run`) command from the app's folder.
 
 ## Parts of the app
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-entra-id.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-entra-id.md
@@ -81,7 +81,7 @@ Use one of the following approaches to run the app:
   * Select the **Run** button.
   * Use **Debug** > **Start Debugging** from the menu.
   * Press <kbd>F5</kbd>.
-* .NET CLI command shell: Execute the `dotnet run` command from the app's folder.
+* .NET CLI command shell: Execute the `dotnet watch` (or `dotnet run`) command from the app's folder.
 
 ## Parts of the app
 

--- a/aspnetcore/blazor/tutorials/signalr-blazor.md
+++ b/aspnetcore/blazor/tutorials/signalr-blazor.md
@@ -559,11 +559,16 @@ Press <kbd>F5</kbd> to run the app with debugging or <kbd>Ctrl</kbd>+<kbd>F5</kb
 
 # [.NET CLI](#tab/net-cli/)
 
-In a command shell from the [solution's](xref:blazor/tooling#visual-studio-solution-file-sln) folder, execute the following commands:
+In a command shell from the [solution's](xref:blazor/tooling#visual-studio-solution-file-sln) folder, execute the following command to change the directory to the `Server` project folder:
 
 ```dotnetcli
 cd Server
-dotnet run
+```
+
+Run the server project with the `dotnet watch` (or `dotnet run`) command:
+
+```dotnetcli
+dotnet watch
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
Fixes #32845

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/debug.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/debug.md) | [Debug ASP.NET Core apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/debug?branch=pr-en-us-32909) |
| [aspnetcore/blazor/host-and-deploy/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/host-and-deploy/index.md) | [[Visual Studio](#tab/visual-studio)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/index?branch=pr-en-us-32909) |
| [aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/host-and-deploy/multiple-hosted-webassembly.md) | [Multiple hosted ASP.NET Core Blazor WebAssembly apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/multiple-hosted-webassembly?branch=pr-en-us-32909) |
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-32909) |
| [aspnetcore/blazor/project-structure.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/project-structure.md) | [aspnetcore/blazor/project-structure](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/project-structure?branch=pr-en-us-32909) |
| [aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/security/webassembly/standalone-with-authentication-library.md) | [Secure an ASP.NET Core Blazor WebAssembly standalone app with the Authentication library](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-authentication-library?branch=pr-en-us-32909) |
| [aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/security/webassembly/standalone-with-azure-active-directory-b2c.md) | [Secure an ASP.NET Core Blazor WebAssembly standalone app with Azure Active Directory B2C](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-azure-active-directory-b2c?branch=pr-en-us-32909) |
| [aspnetcore/blazor/security/webassembly/standalone-with-microsoft-accounts.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-accounts.md) | [Secure an ASP.NET Core Blazor WebAssembly standalone app with Microsoft Accounts](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-microsoft-accounts?branch=pr-en-us-32909) |
| [aspnetcore/blazor/security/webassembly/standalone-with-microsoft-entra-id.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/security/webassembly/standalone-with-microsoft-entra-id.md) | [aspnetcore/blazor/security/webassembly/standalone-with-microsoft-entra-id](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-microsoft-entra-id?branch=pr-en-us-32909) |
| [aspnetcore/blazor/tutorials/signalr-blazor.md](https://github.com/dotnet/AspNetCore.Docs/blob/51bb4e9140d3a1f9e338878e327aa196004e252e/aspnetcore/blazor/tutorials/signalr-blazor.md) | [Use ASP.NET Core SignalR with Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/signalr-blazor?branch=pr-en-us-32909) |

<!-- PREVIEW-TABLE-END -->