### PR TITLE
[Blazor] Render-modes.md - null typography

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -287,7 +287,7 @@ else
 
 In the preceding example:
 
-* When the value of `AssignedRenderMode` is null, the component adopts static SSR. Blazor event handling isn't functional in a browser with static SSR, so the component submits a form (GET request) with a `titleFilter` query string set to the user's `<input>` value. The `Movie` component (`/movie`) can read the query string and process the value of `titleFilter` to render the component with the filtered results.
+* When the value of `AssignedRenderMode` is `null`, the component adopts static SSR. Blazor event handling isn't functional in a browser with static SSR, so the component submits a form (GET request) with a `titleFilter` query string set to the user's `<input>` value. The `Movie` component (`/movie`) can read the query string and process the value of `titleFilter` to render the component with the filtered results.
 * Otherwise, the render mode is any of `InteractiveServer`, `InteractiveWebAssembly`, or `InteractiveAuto`. The component is capable of using an event handler delegate (`FilterMovies`) and the value bound to the `<input>` element (`titleFilter`) to filter movies interactively over the background SignalR connection.
 
 :::moniker-end


### PR DESCRIPTION
cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/dfc187a6b5c0341f5b5a8f7beff641ea29d78f76/aspnetcore/blazor/components/render-modes.md) | [ASP.NET Core Blazor render modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-33008) |

<!-- PREVIEW-TABLE-END -->