### PR TITLE
Update quest-config.json

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -11,6 +11,10 @@
         {
             "Label": "9.0",
             "Tag": "new feature"
+        },
+        {
+            "Label": ":label: content-curation",
+            "Tag": "content-curation"
         }
     ]
 }


### PR DESCRIPTION
- Add the content curation tag for quest items.

The actual github label used to trigger the quest label is something you can change. I used `🏷️ content-curation` but feel free to edit this PR to change it to what you want.

You'll need to add this label to this repo and then use it for curation items.