### PR TITLE
Fix syntax error in openapi9.md

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/includes/openapi9.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/openapi9.md
@@ -111,7 +111,7 @@ Using <xref:Microsoft.AspNetCore.Http.TypedResults> in the implementation of an 
 ```csharp
 app.MapGet("/todos", async (TodoDb db) =>
 {
-    var todos = await db.Todos.ToListAsync());
+    var todos = await db.Todos.ToListAsync();
     return TypedResults.Ok(todos);
 });
 ```


### PR DESCRIPTION
This PR removes an extra closing parenthesis to fix a syntax error.