### PR TITLE
gRPC health checks security

### DIFF
--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -50,7 +50,7 @@ gRPC health checks returns health status about an app, which could be sensitive 
 
 Access to the service can be controlled through standard ASP.NET Core authorization extension methods, such as [`AllowAnonymous`](/dotnet/api/microsoft.aspnetcore.builder.authorizationendpointconventionbuilderextensions.allowanonymous) and [`RequireAuthorization`](/dotnet/api/microsoft.aspnetcore.builder.authorizationendpointconventionbuilderextensions.requireauthorization).
 
-For example, if an app has been configured to require authorizaiton by default, configuration the gRPC health checks endpoint with `AllowAnonymous()` to skip authentication and authorization.
+For example, if an app has been configured to require authorizaiton by default, configure the gRPC health checks endpoint with `AllowAnonymous` to skip authentication and authorization.
 
 ```csharp
 app.MapGrpcHealthChecksService().AllowAnonymous();

--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -44,6 +44,18 @@ When health checks is set up:
   * `NotServing` is reported when there are any health results of <xref:Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus.Unhealthy?displayProperty=nameWithType>.
   * Otherwise, `Serving` is reported.
 
+### Health checks service security
+
+gRPC health checks returns health status about an app, which could be sensitive information. Care should be taken to limit access to the gRPC health checks service.
+
+Access to the service can be controlled through standard ASP.NET Core authorization extension methods, such as <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.AllowAnonymous<TBuilder>(TBuilder)> and <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization<TBuilder>(TBuilder)>.
+
+For example, if an app has been configured to require authorizaiton by default, configuration the gRPC health checks endpoint with `AllowAnonymous()` to skip authentication and authorization.
+
+```csharp
+app.MapGrpcHealthChecksService().AllowAnonymous();
+```
+
 ### Configure `Grpc.AspNetCore.HealthChecks`
 
 By default, the gRPC health checks service uses all registered health checks to determine health status. gRPC health checks can be customized when registered to use a subset of health checks. The `MapService` method is used to map health results to service names, along with a predicate for filtering health results:

--- a/aspnetcore/grpc/health-checks.md
+++ b/aspnetcore/grpc/health-checks.md
@@ -48,7 +48,7 @@ When health checks is set up:
 
 gRPC health checks returns health status about an app, which could be sensitive information. Care should be taken to limit access to the gRPC health checks service.
 
-Access to the service can be controlled through standard ASP.NET Core authorization extension methods, such as <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.AllowAnonymous<TBuilder>(TBuilder)> and <xref:Microsoft.AspNetCore.Builder.AuthorizationEndpointConventionBuilderExtensions.RequireAuthorization<TBuilder>(TBuilder)>.
+Access to the service can be controlled through standard ASP.NET Core authorization extension methods, such as [`AllowAnonymous`](/dotnet/api/microsoft.aspnetcore.builder.authorizationendpointconventionbuilderextensions.allowanonymous) and [`RequireAuthorization`](/dotnet/api/microsoft.aspnetcore.builder.authorizationendpointconventionbuilderextensions.requireauthorization).
 
 For example, if an app has been configured to require authorizaiton by default, configuration the gRPC health checks endpoint with `AllowAnonymous()` to skip authentication and authorization.
 


### PR DESCRIPTION
Like https://github.com/dotnet/AspNetCore.Docs/pull/33092 but for health checks which is registered in a similar way.

Expert required to fix up the busted API links.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/health-checks.md](https://github.com/dotnet/AspNetCore.Docs/blob/a10c7a372181aa44fef45b7eb7107dc93784d6db/aspnetcore/grpc/health-checks.md) | [gRPC health checks in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/health-checks?branch=pr-en-us-33093) |


<!-- PREVIEW-TABLE-END -->