### PR TITLE
Clarify setting the resource path value

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -1618,7 +1618,7 @@ To create localization shared resources, adopt the following approach.
   * `Localization/SharedResource.es.resx`
 
   > [!NOTE]
-  > Use <xref:Microsoft.Extensions.Localization.LocalizationOptions.ResourcesPath%2A?displayProperty=nameWithType> to set a different path when shared resource files aren't in the same folder as the dummy class. **Supply a path relative to the location of the dummy class, not the root of the app.**
+  > Use <xref:Microsoft.Extensions.Localization.LocalizationOptions.ResourcesPath%2A?displayProperty=nameWithType> to set a different path for resource files that aren't in the same folder as the dummy class. When providing a resources path, make the path relative to the location of the dummy class. If you supply a resource path, you can't simultaneously use <xref:Microsoft.Extensions.Localization.IStringLocalizerFactory.Create%2A?displayProperty=nameWithType> to load resources.
 
 * To reference the dummy class for an injected <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> in a Razor component, either place an [`@using`](xref:mvc/views/razor#using) directive for the localization namespace or include the localization namespace in the dummy class reference. In the following examples:
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -1617,8 +1617,8 @@ To create localization shared resources, adopt the following approach.
   * `Localization/SharedResource.resx`
   * `Localization/SharedResource.es.resx`
 
-  > [!NOTE]
-  > Use <xref:Microsoft.Extensions.Localization.LocalizationOptions.ResourcesPath%2A?displayProperty=nameWithType> to set a different path for resource files that aren't in the same folder as the dummy class. When providing a resources path, make the path relative to the location of the dummy class. If you supply a resource path, you can't simultaneously use <xref:Microsoft.Extensions.Localization.IStringLocalizerFactory.Create%2A?displayProperty=nameWithType> to load resources.
+  > [!WARNING]
+  > When following the approach in this section, you can't simultaneously set <xref:Microsoft.Extensions.Localization.LocalizationOptions.ResourcesPath%2A?displayProperty=nameWithType> and use <xref:Microsoft.Extensions.Localization.IStringLocalizerFactory.Create%2A?displayProperty=nameWithType> to load resources.
 
 * To reference the dummy class for an injected <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> in a Razor component, either place an [`@using`](xref:mvc/views/razor#using) directive for the localization namespace or include the localization namespace in the dummy class reference. In the following examples:
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -1618,7 +1618,7 @@ To create localization shared resources, adopt the following approach.
   * `Localization/SharedResource.es.resx`
 
   > [!NOTE]
-  > `Localization` is resource path that can be set via <xref:Microsoft.Extensions.Localization.LocalizationOptions>.
+  > Use <xref:Microsoft.Extensions.Localization.LocalizationOptions.ResourcesPath%2A?displayProperty=nameWithType> to set a different path when shared resource files aren't in the same folder as the dummy class. **Supply a path relative to the location of the dummy class, not the root of the app.**
 
 * To reference the dummy class for an injected <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> in a Razor component, either place an [`@using`](xref:mvc/views/razor#using) directive for the localization namespace or include the localization namespace in the dummy class reference. In the following examples:
 


### PR DESCRIPTION
Fixes #33078

Thanks @voroninp! 🚀 ... I'm not aware of how `IStringLocalizer` comes into the pattern, so I didn't remark on ...

> It also means that combining the usage of both `IStringLocalizer` and `IStringLocalizer<T>` when resources are placed differently won't work.

The section's approach only uses `IStringLocalizer<T>`. Do you want to suggest a line of text for the note on that? It can't state "combined usage of." It has to say which one isn't supported in this scenario, and it might add a remark on why.

cc: @hishamco ... Do you want to review?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/globalization-localization.md](https://github.com/dotnet/AspNetCore.Docs/blob/31a2ef5da1a7cf4076e18953aca0b2f180a17a8a/aspnetcore/blazor/globalization-localization.md) | [ASP.NET Core Blazor globalization and localization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?branch=pr-en-us-33102) |


<!-- PREVIEW-TABLE-END -->