### PR TITLE
Error handling section improvements

### DIFF
--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -208,8 +208,8 @@ The framework terminates a circuit when an unhandled exception occurs for the fo
 
 For approaches to handling exceptions globally, see the following sections:
 
-* [Error boundaries](#error-boundaries): Useful in any Blazor app.
-* [Alternative global exception handling](#alternative-global-exception-handling)
+* [Error boundaries](#error-boundaries): Applies to all Blazor apps.
+* [Alternative global exception handling](#alternative-global-exception-handling): Applies to Blazor Server, Blazor WebAssembly, and Blazor Web Apps (8.0 or later) that adopt a global interactive render mode.
 
 ## Error boundaries
 


### PR DESCRIPTION
Fixes  #33091

Thanks @TimMurphy! 🚀 ... This PR has the section clarify that the alternative approach is only for Blazor WASM, Blazor Server, and BWAs that adopt a global interactive render mode. It includes an explanation on why that's the case with BWAs. I went with "`ProcessError`" for the component name to avoid a conflict with the `Error` component in the BWA template. The component's demonstration method is now "`LogError`." I also made some additional description improvements, and I resurfaced the Blazor Server coverage because we're still supporting Blazor Server ... it's just not a project template any longer.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/handle-errors.md](https://github.com/dotnet/AspNetCore.Docs/blob/c22526e5dd811f5e8303fe895d5eb6e629b5c4a9/aspnetcore/blazor/fundamentals/handle-errors.md) | [Handle errors in ASP.NET Core Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/handle-errors?branch=pr-en-us-33106) |


<!-- PREVIEW-TABLE-END -->