### PR TITLE
Add composite file provider guidance

### DIFF
--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -237,7 +237,7 @@ For the location of `<head>` content where static file links are placed, see <xr
 
 :::moniker-end
 
-.NET 9 or later
+### .NET 9 or later
 
 App type | `href` value | Examples
 --- | --- | ---
@@ -245,7 +245,7 @@ Blazor Web App | `@Assets["{PATH}"]` | `<link rel="stylesheet" href="@Assets["ap
 Blazor Server&dagger; | `@Assets["{PATH}"]` | `<link href="@Assets["css/site.css"]" rel="stylesheet" />`<br>`<link href="@Assets["_content/ComponentLib/styles.css"]" rel="stylesheet" />`
 Standalone Blazor WebAssembly | `{PATH}` | `<link rel="stylesheet" href="css/app.css" />`<br>`<link href="_content/ComponentLib/styles.css" rel="stylesheet" />`
 
-.NET 8.x
+### .NET 8.x
 
 App type | `href` value | Examples
 --- | --- | ---
@@ -253,7 +253,7 @@ Blazor Web App | `{PATH}` | `<link rel="stylesheet" href="app.css" />`<br>`<link
 Blazor Server&dagger; | `{PATH}` | `<link href="css/site.css" rel="stylesheet" />`<br>`<link href="_content/ComponentLib/styles.css" rel="stylesheet" />`
 Standalone Blazor WebAssembly | `{PATH}` | `<link rel="stylesheet" href="css/app.css" />`<br>`<link href="_content/ComponentLib/styles.css" rel="stylesheet" />`
 
-.NET 7.x or earlier
+### .NET 7.x or earlier
 
 App type | `href` value | Examples
 --- | --- | ---
@@ -472,6 +472,53 @@ To create additional file mappings with a <xref:Microsoft.AspNetCore.StaticFiles
       .StartsWithSegments("/_framework/blazor.server.js"),
           subApp => subApp.UseStaticFiles(new StaticFileOptions() { ... }));
   ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
+
+## Serve files from multiple locations
+
+*The guidance in this section only applies to Blazor Web Apps.*
+
+To serve files from multiple locations with a <xref:Microsoft.Extensions.FileProviders.CompositeFileProvider>:
+
+* Add the namespace for <xref:Microsoft.Extensions.FileProviders?displayProperty=fullName> to the top of the `Program` file of the server project.
+* In the server project's `Program` file ***before*** the call to <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A>:
+  * Create a <xref:Microsoft.Extensions.FileProviders.PhysicalFileProvider> with the path to the static assets.
+  * Create a <xref:Microsoft.Extensions.FileProviders.CompositeFileProvider> from the <xref:Microsoft.AspNetCore.Hosting.IWebHostEnvironment.WebRootFileProvider> and the <xref:Microsoft.Extensions.FileProviders.PhysicalFileProvider>. Assign the composite file provider back to the app's <xref:Microsoft.AspNetCore.Hosting.IWebHostEnvironment.WebRootFileProvider>.
+
+Example:
+
+Create a new folder in the server project named `AdditionalStaticAssets`. Place an image into the folder.
+
+Add the following `using` statement to the top of the server project's `Program` file:
+
+```csharp
+using Microsoft.Extensions.FileProviders;
+```
+
+In the server project's `Program` file ***before*** the call to <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A>, add the following code:
+
+```csharp
+var secondaryProvider = new PhysicalFileProvider(
+    Path.Combine(builder.Environment.ContentRootPath, "AdditionalStaticAssets"));
+app.Environment.WebRootFileProvider = new CompositeFileProvider(
+    app.Environment.WebRootFileProvider, secondaryProvider);
+```
+
+In the app's `Home` component (`Home.razor`) markup, reference the image with an `<img>` tag:
+
+```razor
+<img src="{IMAGE FILE NAME}" alt="{ALT TEXT}" />
+```
+
+In the preceding example:
+
+* The `{IMAGE FILE NAME}` placeholder is the image file name. There's no need to provide a path segment if the image file is at the root of the `AdditionalStaticAssets` folder.
+* The `{ALT TEXT}` placeholder is the image alternate text.
+
+Run the app.
 
 :::moniker-end
 

--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -248,6 +248,9 @@ The following code updates the `WebRootFileProvider`, which enables the Image Ta
 
 [!code-csharp[](~/fundamentals/static-files/samples/9.x/StaticFilesSample/Program.cs?name=snippet_mult2)]
 
+> [!NOTE]
+> The preceding approach applies to Razor Pages and MVC apps. For guidance that applies to Blazor Web Apps, see <xref:blazor/fundamentals/static-files#serve-files-from-multiple-locations>.
+
 <a name="sc"></a>
 
 ### Security considerations for static files

--- a/aspnetcore/fundamentals/static-files/includes/static-files8.md
+++ b/aspnetcore/fundamentals/static-files/includes/static-files8.md
@@ -229,6 +229,9 @@ The following code updates the `WebRootFileProvider`, which enables the Image Ta
 
 [!code-csharp[](~/fundamentals/static-files/samples/6.x/StaticFilesSample/Program.cs?name=snippet_mult2)]
 
+> [!NOTE]
+> The preceding approach applies to Razor Pages and MVC apps. For guidance that applies to Blazor Web Apps, see <xref:blazor/fundamentals/static-files#serve-files-from-multiple-locations>.
+
 <a name="sc"></a>
 
 ### Security considerations for static files


### PR DESCRIPTION
Fixes #32891

Thanks @ventureaaron! 🚀 ... I tested the other approach earlier in the main doc set section with the physical file provider. That one worked ok in a BWA ... and both of them work in a Blazor Server app at 8.0. It looks like it was just the composite file provider that doesn't work in a BWA, so that's the focus of the PR.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/static-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/4407f6a25f3533349bcffcdbcb518efe2bf4544d/aspnetcore/blazor/fundamentals/static-files.md) | [ASP.NET Core Blazor static files](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?branch=pr-en-us-33118) |
| [aspnetcore/fundamentals/static-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/4407f6a25f3533349bcffcdbcb518efe2bf4544d/aspnetcore/fundamentals/static-files.md) | [Static files in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/static-files?branch=pr-en-us-33118) |

<!-- PREVIEW-TABLE-END -->