### PR TITLE
Fix spelling issues

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -48,7 +48,7 @@ Developers typically create Razor components from Razor component files (`.razor
 
 Components use [Razor syntax](xref:mvc/views/razor). Two Razor features are extensively used by components, *directives* and *directive attributes*. These are reserved keywords prefixed with `@` that appear in Razor markup:
 
-* [Directives](xref:mvc/views/razor#directives): Change the way component markup is compiled or functions. For example, the [`@page`][9] directive specifies a routable component with a route template and can be reached directly by a user's request in the browser at a specific URL.
+* [Directives](xref:mvc/views/razor#directives): Change the way component markup is compiled or functions. For example, the [`@page`][9] directive specifies a routable component with a route template that can be reached directly by a user's request in the browser at a specific URL.
 
   By convention, a component's directives at the top of a component definition (`.razor` file) are placed in a consistent order. For repeated directives, directives are placed alphabetically by namespace or type, except `@using` directives, which have special second-level ordering.
   

--- a/aspnetcore/blazor/components/js-spa-frameworks.md
+++ b/aspnetcore/blazor/components/js-spa-frameworks.md
@@ -43,7 +43,7 @@ The example in this section renders the following Razor component into a page vi
 
 In the `Program` file, add the [namespace for the location of the component](xref:blazor/components/index#component-name-class-name-and-namespace).
 
-Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register the a Razor component as a root component for JS rendering.
+Call <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> on the app's root component collection to register a Razor component as a root component for JS rendering.
 
 <xref:Microsoft.AspNetCore.Components.Web.JSComponentConfigurationExtensions.RegisterForJavaScript%2A> includes an overload that accepts the name of a JS function that executes initialization logic (`javaScriptInitializer`). The JS function is called once per component registration immediately after the Blazor app starts and before any components are rendered. This function can be used for integration with JS technologies, such as HTML custom elements or a JS-based SPA framework.
 

--- a/aspnetcore/blazor/components/layouts.md
+++ b/aspnetcore/blazor/components/layouts.md
@@ -105,7 +105,7 @@ In an app created from a [Blazor project template](xref:blazor/project-structure
   @using BlazorSample.Components.Layout
   ```
 
-* Add an `@using` directive at the top the component definition where the layout is used:
+* Add an `@using` directive at the top of the component definition where the layout is used:
 
   ```razor
   @using BlazorSample.Components.Layout

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -34,7 +34,7 @@ Component lifecycle events:
 1. Render for all synchronous work and complete <xref:System.Threading.Tasks.Task>s.
 
 > [!NOTE]
-> Asynchronous actions performed in lifecycle events might not have been completed before a component is rendered. For more information, see the [Handle incomplete async actions at render](#handle-incomplete-async-actions-at-render) section later in this article.
+> Asynchronous actions performed in lifecycle events might not complete before a component is rendered. For more information, see the [Handle incomplete async actions at render](#handle-incomplete-async-actions-at-render) section later in this article.
 
 A parent component renders before its children components because rendering is what determines which children are present. If synchronous parent component initialization is used, the parent initialization is guaranteed to be completed first. If asynchronous parent component initialization is used, the completion order of parent and child component initialization can't be determined because it depends on the initialization code running.
 

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -34,9 +34,9 @@ Component lifecycle events:
 1. Render for all synchronous work and complete <xref:System.Threading.Tasks.Task>s.
 
 > [!NOTE]
-> Asynchronous actions performed in lifecycle events might not have completed before a component is rendered. For more information, see the [Handle incomplete async actions at render](#handle-incomplete-async-actions-at-render) section later in this article.
+> Asynchronous actions performed in lifecycle events might not have been completed before a component is rendered. For more information, see the [Handle incomplete async actions at render](#handle-incomplete-async-actions-at-render) section later in this article.
 
-A parent component renders before its children components because rendering is what determines which children are present. If synchronous parent component initialization is used, the parent initialization is guaranteed to complete first. If asynchronous parent component initialization is used, the completion order of parent and child component initialization can't be determined because it depends on the initialization code running.
+A parent component renders before its children components because rendering is what determines which children are present. If synchronous parent component initialization is used, the parent initialization is guaranteed to be completed first. If asynchronous parent component initialization is used, the completion order of parent and child component initialization can't be determined because it depends on the initialization code running.
 
 <!-- UPDATE 9.0 Update the diagram to drop "Property injection"?
                 https://github.com/dotnet/AspNetCore.Docs/issues/32091 -->

--- a/aspnetcore/blazor/components/lifecycle.md
+++ b/aspnetcore/blazor/components/lifecycle.md
@@ -36,7 +36,7 @@ Component lifecycle events:
 > [!NOTE]
 > Asynchronous actions performed in lifecycle events might not complete before a component is rendered. For more information, see the [Handle incomplete async actions at render](#handle-incomplete-async-actions-at-render) section later in this article.
 
-A parent component renders before its children components because rendering is what determines which children are present. If synchronous parent component initialization is used, the parent initialization is guaranteed to be completed first. If asynchronous parent component initialization is used, the completion order of parent and child component initialization can't be determined because it depends on the initialization code running.
+A parent component renders before its children components because rendering is what determines which children are present. If synchronous parent component initialization is used, the parent initialization is guaranteed to complete first. If asynchronous parent component initialization is used, the completion order of parent and child component initialization can't be determined because it depends on the initialization code running.
 
 <!-- UPDATE 9.0 Update the diagram to drop "Property injection"?
                 https://github.com/dotnet/AspNetCore.Docs/issues/32091 -->


### PR DESCRIPTION
Hello
I found several spelling issues in your docs.
Hope it helps.
Br, Elias.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/fa114b219a3f11002680c5c2a42df26faadb2ad1/aspnetcore/blazor/components/index.md) | [ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/index?branch=pr-en-us-33133) |
| [aspnetcore/blazor/components/js-spa-frameworks.md](https://github.com/dotnet/AspNetCore.Docs/blob/fa114b219a3f11002680c5c2a42df26faadb2ad1/aspnetcore/blazor/components/js-spa-frameworks.md) | [Use Razor components in JavaScript apps and SPA frameworks](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/js-spa-frameworks?branch=pr-en-us-33133) |
| [aspnetcore/blazor/components/layouts.md](https://github.com/dotnet/AspNetCore.Docs/blob/fa114b219a3f11002680c5c2a42df26faadb2ad1/aspnetcore/blazor/components/layouts.md) | [ASP.NET Core Blazor layouts](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/layouts?branch=pr-en-us-33133) |
| [aspnetcore/blazor/components/lifecycle.md](https://github.com/dotnet/AspNetCore.Docs/blob/fa114b219a3f11002680c5c2a42df26faadb2ad1/aspnetcore/blazor/components/lifecycle.md) | [ASP.NET Core Razor component lifecycle](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/lifecycle?branch=pr-en-us-33133) |


<!-- PREVIEW-TABLE-END -->