### PR TITLE
Dynamic endpoint discovery is in VS 17.11

### DIFF
--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -473,7 +473,7 @@ Some aspects of `.http` file behavior can be configured. To see what's available
 
 **Endpoints Explorer** is a tool window that shows all the endpoints that a web API defines. The tool enables you to send requests to the endpoints by using an `.http` file.
 
-The initial set of endpoints that **Endpoints Explorer** displays are discovered statically. There are some endpoints that can't be discovered statically. For example, endpoints defined in a class library project can't be discovered until runtime. When you run or debug a web API, Visual Studio also discovers endpoints dynamically at run time and adds those to **Endpoints Explorer**.
+The initial set of endpoints that **Endpoints Explorer** displays are discovered statically. There are some endpoints that can't be discovered statically. For example, endpoints defined in a class library project can't be discovered until runtime. When you run or debug a web API, Visual Studio version 17.11 Preview discovers endpoints dynamically at run time also and adds those to **Endpoints Explorer**.
 
 ### Open Endpoints Explorer
 


### PR DESCRIPTION
Mention that you don't get dynamic endpoint discovery until you have 17.11

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/http-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/4dbf150d5a3ebfec7d5d32cf3b06f76071847461/aspnetcore/test/http-files.md) | [Use .http files in Visual Studio 2022](https://review.learn.microsoft.com/en-us/aspnet/core/test/http-files?branch=pr-en-us-33138) |

<!-- PREVIEW-TABLE-END -->