### PR TITLE
Update the floating labels in Register.cshtml 

### DIFF
--- a/aspnetcore/security/authentication/add-user-data/samples/6.x/SampleApp/Areas/Identity/Pages/Account/Register.cshtml
+++ b/aspnetcore/security/authentication/add-user-data/samples/6.x/SampleApp/Areas/Identity/Pages/Account/Register.cshtml
@@ -14,13 +14,13 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
 
             <div class="form-floating">
-                <label asp-for="Input.Name"></label>
                 <input asp-for="Input.Name" class="form-control" />
+                <label asp-for="Input.Name"></label>
                 <span asp-validation-for="Input.Name" class="text-danger"></span>
             </div>
             <div class="form-floating">
-                <label asp-for="Input.DOB"></label>
                 <input asp-for="Input.DOB" class="form-control" />
+                <label asp-for="Input.DOB"></label>
                 <span asp-validation-for="Input.DOB" class="text-danger"></span>
             </div>
 


### PR DESCRIPTION
When using the `form-floating` to enable floating labels with Bootstrap’s textual form fields, the `<input>` must come first, otherwise it might cause the labels overflow issue. Refer to this document: https://getbootstrap.com/docs/5.0/forms/floating-labels/



Fixes #33153