### PR TITLE
Fix bad link

### DIFF
--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -132,7 +132,7 @@ The preceding approach requires a page or endpoint per file. The following code 
 
 :::code language="csharp" source="~/fundamentals/static-files/samples/9.x/StaticFileAuth/Program.cs" id="snippet_1":::
 
-IFormFile in the preceding sample uses memory buffer for uploading. For handling large file use streaming. See [Upload large files with streaming](/mvc/models/file-uploads#upload-large-files-with-streaming).
+IFormFile in the preceding sample uses memory buffer for uploading. For handling large file use streaming. See [Upload large files with streaming](xref:mvc/models/file-uploads#upload-large-files-with-streaming).
 
 See the [StaticFileAuth](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/fundamentals/static-files/samples/9.x/StaticFileAuth) GitHub folder for the complete sample.
 


### PR DESCRIPTION
# 😈 

This link somehow got past the build and was merged, which I think is breaking the live merge ...

https://buildapi.docs.microsoft.com/Output/PullRequest/332f35cd-658d-4914-0f85-907e40ee89f0/202407250151226132-33050/BuildReport?accessString=a36de54572e65899527793f95eab7201f190f021e15d8c7388d7eb32ce2d027f

Trying to fix it here, but the build system isn't cooperating at the moment.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/static-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/7148de58da5771b723827db8d896532f2645803f/aspnetcore/fundamentals/static-files.md) | [Static files in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/static-files?branch=pr-en-us-33198) |

<!-- PREVIEW-TABLE-END -->