### PR TITLE
Min Web API: Remove using statement update content & code

### DIFF
--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -208,7 +208,7 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 * In Program.cs add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
-  [!code-csharp[](~/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
+  [!code-csharp[](~/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=7-13)]
 
 In the previous code:
 

--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -208,7 +208,7 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 * In Program.cs add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
-  [!code-csharp[](~/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=9-15)]
+  [!code-csharp[](~/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
 
 In the previous code:
 

--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -3,7 +3,7 @@ title: "Tutorial: Create a minimal API with ASP.NET Core"
 author: wadepickett
 description: Learn how to build a minimal API with ASP.NET Core.
 ms.author: wpickett
-ms.date: 06/27/2024
+ms.date: 07/29/2024
 ms.custom: engagement-fy24
 monikerRange: '>= aspnetcore-6.0'
 uid: tutorials/min-web-api
@@ -206,13 +206,9 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 ### Configure Swagger middleware
 
-* In Program.cs add the following `using` statements at the top:
+* In Program.cs add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
-  [!code-csharp[](~/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_using_statements)]
-
-* Add the following highlighted code before `app` is defined in line `var app = builder.Build();`
-
-  [!code-csharp[](~/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
+  [!code-csharp[](~/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=9-15)]
 
 In the previous code:
 

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
@@ -172,13 +172,9 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 ### Configure Swagger middleware
 
-* In Program.cs add the following `using` statements at the top:
-
-  [!code-csharp[](~/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_using_statements)]
-
 * Add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
-  [!code-csharp[](~/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
+  [!code-csharp[](~/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=7-13)]
 
 In the previous code:
 

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
@@ -172,6 +172,10 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 ### Configure Swagger middleware
 
+* In Program.cs add the following `using` statements at the top:
+
+  [!code-csharp[](~/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_using_statements)]
+
 * Add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
   [!code-csharp[](~/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
@@ -631,7 +635,7 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 * Add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
-  [!code-csharp[](~/tutorials/min-web-api/samples/6.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=7-13)]
+  [!code-csharp[](~/tutorials/min-web-api/samples/6.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
 
 In the previous code:
 

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
@@ -172,10 +172,6 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 ### Configure Swagger middleware
 
-* In Program.cs add the following `using` statements at the top:
-
-  [!code-csharp[](~/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_using_statements)]
-
 * Add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
   [!code-csharp[](~/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
@@ -631,7 +631,7 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 * Add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
-  [!code-csharp[](~/tutorials/min-web-api/samples/6.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
+  [!code-csharp[](~/tutorials/min-web-api/samples/6.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=7-13)]
 
 In the previous code:
 

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api8.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api8.md
@@ -187,13 +187,9 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 ### Configure Swagger middleware
 
-* In Program.cs add the following `using` statements at the top:
-
-  [!code-csharp[](~/tutorials/min-web-api/samples/8.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_using_statements)]
-
 * Add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
-  [!code-csharp[](~/tutorials/min-web-api/samples/8.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
+  [!code-csharp[](~/tutorials/min-web-api/samples/8.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=9-15)]
 
 In the previous code:
 

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api8.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api8.md
@@ -189,7 +189,7 @@ The previous command adds the [NSwag.AspNetCore](https://www.nuget.org/packages/
 
 * Add the following highlighted code before `app` is defined in line `var app = builder.Build();`
 
-  [!code-csharp[](~/tutorials/min-web-api/samples/8.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=9-15)]
+  [!code-csharp[](~/tutorials/min-web-api/samples/8.x/todo_SwaggerVersion/Program.cs?name=snippet_swagger_add_service&highlight=8-14)]
 
 In the previous code:
 

--- a/aspnetcore/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/7.x/todo_SwaggerVersion/Program.cs
@@ -12,8 +12,6 @@ app.Run();
 // <snippet_all>
 // <snippet_swagger_add_service>
 // <snippet_swagger_using_statements>
-using NSwag.AspNetCore;
-// </snippet_swagger_using_statements>
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/aspnetcore/tutorials/min-web-api/samples/9.x/todoDTO_SwaggerVersion/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/9.x/todoDTO_SwaggerVersion/Program.cs
@@ -1,5 +1,4 @@
 // <snippet_all>
-using NSwag.AspNetCore;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/aspnetcore/tutorials/min-web-api/samples/9.x/todoGroup_SwaggerVersion/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/9.x/todoGroup_SwaggerVersion/Program.cs
@@ -1,5 +1,4 @@
 // <snippet_all>
-using NSwag.AspNetCore;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/aspnetcore/tutorials/min-web-api/samples/9.x/todoTypedResults_SwaggerVersion/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/9.x/todoTypedResults_SwaggerVersion/Program.cs
@@ -1,5 +1,4 @@
 // <snippet_all>
-using NSwag.AspNetCore;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);

--- a/aspnetcore/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs
+++ b/aspnetcore/tutorials/min-web-api/samples/9.x/todo_SwaggerVersion/Program.cs
@@ -11,9 +11,6 @@ app.Run();
 #elif FINAL
 // <snippet_all>
 // <snippet_swagger_add_service>
-// <snippet_swagger_using_statements>
-using NSwag.AspNetCore;
-// </snippet_swagger_using_statements>
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);


### PR DESCRIPTION
fixes #32769

For VS Code tab version:

- Removed unneeded using statement for Nswag from code samples and removed instructions from topic.
- Updated code line highlights to match code update.
- Tested code by instructions for versions 7-9.
- Did side by side comparison of build version in browser to verify code, text and code highlighting correct.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/min-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/698fc0d7746e752c1458274bacf3ca814a5661c7/aspnetcore/tutorials/min-web-api.md) | [Tutorial: Create a minimal API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?branch=pr-en-us-33200) |


<!-- PREVIEW-TABLE-END -->