### PR TITLE
Add roles/groups coverage to the BWA+OIDC article

### DIFF
--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -636,7 +636,7 @@ A nonce isn't required or used when a refresh token is exchanged for a new acces
 
 ## Application roles for apps not registered with Microsoft Entra (ME-ID)
 
-*This section pertains to apps that don't use ME-ID as the identity provider. For apps registered with [Microsoft Entra ID (ME-ID)](https://www.microsoft.com/security/business/microsoft-entra), see the [Application roles for apps registered with Microsoft Entra (ME-ID)](#application-roles-for-apps-registered-with-microsoft-entra-me-id) section.*
+*This section pertains to apps that don't use [Microsoft Entra ID (ME-ID)](https://www.microsoft.com/security/business/microsoft-entra) as the identity provider. For apps registered with ME-ID, see the [Application roles for apps registered with Microsoft Entra (ME-ID)](#application-roles-for-apps-registered-with-microsoft-entra-me-id) section.*
 
 Configure the role claim type (<xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.RoleClaimType?displayProperty=nameWithType>) in the <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions> of `Program.cs`:
 
@@ -709,13 +709,13 @@ Configure the role claim type (<xref:Microsoft.IdentityModel.Tokens.TokenValidat
 oidcOptions.TokenValidationParameters.RoleClaimType = "roles";
 ```
 
-Although you can't [assign roles to groups](/entra/identity/role-based-access-control/groups-concept) without an Microsoft Entra ID Premium account, you can assign roles to users and receive role claims for users with a standard Azure account. The guidance in this section doesn't require an ME-ID Premium account.
+Although you can't [assign roles to groups](/entra/identity/role-based-access-control/groups-concept) without an ME-ID Premium account, you can assign roles to users and receive role claims for users with a standard Azure account. The guidance in this section doesn't require an ME-ID Premium account.
 
 When working with the default directory, follow the guidance in [Add app roles to your application and receive them in the token (ME-ID documentation)](/entra/identity-platform/howto-add-app-roles-in-apps) to configure and assign roles. If you aren't working with the default directory, edit the app's manifest in the Azure portal to establish the app's roles manually in the `appRoles` entry of the manifest file. For more information, see [Configure the role claim (ME-ID documentation)](/entra/identity-platform/enterprise-app-role-management).
 
 A user's Azure security groups arrive in `groups` claims, and a user's built-in ME-ID administrator role assignments arrive in [well-known IDs (`wids`) claims](/entra/identity-platform/access-tokens#payload-claims). Values for both claim types are GUIDs. When received by the app, these claims can be used to establish [role and policy authorization in Razor components](xref:blazor/security/index#role-based-and-policy-based-authorization).
 
-In the app's manifest in the Azure portal, set the [`groupMembershipClaims` attribute](/entra/identity-platform/reference-app-manifest#groupmembershipclaims-attribute) to `All`. A value of `All` results in ME-ID sending all of the security/distribution groups (`groups` claims) and roles of the signed-in user (`wids` claims). To set the `groupMembershipClaims` attribute:
+In the app's manifest in the Azure portal, set the [`groupMembershipClaims` attribute](/entra/identity-platform/reference-app-manifest#groupmembershipclaims-attribute) to `All`. A value of `All` results in ME-ID sending all of the security/distribution groups (`groups` claims) and roles (`wids` claims) of the signed-in user. To set the `groupMembershipClaims` attribute:
 
 1. Open the app's registration in the Azure portal.
 1. Select **Manage** > **Manifest** in the sidebar.
@@ -803,4 +803,3 @@ At this point, Razor components can adopt [role-based and policy-based authoriza
 * [`AuthenticationStateProvider` service](xref:blazor/security/index#authenticationstateprovider-service)
 * [Manage authentication state in Blazor Web Apps](xref:blazor/security/server/index#manage-authentication-state-in-blazor-web-apps)
 * [Refresh token during http request in Blazor Interactive Server with OIDC (`dotnet/aspnetcore` #55213)](https://github.com/dotnet/aspnetcore/issues/55213)
-* 

--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -145,7 +145,7 @@ The following <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConn
   oidcOptions.ResponseType = OpenIdConnectResponseType.Code;
   ```
 
-* <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> and configuration of <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType%2A> and <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.RoleClaimType%2A>: Many OIDC servers use "`name`" and "`role`" rather than the SOAP/WS-Fed defaults in <xref:System.Security.Claims.ClaimTypes>. When <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> is set to `false`, the handler doesn't perform claims mappings and the claim names from the JWT are used directly by the app. The following example manually maps the name and role claims:
+* <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> and configuration of <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType%2A> and <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.RoleClaimType%2A>: Many OIDC servers use "`name`" and "`role`" rather than the SOAP/WS-Fed defaults in <xref:System.Security.Claims.ClaimTypes>. When <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> is set to `false`, the handler doesn't perform claims mappings, and the claim names from the JWT are used directly by the app. The following example sets the role claim type to "`roles`," which is appropriate for [Microsoft Entra ID (ME-ID)](https://www.microsoft.com/security/business/microsoft-entra). Consult your identity provider's documentation for more information.
 
 > [!NOTE]
 > <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> must be set to `false` for most OIDC providers, which prevents renaming claims.
@@ -153,7 +153,7 @@ The following <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConn
   ```csharp
   oidcOptions.MapInboundClaims = false;
   oidcOptions.TokenValidationParameters.NameClaimType = JwtRegisteredClaimNames.Name;
-  oidcOptions.TokenValidationParameters.RoleClaimType = "role";
+  oidcOptions.TokenValidationParameters.RoleClaimType = "roles";
   ```
 
 * Path configuration: Paths must match the redirect URI (login callback path) and post logout redirect (signed-out callback path) paths configured when registering the application with the OIDC provider. In the Azure portal, paths are configured in the **Authentication** blade of the app's registration. Both the sign-in and sign-out paths must be registered as redirect URIs. The default values are `/signin-oidc` and `/signout-callback-oidc`.
@@ -413,7 +413,7 @@ The following <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConn
   oidcOptions.ResponseType = OpenIdConnectResponseType.Code;
   ```
 
-* <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> and configuration of <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType%2A> and <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.RoleClaimType%2A>: Many OIDC servers use "`name`" and "`role`" rather than the SOAP/WS-Fed defaults in <xref:System.Security.Claims.ClaimTypes>. When <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> is set to `false`, the handler doesn't perform claims mappings and the claim names from the JWT are used directly by the app. The following example manually maps the name and role claims:
+* <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> and configuration of <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.NameClaimType%2A> and <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.RoleClaimType%2A>: Many OIDC servers use "`name`" and "`role`" rather than the SOAP/WS-Fed defaults in <xref:System.Security.Claims.ClaimTypes>. When <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> is set to `false`, the handler doesn't perform claims mappings and the claim names from the JWT are used directly by the app. The following example sets the role claim type to "`roles`," which is appropriate for [Microsoft Entra ID (ME-ID)](https://www.microsoft.com/security/business/microsoft-entra). Consult your identity provider's documentation for more information.
 
 > [!NOTE]
 > <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConnectOptions.MapInboundClaims%2A> must be set to `false` for most OIDC providers, which prevents renaming claims.
@@ -421,7 +421,7 @@ The following <xref:Microsoft.AspNetCore.Authentication.OpenIdConnect.OpenIdConn
   ```csharp
   oidcOptions.MapInboundClaims = false;
   oidcOptions.TokenValidationParameters.NameClaimType = JwtRegisteredClaimNames.Name;
-  oidcOptions.TokenValidationParameters.RoleClaimType = "role";
+  oidcOptions.TokenValidationParameters.RoleClaimType = "roles";
   ```
 
 * Path configuration: Paths must match the redirect URI (login callback path) and post logout redirect (signed-out callback path) paths configured when registering the application with the OIDC provider. In the Azure portal, paths are configured in the **Authentication** blade of the app's registration. Both the sign-in and sign-out paths must be registered as redirect URIs. The default values are `/signin-oidc` and `/signout-callback-oidc`.

--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -646,7 +646,7 @@ oidcOptions.TokenValidationParameters.RoleClaimType = "{ROLE CLAIM TYPE}";
 
 For many OIDC identity providers, the role claim type is `role`. Check your identity provider's documentation for the correct value.
 
-Replace the `UserInfo` class in the `BlazorWebAppOidc.Client` project with the following class. Confirm that the role claim type constant (`RoleClaimType`) matches the value assigned to <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.RoleClaimType> in the OIDC configuration.
+Replace the `UserInfo` class in the `BlazorWebAppOidc.Client` project with the following class.
 
 `UserInfo.cs`:
 

--- a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
+++ b/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md
@@ -525,24 +525,20 @@ The following example assumes that the **CLIENT** and **SERVER** apps are config
 :::moniker range=">= aspnetcore-8.0"
 
 > [!NOTE]
-> When developing a client-server pair of standalone apps (a standalone Blazor WebAssembly app and an ASP.NET Core server API/web API app), the `appRoles` manifest property of both the client and the server Azure portal app registrations must include the same configured roles. After establishing the roles in the client app's manifest, copy them in their entirety to the server app's manifest. If you don't mirror the manifest `appRoles` between the client and server app registrations, role claims aren't established for authenticated users of the server API/web API, even if their access token has the correct entries in the `role` claims.
+> When developing a client-server pair of standalone apps (a standalone Blazor WebAssembly app and an ASP.NET Core server API/web API app), the `appRoles` manifest property of both the client and the server Azure portal app registrations must include the same configured roles. After establishing the roles in the client app's manifest, copy them in their entirety to the server app's manifest. If you don't mirror the manifest `appRoles` between the client and server app registrations, role claims aren't established for authenticated users of the server API/web API, even if their access token has the correct entries in the role claims.
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-8.0"
 
 > [!NOTE]
-> When developing a hosted Blazor WebAssembly app or a client-server pair of standalone apps (a standalone Blazor WebAssembly app and an ASP.NET Core server API/web API app), the `appRoles` manifest property of both the client and the server Azure portal app registrations must include the same configured roles. After establishing the roles in the client app's manifest, copy them in their entirety to the server app's manifest. If you don't mirror the manifest `appRoles` between the client and server app registrations, role claims aren't established for authenticated users of the server API/web API, even if their access token has the correct entries in the `role` claims.
+> When developing a hosted Blazor WebAssembly app or a client-server pair of standalone apps (a standalone Blazor WebAssembly app and an ASP.NET Core server API/web API app), the `appRoles` manifest property of both the client and the server Azure portal app registrations must include the same configured roles. After establishing the roles in the client app's manifest, copy them in their entirety to the server app's manifest. If you don't mirror the manifest `appRoles` between the client and server app registrations, role claims aren't established for authenticated users of the server API/web API, even if their access token has the correct entries in the role claims.
 
 :::moniker-end
 
-Although you can't assign roles to groups without an Microsoft Entra ID Premium account, you can assign roles to users and receive a `role` claim for users with a standard Azure account. The guidance in this section doesn't require an ME-ID Premium account.
+Although you can't [assign roles to groups](/entra/identity/role-based-access-control/groups-concept) without an Microsoft Entra ID Premium account, you can assign roles to users and receive role claims for users with a standard Azure account. The guidance in this section doesn't require an ME-ID Premium account.
 
-If you have a Premium tier Azure account, **Manage** > **App roles** appears in the Azure portal app registration sidebar. Follow the guidance in [Add app roles to your application and receive them in the token](/entra/identity-platform/howto-add-app-roles-in-apps) to configure the app's roles.
-
-If you don't have a Premium tier Azure account, edit the app's manifest in the Azure portal. Follow the guidance in [Application roles: Implementation](/azure/architecture/guide/multitenant/considerations/identity#implementation) to establish the app's roles manually in the `appRoles` entry of the manifest file. Save the changes to the file.
-
-The following is an example `appRoles` entry that creates `Admin` and `Developer` roles. These example roles are used later in this section's example at the component level to implement access restrictions:
+When working with the default directory, follow the guidance in [Add app roles to your application and receive them in the token](/entra/identity-platform/howto-add-app-roles-in-apps) to configure and assign roles. If you aren't working with the default directory, edit the app's manifest in the Azure portal to establish the app's roles manually in the `appRoles` entry of the manifest file. The following is an example `appRoles` entry that creates `Admin` and `Developer` roles. These example roles are used later in this section's example at the component level to implement access restrictions:
 
 ```json
 "appRoles": [
@@ -578,7 +574,7 @@ The following is an example `appRoles` entry that creates `Admin` and `Developer
 
 To assign a role to a user (or group if you have a Premium tier Azure account):
 
-1. Navigate to **Enterprise applications** in the ME-ID area of the Azure portal.
+1. Navigate to **Enterprise applications** in the ME-ID area of the [Azure portal](https://portal.azure.com/).
 1. Select the app. Select **Manage** > **Users and groups** from the sidebar.
 1. Select the checkbox for one or more user accounts.
 1. From the menu above the list of users, select **Edit assignment**.


### PR DESCRIPTION
Fixes #32512

Thanks @travaille-dev! 🎸 ...

* I'm going with two sections for this, one focused on roles for general OIDC providers and one for ME-ID.
* The ME-ID section includes guidance for Azure security/distribution groups (`groups` claims) and ME-ID built-in administrator roles (`wids` claims), which devs can then base authz policies on. A lot of devs want to know how to use these Azure/ME-ID features, but it can be difficult to track down the guidance in the Azure/ME-ID docs. *This should make it a snap!* ✨
* I also made an update to the sample apps to assign `roles` instead of `role` to the role claim type. I call out in the article that it's done for ME-ID and to consult their IdP docs on it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/blazor-web-app-with-oidc.md](https://github.com/dotnet/AspNetCore.Docs/blob/7dfe325a696379a84575241d2c0f217627791ebd/aspnetcore/blazor/security/blazor-web-app-with-oidc.md) | [Secure an ASP.NET Core Blazor Web App with OpenID Connect (OIDC)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-oidc?branch=pr-en-us-33201) |
| [aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md](https://github.com/dotnet/AspNetCore.Docs/blob/7dfe325a696379a84575241d2c0f217627791ebd/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles.md) | [ASP.NET Core Blazor WebAssembly with Microsoft Entra ID groups and roles](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/microsoft-entra-id-groups-and-roles?branch=pr-en-us-33201) |


<!-- PREVIEW-TABLE-END -->