### PR TITLE
Update Linux dev cert trust instructions

### DIFF
--- a/aspnetcore/includes/trustCertVSC.md
+++ b/aspnetcore/includes/trustCertVSC.md
@@ -4,7 +4,7 @@
   dotnet dev-certs https --trust
   ```
   
-  Prior to 9.0, the preceding command doesn't work on Linux. See your Linux distribution's documentation for trusting a certificate.
+ The preceding command requires .NET 9.0 or higher on Linux.  For Linux on .NET 8 and earlier, see your Linux distribution's documentation for trusting a certificate.
 
   The preceding command displays the following dialog, provided the certificate was not previously trusted:
 

--- a/aspnetcore/includes/trustCertVSC.md
+++ b/aspnetcore/includes/trustCertVSC.md
@@ -4,7 +4,7 @@
   dotnet dev-certs https --trust
   ```
   
-  The preceding command doesn't work on Linux. See your Linux distribution's documentation for trusting a certificate.
+  Prior to 9.0, the preceding command doesn't work on Linux. See your Linux distribution's documentation for trusting a certificate.
 
   The preceding command displays the following dialog, provided the certificate was not previously trusted:
 

--- a/aspnetcore/security/docker-compose-https.md
+++ b/aspnetcore/security/docker-compose-https.md
@@ -99,7 +99,7 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p $CREDENTIAL_PL
 dotnet dev-certs https --trust
 ```
 
-`dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certificates on Linux in the way that is supported by your distribution. It is likely that you need to trust the certificate in your browser.
+Prior to 9.0, `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certificates on Linux in the way that is supported by your distribution. It is likely that you need to trust the certificate in your browser.
 
 In the preceding commands, replace `$CREDENTIAL_PLACEHOLDER$` with a password.
 

--- a/aspnetcore/security/docker-compose-https.md
+++ b/aspnetcore/security/docker-compose-https.md
@@ -99,7 +99,7 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p $CREDENTIAL_PL
 dotnet dev-certs https --trust
 ```
 
-Prior to 9.0, `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certificates on Linux in the way that is supported by your distribution. It is likely that you need to trust the certificate in your browser.
+On Linux, `dotnet dev-certs https --trust` requires .NET 9 and later. For Linux on .NET 8 and earlier, see your Linux distribution's documentation for trusting a certificate.
 
 In the preceding commands, replace `$CREDENTIAL_PLACEHOLDER$` with a password.
 

--- a/aspnetcore/security/docker-https.md
+++ b/aspnetcore/security/docker-https.md
@@ -80,8 +80,7 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p <CREDENTIAL_PL
 dotnet dev-certs https --trust
 ```
 
-`dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certs on Linux in the way that is supported by your distribution. It is likely that you need to trust the certificate in your browser.
-
+Prior to 9.0, `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certs on Linux in the way that is supported by your distribution. It is likely that you need to trust the certificate in your browser.
 In the preceding commands, replace `<CREDENTIAL_PLACEHOLDER>` with a password.
 
 Run the container image with ASP.NET Core configured for HTTPS:

--- a/aspnetcore/security/docker-https.md
+++ b/aspnetcore/security/docker-https.md
@@ -80,7 +80,7 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p <CREDENTIAL_PL
 dotnet dev-certs https --trust
 ```
 
-Prior to 9.0, `dotnet dev-certs https --trust` is only supported on macOS and Windows. You need to trust certs on Linux in the way that is supported by your distribution. It is likely that you need to trust the certificate in your browser.
+On Linux, `dotnet dev-certs https --trust` requires .NET 9 and later. For Linux on .NET 8 and earlier, see your Linux distribution's documentation for trusting a certificate.
 In the preceding commands, replace `<CREDENTIAL_PLACEHOLDER>` with a password.
 
 Run the container image with ASP.NET Core configured for HTTPS:


### PR DESCRIPTION
The dev experience should mostly match other platforms now, but I've added a section with caveats.

Firefox no longer seems to need special handling on Windows or macOS.  I strongly suspect that section could also be removed in the pre-6.0 doc, but I haven't had a chance to confirm.

Context: https://github.com/dotnet/aspnetcore/pull/56582

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/docker-compose-https.md](https://github.com/dotnet/AspNetCore.Docs/blob/e8c64bc0717f68cdaec278484e8e11e180bbc1ea/aspnetcore/security/docker-compose-https.md) | [Hosting ASP.NET Core images with Docker Compose over HTTPS](https://review.learn.microsoft.com/en-us/aspnet/core/security/docker-compose-https?branch=pr-en-us-33221) |
| [aspnetcore/security/docker-https.md](https://github.com/dotnet/AspNetCore.Docs/blob/e8c64bc0717f68cdaec278484e8e11e180bbc1ea/aspnetcore/security/docker-https.md) | [Hosting ASP.NET Core Images with Docker over HTTPS](https://review.learn.microsoft.com/en-us/aspnet/core/security/docker-https?branch=pr-en-us-33221) |
| [aspnetcore/security/enforcing-ssl.md](https://github.com/dotnet/AspNetCore.Docs/blob/e8c64bc0717f68cdaec278484e8e11e180bbc1ea/aspnetcore/security/enforcing-ssl.md) | [Enforce HTTPS in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?branch=pr-en-us-33221) |


<!-- PREVIEW-TABLE-END -->