### PR TITLE
ASP.NET Core Extensions and Generic host removed /7

### DIFF
--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -82,7 +82,7 @@ App settings in the Azure Portal permit you to set environment variables for the
 
 When an app setting is created or modified in the Azure Portal and the **Save** button is selected, the Azure App is restarted. The environment variable is available to the app after the service restarts.
 
-When an app uses the [Generic Host](xref:fundamentals/host/generic-host), environment variables are loaded into the app's configuration when <xref:Microsoft.Extensions.Hosting.Host.CreateDefaultBuilder%2A> is called to build the host. For more information, see <xref:fundamentals/host/generic-host> and the [Environment Variables Configuration Provider](xref:fundamentals/configuration/index#environment-variables).
+Environment variables are loaded into the app's configuration when [CreateBuilder](/dotnet/api/microsoft.aspnetcore.builder.webapplication.createbuilder) is called to build the host. For more information, see the [Environment Variables Configuration Provider](xref:fundamentals/configuration/index#environment-variables).
 
 :::moniker-end
 :::moniker range="< aspnetcore-3.0"

--- a/aspnetcore/host-and-deploy/azure-apps/index.md
+++ b/aspnetcore/host-and-deploy/azure-apps/index.md
@@ -239,9 +239,6 @@ When the operation completes, the latest .NET Core preview is installed. Verify 
 >
 > The command returns `True` when the x64 preview runtime is installed.
 
-> [!NOTE]
-> **ASP.NET Core Extensions** enables additional functionality for ASP.NET Core on Azure App Services, such as enabling Azure logging. The extension is installed automatically when deploying from Visual Studio. If the extension isn't installed, install it for the app.
-
 **Use the preview site extension with an ARM template**
 
 If an ARM template is used to create and deploy apps, the `Microsoft.Web/sites/siteextensions` resource type can be used to add the site extension to a web app. In the following example, the ASP.NET Core 5.0 (x64) Runtime site extension (`AspNetCoreRuntime.5.0.x64`) is added to the app:


### PR DESCRIPTION
Fixes #33234
Contributes to #32808

See [Override app configuration using the Azure Portal](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/azure-apps/?view=aspnetcore-8.0&branch=pr-en-us-33235&tabs=visual-studio#override-app-configuration-using-the-azure-portal) and compare to [current version](https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/azure-apps/?view=aspnetcore-8.0&branch=pr-en-us-33235&tabs=visual-studio#override-app-configuration-using-the-azure-portal)


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/azure-apps/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/3738bffe90fa65c01ab7082710ee9578a9536480/aspnetcore/host-and-deploy/azure-apps/index.md) | [Deploy ASP.NET Core apps to Azure App Service](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/azure-apps/index?branch=pr-en-us-33235) |

<!-- PREVIEW-TABLE-END -->