### PR TITLE
Removed double space in object initialization

### DIFF
--- a/aspnetcore/mvc/views/working-with-forms/sample/final/ViewModels/CountryViewModel.cs
+++ b/aspnetcore/mvc/views/working-with-forms/sample/final/ViewModels/CountryViewModel.cs
@@ -11,7 +11,7 @@ namespace FormsTagHelper.ViewModels
         {
             new SelectListItem { Value = "MX", Text = "Mexico" },
             new SelectListItem { Value = "CA", Text = "Canada" },
-            new SelectListItem { Value = "US", Text = "USA"  },
+            new SelectListItem { Value = "US", Text = "USA" },
         };
     }
 }


### PR DESCRIPTION
Removed double space in `SelectListItem` object initialization.

Before:
```cs
new SelectListItem { Value = "US", Text = "USA"  }, // two spaces after "USA"
```

After:
```cs
new SelectListItem { Value = "US", Text = "USA" }, // one space after "USA"
```