### PR TITLE
WN9 ProblemValidation on route groups /a

### DIFF
--- a/aspnetcore/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs
+++ b/aspnetcore/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs
@@ -2,12 +2,10 @@
 #if NEVER
 #elif FIRST
 // <snippet_1>
-using Microsoft.AspNetCore.Http;
-
 var app = WebApplication.Create();
 
 var todos = app.MapGroup("/todos")
-    .ProducesProblem();
+    .ProducesProblem(StatusCodes.Status500InternalServerError);
 
 todos.MapGet("/", () => new Todo(1, "Create sample app", false));
 todos.MapPost("/", (Todo todo) => Results.Ok(todo));
@@ -18,15 +16,18 @@ record Todo(int Id, string Title, bool IsCompleted);
 // </snippet_1>
 #elif SECOND
 // <snippet_2>
-using Microsoft.AspNetCore.Http;
-
 var app = WebApplication.Create();
 
 app.MapGet("/", () =>
 {
-	var extensions = new List<KeyValuePair<string, object>> { new("test", "value") };
-	return TypedResults.Problem("This is an error with extensions",
-                                                       extensions: extensions);
+    var app = WebApplication.Create();
+
+    app.MapGet("/", () =>
+    {
+        var extensions = new List<KeyValuePair<string, object?>> { new("test", "value") };
+        return TypedResults.Problem("This is an error with extensions", extensions: extensions);
+    });
+
 });
 // </snippet_2>
 #endif

--- a/aspnetcore/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs
+++ b/aspnetcore/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs
@@ -21,7 +21,8 @@ var app = WebApplication.Create();
 app.MapGet("/", () =>
 {
     var extensions = new List<KeyValuePair<string, object?>> { new("test", "value") };
-    return TypedResults.Problem("This is an error with extensions", extensions: extensions);
+    return TypedResults.Problem("This is an error with extensions",
+                                                       extensions: extensions);
 });
 
 // </snippet_2>

--- a/aspnetcore/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs
+++ b/aspnetcore/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs
@@ -20,14 +20,9 @@ var app = WebApplication.Create();
 
 app.MapGet("/", () =>
 {
-    var app = WebApplication.Create();
-
-    app.MapGet("/", () =>
-    {
-        var extensions = new List<KeyValuePair<string, object?>> { new("test", "value") };
-        return TypedResults.Problem("This is an error with extensions", extensions: extensions);
-    });
-
+    var extensions = new List<KeyValuePair<string, object?>> { new("test", "value") };
+    return TypedResults.Problem("This is an error with extensions", extensions: extensions);
 });
+
 // </snippet_2>
 #endif

--- a/aspnetcore/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs
+++ b/aspnetcore/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs
@@ -24,6 +24,5 @@ app.MapGet("/", () =>
     return TypedResults.Problem("This is an error with extensions",
                                                        extensions: extensions);
 });
-
 // </snippet_2>
 #endif

--- a/aspnetcore/release-notes/aspnetcore-9/includes/prob_validation.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/prob_validation.md
@@ -1,4 +1,4 @@
-<!-- Add this include to WN9 
+<!-- Add this include to the OpenAPI section
 [!INCLUDE[](~/release-notes/aspnetcore-9/includes/prob_validation.md)]
 -->
 ## Support calling `ProducesProblem` and `ProducesValidationProblem` on route groups
@@ -9,7 +9,7 @@ The [ProducesProblem](/dotnet/api/microsoft.aspnetcore.http.openapiroutehandlerb
 
 ## `Problem` and `ValidationProblem` result types support construction with `IEnumerable<KeyValuePair<string, object?>>` values
 
-Prior to this .NET 9, constructing [Problem](/dotnet/api/microsoft.aspnetcore.http.typedresults.problem) and [ValidationProblem](/dotnet/api/microsoft.aspnetcore.http.typedresults.validationproblem) result types in minimal APIs required that the `errors` and `extensions` properties be initialized with an implementation of `IDictionary<string, object?>`. In this release, these construction APIs support overloads that consume `IEnumerable<KeyValuePair<string, object?>>`.
+Prior to .NET 9, constructing [Problem](/dotnet/api/microsoft.aspnetcore.http.typedresults.problem) and [ValidationProblem](/dotnet/api/microsoft.aspnetcore.http.typedresults.validationproblem) result types in minimal APIs required that the `errors` and `extensions` properties be initialized with an implementation of `IDictionary<string, object?>`. In this release, these construction APIs support overloads that consume `IEnumerable<KeyValuePair<string, object?>>`.
 
 :::code language="csharp" source="~/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs" id="snippet_2" :::
 

--- a/aspnetcore/release-notes/aspnetcore-9/includes/prob_validation.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/prob_validation.md
@@ -1,13 +1,13 @@
 <!-- Add this include to the OpenAPI section
 [!INCLUDE[](~/release-notes/aspnetcore-9/includes/prob_validation.md)]
 -->
-## Support calling `ProducesProblem` and `ProducesValidationProblem` on route groups
+### Support calling `ProducesProblem` and `ProducesValidationProblem` on route groups
 
 The [ProducesProblem](/dotnet/api/microsoft.aspnetcore.http.openapiroutehandlerbuilderextensions.producesproblem) and [ProducesValidationProblem](/dotnet/api/microsoft.aspnetcore.http.openapiroutehandlerbuilderextensions.producesvalidationproblem) extension methods have been updated for route groups. These methods can be used to indicate that all endpoints in a route group can return `ProblemDetails` or `ValidationProblemDetails` responses for the purposes of OpenAPI metadata.
 
 :::code language="csharp" source="~/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs" id="snippet_1" :::
 
-## `Problem` and `ValidationProblem` result types support construction with `IEnumerable<KeyValuePair<string, object?>>` values
+### `Problem` and `ValidationProblem` result types support construction with `IEnumerable<KeyValuePair<string, object?>>` values
 
 Prior to .NET 9, constructing [Problem](/dotnet/api/microsoft.aspnetcore.http.typedresults.problem) and [ValidationProblem](/dotnet/api/microsoft.aspnetcore.http.typedresults.validationproblem) result types in minimal APIs required that the `errors` and `extensions` properties be initialized with an implementation of `IDictionary<string, object?>`. In this release, these construction APIs support overloads that consume `IEnumerable<KeyValuePair<string, object?>>`.
 

--- a/aspnetcore/release-notes/aspnetcore-9/includes/prob_validation.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/prob_validation.md
@@ -1,13 +1,16 @@
+<!-- Add this include to WN9 
+[!INCLUDE[](~/release-notes/aspnetcore-9/includes/prob_validation.md)]
+-->
 ## Support calling `ProducesProblem` and `ProducesValidationProblem` on route groups
 
-The `ProducesProblem` and `ProducesValidationProblem` extension methods have been updated to support application on route groups, as in the sample below. These methods can be used to indicate that all endpoints in a route group can return `ProblemDetails` or `ValidationProblemDetails` responses for the purposes of OpenAPI metadata.
+The [ProducesProblem](/dotnet/api/microsoft.aspnetcore.http.openapiroutehandlerbuilderextensions.producesproblem) and [ProducesValidationProblem](/dotnet/api/microsoft.aspnetcore.http.openapiroutehandlerbuilderextensions.producesvalidationproblem) extension methods have been updated for route groups. These methods can be used to indicate that all endpoints in a route group can return `ProblemDetails` or `ValidationProblemDetails` responses for the purposes of OpenAPI metadata.
 
 :::code language="csharp" source="~/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs" id="snippet_1" :::
 
 ## `Problem` and `ValidationProblem` result types support construction with `IEnumerable<KeyValuePair<string, object?>>` values
 
-Prior to this preview, constructing `Problem` and `ValidationProblem` result types in minimal APIs required that the `errors` and `extensions` properties be initialized with an implementation of `IDictionary<string, object?>`. Starting in this release, these construction APIs support overloads that consume `IEnumerable<KeyValuePair<string, object?>>`.
+Prior to this .NET 9, constructing [Problem](/dotnet/api/microsoft.aspnetcore.http.typedresults.problem) and [ValidationProblem](/dotnet/api/microsoft.aspnetcore.http.typedresults.validationproblem) result types in minimal APIs required that the `errors` and `extensions` properties be initialized with an implementation of `IDictionary<string, object?>`. In this release, these construction APIs support overloads that consume `IEnumerable<KeyValuePair<string, object?>>`.
 
 :::code language="csharp" source="~/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs" id="snippet_2" :::
 
-Thanks to GitHub user "joegoldman2" for this contribution!
+Thanks to GitHub user [joegoldman2](https://github.com/joegoldman2) for this contribution!


### PR DESCRIPTION
contributes to #33309

@captainsafia, this PR shows only the changes I made to [Problem and ValidationProblem result types support construction with IEnumerable<KeyValuePair<string, object?>> values](https://github.com/dotnet/AspNetCore.Docs/issues/33031#issuecomment-2274516260):

* Copy/pasted [Problem and ValidationProblem result types support construction with IEnumerable<KeyValuePair<string, object?>> values](https://github.com/dotnet/AspNetCore.Docs/issues/33031#issuecomment-2274516260) to an include file and project unchanged
* Merged the copy/paste PR so you can see all the changes I made in this PR. Copy/paste PR is #33329