### PR TITLE
Class field of type function not supported

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -62,6 +62,40 @@ In a few documentation examples, JS interop is used to mutate an element *purely
 
 For more information, see <xref:blazor/js-interop/call-javascript-from-dotnet#capture-references-to-elements>.
 
+## JavaScript class with a field of type function
+
+A JavaScript class with a field of type function is ***not*** supported by Blazor JS interop. Use Javascript functions in classes.
+
+<span aria-hidden="true">❌</span><span class="visually-hidden">Unsupported:</span> `GreetingHelpers.sayHello` in the following class as a field of type function isn't discovered by Blazor's JS interop and can't be executed from C# code:
+
+```javascript
+export class GreetingHelpers {
+  sayHello = function() {
+    ...
+  }
+}
+```
+
+<span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> `GreetingHelpers.sayHello` in the following class as a function is supported:
+
+```javascript
+export class GreetingHelpers {
+  sayHello() {
+    ...
+  }
+}
+```
+
+Arrow functions are also supported:
+
+```javascript
+export class GreetingHelpers {
+  sayHello = () => {
+    ...
+  }
+}
+```
+
 ## Avoid inline event handlers
 
 A JavaScript function can be invoked directly from an inline event handler. In the following example, `alertUser` is a JavaScript function called when the button is selected by the user:


### PR DESCRIPTION
Fixes #30311

Thanks @macias! 🚀 ... I finally made it to the P3 priority issues after a rather grueling 8.0 release cycle. It's taken almost a ***year*** to reach this batch of issues, but I'm finally here 😅. I'm focusing this on the main remark that Javier made about your ask: fields of type function aren't supported. I see that you may have had a followup problem that wasn't resolved on the product unit issue, but I think that was probably related to some other aspect of your code (a different concept).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/8fe20d7199456aef441b589751db765c020dfa38/aspnetcore/blazor/javascript-interoperability/index.md) | [ASP.NET Core Blazor JavaScript interoperability (JS interop)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/index?branch=pr-en-us-33337) |

<!-- PREVIEW-TABLE-END -->