### PR TITLE
Expand images coverage to include documents

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1307,6 +1307,11 @@
             "source_path": "aspnetcore/blazor/http-caching-issues.md",
             "redirect_url": "/aspnet/core/blazor/host-and-deploy/webassembly-caching/http-caching-issues",
             "redirect_document_id": false
+        },
+        {
+            "source_path": "aspnetcore/blazor/images.md",
+            "redirect_url": "/aspnet/core/blazor/images-and-documents",
+            "redirect_document_id": false
         }
     ]
 }

--- a/aspnetcore/blazor/images-and-documents.md
+++ b/aspnetcore/blazor/images-and-documents.md
@@ -146,9 +146,9 @@ The following `ShowFile` component loads either a text file (`files/quote.txt`) 
 [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main/8.0/BlazorSample_BlazorWebApp/wwwroot/files): Navigate to `BlazorSample_BlazorWebApp` (8.0 or later), `BlazorSample_Server` (7.0 or earlier), or `BlazorSample_WebAssembly`. Locate the files in the `wwwroot/files` directory of the sample app.
 
 > [!CAUTION]
-> Use of the `<iframe>` element in the following example is safe and doesn't require [sandboxing](https://developer.mozilla.org/docs/Web/HTML/Element/iframe#sandbox) because content is loaded from the app, a trusted source, and not from an untrusted external source or user input.
+> Use of the `<iframe>` element in the following example is safe and doesn't require \[sandboxing](https://developer.mozilla.org/docs/Web/HTML/Element/iframe#sandbox) because content is loaded from the app, a trusted source.
 >
-> An improperly implemented `<iframe>` element risks creating security vulnerabilities. When using an `<iframe>` element in a context outside of this article, consult `<iframe>` security guidance.
+> When loading content from an untrusted source or user input, an improperly implemented `<iframe>` element risks creating security vulnerabilities.
 
 `ShowFile.razor`:
 

--- a/aspnetcore/blazor/images-and-documents.md
+++ b/aspnetcore/blazor/images-and-documents.md
@@ -145,7 +145,7 @@ The following `ShowFile` component loads either a text file (`files/quote.txt`) 
 
 [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples/tree/main/8.0/BlazorSample_BlazorWebApp/wwwroot/files): Navigate to `BlazorSample_BlazorWebApp` (8.0 or later), `BlazorSample_Server` (7.0 or earlier), or `BlazorSample_WebAssembly`. Locate the files in the `wwwroot/files` directory of the sample app.
 
-> [!WARNING]
+> [!CAUTION]
 > Use of the `<iframe>` element in the following example is safe and doesn't require [sandboxing](https://developer.mozilla.org/docs/Web/HTML/Element/iframe#sandbox) because content is loaded from the app, a trusted source, and not from an untrusted external source or user input.
 >
 > An improperly implemented `<iframe>` element risks creating security vulnerabilities. When using an `<iframe>` element in a context outside of this article, consult `<iframe>` security guidance.

--- a/aspnetcore/release-notes/aspnetcore-6.0.md
+++ b/aspnetcore/release-notes/aspnetcore-6.0.md
@@ -252,7 +252,7 @@ Use a deployment layout to enable Blazor WebAssembly app downloads in restricted
 In addition to the Blazor features described in the preceding sections, new Blazor articles are available on the following subjects:
 
 * <xref:blazor/file-downloads>: Learn how to download a file using native `byte[]` streaming interop to ensure efficient transfer to the client.
-* <xref:blazor/images>: Discover how to work with images in Blazor apps, including how to stream image data and preview an image.
+* <xref:blazor/images-and-documents>: Discover how to work with images and documents in Blazor apps, including how to stream image and document data.
 
 ## Build Blazor Hybrid apps with .NET MAUI, WPF, and Windows Forms
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -572,8 +572,8 @@ items:
                 uid: blazor/js-interop/ssr
           - name: Call a web API
             uid: blazor/call-web-api
-          - name: Images
-            uid: blazor/images
+          - name: Images and documents
+            uid: blazor/images-and-documents
           - name: Security and Identity
             items:
               - name: Overview


### PR DESCRIPTION
Fixes #31948

Thanks @maraf! 🎷

@blowdart ... TL;DR: This uses an `<iframe>` to display a trusted document from the `wwwroot` folder of an app. I'm including a passing CAUTION remark. Do you have any change suggestions for it?

> [!CAUTION]
> Use of the `<iframe>` element in the following example is safe and doesn't require \[sandboxing](https://developer.mozilla.org/docs/Web/HTML/Element/iframe#sandbox) because content is loaded from the app, a trusted source.
>
> When loading content from an untrusted source or user input, an improperly implemented `<iframe>` element risks creating security vulnerabilities.

