### PR TITLE
File uploads (writing to memory/Autofac content)

### DIFF
--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -65,6 +65,8 @@ To avoid coping all of the file's bytes into a <xref:System.IO.MemoryStream> or 
 * Copy the stream directly to a file on disk without reading it into memory. Note that Blazor apps executing code on the server aren't able to access the client's file system directly. 
 * Upload files from the client directly to an external service. For more information, see the [Upload files to an external service](#upload-files-to-an-external-service) section.
 
+:::moniker-end
+
 :::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
 
 If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array:

--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -56,12 +56,6 @@ If you need access to a <xref:System.IO.Stream> that represents the file's bytes
 
 In the following examples, `browserFile` represents the uploaded file and implements <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile>. Working implementations for <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile> are shown in the file upload components later in this article.
 
-<span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> The following approach is **recommended** because the file's <xref:System.IO.Stream> is provided directly to the consumer, a new <xref:System.Net.Http.StreamContent> that contains the file's content:
-
-```csharp
-var fileContent = new StreamContent(browserFile.OpenReadStream(maxFileSize));
-```
-
 <span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> The following approach is **recommended** because the file's <xref:System.IO.Stream> is provided directly to the consumer, a <xref:System.IO.FileStream> that creates the file at the provided path:
 
 ```csharp
@@ -76,14 +70,14 @@ await blobContainerClient.UploadBlobAsync(
     trustedFileName, browserFile.OpenReadStream());
 ```
 
-<span aria-hidden="true">❌</span><span class="visually-hidden">Unsupported:</span> The following approach is **NOT recommended** because the file's <xref:System.IO.Stream> content is read into a <xref:System.String> in memory (`reader`):
+<span aria-hidden="true">❌</span><span class="visually-hidden">Not recommended:</span> The following approach is **NOT recommended** because the file's <xref:System.IO.Stream> content is read into a <xref:System.String> in memory (`reader`):
 
 ```csharp
 var reader = 
     await new StreamReader(browserFile.OpenReadStream()).ReadToEndAsync();
 ```
 
-<span aria-hidden="true">❌</span><span class="visually-hidden">Unsupported:</span> The following approach is **NOT recommended** for [Microsoft Azure Blob Storage](/azure/storage/blobs/storage-blobs-overview) because the file's <xref:System.IO.Stream> content is copied into a <xref:System.IO.MemoryStream> in memory (`memoryStream`) before calling <xref:Azure.Storage.Blobs.BlobContainerClient.UploadBlobAsync%2A>:
+<span aria-hidden="true">❌</span><span class="visually-hidden">Not recommended:</span> The following approach is **NOT recommended** for [Microsoft Azure Blob Storage](/azure/storage/blobs/storage-blobs-overview) because the file's <xref:System.IO.Stream> content is copied into a <xref:System.IO.MemoryStream> in memory (`memoryStream`) before calling <xref:Azure.Storage.Blobs.BlobContainerClient.UploadBlobAsync%2A>:
 
 ```csharp
 var memoryStream = new MemoryStream();
@@ -94,8 +88,10 @@ await blobContainerClient.UploadBlobAsync(
 
 A component that receives an image file can call the <xref:Microsoft.AspNetCore.Components.Forms.BrowserFileExtensions.RequestImageFileAsync%2A?displayProperty=nameWithType> convenience method on the file to resize the image data within the browser's JavaScript runtime before the image is streamed into the app. Use cases for calling <xref:Microsoft.AspNetCore.Components.Forms.BrowserFileExtensions.RequestImageFileAsync%2A> are most appropriate for Blazor WebAssembly apps.
 
-
 :::moniker range="< aspnetcore-9.0"
+
+<!-- UPDATE 10.0 Remove this section. Leave the coverage in the 
+                 Troubleshoot section. -->
 
 ## Autofac Inversion of Control (IoC) container users
 
@@ -264,15 +260,17 @@ public class UploadResult
 > [!NOTE]
 > A security best practice for production apps is to avoid sending error messages to clients that might reveal sensitive information about an app, server, or network. Providing detailed error messages can aid a malicious user in devising attacks on an app, server, or network. The example code in this section only sends back an error code number (`int`) for display by the component client-side if a server-side error occurs. If a user requires assistance with a file upload, they provide the error code to support personnel for support ticket resolution without ever knowing the exact cause of the error.
 
-:::moniker range="< aspnetcore-9.0"
+<!-- UPDATE 9.0 HOLD moniker range="< aspnetcore-9.0" -->
 
 The following `LazyBrowserFileStream` class defines a custom stream type that lazily calls <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A> just before the first bytes of the stream are requested. The stream isn't transmitted from the browser to the server until reading the stream begins in .NET.
 
 `LazyBrowserFileStream.cs`:
 
-:::moniker-end
+<!-- UPDATE 9.0 HOLD moniker-end -->
 
-:::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
+<!-- UPDATE 9.0 HOLD for next line: < aspnetcore-9.0 -->
+
+:::moniker range=">= aspnetcore-8.0"
 
 :::code language="csharp" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/LazyBrowserFileStream.cs":::
 
@@ -335,7 +333,9 @@ The following `FileUpload2` component:
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
+<!-- UPDATE 9.0 HOLD for the next line: < aspnetcore-9.0 -->
+
+:::moniker range=">= aspnetcore-8.0"
 
 If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid the use of the `LazyBrowserFileStream` and use a <xref:System.IO.Stream>. The following demonstrates the changes for the `FileUpload2` component:
 
@@ -942,14 +942,17 @@ The line that calls <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.Ope
 
 Possible causes:
 
-* Using the [Autofac Inversion of Control (IoC) container](https://autofac.org/) instead of the built-in ASP.NET Core dependency injection container in versions of ASP.NET Core earlier than 9.0. To resolve the issue, set <xref:Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServicesParameters%2A> to `true` in the [server-side circuit handler hub options](xref:blazor/fundamentals/signalr#server-side-circuit-handler-options). For more information, see [FileUpload: Did not receive any data in the allotted time (`dotnet/aspnetcore` #38842)](https://github.com/dotnet/aspnetcore/issues/38842#issuecomment-1342540950).
+<!-- UPDATE 9.0 HOLD: in versions of ASP.NET Core earlier than 9.0 -->
+
+* Using the [Autofac Inversion of Control (IoC) container](https://autofac.org/) instead of the built-in ASP.NET Core dependency injection container. To resolve the issue, set <xref:Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServicesParameters%2A> to `true` in the [server-side circuit handler hub options](xref:blazor/fundamentals/signalr#server-side-circuit-handler-options). For more information, see [FileUpload: Did not receive any data in the allotted time (`dotnet/aspnetcore` #38842)](https://github.com/dotnet/aspnetcore/issues/38842#issuecomment-1342540950).
 
 * Not reading the stream to completion. This isn't a framework issue. Trap the exception and investigate it further in your local environment/network.
 
-* Using server-side rendering and calling <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A> on multiple files before reading them to completion in versions of ASP.NET Core earlier than 9.0. To resolve the issue, adopt ***either*** of the following approaches:
+<!-- UPDATE 9.0 HOLD in versions of ASP.NET Core earlier than 9.0 
+                adopt ***either*** of the following approaches: * Upgrade the app to ASP.NET Core 9.0 or later. 
+                with the article version selector set to "ASP.NET Core in .NET 8" or earlier -->
 
-  * Upgrade the app to ASP.NET Core 9.0 or later.
-  * Use the `LazyBrowserFileStream` class and approach described in the [Upload files to a server with server-side rendering](#upload-files-to-a-server-with-server-side-rendering) section of this article with the article version selector set to "ASP.NET Core in .NET 8" or earlier.
+* Using server-side rendering and calling <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A> on multiple files before reading them to completion. To resolve the issue, use the `LazyBrowserFileStream` class and approach described in the [Upload files to a server with server-side rendering](#upload-files-to-a-server-with-server-side-rendering) section of this article.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -336,7 +336,7 @@ The following `FileUpload2` component:
 
 :::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
 
-If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array. The following example demonstrates the changes for the `FileUpload2` component:
+If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array. The following demonstrates the changes for the `FileUpload2` component:
 
 ```diff
 - var memoryStream = new MemoryStream();
@@ -351,7 +351,7 @@ If the component limits file uploads to a single file at a time or if the compon
 
 :::moniker range="< aspnetcore-8.0"
 
-If the component limits file uploads to a single file at a time, the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array. The following example demonstrates the changes for the `FileUpload2` component:
+If the component limits file uploads to a single file at a time, the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array. The following demonstrates the changes for the `FileUpload2` component:
 
 ```diff
 - var memoryStream = new MemoryStream();

--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -85,8 +85,6 @@ var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
 
 :::moniker-end
 
-:::moniker-end
-
 In the following examples, `browserFile` represents the uploaded file and implements <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile>. Working implementations for <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile> are shown in the file upload components later in this article.
 
 <span aria-hidden="true">❌</span><span class="visually-hidden">Unsupported:</span> The following approach is **NOT recommended** because the file's <xref:System.IO.Stream> content is read into a <xref:System.String> in memory (`reader`):

--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -49,65 +49,18 @@ To read data from a user-selected file, call <xref:Microsoft.AspNetCore.Componen
 
 <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A> enforces a maximum size in bytes of its <xref:System.IO.Stream>. Reading one file or multiple files larger than 500 KB results in an exception. This limit prevents developers from accidentally reading large files into memory. The `maxAllowedSize` parameter of <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A> can be used to specify a larger size if required.
 
-:::moniker range=">= aspnetcore-9.0"
-
 If you need access to a <xref:System.IO.Stream> that represents the file's bytes, use <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A?displayProperty=nameWithType>. Avoid reading the incoming file stream directly into memory all at once. For example, don't copy all of the file's bytes into a <xref:System.IO.MemoryStream> or read the entire stream into a byte array all at once. These approaches can result in degraded app performance and potential [Denial of Service (DoS)](xref:blazor/security/server/interactive-server-side-rendering#denial-of-service-dos-attacks) risk, especially for server-side components. Instead, consider adopting either of the following approaches:
 
 * Copy the stream directly to a file on disk without reading it into memory. Note that Blazor apps executing code on the server aren't able to access the client's file system directly. 
 * Upload files from the client directly to an external service. For more information, see the [Upload files to an external service](#upload-files-to-an-external-service) section.
 
-:::moniker-end
-
-:::moniker range="< aspnetcore-9.0"
-
-To avoid coping all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array all at once when uploading files to a server, which can result in degraded app performance and potential [Denial of Service (DoS)](xref:blazor/security/server/interactive-server-side-rendering#denial-of-service-dos-attacks) risk, consider adopting either of the following approaches:
-
-* Copy the stream directly to a file on disk without reading it into memory. Note that Blazor apps executing code on the server aren't able to access the client's file system directly. 
-* Upload files from the client directly to an external service. For more information, see the [Upload files to an external service](#upload-files-to-an-external-service) section.
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
-
-If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array:
-
-```csharp
-var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
-```
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-8.0"
-
-If the component limits file uploads to a single file at a time, the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array:
-
-```csharp
-var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
-```
-
-:::moniker-end
-
 In the following examples, `browserFile` represents the uploaded file and implements <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile>. Working implementations for <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile> are shown in the file upload components later in this article.
 
-<span aria-hidden="true">❌</span><span class="visually-hidden">Unsupported:</span> The following approach is **NOT recommended** because the file's <xref:System.IO.Stream> content is read into a <xref:System.String> in memory (`reader`):
+<span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> The following approach is **recommended** because the file's <xref:System.IO.Stream> is provided directly to the consumer, a new <xref:System.Net.Http.StreamContent> that contains the file's content:
 
 ```csharp
-var reader = 
-    await new StreamReader(browserFile.OpenReadStream()).ReadToEndAsync();
+var fileContent = new StreamContent(browserFile.OpenReadStream(maxFileSize));
 ```
-
-:::moniker range=">= aspnetcore-9.0"
-
-<span aria-hidden="true">❌</span><span class="visually-hidden">Unsupported:</span> The following approach is **NOT recommended** for [Microsoft Azure Blob Storage](/azure/storage/blobs/storage-blobs-overview) because the file's <xref:System.IO.Stream> content is copied into a <xref:System.IO.MemoryStream> in memory (`memoryStream`) before calling <xref:Azure.Storage.Blobs.BlobContainerClient.UploadBlobAsync%2A>:
-
-```csharp
-var memoryStream = new MemoryStream();
-await browserFile.OpenReadStream().CopyToAsync(memoryStream);
-await blobContainerClient.UploadBlobAsync(
-    trustedFileName, memoryStream));
-```
-
-:::moniker-end
 
 <span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> The following approach is **recommended** because the file's <xref:System.IO.Stream> is provided directly to the consumer, a <xref:System.IO.FileStream> that creates the file at the provided path:
 
@@ -121,6 +74,22 @@ await browserFile.OpenReadStream().CopyToAsync(fs);
 ```csharp
 await blobContainerClient.UploadBlobAsync(
     trustedFileName, browserFile.OpenReadStream());
+```
+
+<span aria-hidden="true">❌</span><span class="visually-hidden">Unsupported:</span> The following approach is **NOT recommended** because the file's <xref:System.IO.Stream> content is read into a <xref:System.String> in memory (`reader`):
+
+```csharp
+var reader = 
+    await new StreamReader(browserFile.OpenReadStream()).ReadToEndAsync();
+```
+
+<span aria-hidden="true">❌</span><span class="visually-hidden">Unsupported:</span> The following approach is **NOT recommended** for [Microsoft Azure Blob Storage](/azure/storage/blobs/storage-blobs-overview) because the file's <xref:System.IO.Stream> content is copied into a <xref:System.IO.MemoryStream> in memory (`memoryStream`) before calling <xref:Azure.Storage.Blobs.BlobContainerClient.UploadBlobAsync%2A>:
+
+```csharp
+var memoryStream = new MemoryStream();
+await browserFile.OpenReadStream().CopyToAsync(memoryStream);
+await blobContainerClient.UploadBlobAsync(
+    trustedFileName, memoryStream));
 ```
 
 A component that receives an image file can call the <xref:Microsoft.AspNetCore.Components.Forms.BrowserFileExtensions.RequestImageFileAsync%2A?displayProperty=nameWithType> convenience method on the file to resize the image data within the browser's JavaScript runtime before the image is streamed into the app. Use cases for calling <xref:Microsoft.AspNetCore.Components.Forms.BrowserFileExtensions.RequestImageFileAsync%2A> are most appropriate for Blazor WebAssembly apps.
@@ -219,7 +188,7 @@ Because the example uses the app's [environment](xref:blazor/fundamentals/enviro
 
 The following example processes file bytes and doesn't send files to a destination outside of the app. For an example of a Razor component that sends a file to a server or service, see the following sections:
 
-* [Upload files to a server](#upload-files-to-a-server)
+* [Upload files to a server with client-side rendering (CSR)](#upload-files-to-a-server-with-client-side-rendering-csr)
 * [Upload files to an external service](#upload-files-to-an-external-service)
 
 The component assumes that the Interactive WebAssembly render mode (`InteractiveWebAssembly`) is inherited from a parent component or applied globally to the app.
@@ -295,6 +264,38 @@ public class UploadResult
 > [!NOTE]
 > A security best practice for production apps is to avoid sending error messages to clients that might reveal sensitive information about an app, server, or network. Providing detailed error messages can aid a malicious user in devising attacks on an app, server, or network. The example code in this section only sends back an error code number (`int`) for display by the component client-side if a server-side error occurs. If a user requires assistance with a file upload, they provide the error code to support personnel for support ticket resolution without ever knowing the exact cause of the error.
 
+:::moniker range="< aspnetcore-9.0"
+
+The following `LazyBrowserFileStream` class defines a custom stream type that lazily calls <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A> just before the first bytes of the stream are requested. The stream isn't transmitted from the browser to the server until reading the stream begins in .NET.
+
+`LazyBrowserFileStream.cs`:
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
+
+:::code language="csharp" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/LazyBrowserFileStream.cs":::
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
+
+:::code language="csharp" source="~/../blazor-samples/7.0/BlazorSample_Server/LazyBrowserFileStream.cs":::
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
+
+:::code language="csharp" source="~/../blazor-samples/6.0/BlazorSample_Server/LazyBrowserFileStream.cs":::
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-6.0"
+
+:::code language="csharp" source="~/../blazor-samples/5.0/BlazorSample_Server/LazyBrowserFileStream.cs":::
+
+:::moniker-end
+
 The following `FileUpload2` component:
 
 * Permits users to upload files from the client.
@@ -336,31 +337,29 @@ The following `FileUpload2` component:
 
 :::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
 
-If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array. The following demonstrates the changes for the `FileUpload2` component:
+If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid the use of the `LazyBrowserFileStream` and use a <xref:System.IO.Stream>. The following demonstrates the changes for the `FileUpload2` component:
 
 ```diff
-- var memoryStream = new MemoryStream();
-- var browserFileStream = file.OpenReadStream(maxFileSize);
-- await browserFileStream.CopyToAsync(memoryStream);
-- memoryStream.Position = 0;
-- var fileContent = new StreamContent(memoryStream);
+- var stream = new LazyBrowserFileStream(file, maxFileSize);
+- var fileContent = new StreamContent(stream);
 + var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
 ```
+
+Remove the `LazyBrowserFileStream` class (`LazyBrowserFileStream.cs`), as it isn't used.
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-8.0"
 
-If the component limits file uploads to a single file at a time, the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array. The following demonstrates the changes for the `FileUpload2` component:
+If the component limits file uploads to a single file at a time, the component can avoid the use of the `LazyBrowserFileStream` and use a <xref:System.IO.Stream>. The following demonstrates the changes for the `FileUpload2` component:
 
 ```diff
-- var memoryStream = new MemoryStream();
-- var browserFileStream = file.OpenReadStream(maxFileSize);
-- await browserFileStream.CopyToAsync(memoryStream);
-- memoryStream.Position = 0;
-- var fileContent = new StreamContent(memoryStream);
+- var stream = new LazyBrowserFileStream(file, maxFileSize);
+- var fileContent = new StreamContent(stream);
 + var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
 ```
+
+Remove the `LazyBrowserFileStream` class (`LazyBrowserFileStream.cs`), as it isn't used.
 
 :::moniker-end
 
@@ -484,9 +483,11 @@ In the preceding code, <xref:System.IO.Path.GetRandomFileName%2A> is called to g
 
 The server app must register controller services and map controller endpoints. For more information, see <xref:mvc/controllers/routing>.
 
-## Upload files to a server
+## Upload files to a server with client-side rendering (CSR)
 
-The following example demonstrates uploading files to a web API controller.
+*This section applies to client-side rendered (CSR) components in Blazor Web Apps or Blazor WebAssembly apps.*
+
+The following example demonstrates uploading files to a backend web API controller in a separate app, possibly on a separate server, from a component in a Blazor Web App that adopts CSR or a component in a Blazor WebAssembly app.
 
 The following `UploadResult` class maintains the result of an uploaded file. When a file fails to upload on the server, an error code is returned in `ErrorCode` for display to the user. A safe file name is generated on the server for each file and returned to the client in `StoredFileName` for display. Files are keyed between the client and server using the unsafe/untrusted file name in `FileName`.
 
@@ -932,6 +933,23 @@ For more information on SignalR configuration and how to set <xref:Microsoft.Asp
 Blazor relies on <xref:Microsoft.AspNetCore.SignalR.HubOptions.MaximumParallelInvocationsPerClient%2A> set to 1, which is the default value.
 
 Increasing the value leads to a high probability that `CopyTo` operations throw `System.InvalidOperationException: 'Reading is not allowed after reader was completed.'`. For more information, see [MaximumParallelInvocationsPerClient > 1 breaks file upload in Blazor Server mode (`dotnet/aspnetcore` #53951)](https://github.com/dotnet/aspnetcore/issues/53951).
+
+## Troubleshoot
+
+The line that calls <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A?displayProperty=nameWithType> throws a <xref:System.TimeoutException?displayProperty=nameWithType>:
+
+> :::no-loc text="System.TimeoutException: Did not receive any data in the allotted time.":::
+
+Possible causes:
+
+* Using the [Autofac Inversion of Control (IoC) container](https://autofac.org/) instead of the built-in ASP.NET Core dependency injection container in versions of ASP.NET Core earlier than 9.0. To resolve the issue, set <xref:Microsoft.AspNetCore.SignalR.HubOptions.DisableImplicitFromServicesParameters%2A> to `true` in the [server-side circuit handler hub options](xref:blazor/fundamentals/signalr#server-side-circuit-handler-options). For more information, see [FileUpload: Did not receive any data in the allotted time (`dotnet/aspnetcore` #38842)](https://github.com/dotnet/aspnetcore/issues/38842#issuecomment-1342540950).
+
+* Not reading the stream to completion. This isn't a framework issue. Trap the exception and investigate it further in your local environment/network.
+
+* Using server-side rendering and calling <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A> on multiple files before reading them to completion in versions of ASP.NET Core earlier than 9.0. To resolve the issue, adopt ***either*** of the following approaches:
+
+  * Upgrade the app to ASP.NET Core 9.0 or later.
+  * Use the `LazyBrowserFileStream` class and approach described in the [Upload files to a server with server-side rendering](#upload-files-to-a-server-with-server-side-rendering) section of this article with the article version selector set to "ASP.NET Core in .NET 8" or earlier.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/file-uploads.md
+++ b/aspnetcore/blazor/file-uploads.md
@@ -53,16 +53,39 @@ To read data from a user-selected file, call <xref:Microsoft.AspNetCore.Componen
 
 If you need access to a <xref:System.IO.Stream> that represents the file's bytes, use <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile.OpenReadStream%2A?displayProperty=nameWithType>. Avoid reading the incoming file stream directly into memory all at once. For example, don't copy all of the file's bytes into a <xref:System.IO.MemoryStream> or read the entire stream into a byte array all at once. These approaches can result in degraded app performance and potential [Denial of Service (DoS)](xref:blazor/security/server/interactive-server-side-rendering#denial-of-service-dos-attacks) risk, especially for server-side components. Instead, consider adopting either of the following approaches:
 
+* Copy the stream directly to a file on disk without reading it into memory. Note that Blazor apps executing code on the server aren't able to access the client's file system directly. 
+* Upload files from the client directly to an external service. For more information, see the [Upload files to an external service](#upload-files-to-an-external-service) section.
+
 :::moniker-end
 
 :::moniker range="< aspnetcore-9.0"
 
-To avoid coping all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array all at once, which can result in degraded app performance and potential [Denial of Service (DoS)](xref:blazor/security/server/interactive-server-side-rendering#denial-of-service-dos-attacks) risk, consider adopting either of the following approaches:
-
-:::moniker-end
+To avoid coping all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array all at once when uploading files to a server, which can result in degraded app performance and potential [Denial of Service (DoS)](xref:blazor/security/server/interactive-server-side-rendering#denial-of-service-dos-attacks) risk, consider adopting either of the following approaches:
 
 * Copy the stream directly to a file on disk without reading it into memory. Note that Blazor apps executing code on the server aren't able to access the client's file system directly. 
 * Upload files from the client directly to an external service. For more information, see the [Upload files to an external service](#upload-files-to-an-external-service) section.
+
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
+
+If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array:
+
+```csharp
+var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
+```
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
+If the component limits file uploads to a single file at a time, the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array:
+
+```csharp
+var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
+```
+
+:::moniker-end
+
+:::moniker-end
 
 In the following examples, `browserFile` represents the uploaded file and implements <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile>. Working implementations for <xref:Microsoft.AspNetCore.Components.Forms.IBrowserFile> are shown in the file upload components later in this article.
 
@@ -308,6 +331,36 @@ The following `FileUpload2` component:
 :::moniker range="< aspnetcore-6.0"
 
 :::code language="razor" source="~/../blazor-samples/5.0/BlazorSample_Server/Pages/file-uploads/FileUpload2.razor":::
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
+
+If the component limits file uploads to a single file at a time or if the component only adopts interactive client-side rendering (CSR, `InteractiveWebAssembly`), the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array. The following example demonstrates the changes for the `FileUpload2` component:
+
+```diff
+- var memoryStream = new MemoryStream();
+- var browserFileStream = file.OpenReadStream(maxFileSize);
+- await browserFileStream.CopyToAsync(memoryStream);
+- memoryStream.Position = 0;
+- var fileContent = new StreamContent(memoryStream);
++ var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
+```
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
+If the component limits file uploads to a single file at a time, the component can avoid copying all of the file's bytes into a <xref:System.IO.MemoryStream> or reading the entire stream into a byte array. The following example demonstrates the changes for the `FileUpload2` component:
+
+```diff
+- var memoryStream = new MemoryStream();
+- var browserFileStream = file.OpenReadStream(maxFileSize);
+- await browserFileStream.CopyToAsync(memoryStream);
+- memoryStream.Position = 0;
+- var fileContent = new StreamContent(memoryStream);
++ var fileContent = new StreamContent(file.OpenReadStream(maxFileSize));
+```
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #33272

Notes ...

* The versioning assumes that the problems associated with multiple file uploads (and avoiding writing to a `MemoryStream`/byte array) and Autofac will be resolved for >=9.0.
* The <9.0 text won't dissuade writing to a `MemoryStream`/byte array any longer. However, I'm leaving the bits about how it can degrade performance and present a possible security risk.
* 🤔 I think the "security risk" that we were generically mentioning before is DoS, so I'm stating that explicitly now on this PR. Let me know if that's an incorrect guess. 👂 
* The sample app changes were made in the Blazor samples repo for Blazor Server and Blazor Web App samples. Here's an example :point_right: https://github.com/dotnet/blazor-samples/blob/main/8.0/BlazorSample_BlazorWebApp/Components/Pages/FileUpload2.razor#L80-L85

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/file-uploads.md](https://github.com/dotnet/AspNetCore.Docs/blob/3ea630aa017b2d398a39815a9264a2e70a167df0/aspnetcore/blazor/file-uploads.md) | [ASP.NET Core Blazor file uploads](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/file-uploads?branch=pr-en-us-33357) |


<!-- PREVIEW-TABLE-END -->