### PR TITLE
Document that TOTP codes can be reused before it expires

### DIFF
--- a/aspnetcore/security/authentication/identity-enable-qrcodes.md
+++ b/aspnetcore/security/authentication/identity-enable-qrcodes.md
@@ -12,6 +12,9 @@ uid: security/authentication/identity-enable-qrcodes
 
 ASP.NET Core ships with support for authenticator applications for individual authentication. Two factor authentication (2FA) authenticator apps, using a Time-based One-time Password Algorithm (TOTP), are the industry recommended approach for 2FA. 2FA using TOTP is preferred to SMS 2FA. An authenticator app provides a 6 to 8 digit code which users must enter after confirming their username and password. Typically an authenticator app is installed on a smartphone.
 
+> [!WARNING]
+> ASP.NET Core TOTP codes should be kept secret because it can be used to authenticate successfully multiple times before it expires.
+
 :::moniker range=">= aspnetcore-8.0"
 
 The ASP.NET Core web app templates support authenticators but don't provide support for QR code generation. QR code generators ease the setup of 2FA. This document provides guidance for Razor Pages and MVC apps on how to add [QR code](https://wikipedia.org/wiki/QR_code) generation to the 2FA configuration page. For guidance that applies to Blazor Web Apps, see <xref:blazor/security/server/qrcodes-for-authenticator-apps>.

--- a/aspnetcore/security/authentication/identity-enable-qrcodes.md
+++ b/aspnetcore/security/authentication/identity-enable-qrcodes.md
@@ -13,7 +13,7 @@ uid: security/authentication/identity-enable-qrcodes
 ASP.NET Core ships with support for authenticator applications for individual authentication. Two factor authentication (2FA) authenticator apps, using a Time-based One-time Password Algorithm (TOTP), are the industry recommended approach for 2FA. 2FA using TOTP is preferred to SMS 2FA. An authenticator app provides a 6 to 8 digit code which users must enter after confirming their username and password. Typically an authenticator app is installed on a smartphone.
 
 > [!WARNING]
-> ASP.NET Core TOTP codes should be kept secret because it can be used to authenticate successfully multiple times before it expires.
+> An ASP.NET Core TOTP code should be kept secret because it can be used to authenticate successfully multiple times before it expires.
 
 :::moniker range=">= aspnetcore-8.0"
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore/issues/14423

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/identity-enable-qrcodes.md](https://github.com/dotnet/AspNetCore.Docs/blob/de3a3313ce2801aee3d1303a11c621c627836915/aspnetcore/security/authentication/identity-enable-qrcodes.md) | [Enable QR code generation for TOTP authenticator apps in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/identity-enable-qrcodes?branch=pr-en-us-33373) |


<!-- PREVIEW-TABLE-END -->