### PR TITLE
Replace HTTP 200 status code with 201 for POST

### DIFF
--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -323,7 +323,7 @@ Note a few of the useful details:
 * cURL: Swagger provides an example cURL command in Unix/Linux syntax, which can be run at the command line with any bash shell that uses Unix/Linux syntax, including Git Bash from [Git for Windows](https://git-scm.com/downloads).
 * Request URL: A simplified representation of the HTTP request made by Swagger UI's JavaScript code for the API call. Actual requests can include details such as headers and query parameters and a request body.
 * Server response: Includes the response body and headers. The response body shows the `id` was set to `1`.
-* Response Code: A 201 `HTTP` status code was returned indicating the request was successfully processed.
+* Response Code: A 201 `HTTP` status code was returned, indicating that the request was successfully processed and resulted in the creation of a new resource.
 
 ---
 

--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -323,7 +323,7 @@ Note a few of the useful details:
 * cURL: Swagger provides an example cURL command in Unix/Linux syntax, which can be run at the command line with any bash shell that uses Unix/Linux syntax, including Git Bash from [Git for Windows](https://git-scm.com/downloads).
 * Request URL: A simplified representation of the HTTP request made by Swagger UI's JavaScript code for the API call. Actual requests can include details such as headers and query parameters and a request body.
 * Server response: Includes the response body and headers. The response body shows the `id` was set to `1`.
-* Response Code: A 200 `HTTP` status code was returned indicating the request was successfully processed.
+* Response Code: A 201 `HTTP` status code was returned indicating the request was successfully processed.
 
 ---
 

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
@@ -227,7 +227,7 @@ Note a few of the useful details:
 * cURL: Swagger provides an example cURL command in Unix/Linux syntax, which can be run at the command line with any bash shell that uses Unix/Linux syntax, including Git Bash from [Git for Windows](https://git-scm.com/downloads).
 * Request URL: A simplified representation of the HTTP request made by Swagger UI's JavaScript code for the API call. Actual requests can include details such as headers and query parameters and a request body.
 * Server response: Includes the response body and headers. The response body shows the `id` was set to `1`.
-* Response Code: A 200 `HTTP` status code was returned indicating the request was successfully processed.
+* Response Code: A 201 `HTTP` status code was returned, indicating that the request was successfully processed and resulted in the creation of a new resource.
 ---
 
 ## Examine the GET endpoints
@@ -684,7 +684,7 @@ Note a few of the useful details:
 * cURL: Swagger provides an example cURL command in Unix/Linux syntax, which can be run at the command line with any bash shell that uses Unix/Linux syntax, including Git Bash from [Git for Windows](https://git-scm.com/downloads).
 * Request URL: A simplified representation of the HTTP request made by Swagger UI's JavaScript code for the API call. Actual requests can include details such as headers and query parameters and a request body.
 * Server response: Includes the response body and headers. The response body shows the `id` was set to `1`.
-* Response Code: A 200 `HTTP` status code was returned indicating the request was successfully processed.
+* Response Code: A 201 `HTTP` status code was returned, indicating that the request was successfully processed and resulted in the creation of a new resource.
 ---
 
 ## Examine the GET endpoints

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api8.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api8.md
@@ -304,7 +304,7 @@ Note a few of the useful details:
 * cURL: Swagger provides an example cURL command in Unix/Linux syntax, which can be run at the command line with any bash shell that uses Unix/Linux syntax, including Git Bash from [Git for Windows](https://git-scm.com/downloads).
 * Request URL: A simplified representation of the HTTP request made by Swagger UI's JavaScript code for the API call. Actual requests can include details such as headers and query parameters and a request body.
 * Server response: Includes the response body and headers. The response body shows the `id` was set to `1`.
-* Response Code: A 200 `HTTP` status code was returned indicating the request was successfully processed.
+* Response Code: A 201 `HTTP` status code was returned, indicating that the request was successfully processed and resulted in the creation of a new resource.
 ---
 
 ## Examine the GET endpoints


### PR DESCRIPTION
The correct status code for successful POST requests is 201, not 200. Even the accompanying image shows 201 as opposed to 200. The presence of a location header is confirmation that the response code is 201 as 200 does not return that header.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/min-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/d5a7af6b1e2d67f7363e586e89635d8a77f6c798/aspnetcore/tutorials/min-web-api.md) | [Tutorial: Create a minimal API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?branch=pr-en-us-33394) |


<!-- PREVIEW-TABLE-END -->