### PR TITLE
Escape quotes in no-loc text

### DIFF
--- a/aspnetcore/client-side/dotnet-interop/index.md
+++ b/aspnetcore/client-side/dotnet-interop/index.md
@@ -273,7 +273,7 @@ The preceding example displays the following output in the browser's debug conso
 > :::no-loc text="{name: 'Example JS Object', answer: 41, question: null, Symbol(wasm cs_owned_js_handle): 5, summarize: ƒ}":::  
 > :::no-loc text="{name: 'Example JS Object', answer: 42, question: null, Symbol(wasm cs_owned_js_handle): 5, summarize: ƒ}":::  
 > :::no-loc text="{name: 'Example JS Object', answer: 42, question: 'What is the answer?', Symbol(wasm cs_owned_js_handle): 5, summarize: ƒ}":::  
-> :::no-loc text="Summary: Question: "What is the answer?" Answer: 42":::
+> :::no-loc text="Summary: Question: \"What is the answer?\" Answer: 42":::
 
 ## Asynchronous interop
 


### PR DESCRIPTION
# 😈 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/client-side/dotnet-interop/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/c59c5c18abb6331269f0bc99d05fd594773cae17/aspnetcore/client-side/dotnet-interop/index.md) | [JavaScript `[JSImport]`/`[JSExport]` interop in .NET WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/client-side/dotnet-interop/index?branch=pr-en-us-33413) |

<!-- PREVIEW-TABLE-END -->