### PR TITLE
Update environmentVarableColon.md - correct line break / fragment

### DIFF
--- a/aspnetcore/includes/environmentVarableColon.md
+++ b/aspnetcore/includes/environmentVarableColon.md
@@ -1,1 +1,3 @@
-The `:` separator doesn't work with environment variable hierarchical keys on all platforms. `__`, the double underscore, is supported by all platforms. For example, the `:` separator is not supported by [Bash](https://linuxhint.com/bash-environment-variables/), but `__` is.
+The `:` separator doesn't work with environment variable hierarchical keys on all platforms. For example, the `:` separator is not supported by [Bash](https://linuxhint.com/bash-environment-variables/). The double underscore, `__`, is:
+* Supported by all platforms.
+* Automatically replaced by a colon, `:`.

--- a/aspnetcore/includes/environmentVarableColon.md
+++ b/aspnetcore/includes/environmentVarableColon.md
@@ -1,4 +1,1 @@
-The `:` separator doesn't work with environment variable hierarchical keys on all platforms. `__`, the double underscore, is:
-
-* Supported by all platforms. For example, the `:` separator is not supported by [Bash](https://linuxhint.com/bash-environment-variables/), but `__` is.
-* Automatically replaced by a `:`
+The `:` separator doesn't work with environment variable hierarchical keys on all platforms. `__`, the double underscore, is supported by all platforms. For example, the `:` separator is not supported by [Bash](https://linuxhint.com/bash-environment-variables/), but `__` is.


### PR DESCRIPTION
Fixes #33434 

Removed what appeared to be an unintended line break/bullet, along with a sentence fragment.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->