### PR TITLE
Test QuickGrid API cross-link

### DIFF
--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -16,7 +16,7 @@ uid: blazor/components/quickgrid
 
 -->
 
-The [`QuickGrid`](xref:Microsoft.AspNetCore.Components.QuickGrid) component is a Razor component for quickly and efficiently displaying data in tabular form. `QuickGrid` provides a simple and convenient data grid component for common grid rendering scenarios and serves as a reference architecture and performance baseline for building data grid components. `QuickGrid` is highly optimized and uses advanced techniques to achieve optimal rendering performance.
+The <xref:Microsoft.AspNetCore.Components.QuickGrid> component is a Razor component for quickly and efficiently displaying data in tabular form. `QuickGrid` provides a simple and convenient data grid component for common grid rendering scenarios and serves as a reference architecture and performance baseline for building data grid components. `QuickGrid` is highly optimized and uses advanced techniques to achieve optimal rendering performance.
 
 ## Package
 


### PR DESCRIPTION
Testing because there might be a problem with link text for this API, namely that the fully-qualified type is displayed even when `displayProperty` isn't stated.