### PR TITLE
UUF: Get started with Swashbuckle: Add missing code highlight

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -5,7 +5,7 @@ description: Learn how to add Swashbuckle to your ASP.NET Core web API project t
 ms.author: wpickett
 monikerRange: ">= aspnetcore-3.1 <= aspnetcore-8.0"
 ms.custom: mvc
-ms.date: 05/14/2024
+ms.date: 08/27/2024
 uid: tutorials/get-started-with-swashbuckle
 ---
 # Get started with Swashbuckle and ASP.NET Core

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle/includes/getting-started-with-swashbuckle8.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle/includes/getting-started-with-swashbuckle8.md
@@ -61,7 +61,7 @@ dotnet add TodoApi.csproj package Swashbuckle.AspNetCore -v 6.6.2
 
 Add the Swagger generator to the services collection in `Program.cs`:
 
-:::code language="csharp" source="~/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs" id="snippet_ServicesDefault" highlight="4":::
+:::code language="csharp" source="~/tutorials/web-api-help-pages-using-swagger/samples/6.x/SwashbuckleSample/Snippets/Program.cs" id="snippet_ServicesDefault" highlight="3,4":::
 
 The call to <xref:Microsoft.Extensions.DependencyInjection.EndpointMetadataApiExplorerServiceCollectionExtensions.AddEndpointsApiExplorer%2A> shown in the preceding example is required only for [minimal APIs](/aspnet/core/fundamentals/minimal-apis/overview). For more information, see [this StackOverflow post](https://stackoverflow.com/a/71933535).
 


### PR DESCRIPTION
Fixes #32864

Added a missing highlight in the code.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/getting-started-with-swashbuckle.md](https://github.com/dotnet/AspNetCore.Docs/blob/c65e8b63494ce0f973cb486a39cadc5e8dc2c10c/aspnetcore/tutorials/getting-started-with-swashbuckle.md) | [Get started with Swashbuckle and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?branch=pr-en-us-33464) |


<!-- PREVIEW-TABLE-END -->