### PR TITLE
CODEOWNERS for Blazor docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,3 +37,7 @@
 # /aspnetcore/tutorials/ @wadepickett
 # /aspnetcore/web-api/ @wadepickett @Rick-Anderson
 # /aspnetcore/whats-new/ @Rick-Anderson
+/client-side/dotnet-interop/index.md @guardrex
+/client-side/dotnet-interop/wasm-browser-app.md @guardrex
+/mvc/views/tag-helpers/built-in/component-tag-helper.md @guardrex
+/mvc/views/tag-helpers/built-in/persist-component-state.md @guardrex


### PR DESCRIPTION
Fixes #33477

* Adds the Blazor files outside of the Blazor node to the CODEOWNERS file.
* Adds them to the bottom of the list in case the earlier entries are ever activated.