### PR TITLE
Update the OpenIddict links to point to a more specific documentation page

### DIFF
--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -13,7 +13,7 @@ By [Valeriy Novytskyy](https://github.com/01binary) and [Rick Anderson](https://
 
 This tutorial demonstrates how to build an ASP.NET Core app that enables users to sign in using OAuth 2.0 with credentials from external authentication providers.
 
-[Facebook](xref:security/authentication/facebook-logins), [Twitter](xref:security/authentication/twitter-logins), [Google](xref:security/authentication/google-logins), and [Microsoft](xref:security/authentication/microsoft-logins) providers are covered in the following sections and use the starter project created in this article. Other providers are available in third-party packages such as [OpenIddict](https://documentation.openiddict.com/guides/getting-started/integrating-with-a-remote-server-instance.html), [AspNet.Security.OAuth.Providers](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers) and [AspNet.Security.OpenId.Providers](https://github.com/aspnet-contrib/AspNet.Security.OpenId.Providers).
+[Facebook](xref:security/authentication/facebook-logins), [Twitter](xref:security/authentication/twitter-logins), [Google](xref:security/authentication/google-logins), and [Microsoft](xref:security/authentication/microsoft-logins) providers are covered in the following sections and use the starter project created in this article. Other providers are available in third-party packages such as [OpenIddict](https://documentation.openiddict.com/integrations/web-providers), [AspNet.Security.OAuth.Providers](https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers) and [AspNet.Security.OpenId.Providers](https://github.com/aspnet-contrib/AspNet.Security.OpenId.Providers).
 
 Enabling users to sign in with their existing credentials:
 

--- a/aspnetcore/security/authentication/social/other-logins.md
+++ b/aspnetcore/security/authentication/social/other-logins.md
@@ -11,7 +11,7 @@ uid: security/authentication/otherlogins
 
 By [Rick Anderson](https://twitter.com/RickAndMSFT), [Pranav Rastogi](https://github.com/rustd), and [Valeriy Novytskyy](https://github.com/01binary)
 
-The following list includes common external OAuth authentication providers that work with ASP.NET Core apps. Third-party NuGet packages, such as the ones maintained by [OpenIddict](https://documentation.openiddict.com/guides/getting-started/integrating-with-a-remote-server-instance.html) or [aspnet-contrib](https://www.nuget.org/packages?q=owners%3Aaspnet-contrib+title%3AOAuth), can be used to complement the authentication providers implemented by the ASP.NET Core team.
+The following list includes common external OAuth authentication providers that work with ASP.NET Core apps. Third-party NuGet packages, such as the ones maintained by [OpenIddict](https://documentation.openiddict.com/integrations/web-providers) or [aspnet-contrib](https://www.nuget.org/packages?q=owners%3Aaspnet-contrib+title%3AOAuth), can be used to complement the authentication providers implemented by the ASP.NET Core team.
 
 * [LinkedIn](https://www.linkedin.com/developer/apps)
 

--- a/aspnetcore/security/authentication/social/twitter-logins.md
+++ b/aspnetcore/security/authentication/social/twitter-logins.md
@@ -15,7 +15,7 @@ By [Valeriy Novytskyy](https://github.com/01binary) and [Rick Anderson](https://
 This sample shows how to enable users to [sign in with their Twitter account](https://dev.twitter.com/web/sign-in/desktop-browser) using a sample ASP.NET Core project created on the [previous page](xref:security/authentication/social/index).
 
 > [!NOTE]
-> The Microsoft.AspNetCore.Authentication.Twitter package described below uses the OAuth 1.0 APIs provided by Twitter. Twitter has since added OAuth 2.0 APIs with a different set of functionality. The [OpenIddict](https://documentation.openiddict.com/guides/getting-started/integrating-with-a-remote-server-instance.html) and [AspNet.Security.OAuth.Twitter](https://www.nuget.org/packages/AspNet.Security.OAuth.Twitter/) packages are community implementations that use the new OAuth 2.0 APIs.
+> The Microsoft.AspNetCore.Authentication.Twitter package described below uses the OAuth 1.0 APIs provided by Twitter. Twitter has since added OAuth 2.0 APIs with a different set of functionality. The [OpenIddict](https://documentation.openiddict.com/integrations/web-providers) and [AspNet.Security.OAuth.Twitter](https://www.nuget.org/packages/AspNet.Security.OAuth.Twitter/) packages are community implementations that use the new OAuth 2.0 APIs.
 
 ## Create the app in Twitter
 


### PR DESCRIPTION
Fixes #33505

The OpenIddict documentation website now has a specific page for the `OpenIddict.Client.WebIntegration` package that lists the supported services and explains the differences between the OpenIddict providers and the older aspnet-contrib providers: https://documentation.openiddict.com/integrations/web-providers.

Note: the `.html` extension was deliberately removed as we now use "clean URLs" 😃  

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/social/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/ee3a6bf6a586ca5acbb5b9d15e4867e5cde3cb87/aspnetcore/security/authentication/social/index.md) | [Facebook, Google, and external provider authentication in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/social/index?branch=pr-en-us-33493) |
| [aspnetcore/security/authentication/social/other-logins.md](https://github.com/dotnet/AspNetCore.Docs/blob/ee3a6bf6a586ca5acbb5b9d15e4867e5cde3cb87/aspnetcore/security/authentication/social/other-logins.md) | [External OAuth authentication providers](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/social/other-logins?branch=pr-en-us-33493) |
| [aspnetcore/security/authentication/social/twitter-logins.md](https://github.com/dotnet/AspNetCore.Docs/blob/ee3a6bf6a586ca5acbb5b9d15e4867e5cde3cb87/aspnetcore/security/authentication/social/twitter-logins.md) | [Twitter external sign-in setup with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/social/twitter-logins?branch=pr-en-us-33493) |

<!-- PREVIEW-TABLE-END -->