### PR TITLE
RPOC: First MVC: Add RPOC warning

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql.md
@@ -3,7 +3,7 @@ title: Part 5, work with a database in an ASP.NET Core MVC app
 author: wadepickett
 description: Part 5 of tutorial series on ASP.NET Core MVC.
 ms.author: wpickett
-ms.date: 07/24/2024
+ms.date: 09/05/2024
 monikerRange: '>= aspnetcore-3.1'
 uid: tutorials/first-mvc-app/working-with-sql
 ---
@@ -36,7 +36,7 @@ The ASP.NET Core [Configuration](xref:fundamentals/configuration/index) system r
 
 ---
 
-When the app is deployed to a test or production server, an environment variable can be used to set the connection string to a production SQL Server. For more information, see [Configuration](xref:fundamentals/configuration/index).
+[!INCLUDE [managed-identities-test-non-production](~/includes/managed-identities-test-non-production.md)]
 
 # [Visual Studio](#tab/visual-studio)
 

--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql/includes/working-with-sql3-5.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql/includes/working-with-sql3-5.md
@@ -20,7 +20,7 @@ The ASP.NET Core [Configuration](xref:fundamentals/configuration/index) system r
 
 ---
 
-When the app is deployed to a test or production server, an environment variable can be used to set the connection string to a production SQL Server. For more information, see [Configuration](xref:fundamentals/configuration/index).
+[!INCLUDE [managed-identities-test-non-production](~/includes/managed-identities-test-non-production.md)]
 
 # [Visual Studio](#tab/visual-studio)
 

--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql/includes/working-with-sql6.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql/includes/working-with-sql6.md
@@ -20,7 +20,7 @@ The ASP.NET Core [Configuration](xref:fundamentals/configuration/index) system r
 
 ---
 
-When the app is deployed to a test or production server, an environment variable can be used to set the connection string to a production SQL Server. For more information, see [Configuration](xref:fundamentals/configuration/index).
+[!INCLUDE [managed-identities-test-non-production](~/includes/managed-identities-test-non-production.md)]
 
 # [Visual Studio](#tab/visual-studio)
 

--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql/includes/working-with-sql7.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql/includes/working-with-sql7.md
@@ -20,7 +20,7 @@ The ASP.NET Core [Configuration](xref:fundamentals/configuration/index) system r
 
 ---
 
-When the app is deployed to a test or production server, an environment variable can be used to set the connection string to a production SQL Server. For more information, see [Configuration](xref:fundamentals/configuration/index).
+[!INCLUDE [managed-identities-test-non-production](~/includes/managed-identities-test-non-production.md)]
 
 # [Visual Studio](#tab/visual-studio)
 

--- a/aspnetcore/tutorials/first-mvc-app/working-with-sql/includes/working-with-sql8.md
+++ b/aspnetcore/tutorials/first-mvc-app/working-with-sql/includes/working-with-sql8.md
@@ -20,7 +20,7 @@ The ASP.NET Core [Configuration](xref:fundamentals/configuration/index) system r
 
 ---
 
-When the app is deployed to a test or production server, an environment variable can be used to set the connection string to a production SQL Server. For more information, see [Configuration](xref:fundamentals/configuration/index).
+[!INCLUDE [managed-identities-test-non-production](~/includes/managed-identities-test-non-production.md)]
 
 # [Visual Studio](#tab/visual-studio)
 


### PR DESCRIPTION
Fixes #33543

For First MVC tutorial series on the working-with-sql.md, added standard include for ROPC warning as we also did for PR #33408

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mvc-app/working-with-sql.md](https://github.com/dotnet/AspNetCore.Docs/blob/80a9015831f5c7a8994a2f1e8fde029f9671eac5/aspnetcore/tutorials/first-mvc-app/working-with-sql.md) | [Part 5, work with a database in an ASP.NET Core MVC app](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/working-with-sql?branch=pr-en-us-33544) |


<!-- PREVIEW-TABLE-END -->