### PR TITLE
swashbuckle.aspnetcore being removed in dotnet 9

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle.md
@@ -5,7 +5,7 @@ description: Learn how to add Swashbuckle to your ASP.NET Core web API project t
 ms.author: wpickett
 monikerRange: ">= aspnetcore-3.1 <= aspnetcore-8.0"
 ms.custom: mvc
-ms.date: 08/27/2024
+ms.date: 8/27/2024
 uid: tutorials/get-started-with-swashbuckle
 ---
 # Get started with Swashbuckle and ASP.NET Core

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle/includes/getting-started-with-swashbuckle8.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle/includes/getting-started-with-swashbuckle8.md
@@ -1,6 +1,9 @@
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-9.0"
 
+> [!NOTE]
+> Swashbuckle is not available in .NET 9 and later. For an alternative, see <xref:fundamentals/openapi/overview>.
+
 There are three main components to Swashbuckle:
 
 * [Swashbuckle.AspNetCore.Swagger](https://www.nuget.org/packages/Swashbuckle.AspNetCore.Swagger/): a Swagger object model and middleware to expose `SwaggerDocument` objects as JSON endpoints.

--- a/aspnetcore/tutorials/getting-started-with-swashbuckle/includes/getting-started-with-swashbuckle8.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle/includes/getting-started-with-swashbuckle8.md
@@ -2,7 +2,7 @@
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-9.0"
 
 > [!NOTE]
-> Swashbuckle is not available in .NET 9 and later. For an alternative, see <xref:fundamentals/openapi/overview>.
+> Swashbuckle is not available in .NET 9 and later. For an alternative, see <xref:fundamentals/openapi/overview?view=aspnetcore-9.0&preserve-view=true>.
 
 There are three main components to Swashbuckle:
 


### PR DESCRIPTION
Fixes #33296

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/getting-started-with-swashbuckle.md](https://github.com/dotnet/AspNetCore.Docs/blob/e32115c991e03c61341bacc7ae8d470c3921a623/aspnetcore/tutorials/getting-started-with-swashbuckle.md) | [Get started with Swashbuckle and ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/getting-started-with-swashbuckle?branch=pr-en-us-33545) |


<!-- PREVIEW-TABLE-END -->