### PR TITLE
Override InputNumber type attribute

### DIFF
--- a/aspnetcore/blazor/forms/input-components.md
+++ b/aspnetcore/blazor/forms/input-components.md
@@ -527,3 +527,87 @@ Assign a custom template to <xref:Microsoft.AspNetCore.Components.Forms.InputDat
 > The ProductionDate field has an incorrect date value.
 
 :::moniker-end
+
+:::moniker range=">= aspnetcore-9.0"
+
+### Override `InputNumber` `type` attribute
+
+The `InputNumber` component supports overriding the `type` attribute, where the `{TYPE}` placeholder represents the `type` value:
+
+```razor
+<InputNumber ... type="{TYPE}" ... />
+```
+
+For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) with an `InputNumber` component to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
+
+```razor
+<InputNumber @bind-Value="..." max="..." min="..." step="..." type="range" />
+```
+
+If the user's browser doesn't support `type="range"`, the `<input>` element gracefully degrades back to a default text box.
+
+In the following example, the `InputNumber` components set their `type` attributes to `range`, resulting in a set of three sliders or dial controls by typical browsers.
+
+`EngineForm.razor`:
+
+```razor
+@page "/engine-form"
+@inject ILogger<EngineForm> Logger
+
+<EditForm Model="Model" OnSubmit="Submit" FormName="EngineForm">
+    <div>
+        <label>
+            Nacelle Count (2-6): 
+            <InputNumber @bind-Value="Model!.NacelleCount" max="6" min="2" 
+                step="1" type="range" />
+        </label>
+    </div>
+    <div>
+        <label>
+            Plasma Injector Count (per nacelle, 2-8): 
+            <InputNumber @bind-Value="Model!.PlasmaInjectorCount" max="8" min="2" 
+                step="1" type="range" />
+        </label>
+    </div>
+    <div>
+        <label>
+            Warp Field Coil Count (per nacelle, 4-20): 
+            <InputNumber @bind-Value="Model!.WarpFieldCoilCount" max="20" min="4" 
+                step="1" type="range" />
+        </label>
+    </div>
+    <div>
+        <button type="submit">Submit</button>
+    </div>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private EngineSpecifications? Model { get; set; }
+
+    protected override void OnInitialized() => Model ??= new();
+
+    private void Submit()
+    {
+        Logger.LogInformation(
+            "Nacelle Count = {NacelleCount}, Plasma Injector Count = " +
+            "{PlasmaInjectorCount}, Warp Field Coil Count = {WarpFieldCoilCount}", 
+            Model?.PlasmaInjectorCount, Model?.WarpFieldCoilCount, 
+            Model?.NacelleCount);
+    }
+
+    public class Starship
+    {
+        [Required, Range(minimum: 2, maximum: 6)]
+        public int NacelleCount { get; set; }
+
+        [Required, Range(minimum: 2, maximum: 8)]
+        public int PlasmaInjectorCount { get; set; }
+
+        [Required, Range(minimum: 4, maximum: 20)]
+        public int WarpFieldCoilCount { get; set; }
+    }
+}
+```
+
+:::moniker-end

--- a/aspnetcore/blazor/forms/input-components.md
+++ b/aspnetcore/blazor/forms/input-components.md
@@ -67,6 +67,18 @@ Input components provide default behavior for validating when a field is changed
 
 Some components include useful parsing logic. For example, <xref:Microsoft.AspNetCore.Components.Forms.InputDate%601> and <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> handle unparseable values gracefully by registering unparseable values as validation errors. Types that can accept null values also support nullability of the target field (for example, `int?` for a nullable integer).
 
+:::moniker range=">= aspnetcore-9.0"
+
+The <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> component supports overriding the `type` attribute. For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
+
+```razor
+<InputNumber @bind-Value="..." max="..." min="..." step="..." type="range" />
+```
+
+If the user's browser doesn't support `type="range"`, the `<input>` element gracefully degrades back to a default text box.
+
+:::moniker-end
+
 :::moniker range=">= aspnetcore-5.0"
 
 For more information on the <xref:Microsoft.AspNetCore.Components.Forms.InputFile> component, see <xref:blazor/file-uploads>.
@@ -525,89 +537,5 @@ Assign a custom template to <xref:Microsoft.AspNetCore.Components.Forms.InputDat
 ```
 
 > The ProductionDate field has an incorrect date value.
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-9.0"
-
-### Override `InputNumber` `type` attribute
-
-The `InputNumber` component supports overriding the `type` attribute, where the `{TYPE}` placeholder represents the `type` value:
-
-```razor
-<InputNumber ... type="{TYPE}" ... />
-```
-
-For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) with an `InputNumber` component to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
-
-```razor
-<InputNumber @bind-Value="..." max="..." min="..." step="..." type="range" />
-```
-
-If the user's browser doesn't support `type="range"`, the `<input>` element gracefully degrades back to a default text box.
-
-In the following example, the `InputNumber` components set their `type` attributes to `range`, resulting in a set of three sliders or dial controls by typical browsers.
-
-`EngineForm.razor`:
-
-```razor
-@page "/engine-form"
-@inject ILogger<EngineForm> Logger
-
-<EditForm Model="Model" OnSubmit="Submit" FormName="EngineForm">
-    <div>
-        <label>
-            Nacelle Count (2-6): 
-            <InputNumber @bind-Value="Model!.NacelleCount" max="6" min="2" 
-                step="1" type="range" />
-        </label>
-    </div>
-    <div>
-        <label>
-            Plasma Injector Count (per nacelle, 2-8): 
-            <InputNumber @bind-Value="Model!.PlasmaInjectorCount" max="8" min="2" 
-                step="1" type="range" />
-        </label>
-    </div>
-    <div>
-        <label>
-            Warp Field Coil Count (per nacelle, 4-20): 
-            <InputNumber @bind-Value="Model!.WarpFieldCoilCount" max="20" min="4" 
-                step="1" type="range" />
-        </label>
-    </div>
-    <div>
-        <button type="submit">Submit</button>
-    </div>
-</EditForm>
-
-@code {
-    [SupplyParameterFromForm]
-    private EngineSpecifications? Model { get; set; }
-
-    protected override void OnInitialized() => Model ??= new();
-
-    private void Submit()
-    {
-        Logger.LogInformation(
-            "Nacelle Count = {NacelleCount}, Plasma Injector Count = " +
-            "{PlasmaInjectorCount}, Warp Field Coil Count = {WarpFieldCoilCount}", 
-            Model?.PlasmaInjectorCount, Model?.WarpFieldCoilCount, 
-            Model?.NacelleCount);
-    }
-
-    public class Starship
-    {
-        [Required, Range(minimum: 2, maximum: 6)]
-        public int NacelleCount { get; set; }
-
-        [Required, Range(minimum: 2, maximum: 8)]
-        public int PlasmaInjectorCount { get; set; }
-
-        [Required, Range(minimum: 4, maximum: 20)]
-        public int WarpFieldCoilCount { get; set; }
-    }
-}
-```
 
 :::moniker-end

--- a/aspnetcore/blazor/forms/input-components.md
+++ b/aspnetcore/blazor/forms/input-components.md
@@ -69,13 +69,11 @@ Some components include useful parsing logic. For example, <xref:Microsoft.AspNe
 
 :::moniker range=">= aspnetcore-9.0"
 
-The <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> component supports overriding the `type` attribute. For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
+The <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> component supports the [`type="range"` attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input/range), which creates a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
 
 ```razor
 <InputNumber @bind-Value="..." max="..." min="..." step="..." type="range" />
 ```
-
-If the user's browser doesn't support `type="range"`, the `<input>` element gracefully degrades back to a default text box.
 
 :::moniker-end
 

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -196,16 +196,32 @@ The default `OverscanCount` is 3. The following example increases the `OverscanC
 
 ### Override `InputNumber` `type` attribute
 
-The `InputNumber` component now supports overriding the `type` attribute, where the `{TYPE}` placeholder represents the `type` value:
+The `InputNumber` component now supports overriding the `type` attribute. For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
 
 ```razor
-<InputNumber ... type="{TYPE}" ... />
+<EditForm Model="Model" OnSubmit="Submit" FormName="EngineForm">
+    <div>
+        <label>
+            Nacelle Count (2-6): 
+            <InputNumber @bind-Value="Model!.NacelleCount" max="6" min="2" 
+                step="1" type="range" />
+        </label>
+    </div>
+    <div>
+        <button type="submit">Submit</button>
+    </div>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private EngineSpecifications? Model { get; set; }
+
+    protected override void OnInitialized() => Model ??= new();
+
+    public class Starship
+    {
+        [Required, Range(minimum: 2, maximum: 6)]
+        public int NacelleCount { get; set; }
+    }
+}
 ```
-
-For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
-
-```razor
-<InputNumber @bind-Value="Model!.Rating" max="10" min="1" step="1" type="range" />
-```
-
-For more information and an example use in a component, see <xref:blazor/forms/input-components?view=aspnetcore-9.0#override-inputnumber-type-attribute>.

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -194,7 +194,7 @@ The default `OverscanCount` is 3. The following example increases the `OverscanC
 </QuickGrid>
 ```
 
-### `InputNumber` component supports `type="range"` attribute
+### `InputNumber` component supports the `type="range"` attribute
 
 The <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> component now supports the [`type="range"` attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input/range), which creates a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
 

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -196,7 +196,7 @@ The default `OverscanCount` is 3. The following example increases the `OverscanC
 
 ### Override `InputNumber` `type` attribute
 
-The `InputNumber` component now supports overriding the `type` attribute. For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
+The <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> component now supports overriding the `type` attribute. For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
 
 ```razor
 <EditForm Model="Model" OnSubmit="Submit" FormName="EngineForm">
@@ -218,10 +218,7 @@ The `InputNumber` component now supports overriding the `type` attribute. For ex
 
     protected override void OnInitialized() => Model ??= new();
 
-    private void Submit()
-    {
-        ...
-    }
+    private void Submit() {}
 
     public class EngineSpecifications
     {

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -218,6 +218,11 @@ The `InputNumber` component now supports overriding the `type` attribute. For ex
 
     protected override void OnInitialized() => Model ??= new();
 
+    private void Submit()
+    {
+        ...
+    }
+
     public class EngineSpecifications
     {
         [Required, Range(minimum: 2, maximum: 6)]

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -208,4 +208,4 @@ For example, specify an [`<input>` element of `type="range"`](https://developer.
 <InputNumber @bind-Value="Model!.Rating" max="10" min="1" step="1" type="range" />
 ```
 
-For more information and an example use in a component, see <xref:xref:blazor/forms/input-components?view=aspnetcore-9.0#override-inputnumber-type-attribute>.
+For more information and an example use in a component, see <xref:blazor/forms/input-components?view=aspnetcore-9.0#override-inputnumber-type-attribute>.

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -193,3 +193,19 @@ The default `OverscanCount` is 3. The following example increases the `OverscanC
     ...
 </QuickGrid>
 ```
+
+### Override `InputNumber` `type` attribute
+
+The `InputNumber` component now supports overriding the `type` attribute, where the `{TYPE}` placeholder represents the `type` value:
+
+```razor
+<InputNumber ... type="{TYPE}" ... />
+```
+
+For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
+
+```razor
+<InputNumber @bind-Value="Model!.Rating" max="10" min="1" step="1" type="range" />
+```
+
+For more information and an example use in a component, see <xref:xref:blazor/forms/input-components?view=aspnetcore-9.0#override-inputnumber-type-attribute>.

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -218,7 +218,7 @@ The `InputNumber` component now supports overriding the `type` attribute. For ex
 
     protected override void OnInitialized() => Model ??= new();
 
-    public class Starship
+    public class EngineSpecifications
     {
         [Required, Range(minimum: 2, maximum: 6)]
         public int NacelleCount { get; set; }

--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -194,9 +194,9 @@ The default `OverscanCount` is 3. The following example increases the `OverscanC
 </QuickGrid>
 ```
 
-### Override `InputNumber` `type` attribute
+### `InputNumber` component supports `type="range"` attribute
 
-The <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> component now supports overriding the `type` attribute. For example, specify an [`<input>` element of `type="range"`](https://developer.mozilla.org/docs/Web/HTML/Element/input/range) to create a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
+The <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> component now supports the [`type="range"` attribute](https://developer.mozilla.org/docs/Web/HTML/Element/input/range), which creates a range input that supports model binding and form validation, typically rendered as a slider or dial control rather than a text box:
 
 ```razor
 <EditForm Model="Model" OnSubmit="Submit" FormName="EngineForm">


### PR DESCRIPTION
Fixes #33556

Mackinnon ...

* This covers both the *9.0 What's New* article and the new section in the *Input Components* article.
* Sorry that I replaced your example. I'm trying to go with Star Trek-themed forms throughout the *Forms* node.
* Is there anything else that we need to tell devs in the article section?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/input-components.md](https://github.com/dotnet/AspNetCore.Docs/blob/378ef5264bf06c9a358fce7da5917206c62d0375/aspnetcore/blazor/forms/input-components.md) | [ASP.NET Core Blazor input components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/input-components?branch=pr-en-us-33557) |


<!-- PREVIEW-TABLE-END -->