### PR TITLE
Cross-link Blazor's security node

### DIFF
--- a/aspnetcore/security/index.md
+++ b/aspnetcore/security/index.md
@@ -22,6 +22,8 @@ ASP.NET Core enables developers to configure and manage security. The following 
 
 These security features allow you to build robust and secure ASP.NET Core apps.
 
+For Blazor security coverage, which adds to or supersedes the guidance in this node, see <xref:blazor/security/index> and the other articles in Blazor's *Security and Identity* node.
+
 ## ASP.NET Core security features
 
 ASP.NET Core provides many tools and libraries to secure ASP.NET Core apps such as built-in identity providers and third-party identity services such as Facebook, Twitter, and LinkedIn. ASP.NET Core provides several approaches to store app secrets.


### PR DESCRIPTION
Addresses #33555

Tom ...

Per DR's blessing offline, we need a link here that surfaces the Blazor *Security and Identity* overview and node. If you're ok with the language, this is all we probably need.

This PR merely "addresses" the issue because I'll be analyzing the main doc set next week for other spots where we need to mention something this effect, especially in the articles that appear before the Blazor node for those readers going right down the ToC to learn ASP.NET Core.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/be632219b377c20077930bd1e0c583d7a586764b/aspnetcore/security/index.md) | [ASP.NET Core security topics](https://review.learn.microsoft.com/en-us/aspnet/core/security/index?branch=pr-en-us-33558) |

<!-- PREVIEW-TABLE-END -->