### PR TITLE
Clarify that "per host" means "per SNI host name" in certauth.md

### DIFF
--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -379,7 +379,7 @@ Kestrel controls client certificate negotiation with the <xref:Microsoft.AspNetC
 
 *NOTE* The application should buffer or consume any request body data before attempting the renegotiation, otherwise `GetClientCertificateAsync` may throw `InvalidOperationException: Client stream needs to be drained before renegotiation.`.
 
-If you're programmatically configuring the TLS settings per host there is a new [UseHttps](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps) overload available in .NET 6 and later that takes <xref:Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions> and controls client certificate renegotiation via <xref:Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.AllowDelayedClientCertificateNegotation%2A?displayProperty=nameWithType>.
+If you're programmatically configuring the TLS settings per SNI host name there is a new [UseHttps](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps) overload available in .NET 6 and later that takes <xref:Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions> and controls client certificate renegotiation via <xref:Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.AllowDelayedClientCertificateNegotation%2A?displayProperty=nameWithType>.
 
     
 :::moniker-end

--- a/aspnetcore/security/authentication/certauth.md
+++ b/aspnetcore/security/authentication/certauth.md
@@ -379,7 +379,7 @@ Kestrel controls client certificate negotiation with the <xref:Microsoft.AspNetC
 
 *NOTE* The application should buffer or consume any request body data before attempting the renegotiation, otherwise `GetClientCertificateAsync` may throw `InvalidOperationException: Client stream needs to be drained before renegotiation.`.
 
-If you're programmatically configuring the TLS settings per SNI host name there is a new [UseHttps](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps) overload available in .NET 6 and later that takes <xref:Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions> and controls client certificate renegotiation via <xref:Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.AllowDelayedClientCertificateNegotation%2A?displayProperty=nameWithType>.
+If you're programmatically configuring the TLS settings per SNI host name, call the [`UseHttps`](xref:fundamentals/servers/kestrel/endpoints#listenoptionsusehttps) overload (.NET 6 or later) that takes <xref:Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackOptions> and controls client certificate renegotiation via <xref:Microsoft.AspNetCore.Server.Kestrel.Https.TlsHandshakeCallbackContext.AllowDelayedClientCertificateNegotation%2A?displayProperty=nameWithType>.
 
     
 :::moniker-end


### PR DESCRIPTION
"Per host" meaning "per SNI host name" can be inferred from the context, but it took me a second to figure out what was meant by "per host" when I was reading it today, so I figured it makes sense to clarify this.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/certauth.md](https://github.com/dotnet/AspNetCore.Docs/blob/40f0ddda95b5adc38cac7a1ad20ccd702df9f690/aspnetcore/security/authentication/certauth.md) | [Configure certificate authentication in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/certauth?branch=pr-en-us-33561) |


<!-- PREVIEW-TABLE-END -->