### PR TITLE
Linux cert feature not in .NET 8 yet

### DIFF
--- a/aspnetcore/includes/trustCertVSC.md
+++ b/aspnetcore/includes/trustCertVSC.md
@@ -5,7 +5,7 @@
   ```
   :::moniker range="<=aspnetcore-8.0"
 
-  The preceding command requires .NET 8.0.402 SDK or later on Linux. For Linux on .NET 8.0.401 SDK and earlier, see your Linux distribution's documentation for trusting a certificate.
+  The preceding command requires .NET 9 SDK or later on Linux. For Linux on .NET 8.0.401 SDK and earlier, see your Linux distribution's documentation for trusting a certificate.
 
   :::moniker-end
 

--- a/aspnetcore/security/docker-compose-https.md
+++ b/aspnetcore/security/docker-compose-https.md
@@ -98,7 +98,7 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p $CREDENTIAL_PL
 dotnet dev-certs https --trust
 ```
 
-On Linux, `dotnet dev-certs https --trust` requires .NET 8.0.402 SDK or later. For Linux on .NET 8.0.401 SDK and earlier, see your Linux distribution's documentation for trusting a certificate.
+On Linux, `dotnet dev-certs https --trust` requires .NET 9 SDK or later. For Linux on .NET 8.0.401 SDK and earlier, see your Linux distribution's documentation for trusting a certificate.
 
 In the preceding commands, replace `$CREDENTIAL_PLACEHOLDER$` with a password.
 

--- a/aspnetcore/security/docker-https.md
+++ b/aspnetcore/security/docker-https.md
@@ -79,7 +79,7 @@ dotnet dev-certs https -ep ${HOME}/.aspnet/https/aspnetapp.pfx -p <CREDENTIAL_PL
 dotnet dev-certs https --trust
 ```
 
-On Linux, `dotnet dev-certs https --trust` requires .NET 8.0.402 SDK or later. For Linux on .NET 8.0.401 SDK and earlier, see your Linux distribution's documentation for trusting a certificate.
+On Linux, `dotnet dev-certs https --trust` requires .NET 9 SDK or later. For Linux on .NET 8.0.401 SDK and earlier, see your Linux distribution's documentation for trusting a certificate.
 
 In the preceding commands, replace `<CREDENTIAL_PLACEHOLDER>` with a password.
 

--- a/aspnetcore/security/enforcing-ssl/includes/enforcing-ssl6-8.md
+++ b/aspnetcore/security/enforcing-ssl/includes/enforcing-ssl6-8.md
@@ -1,7 +1,7 @@
 :::moniker range=">= aspnetcore-6.0 <=aspnetcore-8.0"
 
 > [!NOTE]
-> If you're using .NET 8.0.402 SDK or later, see the updated Linux procedures in the [.NET 9 version of this article](?view=aspnetcore-9.0&preserve-view=true).
+> If you're using .NET 9 SDK or later, see the updated Linux procedures in the [.NET 9 version of this article](?view=aspnetcore-9.0&preserve-view=true).
 
 > [!WARNING]
 > ## API projects


### PR DESCRIPTION
Fixes #33579


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/docker-compose-https.md](https://github.com/dotnet/AspNetCore.Docs/blob/45a274aa61af4cb8a7dd483da87800e938ebed4d/aspnetcore/security/docker-compose-https.md) | [Hosting ASP.NET Core images with Docker Compose over HTTPS](https://review.learn.microsoft.com/en-us/aspnet/core/security/docker-compose-https?branch=pr-en-us-33580) |
| [aspnetcore/security/docker-https.md](https://github.com/dotnet/AspNetCore.Docs/blob/45a274aa61af4cb8a7dd483da87800e938ebed4d/aspnetcore/security/docker-https.md) | [Hosting ASP.NET Core Images with Docker over HTTPS](https://review.learn.microsoft.com/en-us/aspnet/core/security/docker-https?branch=pr-en-us-33580) |

<!-- PREVIEW-TABLE-END -->