### PR TITLE
MapHub is not present on ApplicationBuilder but on EndpointRouteBuilder

### DIFF
--- a/aspnetcore/signalr/authn-and-authz/6.0sample/SignalRAuthenticationSample/Program.cs
+++ b/aspnetcore/signalr/authn-and-authz/6.0sample/SignalRAuthenticationSample/Program.cs
@@ -39,7 +39,11 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapRazorPages();
-app.MapHub<ChatHub>("/chat");
+
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHub<ChatHub>("/chat");
+});
 
 app.Run();
 #endregion

--- a/aspnetcore/tutorials/signalr/samples/6.x/SignalRChat/Program.cs
+++ b/aspnetcore/tutorials/signalr/samples/6.x/SignalRChat/Program.cs
@@ -21,6 +21,9 @@ app.UseRouting();
 app.UseAuthorization();
 
 app.MapRazorPages();
-app.MapHub<ChatHub>("/chatHub");
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHub<ChatHub>("/chatHub");
+});
 
 app.Run();

--- a/aspnetcore/tutorials/signalr/samples/7.x/SignalRChat/Program.cs
+++ b/aspnetcore/tutorials/signalr/samples/7.x/SignalRChat/Program.cs
@@ -24,6 +24,9 @@ app.UseRouting();
 app.UseAuthorization();
 
 app.MapRazorPages();
-app.MapHub<ChatHub>("/chatHub");
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHub<ChatHub>("/chatHub");
+});
 
 app.Run();

--- a/aspnetcore/tutorials/signalr/samples/8.x/SignalRChat/Program.cs
+++ b/aspnetcore/tutorials/signalr/samples/8.x/SignalRChat/Program.cs
@@ -24,6 +24,9 @@ app.UseRouting();
 app.UseAuthorization();
 
 app.MapRazorPages();
-app.MapHub<ChatHub>("/chatHub");
+app.UseEndpoints(endpoints =>
+{
+    endpoints.MapHub<ChatHub>("/chatHub");
+});
 
 app.Run();


### PR DESCRIPTION
`MapHub<>` extension method is not present on `IApplicationBuilder` anymore, instead its on `IEndpointRouteBuilder`

Even in [source code](https://github.com/dotnet/aspnetcore/tree/main/src/SignalR/server/SignalR/src) you do not have any other extensions than to `IEndpointRouteBuilder`