### PR TITLE
Add content on data types and schema transformers

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/Program.cs
@@ -235,10 +235,7 @@ internal sealed class BearerSecuritySchemeTransformer(IAuthenticationSchemeProvi
 
 #if SCHEMAtransformer1
 // <snippet_schematransformer1>
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.OpenApi;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder();
 

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/Program.cs
@@ -1,7 +1,7 @@
-//#define DEFAULT 
-//#define DOCUMENTtransformerInOut 
-//#define DOCUMENTtransformer1 
-//#define DOCUMENTtransformer2 
+//#define DEFAULT
+//#define DOCUMENTtransformerInOut
+//#define DOCUMENTtransformer1
+//#define DOCUMENTtransformer2
 #define DOCUMENTtransformerUse999
 //#define DEFAULT
 //#define FIRST
@@ -233,6 +233,41 @@ internal sealed class BearerSecuritySchemeTransformer(IAuthenticationSchemeProvi
 // </snippet_multidoc_operationtransformer1>
 #endif
 
+#if SCHEMAtransformer1
+// <snippet_schematransformer1>
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder();
+
+builder.Services.AddOpenApi(options => {
+    // Schema transformer to set the format of decimal to 'decimal'
+    options.AddSchemaTransformer((schema, context, cancellationToken) =>
+    {
+        if (context.JsonTypeInfo.Type == typeof(decimal))
+        {
+            schema.Format = "decimal";
+        }
+        return Task.CompletedTask;
+    });
+});
+
+var app = builder.Build();
+
+app.MapOpenApi();
+
+app.MapGet("/", () => new Body { Amount = 1.1m });
+
+app.Run();
+
+public class Body {
+    public decimal Amount { get; set; }
+}
+// </snippet_schematransformer1>
+#endif
+
 #if SWAGGERUI
 // <snippet_swaggerui>
 using Microsoft.AspNetCore.Authentication;
@@ -371,7 +406,7 @@ var builder = WebApplication.CreateBuilder();
 
 builder.Services.AddOpenApi(options =>
 {
-    options.AddDocumentTransformer((document, context, cancellationToken) 
+    options.AddDocumentTransformer((document, context, cancellationToken)
                              => Task.CompletedTask);
     options.AddDocumentTransformer(new MyDocumentTransformer());
     options.AddDocumentTransformer<MyDocumentTransformer>();

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/WebMinOpenApi.csproj
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/WebMinOpenApi.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-preview.7.24406.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0-preview.7.24406.2" />
-    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-preview.7.24406.2">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0-rc.1.24452.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.0-rc.1.24452.1" />
+    <PackageReference Include="Microsoft.Extensions.ApiDescription.Server" Version="9.0.0-rc.1.24452.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/WebMinOpenApi.json
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/WebMinOpenApi.json
@@ -2,6 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "GetDocument.Insider | v1",
+    "description": "Transformed OpenAPI document",
     "version": "1.0.0"
   },
   "paths": {
@@ -10,22 +11,24 @@
         "tags": [
           "GetDocument.Insider"
         ],
+        "summary": "Transformed OpenAPI operation",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "text/plain": {
                 "schema": {
-                  "type": "string"
+                  "type": "string",
+                  "description": "Transformed OpenAPI schema"
                 }
               }
             }
           }
-        },
-        "x-aspnetcore-id": "14ccb7f6-1846-48e4-aeaf-c760aadda7c3"
+        }
       }
     }
   },
+  "components": { },
   "tags": [
     {
       "name": "GetDocument.Insider"

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/nuget.config
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/WebMinOpenApi/nuget.config
@@ -4,6 +4,5 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet9" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet9/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -349,10 +349,9 @@ app.MapGet("/attributes",
 C# classes or records used in request or response bodies are represented as schemas
 in the generated OpenAPI document.
 By default, only public properties are represented in the schema, but there are
-<xref:System.Text.Json.Serialization.JsonSerializerOptions>
-to also create schema properties for fields.
+<xref:System.Text.Json.JsonSerializerOptions> to also create schema properties for fields.
 
-When the <xref:System.Text.Json.Serialization.PropertyNamingPolicy> is set to camel-case (this is the default
+When the <xref:System.Text.Json.JsonSerializerOptions.PropertyNamingPolicy> is set to camel-case (this is the default
 in ASP.NET web applications), property names in a schema are the camel-case form
 of the class or record property name.
 The <xref:System.Text.Json.Serialization.JsonPropertyNameAttribute> can be used on an individual property to specify the name
@@ -417,7 +416,7 @@ but validation must be performed by the route handler.
 
 Properties can also be marked as `required` with the [required] modifier.
 
-[required]: https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-11.0/required-members#required-modifier
+[required]: /dotnet/csharp/language-reference/proposals/csharp-11.0/required-members#required-modifier
 
 ### enum
 
@@ -465,7 +464,7 @@ but since the discriminator property is not defined in the concrete base class, 
 
 You can use a schema transformer to override any default metadata or add additional metadata,
 such as `example` values, to the generated schema.
-See <xref:use-schema-transformers> for more information.
+See [Use schema transformers](#use-schema-transformers) for more information.
 
 ## Options to Customize OpenAPI document generation
 

--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -412,12 +412,8 @@ Properties can also be marked as `required` with the [required](/dotnet/csharp/l
 
 ### enum
 
-Properties with an `enum` type are represented as an `enum` in the generated schema. Since all C# enums are integer-based:
-
-* The property is defined with `type: integer` and `format: int32`
-*  The `enum` values are the implicit or explicit values of the C# enum.
-
-To get string-based enums, use the <xref:System.Text.Json.Serialization.JsonConverterAttribute> with a <xref:System.Text.Json.Serialization.JsonStringEnumConverter> on a regular C# enum type.
+Enum types in C# are integer-based, but can be represented as strings in JSON with a  <xref:System.Text.Json.Serialization.JsonConverterAttribute> and a <xref:System.Text.Json.Serialization.JsonStringEnumConverter>. When an enum type is represented as a string in JSON, the generated schema will have an `enum` property with the string values of the enum.
+An enum type without a  <xref:System.Text.Json.Serialization.JsonConverterAttribute> will be defined as `type: integer` in the generated schema.
 
 **Note:** The <xref:System.ComponentModel.DataAnnotations.AllowedValuesAttribute> does not set the `enum` values of a property.
 

--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -402,7 +402,7 @@ The following table summarizes attributes from the `System.ComponentModel` names
 | <xref:System.ComponentModel.DataAnnotations.MaxLengthAttribute>         | Sets the `maxLength` of a string. |
 | <xref:System.ComponentModel.DataAnnotations.RegularExpressionAttribute> | Sets the `pattern` of a string. |
 
-Note that in controller-based apps, these attributes add filters to the operation to validate that any incoming data satisfies the constraints. In Minimal APIs, these attributes set the metadata in the generated schema but validation must be performed by the route handler.
+Note that in controller-based apps, these attributes add filters to the operation to validate that any incoming data satisfies the constraints. In Minimal APIs, these attributes set the metadata in the generated schema but validation must be performed explicitly via an endpoint filter, in the route handler's logic, or via a third-party package.
 
 ## Other sources of metadata for generated schemas
 
@@ -431,7 +431,7 @@ Schemas are generated without an `additionalProperties` assertion by default, wh
 
 If the additional properties of a schema should only have values of a specific type, define the property or class as a `Dictionary<string, type>`. The key type for the dictionary must be `string`. This generates a schema with `additionalProperties` specifying the schema for "type" as the required value types.
 
-### metadata for polymorphic types
+### Metadata for polymorphic types
 
 Use the <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute> and <xref:System.Text.Json.Serialization.JsonDerivedTypeAttribute> attributes on a parent class to to specify the discriminator field and subtypes for a polymorphic type.
 


### PR DESCRIPTION
This PR adds content to the .NET 9 OpenAPI section that describes how C# data types are rendered in the generated OpenAPI document. It also adds detail on schema transformers.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/e1d0983abc415425964fc3ed49a3495c52933f19/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md) | [Generate OpenAPI documents](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?branch=pr-en-us-33603) |


<!-- PREVIEW-TABLE-END -->