### PR TITLE
[Blazor] handle-errors.md - overriding async method with sync code

### DIFF
--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -454,7 +454,7 @@ The following example permits the user to recover from the exception with a butt
 }
 ```
 
-You can also subclass <xref:Microsoft.AspNetCore.Components.Web.ErrorBoundary> for custom processing by overriding <xref:Microsoft.AspNetCore.Components.Web.ErrorBoundary.OnErrorAsync%2A>. The following example merely logs the error, but you can implement any error handling code you wish. You can remove the line that awaits a <xref:System.Threading.Tasks.Task.CompletedTask> if your code awaits an asynchronous task.
+You can also subclass <xref:Microsoft.AspNetCore.Components.Web.ErrorBoundary> for custom processing by overriding <xref:Microsoft.AspNetCore.Components.Web.ErrorBoundary.OnErrorAsync%2A>. The following example merely logs the error, but you can implement any error handling code you wish. You can remove the line that returns a <xref:System.Threading.Tasks.Task.CompletedTask> if your code awaits an asynchronous task.
 
 `CustomErrorBoundary.razor`:
 
@@ -475,7 +475,7 @@ else if (ErrorContent is not null)
     protected override Task OnErrorAsync(Exception ex)
     {
         Logger.LogError(ex, "😈 A rotten gremlin got us. Sorry!");
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 }
 ```
@@ -495,10 +495,10 @@ public class CustomErrorBoundary : ErrorBoundary
     [Inject]
     ILogger<CustomErrorBoundary> Logger {  get; set; } = default!;
 
-    protected override async Task OnErrorAsync(Exception ex)
+    protected override Task OnErrorAsync(Exception ex)
     {
         Logger.LogError(ex, "😈 A rotten gremlin got us. Sorry!");
-        await Task.CompletedTask;
+        return Task.CompletedTask;
     }
 }
 ```


### PR DESCRIPTION
@guardrex I don't think it makes sense to await `Task.CompletedTask`.  
(The first example won't even compile - you have to use `async` in the method definition when you want to use `await` inside.)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/handle-errors.md](https://github.com/dotnet/AspNetCore.Docs/blob/64fcca43e8f1d2199487d708dfcb792b765f78b6/aspnetcore/blazor/fundamentals/handle-errors.md) | [Handle errors in ASP.NET Core Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/handle-errors?branch=pr-en-us-33620) |

<!-- PREVIEW-TABLE-END -->