### PR TITLE
Initialize form data with static SSR

### DIFF
--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -146,6 +146,59 @@ builder.Services.AddRazorComponents(options =>
 }).AddInteractiveServerComponents();
 ```
 
+## Initialize form data with static SSR
+
+When a component adopts static SSR, the [`OnInitialized{Async}` lifecycle method](xref:blazor/components/lifecycle#component-initialization-oninitializedasync) and the [`OnParametersSet{Async}` lifecycle method](xref:blazor/components/lifecycle#after-parameters-are-set-onparameterssetasync) fire when the component is initially rendered and on every form POST to the server. To initialize form model values, confirm if the model already has data before assigning new model values in `OnParametersSet{Async}`, as the following example demonstrates.
+
+`StarshipInit.razor`:
+
+```razor
+@page "/starship-init"
+@inject ILogger<StarshipInit> Logger
+
+<EditForm Model="Model" OnValidSubmit="Submit" FormName="Starship1">
+    <div>
+        <label>
+            Identifier:
+            <InputText @bind-Value="Model!.Id" />
+        </label>
+    </div>
+    <div>
+        <button type="submit">Submit</button>
+    </div>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private Starship? Model { get; set; }
+
+    protected override void OnInitialized() => Model ??= new();
+
+    protected override void OnParametersSet()
+    {
+        if (Model!.Id == default)
+        {
+            LoadData();
+        }
+    }
+
+    private void LoadData()
+    {
+        Model!.Id = "Set by LoadData";
+    }
+
+    private void Submit()
+    {
+        Logger.LogInformation("Id = {Id}", Model?.Id);
+    }
+
+    public class Starship
+    {
+        public string? Id { get; set; }
+    }
+}
+```
+
 ## Form names
 
 Use the <xref:Microsoft.AspNetCore.Components.Forms.EditForm.FormName%2A> parameter to assign a form name. Form names must be unique to bind model data. The following form is named `RomulanAle`:

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -146,59 +146,6 @@ builder.Services.AddRazorComponents(options =>
 }).AddInteractiveServerComponents();
 ```
 
-## Initialize form data with static SSR
-
-When a component adopts static SSR, the [`OnInitialized{Async}` lifecycle method](xref:blazor/components/lifecycle#component-initialization-oninitializedasync) and the [`OnParametersSet{Async}` lifecycle method](xref:blazor/components/lifecycle#after-parameters-are-set-onparameterssetasync) fire when the component is initially rendered and on every form POST to the server. To initialize form model values, confirm if the model already has data before assigning new model values in `OnParametersSet{Async}`, as the following example demonstrates.
-
-`StarshipInit.razor`:
-
-```razor
-@page "/starship-init"
-@inject ILogger<StarshipInit> Logger
-
-<EditForm Model="Model" OnValidSubmit="Submit" FormName="StarshipInit">
-    <div>
-        <label>
-            Identifier:
-            <InputText @bind-Value="Model!.Id" />
-        </label>
-    </div>
-    <div>
-        <button type="submit">Submit</button>
-    </div>
-</EditForm>
-
-@code {
-    [SupplyParameterFromForm]
-    private Starship? Model { get; set; }
-
-    protected override void OnInitialized() => Model ??= new();
-
-    protected override void OnParametersSet()
-    {
-        if (Model!.Id == default)
-        {
-            LoadData();
-        }
-    }
-
-    private void LoadData()
-    {
-        Model!.Id = "Set by LoadData";
-    }
-
-    private void Submit()
-    {
-        Logger.LogInformation("Id = {Id}", Model?.Id);
-    }
-
-    public class Starship
-    {
-        public string? Id { get; set; }
-    }
-}
-```
-
 ## Form names
 
 Use the <xref:Microsoft.AspNetCore.Components.Forms.EditForm.FormName%2A> parameter to assign a form name. Form names must be unique to bind model data. The following form is named `RomulanAle`:
@@ -320,6 +267,59 @@ The main form is bound to the `Ship` class. The `StarshipSubform` component is u
 `Starship7.razor`:
 
 :::code language="razor" source="~/../blazor-samples/8.0/BlazorSample_BlazorWebApp/Components/Pages/Starship7.razor":::
+
+## Initialize form data with static SSR
+
+When a component adopts static SSR, the [`OnInitialized{Async}` lifecycle method](xref:blazor/components/lifecycle#component-initialization-oninitializedasync) and the [`OnParametersSet{Async}` lifecycle method](xref:blazor/components/lifecycle#after-parameters-are-set-onparameterssetasync) fire when the component is initially rendered and on every form POST to the server. To initialize form model values, confirm if the model already has data before assigning new model values in `OnParametersSet{Async}`, as the following example demonstrates.
+
+`StarshipInit.razor`:
+
+```razor
+@page "/starship-init"
+@inject ILogger<StarshipInit> Logger
+
+<EditForm Model="Model" OnValidSubmit="Submit" FormName="StarshipInit">
+    <div>
+        <label>
+            Identifier:
+            <InputText @bind-Value="Model!.Id" />
+        </label>
+    </div>
+    <div>
+        <button type="submit">Submit</button>
+    </div>
+</EditForm>
+
+@code {
+    [SupplyParameterFromForm]
+    private Starship? Model { get; set; }
+
+    protected override void OnInitialized() => Model ??= new();
+
+    protected override void OnParametersSet()
+    {
+        if (Model!.Id == default)
+        {
+            LoadData();
+        }
+    }
+
+    private void LoadData()
+    {
+        Model!.Id = "Set by LoadData";
+    }
+
+    private void Submit()
+    {
+        Logger.LogInformation("Id = {Id}", Model?.Id);
+    }
+
+    public class Starship
+    {
+        public string? Id { get; set; }
+    }
+}
+```
 
 ## Advanced form mapping error scenarios
 

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -156,7 +156,7 @@ When a component adopts static SSR, the [`OnInitialized{Async}` lifecycle method
 @page "/starship-init"
 @inject ILogger<StarshipInit> Logger
 
-<EditForm Model="Model" OnValidSubmit="Submit" FormName="Starship1">
+<EditForm Model="Model" OnValidSubmit="Submit" FormName="StarshipInit">
     <div>
         <label>
             Identifier:


### PR DESCRIPTION
Fixes #33629

Javier ... Adding a bit to reflect your remarks at https://github.com/dotnet/aspnetcore/issues/51978#issuecomment-1814352531.

~The code is a bit long for such a simple concept, so we could have a pseudo-code version here (as you have in your PU issue remark), and I can cross-link to the Blazor sample app where this fully working component example can live. This would merely show ...~

```csharp
protected override void OnInitialized() => Model ??= new();

protected override void OnParametersSet()
{
    if (Model!.Id == default)
    {
        LoadData();
    }
}
```

~Mmmmmmmm 🤔 ... I do kind'a like that approach. Anyway, you can review this in this form, and I'll take care of moving it on a future commit.~

***Changed my mind on that ☝️!*** Our BWA sample adopts global interactive SSR, so it isn't ideal for just placing it. Let's just roll with this. It's long, but it's good to see the full component.

... and is there anything else that you'd like to add?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/231a9023c0ca02b3f5698ecda6878b53b023ec73/aspnetcore/blazor/forms/binding.md) | [ASP.NET Core Blazor forms binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?branch=pr-en-us-33630) |


<!-- PREVIEW-TABLE-END -->