### PR TITLE
Directory path notation (./) for RCL assets

### DIFF
--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -148,8 +148,9 @@ Use of scripts and modules for collocated JS in a Razor class library (RCL) is o
 
 For scripts or modules provided by a Razor class library (RCL) using <xref:Microsoft.JSInterop.IJSRuntime>-based JS interop, the following path is used:
 
-`_content/{PACKAGE ID}/{PATH}/{COMPONENT}.{EXTENSION}.js`
+`./_content/{PACKAGE ID}/{PATH}/{COMPONENT}.{EXTENSION}.js`
 
+* The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
 * The `{PACKAGE ID}` placeholder is the RCL's package identifier (or library name for a class library referenced by the app).
 * The `{PATH}` placeholder is the path to the component. If a Razor component is located at the root of the RCL, the path segment isn't included.
 * The `{COMPONENT}` placeholder is the component name.

--- a/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
@@ -143,9 +143,8 @@ You can also serve scripts directly from the `wwwroot` folder if you prefer not 
 <script src="scripts.js"></script>
 ```
 
-When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the JS file using its stable static web asset path: `./_content/{PACKAGE ID}/{SCRIPT PATH AND FILE NAME (.js)}`:
+When the external JS file is supplied by a [Razor class library](xref:blazor/components/class-libraries), specify the JS file using its stable static web asset path: `_content/{PACKAGE ID}/{SCRIPT PATH AND FILE NAME (.js)}`:
 
-* The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
 * The `{PACKAGE ID}` placeholder is the library's [package ID](/nuget/create-packages/creating-a-package-msbuild#set-properties). The package ID defaults to the project's assembly name if `<PackageId>` isn't specified in the project file.
 * The `{SCRIPT PATH AND FILE NAME (.js)}` placeholder is the path and file name under `wwwroot`.
 
@@ -154,7 +153,7 @@ When the external JS file is supplied by a [Razor class library](xref:blazor/com
     ...
 
     <script src="{BLAZOR SCRIPT}"></script>
-    <script src="./_content/{PACKAGE ID}/{SCRIPT PATH AND FILE NAME (.js)}"></script>
+    <script src="_content/{PACKAGE ID}/{SCRIPT PATH AND FILE NAME (.js)}"></script>
 </body>
 ```
 
@@ -164,7 +163,7 @@ In the following example of the preceding `<script>` tag:
 * The `scripts.js` file is in the class library's `wwwroot` folder.
 
 ```html
-<script src="./_content/ComponentLibrary/scripts.js"></script>
+<script src="_content/ComponentLibrary/scripts.js"></script>
 ```
 
 For more information, see <xref:blazor/components/class-libraries>.


### PR DESCRIPTION
Fixes #33631

* For `<script>` tags, current directory path notation (`./`) isn't required.
* For JS interop module loading (`JS.InvokeAsync<IJSObjectReference>()`), current directory path notation (`./`) *IS* required.

This PR should fix the few rough spots that we have.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/location-of-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/48e7001d4b7b538d18cea5b60b155f9dc8af7fe3/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md) | [JavaScript location in ASP.NET Core Blazor apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/location-of-javascript?branch=pr-en-us-33632) |

<!-- PREVIEW-TABLE-END -->