### PR TITLE
[Blazor] JS Interop - excessive ')' character

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -308,7 +308,7 @@ JavaScript (JS) interop calls can't be issued after a SignalR circuit is disconn
 * JS interop method calls
   * <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A?displayProperty=nameWithType>
   * <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeAsync%2A?displayProperty=nameWithType>
-  * <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A?displayProperty=nameWithType>)
+  * <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A?displayProperty=nameWithType>
 * `Dispose`/`DisposeAsync` calls on any <xref:Microsoft.JSInterop.IJSObjectReference>.
 
 In order to avoid logging <xref:Microsoft.JSInterop.JSDisconnectedException> or to log custom information, catch the exception in a [`try-catch`](/dotnet/csharp/language-reference/keywords/try-catch) statement.


### PR DESCRIPTION
cc @guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/8edb1c1500bb5436ab3d04cd08cdf91f0c03059e/aspnetcore/blazor/javascript-interoperability/index.md) | [ASP.NET Core Blazor JavaScript interoperability (JS interop)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/index?branch=pr-en-us-33636) |

<!-- PREVIEW-TABLE-END -->