### PR TITLE
Remove Access-Control-Allow-Methods from request header list

### DIFF
--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -360,7 +360,6 @@ The preflight request uses the [HTTP OPTIONS](https://developer.mozilla.org/docs
 
 * [Access-Control-Request-Method](https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Request-Method): The HTTP method that will be used for the actual request.
 * [Access-Control-Request-Headers](https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Allow-Headers): A list of request headers that the app sets on the actual request. As stated earlier, this doesn't include headers that the browser sets, such as `User-Agent`.
-* [Access-Control-Allow-Methods](https://developer.mozilla.org/docs/Web/HTTP/Headers/Access-Control-Allow-Methods)
 
 If the preflight request is denied, the app returns a `200 OK` response but doesn't set the CORS headers. Therefore, the browser doesn't attempt the cross-origin request. For an example of a denied preflight request, see the [Test CORS](#testc6) section of this document.
 


### PR DESCRIPTION
Fixes #33660 
Access-Control-Allow-Methods is a response header, not a request header




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/cors.md](https://github.com/dotnet/AspNetCore.Docs/blob/47dfd2928ebf3f547ffa6e631d79c0241150485e/aspnetcore/security/cors.md) | [Enable Cross-Origin Requests (CORS) in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/cors?branch=pr-en-us-33673) |

<!-- PREVIEW-TABLE-END -->