### PR TITLE
Add missing curly brace in json transcoding openapi sample

### DIFF
--- a/aspnetcore/grpc/json-transcoding-openapi.md
+++ b/aspnetcore/grpc/json-transcoding-openapi.md
@@ -25,7 +25,7 @@ To enable OpenAPI with gRPC JSON transcoding:
 1. Add a package reference to [`Microsoft.AspNetCore.Grpc.Swagger`](https://www.nuget.org/packages/Microsoft.AspNetCore.Grpc.Swagger). The version must be 0.3.0-xxx or later.
 2. Configure Swashbuckle in startup. The `AddGrpcSwagger` method configures Swashbuckle to include gRPC endpoints.
 
-[!code-csharp[](~/grpc/json-transcoding-openapi/Program.cs?name=snippet_1&highlight=3-8,11-15)]
+[!code-csharp[](~/grpc/json-transcoding-openapi/Program.cs?name=snippet_1&highlight=3-8,11-16)]
 
 [!INCLUDE[](~/includes/package-reference.md)]
 

--- a/aspnetcore/grpc/json-transcoding-openapi/Program.cs
+++ b/aspnetcore/grpc/json-transcoding-openapi/Program.cs
@@ -11,6 +11,7 @@ builder.Services.AddSwaggerGen(c =>
 var app = builder.Build();
 app.UseSwagger();
 if (app.Environment.IsDevelopment())
+{
     app.UseSwaggerUI(c =>
     {
         c.SwaggerEndpoint("/swagger/v1/swagger.json", "My API V1");


### PR DESCRIPTION
Fixed: Add missing curly brace in json transcoding openAPI [getting started](https://learn.microsoft.com/en-us/aspnet/core/grpc/json-transcoding-openapi?view=aspnetcore-8.0#get-started
) sample

Fixes #33694
<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/json-transcoding-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/daa8b4c86edacceb770b2ed790efd554df2c69c1/aspnetcore/grpc/json-transcoding-openapi.md) | [gRPC JSON transcoding documentation with Swagger / OpenAPI](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/json-transcoding-openapi?branch=pr-en-us-33674) |

<!-- PREVIEW-TABLE-END -->