### PR TITLE
[Blazor] Components - loop samples - intro text removal

### DIFF
--- a/aspnetcore/blazor/components/index.md
+++ b/aspnetcore/blazor/components/index.md
@@ -1270,8 +1270,6 @@ Consider the following `RenderFragmentChild2` component that has both a componen
 When rendering the `RenderFragmentChild2` component in a parent component, use a local index variable (`ct` in the following example) instead of the loop variable (`c`) when assigning the component parameter value and providing the child component's content:
 
 ```razor
-<h1>Three children with a <code>for</code> loop and an index variable</h1>
-
 @for (int c = 1; c < 4; c++)
 {
     var ct = c;
@@ -1285,8 +1283,6 @@ When rendering the `RenderFragmentChild2` component in a parent component, use a
 Alternatively, use a [`foreach`](/dotnet/csharp/language-reference/keywords/foreach-in) loop with <xref:System.Linq.Enumerable.Range%2A?displayProperty=nameWithType> instead of a [`for`](/dotnet/csharp/language-reference/keywords/for) loop:
 
 ```razor
-<h1>Alternative approach without an index variable</h1>
-
 @foreach (var c in Enumerable.Range(1, 3))
 {
     <RenderFragmentChild2 Id="@($"Child{c}")">


### PR DESCRIPTION
It seems the intro text was originally not intended to be part of the sample code and somehow got included over time. In my opinion, the code samples work better without the intro HTML.

(Testing the code ownership without a mention. :-D)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/0788963c7dbbb431ee2e4613427f4ac412b71f4b/aspnetcore/blazor/components/index.md) | [ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/index?branch=pr-en-us-33675) |

<!-- PREVIEW-TABLE-END -->