### PR TITLE
Added missing `add` in the migration command of Blazor Movie Tutorial…

### DIFF
--- a/aspnetcore/blazor/tutorials/movie-database-app/part-7.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-7.md
@@ -199,7 +199,7 @@ Modify the one movie that isn't rated *R*:
 In the **Terminal** (**Terminal** menu > **New Terminal**), execute the following command to add a migration. The migration name (`AddRatingField`) is an arbitrary description for the migration:
 
 ```dotnetcli
-dotnet ef migrations AddRatingField
+dotnet ef migrations add AddRatingField
 ```
 
 The `dotnet-ef migrations` command:

--- a/aspnetcore/blazor/tutorials/movie-database-app/part-7.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-7.md
@@ -247,7 +247,7 @@ Modify the one movie that isn't rated *R*:
 In a command shell opened to the project's root folder, execute the following command to add a migration. The migration name (`AddRatingField`) is an arbitrary description for the migration:
 
 ```dotnetcli
-dotnet ef migrations AddRatingField
+dotnet ef migrations add AddRatingField
 ```
 
 The `dotnet-ef migrations` command:


### PR DESCRIPTION
… Part 7

Added missing `add` in the migration command.

Fixes #33677



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tutorials/movie-database-app/part-7.md](https://github.com/dotnet/AspNetCore.Docs/blob/12f3bb57e8e68af89eabdf39d6557bbbf2c8146a/aspnetcore/blazor/tutorials/movie-database-app/part-7.md) | [Build a Blazor movie database app (Part 7 - Add a new field)](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/movie-database-app/part-7?branch=pr-en-us-33678) |


<!-- PREVIEW-TABLE-END -->