### PR TITLE
Update repoman config to latest version

### DIFF
--- a/.repoman.yml
+++ b/.repoman.yml
@@ -1,5 +1,5 @@
-revision: 4
-schema-version: 1
+revision: 5
+schema-version: 5
 owner-ms-alias: adegeo
 
 config:
@@ -18,18 +18,41 @@ issues:
     # New issue opened, add Not Triaged  
     - labels-add: [":watch: Not Triaged"]
 
+    # Try to detect an empty issue
+    - check:
+        - type: comment-body
+          value: "### Description[\\n\\r]+\\[Enter feedback here\\][\\n\\r]+###"
+      pass:
+        - labels-add: ["needs-more-info"]
+        - labels-remove: [":watch: Not Triaged"]
+        - close
+
     # default for doc comment
     - check:
         - type: metadata-exists
       pass:
         - labels-add: ["Source - Docs.ms"]
-        - prod_tech_labels: true
+        - svc_subsvc_labels: true
+
+    # Add links to related issues if it's a doc issue
+    - check:
+        - type: metadata-exists
+        - type: variable-exists
+          name: "document_version_independent_id"
+      pass:
+        - link-related-issues
 
   labeled:
 
     # Temporary label to mark issues as updated for Quest. The label is instantly removed
     - check:
         - type: query
-          value: "length(Issue.labels[?name == ':world_map: mapQUEST']) != `0`"
+          value: "length(Issue.Labels[?Name == 'mapQuest']) != `0`"
       pass:
-        - labels-remove: [":world_map: mapQUEST"]
+        - labels-remove: ["mapQuest"]
+
+projects_v2_item:
+
+  reordered:
+
+    - labels-add: ["mapQuest"]


### PR DESCRIPTION
DO NOT MERGE WITHOUT ME. THE GITHUB APP NEEDS TO BE INSTALLED TO THIS REPO AND THE OLD WEBHOOK DISABLED

This new config adds the following changes:

- Use regex to see if the details of the issue is still the default.

  This config setting is good at detecting spam. If someone comes in and only fills out a subject with no extra text, it will get closed. Let me know if you want me to remove this setting.

  This config takes the following actions when it detects the issue just has the default description text:

  - Add `needs-more-info` label.
  - Remove `not triaged" label.
  - Close the issue
 
- Turns on a new feature which adds a link to the bottom of the issue that is a search for issues related to the article.
- Support for moving issues related to project items around, and not having to manually add a label to the issue to get quest to pick up changed details.