### PR TITLE
Update SIMD cross-link

### DIFF
--- a/aspnetcore/blazor/webassembly-build-tools-and-aot.md
+++ b/aspnetcore/blazor/webassembly-build-tools-and-aot.md
@@ -126,7 +126,7 @@ With the .NET WebAssembly build tools installed, runtime relinking is performed 
 
 :::moniker range=">= aspnetcore-8.0"
 
-Blazor uses [WebAssembly Single Instruction, Multiple Data (SIMD)](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) to improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction.
+Blazor uses [WebAssembly Single Instruction, Multiple Data (SIMD)](https://wikipedia.org/wiki/Single_instruction,_multiple_data) to improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction.
 
 To disable SIMD, for example when targeting old browsers or browsers on mobile devices that don't support SIMD, set the `<WasmEnableSIMD>` property to `false` in the app's project file (`.csproj`):
 
@@ -142,7 +142,7 @@ For more information, see [Configuring and hosting .NET WebAssembly applications
 
 :::moniker range="< aspnetcore-8.0"
 
-Blazor uses [WebAssembly Single Instruction, Multiple Data (SIMD)](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) to improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction.
+Blazor uses [WebAssembly Single Instruction, Multiple Data (SIMD)](https://wikipedia.org/wiki/Single_instruction,_multiple_data) to improve the throughput of vectorized computations by performing an operation on multiple pieces of data in parallel using a single instruction.
 
 To enable SIMD, add the `<WasmEnableSIMD>` property set to `true` in the app's project file (`.csproj`):
 

--- a/aspnetcore/release-notes/aspnetcore-7.0.md
+++ b/aspnetcore/release-notes/aspnetcore-7.0.md
@@ -517,7 +517,7 @@ In the preceding example, `ExternalAuthStateProvider` is the developer's service
 
 New features in the `wasm-tools` workload for .NET 7 that help improve performance and handle exceptions:
 
-* [WebAssembly Single Instruction, Multiple Data (SIMD)](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) support (only with AOT, not supported by Apple Safari)
+* [WebAssembly Single Instruction, Multiple Data (SIMD)](https://wikipedia.org/wiki/Single_instruction,_multiple_data) support (only with AOT, not supported by Apple Safari)
 * WebAssembly exception handling support
 
 For more information, see <xref:blazor/tooling/webassembly?view=aspnetcore-7.0>.

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -205,7 +205,7 @@ For more information, see <xref:blazor/host-and-deploy/webassembly?view=aspnetco
 
 ### Ahead-of-time (AOT) SIMD and exception handling
 
-Blazor WebAssembly ahead-of-time (AOT) compilation now uses [WebAssembly Fixed-width SIMD](https://github.com/WebAssembly/simd/blob/master/proposals/simd/SIMD.md) and [WebAssembly Exception handling](https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md) by default to improve runtime performance.
+Blazor WebAssembly ahead-of-time (AOT) compilation now uses [WebAssembly Fixed-width SIMD](https://wikipedia.org/wiki/Single_instruction,_multiple_data) and [WebAssembly Exception handling](https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md) by default to improve runtime performance.
 
 For more information, see the following articles:
 


### PR DESCRIPTION
Fixes #33707

I don't like using the Wikipedia page, but the MDN page just provides a quick definition with a cross-link to Wikipedia.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/webassembly-build-tools-and-aot.md](https://github.com/dotnet/AspNetCore.Docs/blob/07ac3489a0f80bafe369d89bc93873ad70f61e06/aspnetcore/blazor/webassembly-build-tools-and-aot.md) | [ASP.NET Core Blazor WebAssembly build tools and ahead-of-time (AOT) compilation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-build-tools-and-aot?branch=pr-en-us-33708) |
| [aspnetcore/release-notes/aspnetcore-7.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/07ac3489a0f80bafe369d89bc93873ad70f61e06/aspnetcore/release-notes/aspnetcore-7.0.md) | [What's new in ASP.NET Core 7.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-7.0?branch=pr-en-us-33708) |
| [aspnetcore/release-notes/aspnetcore-8.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/07ac3489a0f80bafe369d89bc93873ad70f61e06/aspnetcore/release-notes/aspnetcore-8.0.md) | [What's new in ASP.NET Core 8.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-8.0?branch=pr-en-us-33708) |

<!-- PREVIEW-TABLE-END -->