### PR TITLE
Fix typo of "CreateModel.cshtml" to "Create.cshtml"

### DIFF
--- a/aspnetcore/razor-pages/index.md
+++ b/aspnetcore/razor-pages/index.md
@@ -134,7 +134,7 @@ The `PageModel` class allows separation of the logic of a page from its presenta
 
 The page has an `OnPostAsync` *handler method*, which runs on `POST` requests (when a user posts the form). Handler methods for any HTTP verb can be added. The most common handlers are:
 
-* `OnGet` to initialize state needed for the page. In the preceding code, the `OnGet` method displays the `CreateModel.cshtml` Razor Page.
+* `OnGet` to initialize state needed for the page. In the preceding code, the `OnGet` method displays the `Create.cshtml` Razor Page.
 * `OnPost` to handle form submissions.
 
 The `Async` naming suffix is optional but is often used by convention for asynchronous functions. The preceding code is typical for Razor Pages.


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

It says `CreateModel.cshtml` in https://learn.microsoft.com/en-us/aspnet/core/razor-pages/?view=aspnetcore-8.0&tabs=visual-studio-code but that doesn't seem to be a file (`Create Model` is the page model class in Create.cshtml.cs).

`Create.cshtml` seems to be the Razor page it's referring to

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/razor-pages/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/b27705b1af3c857cc3bf16b135cef2ccbbd57980/aspnetcore/razor-pages/index.md) | [Introduction to Razor Pages in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/razor-pages/index?branch=pr-en-us-33712) |

<!-- PREVIEW-TABLE-END -->