### PR TITLE
Add semester changover information to quest

### DIFF
--- a/quest-config.json
+++ b/quest-config.json
@@ -9,38 +9,79 @@
     "ParentNodes": [
         {
             "Label": "okr-freshness",
+            "Semester": "Selenium",
+            "ParentNodeId": 286034
+        },
+        {
+            "Label": "okr-curation",
+            "Semester": "Selenium",
+            "ParentNodeId": 286038
+        },
+        {
+            "Label": "user-feedback",
+            "Semester": "Selenium",
+            "ParentNodeId": 286039
+        },
+        {
+            "Label": "okr-health",
+            "Semester": "Selenium",
+            "ParentNodeId": 286038
+        },
+        {
+            "Label": "doc-bug",
+            "Semester": "Selenium",
+            "ParentNodeId": 286039
+        },
+        {
+            "Semester": "Selenium",
+            "ParentNodeId": 286017
+        },
+        {
+            "Label": "okr-freshness",
+            "Semester": "Dilithium",
             "ParentNodeId": 237266
         },
         {
             "Label": "okr-curation",
+            "Semester": "Dilithium",
             "ParentNodeId": 237271
         },
         {
             "Label": "user-feedback",
+            "Semester": "Dilithium",
             "ParentNodeId": 233465
         },
         {
             "Label": "okr-health",
+            "Semester": "Dilithium",
             "ParentNodeId": 237266
         },
         {
             "Label": "doc-bug",
+            "Semester": "Dilithium",
             "ParentNodeId": 233465
         },
         {
             "Label": "sfi-ropc",
+            "Semester": "Dilithium",
             "ParentNodeId": 271716
         },
         {
             "Label": "sfi-admin",
+            "Semester": "Dilithium",
             "ParentNodeId": 271716
         },
         {
             "Label": "sfi-images",
+            "Semester": "Dilithium",
             "ParentNodeId": 286370
+        },
+        {
+            "Semester": "Dilithium",
+            "ParentNodeId": 227486
         }
     ],
-    "DefaultParentNode": 227486,
+    "DefaultParentNode": 286017,
     "WorkItemTags": [
         {
             "Label": "9.0",


### PR DESCRIPTION
dotnet/docs-tools#413 enhances the config object to support different parents per semester. This adds the updated config for that purpose.
