### PR TITLE
SFI:ROPC metadata

### DIFF
--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -5,6 +5,7 @@ description: Learn how to create an ASP.NET Core web app with user data protecte
 ms.author: riande
 ms.date: 12/5/2021
 ms.custom: mvc
+ms.sfi.ropc: t
 uid: security/authorization/secure-data
 ---
 
@@ -293,7 +294,7 @@ In the preceding code:
 
 If you haven't already set a password for seeded user accounts, use the [Secret Manager tool](xref:security/app-secrets#secret-manager) to set a password:
 
-* Choose a strong password: Use eight or more characters and at least one upper-case character, number, and symbol.
+* Choose a non-weak password: Use eight or more characters and at least one upper-case character, number, and symbol. Note those requirements don't guarantee a strong password.
 * Execute the following command from the project's folder, where `<PW>` is the password:
 
   ```dotnetcli

--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -294,7 +294,7 @@ In the preceding code:
 
 If you haven't already set a password for seeded user accounts, use the [Secret Manager tool](xref:security/app-secrets#secret-manager) to set a password:
 
-* Choose a [strong password](https://support.microsoft.com/en-us/windows/create-and-use-strong-passwords-c5cebb49-8c53-4f5e-2bc4-fe357ca048eb):
+* Choose a [strong password](https://support.microsoft.com/en-us/windows/create-and-use-strong-passwords-c5cebb49-8c53-4f5e-2bc4-fe357ca048eb). Although the following password isn't strong, it meets the minimum requirements:
   * At least 12 characters long but 14 or more is better.
   * A combination of uppercase letters, lowercase letters, numbers, and symbols.
   * Not a word that can be found in a dictionary or the name of a person, character, product, or organization.

--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -294,7 +294,12 @@ In the preceding code:
 
 If you haven't already set a password for seeded user accounts, use the [Secret Manager tool](xref:security/app-secrets#secret-manager) to set a password:
 
-* Choose a non-weak password: Use eight or more characters and at least one upper-case character, number, and symbol. Note those requirements don't guarantee a strong password.
+* Choose a [strong password](https://support.microsoft.com/en-us/windows/create-and-use-strong-passwords-c5cebb49-8c53-4f5e-2bc4-fe357ca048eb):
+  * At least 12 characters long but 14 or more is better.
+  * A combination of uppercase letters, lowercase letters, numbers, and symbols.
+  * Not a word that can be found in a dictionary or the name of a person, character, product, or organization.
+  * Significantly different from your previous passwords.
+  * Easy for you to remember but difficult for others to guess. Consider using a memorable phrase like "6MonkeysRLooking^".
 * Execute the following command from the project's folder, where `<PW>` is the password:
 
   ```dotnetcli

--- a/aspnetcore/security/authorization/secure-data.md
+++ b/aspnetcore/security/authorization/secure-data.md
@@ -294,7 +294,7 @@ In the preceding code:
 
 If you haven't already set a password for seeded user accounts, use the [Secret Manager tool](xref:security/app-secrets#secret-manager) to set a password:
 
-* Choose a [strong password](https://support.microsoft.com/en-us/windows/create-and-use-strong-passwords-c5cebb49-8c53-4f5e-2bc4-fe357ca048eb). Although the following password isn't strong, it meets the minimum requirements:
+* Choose a [strong password](https://support.microsoft.com/en-us/windows/create-and-use-strong-passwords-c5cebb49-8c53-4f5e-2bc4-fe357ca048eb):
   * At least 12 characters long but 14 or more is better.
   * A combination of uppercase letters, lowercase letters, numbers, and symbols.
   * Not a word that can be found in a dictionary or the name of a person, character, product, or organization.


### PR DESCRIPTION
I think we should standardize on ROPC hits that have been fixed.

Fixes  #33727

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authorization/secure-data.md](https://github.com/dotnet/AspNetCore.Docs/blob/fee61532efcb8ed614d415e222e4b75fc8ea82ff/aspnetcore/security/authorization/secure-data.md) | [Create an ASP.NET Core web app with user data protected by authorization](https://review.learn.microsoft.com/en-us/aspnet/core/security/authorization/secure-data?branch=pr-en-us-33726) |


<!-- PREVIEW-TABLE-END -->