### PR TITLE
Fix incorrect http/2 Kestrel's default stream window size

### DIFF
--- a/aspnetcore/grpc/performance.md
+++ b/aspnetcore/grpc/performance.md
@@ -185,7 +185,7 @@ builder.WebHost.ConfigureKestrel(options =>
 
 Recommendations:
 
-* If a gRPC service often receives messages larger than 96 KB, Kestrel's default stream window size, then consider increasing the connection and stream window size.
+* If a gRPC service often receives messages larger than 768 KB, Kestrel's default stream window size, then consider increasing the connection and stream window size.
 * The connection window size should always be equal to or greater than the stream window size. A stream is part of the connection, and the sender is limited by both.
 
 For more information about how flow control works, see [HTTP/2 Flow Control (blog post)](https://medium.com/coderscorner/http-2-flow-control-77e54f7fd518).


### PR DESCRIPTION
Fixes #33783

According to https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.initialstreamwindowsize?view=aspnetcore-8.0#microsoft-aspnetcore-server-kestrel-core-http2limits-initialstreamwindowsize, the default size is 768 KB not 96 KB



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/performance.md](https://github.com/dotnet/AspNetCore.Docs/blob/a86bda1fc386e1dd40af40c11360ec16dab468c5/aspnetcore/grpc/performance.md) | [Performance best practices with gRPC](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/performance?branch=pr-en-us-33745) |

<!-- PREVIEW-TABLE-END -->