### PR TITLE
Fix tutorial's previous button text

### DIFF
--- a/aspnetcore/blazor/tutorials/movie-database-app/part-8.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-8.md
@@ -258,4 +258,4 @@ In the documentation website's sidebar navigation, articles are organized by sub
 [!INCLUDE[](~/blazor/tutorials/movie-database-app/includes/troubleshoot.md)]
 
 > [!div class="step-by-step"]
-> [Previous: Add validation](xref:blazor/tutorials/movie-database-app/part-7)
+> [Previous: Add a new field](xref:blazor/tutorials/movie-database-app/part-7)


### PR DESCRIPTION
Fixes #33790

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tutorials/movie-database-app/part-8.md](https://github.com/dotnet/AspNetCore.Docs/blob/c44762b5fde459723abcf8d8f19d7184dc24dcbe/aspnetcore/blazor/tutorials/movie-database-app/part-8.md) | [aspnetcore/blazor/tutorials/movie-database-app/part-8](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/movie-database-app/part-8?branch=pr-en-us-33791) |

<!-- PREVIEW-TABLE-END -->