### PR TITLE
SQLite doesn't support automatic concurrency

### DIFF
--- a/aspnetcore/blazor/blazor-ef-core.md
+++ b/aspnetcore/blazor/blazor-ef-core.md
@@ -251,7 +251,7 @@ A `DbContext` is created using the factory (`DbFactory`) to delete a contact in 
 
 ## Scope to the component lifetime
 
-You may wish to create a <xref:Microsoft.EntityFrameworkCore.DbContext> that exists for the lifetime of a component. This allows you to use it as a [unit of work](https://martinfowler.com/eaaCatalog/unitOfWork.html) and take advantage of built-in features, such as change tracking and  resolution.
+You may wish to create a <xref:Microsoft.EntityFrameworkCore.DbContext> that exists for the lifetime of a component. This allows you to use it as a [unit of work](https://martinfowler.com/eaaCatalog/unitOfWork.html) and take advantage of built-in features, such as change tracking and concurrency resolution.
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/blazor-ef-core.md
+++ b/aspnetcore/blazor/blazor-ef-core.md
@@ -44,7 +44,9 @@ For Microsoft Azure services, we recommend using *managed identities*. Managed i
 
 ## Sample app
 
-The sample app was built as a reference for server-side Blazor apps that use EF Core. The sample app includes a grid with sorting and filtering, delete, add, and update operations. The sample demonstrates use of EF Core to handle optimistic concurrency.
+The sample app was built as a reference for server-side Blazor apps that use EF Core. The sample app includes a grid with sorting and filtering, delete, add, and update operations.
+
+The sample demonstrates use of EF Core to handle optimistic concurrency. However, [native database-generated concurrency tokens](/ef/core/saving/concurrency?tabs=fluent-api#native-database-generated-concurrency-tokens) aren't supported for SQLite databases, which is the database provider for the sample app. To demontrate concurrency with the sample app, adopt a differnt database provider that supports database-generated concurrency tokens (for example, SQL Server).
 
 :::moniker range=">= aspnetcore-8.0"
 
@@ -249,7 +251,7 @@ A `DbContext` is created using the factory (`DbFactory`) to delete a contact in 
 
 ## Scope to the component lifetime
 
-You may wish to create a <xref:Microsoft.EntityFrameworkCore.DbContext> that exists for the lifetime of a component. This allows you to use it as a [unit of work](https://martinfowler.com/eaaCatalog/unitOfWork.html) and take advantage of built-in features, such as change tracking and concurrency resolution.
+You may wish to create a <xref:Microsoft.EntityFrameworkCore.DbContext> that exists for the lifetime of a component. This allows you to use it as a [unit of work](https://martinfowler.com/eaaCatalog/unitOfWork.html) and take advantage of built-in features, such as change tracking and  resolution.
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/blazor-ef-core.md
+++ b/aspnetcore/blazor/blazor-ef-core.md
@@ -46,7 +46,7 @@ For Microsoft Azure services, we recommend using *managed identities*. Managed i
 
 The sample app was built as a reference for server-side Blazor apps that use EF Core. The sample app includes a grid with sorting and filtering, delete, add, and update operations.
 
-The sample demonstrates use of EF Core to handle optimistic concurrency. However, [native database-generated concurrency tokens](/ef/core/saving/concurrency?tabs=fluent-api#native-database-generated-concurrency-tokens) aren't supported for SQLite databases, which is the database provider for the sample app. To demontrate concurrency with the sample app, adopt a differnt database provider that supports database-generated concurrency tokens (for example, the [SQL Server database provider](/ef/core/providers/sql-server)).
+The sample demonstrates use of EF Core to handle optimistic concurrency. However, [native database-generated concurrency tokens](/ef/core/saving/concurrency?tabs=fluent-api#native-database-generated-concurrency-tokens) aren't supported for SQLite databases, which is the database provider for the sample app. To demontrate concurrency with the sample app, adopt a differnt database provider that supports database-generated concurrency tokens (for example, the [SQL Server provider](/ef/core/providers/sql-server)).
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/blazor-ef-core.md
+++ b/aspnetcore/blazor/blazor-ef-core.md
@@ -46,7 +46,7 @@ For Microsoft Azure services, we recommend using *managed identities*. Managed i
 
 The sample app was built as a reference for server-side Blazor apps that use EF Core. The sample app includes a grid with sorting and filtering, delete, add, and update operations.
 
-The sample demonstrates use of EF Core to handle optimistic concurrency. However, [native database-generated concurrency tokens](/ef/core/saving/concurrency?tabs=fluent-api#native-database-generated-concurrency-tokens) aren't supported for SQLite databases, which is the database provider for the sample app. To demontrate concurrency with the sample app, adopt a differnt database provider that supports database-generated concurrency tokens (for example, SQL Server).
+The sample demonstrates use of EF Core to handle optimistic concurrency. However, [native database-generated concurrency tokens](/ef/core/saving/concurrency?tabs=fluent-api#native-database-generated-concurrency-tokens) aren't supported for SQLite databases, which is the database provider for the sample app. To demontrate concurrency with the sample app, adopt a differnt database provider that supports database-generated concurrency tokens (for example, the [SQL Server database provider](/ef/core/providers/sql-server)).
 
 :::moniker range=">= aspnetcore-8.0"
 


### PR DESCRIPTION
Fixes #33799

Based on ...

* A passing mention in the [EF Core concurrency article](https://learn.microsoft.com/en-us/ef/core/saving/concurrency?tabs=fluent-api#native-database-generated-concurrency-tokens) that SQLite doesn't support dB-generated concurrency tokens.
* The sample doesn't demo concurrency in local test runs and is developed with both ...
  * A requirement on native dB-concurrency tokens.
  * The SQLite dB provider.

Will track on https://github.com/dotnet/EntityFramework.Docs/issues/4827 for additional info.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/blazor-ef-core.md](https://github.com/dotnet/AspNetCore.Docs/blob/5bbeebe14e2c1805e8d12454acf7f6b7861dffa6/aspnetcore/blazor/blazor-ef-core.md) | [aspnetcore/blazor/blazor-ef-core](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/blazor-ef-core?branch=pr-en-us-33800) |


<!-- PREVIEW-TABLE-END -->