### PR TITLE
[Blazor] prerender.md - no data protection on prerendered state

### DIFF
--- a/aspnetcore/blazor/components/prerender.md
+++ b/aspnetcore/blazor/components/prerender.md
@@ -114,8 +114,6 @@ When the component executes, `currentCount` is only set once during prerendering
 
 By initializing components with the same state used during prerendering, any expensive initialization steps are only executed once. The rendered UI also matches the prerendered UI, so no flicker occurs in the browser.
 
-The prerendered data sent to the client by the <xref:Microsoft.AspNetCore.Components.PersistentComponentState> service is protected by [ASP.NET Core Data Protection](xref:security/data-protection/introduction), so the state can't be read by a malicious user.
-
 ## Components embedded into pages and views (Razor Pages/MVC)
 
 For components embedded into a page or view of a Razor Pages or MVC app, you must add the [Persist Component State Tag Helper](xref:mvc/views/tag-helpers/builtin-th/persist-component-state-tag-helper) with the `<persist-component-state />` HTML tag inside the closing `</body>` tag of the app's layout. **This is only required for Razor Pages and MVC apps.** For more information, see <xref:mvc/views/tag-helpers/builtin-th/persist-component-state-tag-helper>.

--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -920,8 +920,6 @@ else
 
 By initializing components with the same state used during prerendering, any expensive initialization steps are only executed once. The rendered UI also matches the prerendered UI, so no flicker occurs in the browser.
 
-The prerendered data sent to the client by the <xref:Microsoft.AspNetCore.Components.PersistentComponentState> service is protected by [ASP.NET Core Data Protection](xref:security/data-protection/introduction), so the state can't be read by a malicious user.
-
 :::zone pivot="webassembly"
 
 ## Additional Blazor WebAssembly resources


### PR DESCRIPTION
There’s no data protection on the prerendered state sent to the WASM client. The WASM client doesn’t have any keys to decrypt protected data.

You can use Data Protection on your own (and there may be scenarios where built-in features do this) if there are specific data pieces you don’t want the client to use directly but rather send back to the server unchanged (where it can be decrypted and processed).

I did a quick test. I took the value from the `<!--Blazor-WebAssembly-Component-State:{VALUE}-->` comment on the prerendered page, and it's just plain Base64-encoded JSON that I can decode and read.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/prerender.md](https://github.com/dotnet/AspNetCore.Docs/blob/78509bd1f1cbfba8b6f854839dfb87ff0bae24a3/aspnetcore/blazor/components/prerender.md) | [Prerender ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/prerender?branch=pr-en-us-33818) |
| [aspnetcore/blazor/components/prerendering-and-integration.md](https://github.com/dotnet/AspNetCore.Docs/blob/78509bd1f1cbfba8b6f854839dfb87ff0bae24a3/aspnetcore/blazor/components/prerendering-and-integration.md) | [Prerender and integrate ASP.NET Core Razor components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/prerendering-and-integration?branch=pr-en-us-33818) |


<!-- PREVIEW-TABLE-END -->