### PR TITLE
[Blazor] Call .NET from JS - OperatingSystem.IsBrowser()

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -827,7 +827,6 @@ In the following `GenericsExample` component:
 
 ```razor
 @page "/generics-example"
-@using System.Runtime.InteropServices
 @implements IDisposable
 @inject IJSRuntime JS
 
@@ -854,8 +853,7 @@ In the following `GenericsExample` component:
 
     public async Task InvokeInterop()
     {
-        var syncInterop =
-            RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+        var syncInterop = OperatingSystem.IsBrowser();
 
         await JS.InvokeVoidAsync(
             "invokeMethodsAsync", syncInterop, objRef1, objRef2);

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -781,7 +781,6 @@ In the following `GenericsExample` component:
 
 ```razor
 @page "/generics-example"
-@using System.Runtime.InteropServices
 @implements IDisposable
 @inject IJSRuntime JS
 
@@ -808,8 +807,7 @@ In the following `GenericsExample` component:
 
     public async Task InvokeInterop()
     {
-        var syncInterop =
-            RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+        var syncInterop = OperatingSystem.IsBrowser();
 
         await JS.InvokeVoidAsync(
             "invokeMethodsAsync", syncInterop, objRef1, objRef2);


### PR DESCRIPTION
`OperatingSystem.IsBrowser()` API was introduced in .NET 5.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/bf604fa4f29eeb46e44a4395c170db2f451a9d21/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md) | [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?branch=pr-en-us-33846) |


<!-- PREVIEW-TABLE-END -->