### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs

### DIFF
--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -239,7 +239,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
 
        ```xml
        <PropertyGroup>
-         <PackageTags>9412ee86-c21b-4eb8-bd89-f650fbf44931</PackageTags>
+         <PackageTags>00001111-aaaa-2222-bbbb-3333cccc4444</PackageTags>
        </PropertyGroup>
        ```
 
@@ -252,7 +252,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
    netsh http add sslcert 
        ipport=10.0.0.4:443 
        certhash=b66ee04419d4ee37464ab8785ff02449980eae10 
-       appid="{9412ee86-c21b-4eb8-bd89-f650fbf44931}"
+       appid="{00001111-aaaa-2222-bbbb-3333cccc4444}"
    ```
 
    When a certificate is registered, the tool responds with `SSL Certificate successfully added`.

--- a/aspnetcore/fundamentals/servers/httpsys/includes/httpsys5-7.md
+++ b/aspnetcore/fundamentals/servers/httpsys/includes/httpsys5-7.md
@@ -206,7 +206,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
 
        ```xml
        <PropertyGroup>
-         <PackageTags>9412ee86-c21b-4eb8-bd89-f650fbf44931</PackageTags>
+         <PackageTags>00001111-aaaa-2222-bbbb-3333cccc4444</PackageTags>
        </PropertyGroup>
        ```
 
@@ -219,7 +219,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
    netsh http add sslcert 
        ipport=10.0.0.4:443 
        certhash=b66ee04419d4ee37464ab8785ff02449980eae10 
-       appid="{9412ee86-c21b-4eb8-bd89-f650fbf44931}"
+       appid="{00001111-aaaa-2222-bbbb-3333cccc4444}"
    ```
 
    When a certificate is registered, the tool responds with `SSL Certificate successfully added`.
@@ -478,7 +478,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
 
        ```xml
        <PropertyGroup>
-         <PackageTags>9412ee86-c21b-4eb8-bd89-f650fbf44931</PackageTags>
+         <PackageTags>00001111-aaaa-2222-bbbb-3333cccc4444</PackageTags>
        </PropertyGroup>
        ```
 
@@ -491,7 +491,7 @@ In Visual Studio, the default launch profile is for IIS Express. To run the proj
    netsh http add sslcert 
        ipport=10.0.0.4:443 
        certhash=b66ee04419d4ee37464ab8785ff02449980eae10 
-       appid="{9412ee86-c21b-4eb8-bd89-f650fbf44931}"
+       appid="{00001111-aaaa-2222-bbbb-3333cccc4444}"
    ```
 
    When a certificate is registered, the tool responds with `SSL Certificate successfully added`.


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/dotnet/AspNetCore.Docs/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/httpsys.md](https://github.com/dotnet/AspNetCore.Docs/blob/94b02cd04df0e7916c28151eea93a3f81ac8de58/aspnetcore/fundamentals/servers/httpsys.md) | [HTTP.sys web server implementation in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/httpsys?branch=pr-en-us-33880) |

<!-- PREVIEW-TABLE-END -->