### PR TITLE
Fix typo in aspnetcore/blazor/call-web-api.md

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -520,7 +520,7 @@ If you're calling an external web API (not in the same URL space as the client a
 
 ```csharp
 builder.Services.AddHttpClient("WebAPI", client => 
-    client.BaseAddress = new Uri(https://localhost:5001));
+    client.BaseAddress = new Uri("https://localhost:5001"));
 ```
 
 In the following component code:
@@ -618,7 +618,7 @@ If you're calling an external web API (not in the same URL space as the client a
 
 ```csharp
 builder.Services.AddHttpClient<ForecastHttpClient>(client => 
-    client.BaseAddress = new Uri(https://localhost:5001));
+    client.BaseAddress = new Uri("https://localhost:5001"));
 ```
 
 Components inject the typed <xref:System.Net.Http.HttpClient> to call the web API.


### PR DESCRIPTION
Fixes a small typo in code snippets where the quotes are missing.

![image](https://github.com/user-attachments/assets/ba1f8a0f-0ebb-409f-91be-cbc0337311e3)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/call-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/bb46096dc91c4029618c9b6938826824180e02dc/aspnetcore/blazor/call-web-api.md) | [Call a web API from ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/call-web-api?branch=pr-en-us-33894) |

<!-- PREVIEW-TABLE-END -->