### PR TITLE
[Blazor] Calling .NET from JS - explanation of scenarios for DotNetObjectReference and instance methods

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -1169,7 +1169,7 @@ In the preceding example:
 
 ## Component instance .NET method helper class
 
-A helper class can invoke a .NET instance method as an <xref:System.Action>. Helper classes are useful in the following scenarios:
+A helper class can invoke a .NET instance method as an <xref:System.Action>. Helper classes are useful in scenarios where using static .NET methods is not applicable:
 
 * When several components of the same type are rendered on the same page.
 * In server-side apps with multiple users concurrently using the same component.
@@ -1345,7 +1345,7 @@ The assignment of a <xref:Microsoft.JSInterop.DotNetObjectReference> to a proper
 * In the component's [`OnAfterRender{Async}` method](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync), a JavaScript (JS) function is invoked with the element reference and the component instance as a <xref:Microsoft.JSInterop.DotNetObjectReference>. The JS function attaches the <xref:Microsoft.JSInterop.DotNetObjectReference> to the element in a property.
 * When an element event is invoked in JS (for example, `onclick`), the element's attached <xref:Microsoft.JSInterop.DotNetObjectReference> is used to call a .NET method.
 
-Similar to the approach described in the [Component instance .NET method helper class](#component-instance-net-method-helper-class) section, this approach is useful in the following scenarios:
+Similar to the approach described in the [Component instance .NET method helper class](#component-instance-net-method-helper-class) section, this approach is useful in scenarios where using static .NET methods is not applicable:
 
 * When several components of the same type are rendered on the same page.
 * In server-side apps with multiple users concurrently using the same component.

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -1169,7 +1169,7 @@ In the preceding example:
 
 ## Component instance .NET method helper class
 
-A helper class can invoke a .NET instance method as an <xref:System.Action>. Helper classes are useful in scenarios where using static .NET methods is not applicable:
+A helper class can invoke a .NET instance method as an <xref:System.Action>. Helper classes are useful in scenarios where using static .NET methods aren't applicable:
 
 * When several components of the same type are rendered on the same page.
 * In server-side apps with multiple users concurrently using the same component.
@@ -1345,7 +1345,7 @@ The assignment of a <xref:Microsoft.JSInterop.DotNetObjectReference> to a proper
 * In the component's [`OnAfterRender{Async}` method](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync), a JavaScript (JS) function is invoked with the element reference and the component instance as a <xref:Microsoft.JSInterop.DotNetObjectReference>. The JS function attaches the <xref:Microsoft.JSInterop.DotNetObjectReference> to the element in a property.
 * When an element event is invoked in JS (for example, `onclick`), the element's attached <xref:Microsoft.JSInterop.DotNetObjectReference> is used to call a .NET method.
 
-Similar to the approach described in the [Component instance .NET method helper class](#component-instance-net-method-helper-class) section, this approach is useful in scenarios where using static .NET methods is not applicable:
+Similar to the approach described in the [Component instance .NET method helper class](#component-instance-net-method-helper-class) section, this approach is useful in scenarios where using static .NET methods aren't applicable:
 
 * When several components of the same type are rendered on the same page.
 * In server-side apps with multiple users concurrently using the same component.

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -1176,7 +1176,7 @@ A helper class can invoke a .NET instance method as an <xref:System.Action>. Hel
 
 In the following example:
 
-* The component contains several `ListItem1` components, which is a shared component in the app's `Shared` folder.
+* The component contains several `ListItem1` components.
 * Each `ListItem1` component is composed of a message and a button.
 * When a `ListItem1` component button is selected, that `ListItem1`'s `UpdateMessage` method changes the list item text and hides the button.
 


### PR DESCRIPTION
When reading this article, I found it difficult to understand the meaning of:

> - In server-side apps with multiple users concurrently using the same component.

Eventually, I realized it refers to the difference between calling static .NET methods (where any static state is shared across circuits) and instance .NET methods (where the instance is held by the component, which is part of an individual circuit).

I think updating the introductory sentence would help future readers better understand this context.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/69891ff038e57cba846d7b20bf89ff7c27bf5d02/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md) | [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?branch=pr-en-us-33910) |


<!-- PREVIEW-TABLE-END -->