### PR TITLE
Fix link in enforcing-ssl

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -5,7 +5,7 @@ description: Learn how to require HTTPS/TLS in an ASP.NET Core web app.
 ms.author: tdykstra
 monikerRange: '>= aspnetcore-3.0'
 ms.custom: mvc, linux-related-content
-ms.date: 10/14/2024
+ms.date: 10/24/2024
 uid: security/enforcing-ssl
 ---
 # Enforce HTTPS in ASP.NET Core

--- a/aspnetcore/security/enforcing-ssl/includes/enforcing-ssl8.md
+++ b/aspnetcore/security/enforcing-ssl/includes/enforcing-ssl8.md
@@ -225,7 +225,7 @@ Create a policy file (`policies.json`) at:
 
 * Windows: `%PROGRAMFILES%\Mozilla Firefox\distribution\`
 * MacOS: `Firefox.app/Contents/Resources/distribution`
-* Linux: See [Trust the certificate with Firefox on Linux](?[tabs=visual-studio%2Clinux-ubuntu%2Clinux-sles#trust-the-certificate-with-firefox-on-linux) in this article.
+* Linux: See [Trust the certificate with Firefox on Linux](/aspnet/core/security/enforcing-ssl?tabs=visual-studio%2Clinux-ubuntu%2Clinux-sles#trust-the-certificate-with-firefox-on-linux) in this article.
 
 Add the following JSON to the Firefox policy file:
 

--- a/aspnetcore/security/enforcing-ssl/includes/enforcing-ssl8.md
+++ b/aspnetcore/security/enforcing-ssl/includes/enforcing-ssl8.md
@@ -225,7 +225,7 @@ Create a policy file (`policies.json`) at:
 
 * Windows: `%PROGRAMFILES%\Mozilla Firefox\distribution\`
 * MacOS: `Firefox.app/Contents/Resources/distribution`
-* Linux: See [Trust the certificate with Firefox on Linux](#trust-ff-linux) in this article.
+* Linux: See [Trust the certificate with Firefox on Linux](#trust-ff-linux8) in this article.
 
 Add the following JSON to the Firefox policy file:
 
@@ -324,7 +324,7 @@ For chromium browsers on Linux:
 
 * Exit and restart the browser.
 
-<a name="trust-ff-linux"></a>
+<a name="trust-ff-linux8"></a>
 
 #### Trust the certificate with Firefox on Linux
 

--- a/aspnetcore/security/enforcing-ssl/includes/enforcing-ssl8.md
+++ b/aspnetcore/security/enforcing-ssl/includes/enforcing-ssl8.md
@@ -225,7 +225,7 @@ Create a policy file (`policies.json`) at:
 
 * Windows: `%PROGRAMFILES%\Mozilla Firefox\distribution\`
 * MacOS: `Firefox.app/Contents/Resources/distribution`
-* Linux: See [Trust the certificate with Firefox on Linux](#trust-ff-linux8) in this article.
+* Linux: See [Trust the certificate with Firefox on Linux](?[tabs=visual-studio%2Clinux-ubuntu%2Clinux-sles#trust-the-certificate-with-firefox-on-linux) in this article.
 
 Add the following JSON to the Firefox policy file:
 


### PR DESCRIPTION
Fixes #33915 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/enforcing-ssl.md](https://github.com/dotnet/AspNetCore.Docs/blob/f245d8bd6d74ac6e5e029c87c804e1a17df5c0da/aspnetcore/security/enforcing-ssl.md) | [Enforce HTTPS in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/enforcing-ssl?branch=pr-en-us-33916) |


<!-- PREVIEW-TABLE-END -->