### PR TITLE
GH Action for processing Blazor issues

### DIFF
--- a/.github/workflows/blazor-issue-processing.yml
+++ b/.github/workflows/blazor-issue-processing.yml
@@ -1,0 +1,53 @@
+name: Issue processing
+on:
+  issues:
+    types:
+      - opened
+    paths:
+      - 'aspnetcore/blazor/**'
+jobs:
+  process-blazor-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### 🍂🎃🏮 *Autumn Skies and Pumpkin Pies!* 🥧☕🍂
+            Stand by! A green dinosaur 🦖 will arrive shortly to assist.`
+            })
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["Blazor"]
+            })
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["aspnet-core/svc"]
+            })
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["blazor/subsvc"]
+            })
+            await github.rest.issues.addAssignees({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: ["guardrex"]
+            })
+            await github.rest.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: [":watch: Not Triaged"]
+            })

--- a/.github/workflows/issue-processing.yml
+++ b/.github/workflows/issue-processing.yml
@@ -63,38 +63,3 @@ jobs:
               repo: context.repo.repo,
               name: [":watch: Not Triaged"]
             })
-
-  process-blazor-issue:
-    if: github.event.label.name == 'blazor/subsvc'
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `### 🍂🎃🏮 *Autumn Skies and Pumpkin Pies!* 🥧☕🍂
-            Stand by! A green dinosaur 🦖 will arrive shortly to assist.`
-            })
-            await github.rest.issues.addLabels({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ["Blazor"]
-            })
-            await github.rest.issues.addAssignees({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              assignees: ["guardrex"]
-            })
-            await github.rest.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: [":watch: Not Triaged"]
-            })


### PR DESCRIPTION
@adegeo (cc: @Rick-Anderson @tdykstra @wadepickett) ... I'll give this a shot and see what happens ...

* Moving the Blazor issue processing over to a new workflow.
* The new workflow will apply the `aspnet-core/svc` and `blazor/subsvc` labels, along with the usual job tasks that I do for Blazor issues: place a 'hello' comment, label it with `Blazor`, assign me to the issue, and remove the `Not Triaged` label (if present ... if Repoman ran and applied it).
* I'll try to run this workflow on an opened issue with a path of `aspnetcore/blazor/**`. I'm not sure about the `on` conditional checks because GH docs don't show an example of this combination working ... but we'll see soon enough! 😆

If this works, my recommendation will be to remove the initial labels that Repoman is applying and apply all them via a workflow.

I'll ping everyone in a moment from a test issue, and we can see if this actually works 🤞🍀. 

If `paths: - 'aspnetcore/blazor/**'` doesn't trigger the job because `paths` only works for file `push` actions, then I'll try a conditional-based approach at the job level to see if I can get it to recognize the path text `aspnet/core/blazor` in the opening comment text.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/workflows/blazor-issue-processing.yml](https://github.com/dotnet/AspNetCore.Docs/blob/23b573dd65668cf943ecc6aa161ae2cd2c832ce6/.github/workflows/blazor-issue-processing.yml) | [.github/workflows/blazor-issue-processing](https://review.learn.microsoft.com/en-us/aspnet/core/.github/workflows/blazor-issue-processing?branch=pr-en-us-33920) |
| [.github/workflows/issue-processing.yml](https://github.com/dotnet/AspNetCore.Docs/blob/23b573dd65668cf943ecc6aa161ae2cd2c832ce6/.github/workflows/issue-processing.yml) | [.github/workflows/issue-processing](https://review.learn.microsoft.com/en-us/aspnet/core/.github/workflows/issue-processing?branch=pr-en-us-33920) |

<!-- PREVIEW-TABLE-END -->