### PR TITLE
Update openAPI_completion.md

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-9/includes/openAPI_completion.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/openAPI_completion.md
@@ -89,9 +89,9 @@ var builder = WebApplication.CreateBuilder();
 
 builder.Services.AddOpenApi(options =>
 {
-    options.UseSchemaTransformer((schema, context, cancellationToken) =>
+    options.AddSchemaTransformer((schema, context, cancellationToken) =>
     {
-        if (context.Type == typeof(Todo))
+        if (context.JsonTypeInfo.Type == typeof(Todo))
         {
             schema.Example = new OpenApiObject
             {


### PR DESCRIPTION
This PR addresses two documentation inaccuracies:

Updated usage of the outdated method `UseSchemaTransformer`, which has been replaced by `AddSchemaTransformer` in recent versions of .NET.

Corrected type checking syntax from `if (c.Type == typeof(Product))` to `if (c.JsonTypeInfo.Type == typeof(Product))`, aligning with the current API structure for accessing type information.