### PR TITLE
Update memory.md

### DIFF
--- a/aspnetcore/performance/memory.md
+++ b/aspnetcore/performance/memory.md
@@ -79,7 +79,7 @@ The chart displays two values for the memory usage:
 
 ### Transient objects
 
-The following API creates a 10-KB String instance and returns it to the client. On each request, a new object is allocated in memory and written to the response. Strings are stored as UTF-16 characters in .NET so each character takes 2 bytes in memory.
+The following API creates a 20-KB String instance and returns it to the client. On each request, a new object is allocated in memory and written to the response. Strings are stored as UTF-16 characters in .NET so each character takes 2 bytes in memory.
 
 ```csharp
 [HttpGet("bigstring")]
@@ -156,7 +156,7 @@ When multiple containerized apps are running on one machine, Workstation GC migh
 
 The GC cannot free objects that are referenced. Objects that are referenced but no longer needed result in a memory leak. If the app frequently allocates objects and fails to free them after they are no longer needed, memory usage will increase over time.
 
-The following API creates a 10-KB String instance and returns it to the client. The difference with the previous example is that this instance is referenced by a static member, which means it's never available for collection.
+The following API creates a 20-KB String instance and returns it to the client. The difference with the previous example is that this instance is referenced by a static member, which means it's never available for collection.
 
 ```csharp
 private static ConcurrentBag<string> _staticStrings = new ConcurrentBag<string>();


### PR DESCRIPTION
Updated size of string from 10KB to 20KB according to

> Note: Strings are stored as UTF-16 characters in .NET so each char takes two bytes in memory.

but also after running

``` cs
Console.WriteLine(
    System.Text.Encoding.Unicode.GetByteCount(
        new String('x', 10 * 1024)));

// Answer: 20480
```

<!-- PREVIEW-TABLE-START -->

---

Fixes #34052


#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/memory.md](https://github.com/dotnet/AspNetCore.Docs/blob/5c870040759ba3c9b0b942756acaecf9d87be80c/aspnetcore/performance/memory.md) | [Memory management and garbage collection (GC) in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/memory?branch=pr-en-us-33937) |

<!-- PREVIEW-TABLE-END -->