### PR TITLE
Add 'How to open an issue' to the README

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -1,0 +1,23 @@
+---
+name: Doc issue
+about: Create an issue to help us improve
+---
+# Before you open an issue
+
+If the issue is with an ASP.NET Core document:
+
+* Do **not** open a new issue using this form.
+* Open the issue using the **Open a documentation issue** link and feedback form at the bottom of the article. 
+
+Using the **Open a documentation issue** link and form to open an issue adds article metadata for tracking, which indicates the article that you're commenting on and pings the author for a faster response.
+
+If the issue is:
+
+* A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
+* A general support question, consider asking on a support forum site:
+  * [Stack Overflow](https://stackoverflow.com/questions)
+  * [ASP.NET Core Slack](https://aspnetcore.slack.com/join/shared_invite/zt-1mv5487zb-EOZxJ1iqb0A0ajowEbxByQ#/shared-invite/email)
+  * [ASP.NET Gitter](https://gitter.im/aspnet/Home)
+* A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).
+* A problem completing a tutorial, compare your code with the completed sample.
+* A duplicate of an open or closed issue, leave a comment on that issue.

--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -2,6 +2,7 @@
 name: Doc issue
 about: Create an issue to help us improve
 ---
+
 # Before you open an issue
 
 If the issue is with an ASP.NET Core document:

--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -16,7 +16,7 @@ If the issue is:
 
 * A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
 * A general support question, consider asking on a support forum site:
-  * [Stack Overflow](https://stackoverflow.com/questions)
+  * [Stack Overflow](https://stackoverflow.com/questions/tagged/asp.net-core)
   * [ASP.NET Core Slack](https://aspnetcore.slack.com/join/shared_invite/zt-1mv5487zb-EOZxJ1iqb0A0ajowEbxByQ#/shared-invite/email)
   * [ASP.NET Gitter](https://gitter.im/aspnet/Home)
 * A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).

--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ This repository contains the [ASP.NET Core documentation](https://learn.microsof
 To provide comments and suggestions on [learn.microsoft.com](https://learn.microsoft.com) site functionality, open an issue in the [`MicrosoftDocs/feedback` GitHub repository](https://github.com/MicrosoftDocs/feedback).
 
 ASP.NET 4.x documentation changes are made in the [`dotnet/AspNetDocs` GitHub repository](https://github.com/dotnet/AspNetDocs).
+
+## How to open an issue
+
+If the issue is with an ASP.NET Core document:
+
+* Do **not** open a blank issue.
+* Open the issue using the **Open a documentation issue** link and feedback form at the bottom of the article. 
+
+Using the **Open a documentation issue** link and form to open an issue adds article metadata for tracking, which indicates the article that you're commenting on and automatically pings the author for a faster response.
+
+If the issue is:
+
+* A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
+* A general support question, consider asking on a support forum site:
+  * [Stack Overflow](https://stackoverflow.com/questions)
+  * [ASP.NET Core Slack](https://aspnetcore.slack.com/join/shared_invite/zt-1mv5487zb-EOZxJ1iqb0A0ajowEbxByQ#/shared-invite/email)
+  * [ASP.NET Gitter](https://gitter.im/aspnet/Home)
+* A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).
+* A problem completing a tutorial, compare your code with the completed sample.
+* A duplicate of an open or closed issue, leave a comment on that issue.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If the issue is:
 
 * A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
 * A general support question, consider asking on a support forum site:
-  * [Stack Overflow](https://stackoverflow.com/questions)
+  * [Stack Overflow](https://stackoverflow.com/questions/tagged/asp.net-core)
   * [ASP.NET Core Slack](https://aspnetcore.slack.com/join/shared_invite/zt-1mv5487zb-EOZxJ1iqb0A0ajowEbxByQ#/shared-invite/email)
   * [ASP.NET Gitter](https://gitter.im/aspnet/Home)
 * A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).


### PR DESCRIPTION
Fixes #33946

Thanks @bukowa! 🚀 

### ❓ 

Rick, Tom, Wade ... It might also help to add a section to the *Fundamenals* > *Overview*. I've been running for many years with one for Blazor that might be helping me a little bit ...

https://learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/?view=aspnetcore-8.0#support-requests

If you'd like me to add a similar section tailored generally for the whole repo, let me know. 👂 I can add it to this PR.

### ~❓~ ***Resolved*** 

~Also... ***Rick*** ... this SO link is lacking your "area" of SO tag thing that you place on your SO links that you give to folks. I couldn't find a quick example of that tag ... what tag/link do you give them ... is it this one ...~

```
https://stackoverflow.com/questions/tagged/asp.net-core
```

~Whatever it is, I'll update the SO link on this PR.~

### ❓ 

I'm seeking to add a `blank-issue.md` template. Is that the right naming? I'm not sure if it's going to load into a blank issue ... it's a guess for sure based on the names of the other templates.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/blank-issue.md](https://github.com/dotnet/AspNetCore.Docs/blob/b5a975f9d83c3b5adc822dde562e1b4b80ef27b4/.github/ISSUE_TEMPLATE/blank-issue.md) | [.github/ISSUE_TEMPLATE/blank-issue](https://review.learn.microsoft.com/en-us/aspnet/core/.github/ISSUE_TEMPLATE/blank-issue?branch=pr-en-us-33947) |


<!-- PREVIEW-TABLE-END -->