### PR TITLE
Template updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -14,11 +14,11 @@ Using the **Open a documentation issue** link and form to open an issue adds art
 
 If the issue is:
 
-* A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
-* A general support question, consider asking on a support forum site:
-  * [Stack Overflow](https://stackoverflow.com/questions/tagged/asp.net-core)
-  * [ASP.NET Core Slack](https://aspnetcore.slack.com/join/shared_invite/zt-1mv5487zb-EOZxJ1iqb0A0ajowEbxByQ#/shared-invite/email)
-  * [ASP.NET Gitter](https://gitter.im/aspnet/Home)
-* A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).
+* A simple typo or similar correction, you can submit a PR. See the Contributor Guide for instructions: https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents
+* A general support question, consider asking on a support forum:
+  * Stack Overflow: https://stackoverflow.com/questions/tagged/asp.net-core
+  * ASP.NET Core Slack: https://aspnetcore.slack.com/join/shared_invite/zt-1mv5487zb-EOZxJ1iqb0A0ajowEbxByQ#/shared-invite/email
+  * ASP.NET Gitter: https://gitter.im/aspnet/Home
+* A site design concern, create an issue at MicrosoftDocs/Feedback: https://github.com/MicrosoftDocs/Feedback/issues/new/choose
 * A problem completing a tutorial, compare your code with the completed sample.
 * A duplicate of an open or closed issue, leave a comment on that issue.

--- a/.github/ISSUE_TEMPLATE/doc-issue.md
+++ b/.github/ISSUE_TEMPLATE/doc-issue.md
@@ -14,9 +14,12 @@ Using the **Open a documentation issue** link and form to open an issue adds art
 
 If the issue is:
 
-* A simple typo or similar correction, you can submit a PR. See [the contributor guide](https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents) for instructions.
-* A general support question, consider asking on a support forum site.
-* A site design concern, create an issue at [MicrosoftDocs/Feedback](https://github.com/MicrosoftDocs/Feedback/issues/new/choose).
+* A simple typo or similar correction, you can submit a PR. See the Contributor Guide for instructions: https://docs.microsoft.com/contribute/#quick-edits-to-existing-documents
+* A general support question, consider asking on a support forum:
+  * Stack Overflow: https://stackoverflow.com/questions/tagged/asp.net-core
+  * ASP.NET Core Slack: https://aspnetcore.slack.com/join/shared_invite/zt-1mv5487zb-EOZxJ1iqb0A0ajowEbxByQ#/shared-invite/email
+  * ASP.NET Gitter: https://gitter.im/aspnet/Home
+* A site design concern, create an issue at MicrosoftDocs/Feedback: https://github.com/MicrosoftDocs/Feedback/issues/new/choose
 * A problem completing a tutorial, compare your code with the completed sample.
 * A duplicate of an open or closed issue, leave a comment on that issue.
 


### PR DESCRIPTION
Touching up links because markdown isn't rendered in textareas. NO periods on the ends ... they screw up the link when the link is a cut-'n-paste into a browser address bar.

Actually, none of the markdown really makes sense here, but I'm heading OOF for the day, so that will have to wait for another time.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/blank-issue.md](https://github.com/dotnet/AspNetCore.Docs/blob/70f9163690467408ad52ebb6450972a78b8f1fdf/.github/ISSUE_TEMPLATE/blank-issue.md) | [.github/ISSUE_TEMPLATE/blank-issue](https://review.learn.microsoft.com/en-us/aspnet/core/.github/ISSUE_TEMPLATE/blank-issue?branch=pr-en-us-33966) |
| [.github/ISSUE_TEMPLATE/doc-issue.md](https://github.com/dotnet/AspNetCore.Docs/blob/70f9163690467408ad52ebb6450972a78b8f1fdf/.github/ISSUE_TEMPLATE/doc-issue.md) | [.github/ISSUE_TEMPLATE/doc-issue](https://review.learn.microsoft.com/en-us/aspnet/core/.github/ISSUE_TEMPLATE/doc-issue?branch=pr-en-us-33966) |

<!-- PREVIEW-TABLE-END -->