### PR TITLE
Inline code to drop namespace

### DIFF
--- a/aspnetcore/blazor/tutorials/build-a-blazor-app.md
+++ b/aspnetcore/blazor/tutorials/build-a-blazor-app.md
@@ -196,37 +196,73 @@ Add a `TodoItem.cs` file to the root of the project (the `TodoList` folder) to h
 
 :::moniker range=">= aspnetcore-9.0"
 
-:::code language="csharp" source="~/../blazor-samples/9.0/BlazorSample_WebAssembly/TodoItem.cs":::
+```csharp
+public class TodoItem
+{
+    public string? Title { get; set; }
+    public bool IsDone { get; set; }
+}
+```
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-8.0 < aspnetcore-9.0"
 
-:::code language="csharp" source="~/../blazor-samples/8.0/BlazorSample_WebAssembly/TodoItem.cs":::
+```csharp
+public class TodoItem
+{
+    public string? Title { get; set; }
+    public bool IsDone { get; set; }
+}
+```
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-7.0 < aspnetcore-8.0"
 
-:::code language="csharp" source="~/../blazor-samples/7.0/BlazorSample_WebAssembly/build-a-blazor-app/TodoItem.cs":::
+```csharp
+public class TodoItem
+{
+    public string? Title { get; set; }
+    public bool IsDone { get; set; }
+}
+```
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-6.0 < aspnetcore-7.0"
 
-:::code language="csharp" source="~/../blazor-samples/6.0/BlazorSample_WebAssembly/build-a-blazor-app/TodoItem.cs":::
+```csharp
+public class TodoItem
+{
+    public string? Title { get; set; }
+    public bool IsDone { get; set; }
+}
+```
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-6.0"
 
-:::code language="csharp" source="~/../blazor-samples/5.0/BlazorSample_WebAssembly/build-a-blazor-app/TodoItem.cs":::
+```csharp
+public class TodoItem
+{
+    public string Title { get; set; }
+    public bool IsDone { get; set; }
+}
+```
 
 :::moniker-end
 
 :::moniker range="< aspnetcore-5.0"
 
-:::code language="csharp" source="~/../blazor-samples/3.1/BlazorSample_WebAssembly/build-a-blazor-app/TodoItem.cs":::
+```csharp
+public class TodoItem
+{
+    public string Title { get; set; }
+    public bool IsDone { get; set; }
+}
+```
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #33968

Thanks @shiruide! 🚀 ... This is going to a bit of a patch fix. I'd like to drop all of the sample app code for this and just go with NRTs (nullable reference types) everywhere. They've been out since ASP.NET Core 6.0 (C# 10), and most folks are using NRTs now. I'll make a tracking item to work on the topic further. Thanks again for the report!

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tutorials/build-a-blazor-app.md](https://github.com/dotnet/AspNetCore.Docs/blob/3a2ef5003ef89afab64aa3e115e1686209491178/aspnetcore/blazor/tutorials/build-a-blazor-app.md) | [aspnetcore/blazor/tutorials/build-a-blazor-app](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/build-a-blazor-app?branch=pr-en-us-33969) |

<!-- PREVIEW-TABLE-END -->