### PR TITLE
WASM+Identity acct conf and PW recovery

### DIFF
--- a/.openpublishing.redirection.json
+++ b/.openpublishing.redirection.json
@@ -1312,6 +1312,16 @@
             "source_path": "aspnetcore/blazor/images.md",
             "redirect_url": "/aspnet/core/blazor/images-and-documents",
             "redirect_document_id": false
+        },
+        {
+            "source_path": "aspnetcore/blazor/security/webassembly/standalone-with-identity.md",
+            "redirect_url": "/aspnet/core/blazor/security/webassembly/standalone-with-identity/",
+            "redirect_document_id": false
+        },
+        {
+            "source_path": "blazor/security/server/account-confirmation-and-password-recovery.md",
+            "redirect_url": "/aspnet/core/blazor/security/account-confirmation-and-password-recovery",
+            "redirect_document_id": false
         }
     ]
 }

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -686,7 +686,7 @@ builder.Services.AddHttpClient(...)
 
 :::moniker range=">= aspnetcore-8.0"
 
-For a demonstration, see <xref:blazor/security/webassembly/standalone-with-identity>.
+For a demonstration, see <xref:blazor/security/webassembly/standalone-with-identity/index>.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/fundamentals/index.md
+++ b/aspnetcore/blazor/fundamentals/index.md
@@ -189,7 +189,7 @@ Samples apps in the repository:
 * Two Blazor Web Apps and a Blazor WebAssembly app for calling web (server) APIs (<xref:blazor/call-web-api>)
 * Blazor Web App with OIDC (BFF and non-BFF patterns) (<xref:blazor/security/blazor-web-app-oidc>)
 * Blazor WebAssembly scopes-enabled logging (<xref:blazor/fundamentals/logging#client-side-log-scopes>)
-* Blazor WebAssembly with ASP.NET Core Identity (<xref:blazor/security/webassembly/standalone-with-identity>)
+* Blazor WebAssembly with ASP.NET Core Identity (<xref:blazor/security/webassembly/standalone-with-identity/index>)
 * .NET MAUI Blazor Hybrid app with a Blazor Web App and a shared UI provided by a Razor class library (RCL) (<xref:blazor/hybrid/tutorials/maui-blazor-web-app>)
 
 :::moniker-end

--- a/aspnetcore/blazor/security/account-confirmation-and-password-recovery.md
+++ b/aspnetcore/blazor/security/account-confirmation-and-password-recovery.md
@@ -5,11 +5,14 @@ description: Learn how to configure an ASP.NET Core Blazor Web App with email co
 ms.author: riande
 monikerRange: '>= aspnetcore-8.0'
 ms.date: 02/09/2024
-uid: blazor/security/server/account-confirmation-and-password-recovery
+uid: blazor/security/account-confirmation-and-password-recovery
 ---
 # Account confirmation and password recovery in ASP.NET Core Blazor
 
 This article explains how to configure an ASP.NET Core Blazor Web App with email confirmation and password recovery.
+
+> [!NOTE]
+> This article only applies to Blazor Web Apps. To implement email confirmation and password recovery for standalone Blazor WebAssembly apps with ASP.NET Core Identity, see <xref:blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery>.
 
 ## Namespace
 
@@ -21,7 +24,7 @@ In this article, [Mailchimp's Transactional API](https://mailchimp.com/developer
 
 Create a class to fetch the secure email API key. The example in this article uses a class named `AuthMessageSenderOptions` with a `EmailAuthKey` property to hold the key.
 
-`AuthMessageSenderOptions`:
+`AuthMessageSenderOptions.cs`:
 
 ```csharp
 namespace BlazorSample;
@@ -40,11 +43,19 @@ builder.Services.Configure<AuthMessageSenderOptions>(builder.Configuration);
 
 ## Configure a user secret for the provider's security key
 
-Set the key with the [Secret Manager tool](xref:security/app-secrets). In the following example, the key name is `EmailAuthKey`, and the key is represented by the `{KEY}` placeholder. In a command shell, navigate to the app's root folder and execute the following command with the API key:
+If the project has already been initialized for the [Secret Manager tool](xref:security/app-secrets), it will already have an app secrets identifier (`<AppSecretsId>`) in its project file (`.csproj`). In Visual Studio, you can tell if the app secrets ID is present by looking at the **Properties** panel when the project is selected in **Solution Explorer**. If the app hasn't been initialized, execute the following command in a command shell opened to the project's directory. In Visual Studio, you can use the Developer PowerShell command prompt.
+
+```dotnetcli
+dotnet user-secrets init
+```
+
+Set the key with the Secret Manager tool. In the following example, the key name is `EmailAuthKey`, and the key is represented by the `{KEY}` placeholder. In a command shell, navigate to the app's root folder and execute the following command with the API key:
 
 ```dotnetcli
 dotnet user-secrets set "EmailAuthKey" "{KEY}"
 ```
+
+If using Visual Studio, you can confirm the secret is set by right-clicking the server project in **Solution Explorer** and selecting **Manage User Secrets**.
 
 For more information, see <xref:security/app-secrets>.
 
@@ -52,7 +63,11 @@ For more information, see <xref:security/app-secrets>.
 
 ## Implement `IEmailSender`
 
-Implement `IEmailSender` for the provider. The following example is based on Mailchimp's Transactional API using [Mandrill.net](https://www.nuget.org/packages/Mandrill.net). For a different provider, refer to their documentation on how to implement sending a message in the `Execute` method.
+The following example is based on Mailchimp's Transactional API using [Mandrill.net](https://www.nuget.org/packages/Mandrill.net). For a different provider, refer to their documentation on how to implement sending an email message.
+
+Add the [Mandrill.net](https://www.nuget.org/packages/Mandrill.net) NuGet package to the project.
+
+Add the following `EmailSender` class to implement <xref:Microsoft.AspNetCore.Identity.IEmailSender>. 
 
 `Components/Account/EmailSender.cs`:
 
@@ -170,7 +185,7 @@ builder.Services.Configure<DataProtectionTokenProviderOptions>(options =>
     options.TokenLifespan = TimeSpan.FromHours(3));
 ```
 
-The built in Identity user tokens ([AspNetCore/src/Identity/Extensions.Core/src/TokenOptions.cs](https://github.com/dotnet/aspnetcore/blob/main/src/Identity/Extensions.Core/src/TokenOptions.cs)) have a [one day timeout](https://github.com/dotnet/AspNetCore/blob/main/src/Identity/Core/src/DataProtectionTokenProviderOptions.cs).
+The built-in Identity user tokens ([AspNetCore/src/Identity/Extensions.Core/src/TokenOptions.cs](https://github.com/dotnet/aspnetcore/blob/main/src/Identity/Extensions.Core/src/TokenOptions.cs)) have a [one day timeout](https://github.com/dotnet/AspNetCore/blob/main/src/Identity/Core/src/DataProtectionTokenProviderOptions.cs).
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
@@ -256,6 +271,13 @@ builder.Services
     .AddTransient<CustomEmailConfirmationTokenProvider<ApplicationUser>>();
 ```
 
+## Enable account confirmation after a site has users
+
+Enabling account confirmation on a site with users locks out all the existing users. Existing users are locked out because their accounts aren't confirmed. To work around existing user lockout, use one of the following approaches:
+
+* Update the database to mark all existing users as confirmed.
+* Confirm existing users. For example, batch-send emails with confirmation links.
+
 ## Troubleshoot
 
 If you can't get email working:
@@ -266,16 +288,6 @@ If you can't get email working:
 * Check your spam folder for messages.
 * Try another email alias on a different email provider, such as Microsoft, Yahoo, or Gmail.
 * Try sending to different email accounts.
-
-> [!WARNING]
-> Do **not** use production secrets in test and development. If you publish the app to Azure, set secrets as application settings in the Azure Web App portal. The configuration system is set up to read keys from environment variables.
-
-## Enable account confirmation after a site has users
-
-Enabling account confirmation on a site with users locks out all the existing users. Existing users are locked out because their accounts aren't confirmed. To work around existing user lockout, use one of the following approaches:
-
-* Update the database to mark all existing users as confirmed.
-* Confirm existing users. For example, batch-send emails with confirmation links.
 
 ## Additional resources
 

--- a/aspnetcore/blazor/security/authentication-state.md
+++ b/aspnetcore/blazor/security/authentication-state.md
@@ -474,7 +474,7 @@ The following component's `SignIn` method creates a claims principal for the use
 * [Server-side unauthorized content display while prerendering with a custom `AuthenticationStateProvider`](xref:blazor/security/server/index#unauthorized-content-display-while-prerendering-with-a-custom-authenticationstateprovider)
 * [How to access an `AuthenticationStateProvider` from a `DelegatingHandler` set up using an `IHttpClientFactory`](xref:blazor/security/server/additional-scenarios#access-authenticationstateprovider-in-outgoing-request-middleware)
 * <xref:blazor/security/blazor-web-app-oidc>
-* <xref:blazor/security/webassembly/standalone-with-identity>
+* <xref:blazor/security/webassembly/standalone-with-identity/index>
 
 :::moniker-end
 
@@ -483,7 +483,7 @@ The following component's `SignIn` method creates a claims principal for the use
 * [Server-side unauthorized content display while prerendering with a custom `AuthenticationStateProvider`](xref:blazor/security/server/index#unauthorized-content-display-while-prerendering-with-a-custom-authenticationstateprovider)
 * [How to access an `AuthenticationStateProvider` from a `DelegatingHandler` set up using an `IHttpClientFactory`](xref:blazor/security/server/additional-scenarios#access-authenticationstateprovider-in-outgoing-request-middleware)
 * <xref:blazor/security/blazor-web-app-oidc>
-* <xref:blazor/security/webassembly/standalone-with-identity>
+* <xref:blazor/security/webassembly/standalone-with-identity/index>
 [Prerendering with authentication in hosted Blazor WebAssembly apps](xref:blazor/security/webassembly/additional-scenarios#prerendering-with-authentication)
 
 :::moniker-end

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery.md
@@ -1,0 +1,621 @@
+---
+title: Account confirmation and password recovery in ASP.NET Core Blazor WebAssembly with ASP.NET Core Identity
+author: guardrex
+description: Learn how to configure an ASP.NET Core Blazor WebAssembly app with ASP.NET Core Identity with email confirmation and password recovery.
+ms.author: riande
+monikerRange: '>= aspnetcore-8.0'
+ms.date: 10/30/2024
+uid: blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery
+---
+# Account confirmation and password recovery in ASP.NET Core Blazor WebAssembly with ASP.NET Core Identity
+
+This article explains how to configure an ASP.NET Core Blazor WebAssembly app with ASP.NET Core Identity with email confirmation and password recovery.
+
+> [!NOTE]
+> This article only applies standalone Blazor WebAssembly apps with ASP.NET Core Identity. To implement email confirmation and password recovery for Blazor Web Apps, see <xref:blazor/security/account-confirmation-and-password-recovery>.
+
+## Namespace
+
+The namespaces used by the examples in this article are:
+
+* `Backend` for the backend server web API project.
+* `BlazorWasmAuth` for the front-end standalone Blazor WebAssembly app.
+
+These namespaces correspond to the projects in the `BlazorWebAssemblyStandaloneWithIdentity` sample solution in the [`dotnet/blazor-samples` GitHub repository](https://github.com/dotnet/blazor-samples). For more information, see <xref:blazor/security/webassembly/standalone-with-identity/index#sample-apps>.
+
+If you aren't using the `BlazorWebAssemblyStandaloneWithIdentity` sample solution, change the namespaces in the code examples to use the namespaces of your projects.
+
+## Select and configure an email provider for the server project
+
+In this article, [Mailchimp's Transactional API](https://mailchimp.com/developer/transactional/api/) is used via [Mandrill.net](https://www.nuget.org/packages/Mandrill.net) to send email. We recommend using an email service to send email rather than SMTP. SMTP is difficult to configure and secure properly. Whichever email service you use, access their guidance for .NET apps, create an account, configure an API key for their service, and install any NuGet packages required.
+
+In the backend server project, create a class to fetch the secure email API key. The example in this article uses a class named `AuthMessageSenderOptions` with a `EmailAuthKey` property to hold the key.
+
+`AuthMessageSenderOptions.cs`:
+
+```csharp
+namespace Backend;
+
+public class AuthMessageSenderOptions
+{
+    public string? EmailAuthKey { get; set; }
+}
+```
+
+Register the `AuthMessageSenderOptions` configuration instance in the backend server project's `Program` file:
+
+```csharp
+builder.Services.Configure<AuthMessageSenderOptions>(builder.Configuration);
+```
+
+## Configure a user secret for the provider's security key
+
+If the backend server web API project (`Backend` in the [sample solution](xref:blazor/security/webassembly/standalone-with-identity/index#sample-apps)) has already been initialized for the [Secret Manager tool](xref:security/app-secrets), it will already have a app secrets identifier (`<AppSecretsId>`) in its project file (`.csproj`). In Visual Studio, you can tell if the app secrets ID is present by looking at the **Properties** panel when the project is selected in **Solution Explorer**. If the app hasn't been initialized, execute the following command in a command shell opened to the backend server project's directory. In Visual Studio, you can use the Developer PowerShell command prompt (use the `cd` command to change the directory to the server project after you open the command shell).
+
+```dotnetcli
+dotnet user-secrets init
+```
+
+Set the email API key with the Secret Manager tool. In the following example, the key name is `EmailAuthKey`, and the key is represented by the `{KEY}` placeholder. Execute the following command with the API key:
+
+```dotnetcli
+dotnet user-secrets set "EmailAuthKey" "{KEY}"
+```
+
+If using Visual Studio, you can confirm the secret is set by right-clicking the server project in **Solution Explorer** and selecting **Manage User Secrets**.
+
+For more information, see <xref:security/app-secrets>.
+
+[!INCLUDE[](~/blazor/security/includes/secure-authentication-flows.md)]
+
+## Implement `IEmailSender` in the server project
+
+The following example is based on Mailchimp's Transactional API using [Mandrill.net](https://www.nuget.org/packages/Mandrill.net). For a different provider, refer to their documentation on how to implement sending an email message.
+
+Add the [Mandrill.net](https://www.nuget.org/packages/Mandrill.net) NuGet package to the backend server project.
+
+Add the following `EmailSender` class to implement <xref:Microsoft.AspNetCore.Identity.IEmailSender>. In the following example, `AppUser` is a <xref:Microsoft.AspNetCore.Identity.IdentityUser>.
+
+`EmailSender.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using Mandrill;
+using Mandrill.Model;
+
+namespace Backend;
+
+public class EmailSender(IOptions<AuthMessageSenderOptions> optionsAccessor,
+    ILogger<EmailSender> logger) : IEmailSender<AppUser>
+{
+    private readonly ILogger logger = logger;
+
+    public AuthMessageSenderOptions Options { get; } = optionsAccessor.Value;
+
+    public Task SendConfirmationLinkAsync(AppUser user, string email, 
+        string confirmationLink) => SendEmailAsync(email, "Confirm your email", 
+        "Please confirm your account by " +
+        $"<a href='{confirmationLink}'>clicking here</a>.");
+
+    public Task SendPasswordResetLinkAsync(AppUser user, string email, 
+        string resetLink) => SendEmailAsync(email, "Reset your password", 
+        $"Please reset your password by <a href='{resetLink}'>clicking here</a>.");
+
+    public Task SendPasswordResetCodeAsync(AppUser user, string email, 
+        string resetCode) => SendEmailAsync(email, "Reset your password", 
+        $"Please reset your password using the following code: {resetCode}");
+
+    public async Task SendEmailAsync(string toEmail, string subject, string message)
+    {
+        if (string.IsNullOrEmpty(Options.EmailAuthKey))
+        {
+            throw new Exception("Null EmailAuthKey");
+        }
+
+        await Execute(Options.EmailAuthKey, subject, message, toEmail);
+    }
+
+    public async Task Execute(string apiKey, string subject, string message, 
+        string toEmail)
+    {
+        var api = new MandrillApi(apiKey);
+        var mandrillMessage = new MandrillMessage("sarah@contoso.com", toEmail, 
+            subject, message);
+        await api.Messages.SendAsync(mandrillMessage);
+
+        logger.LogInformation("Email to {EmailAddress} sent!", toEmail);
+    }
+}
+```
+
+> [!NOTE]
+> Body content for messages might require special encoding for the email service provider. If links in the message body can't be followed, consult the service provider's documentation. 
+
+## Configure the server project to support email
+
+In the backend server's `Program` file, require a confirmed email to register an account. Locate the line that calls <xref:Microsoft.Extensions.DependencyInjection.IdentityServiceCollectionExtensions.AddIdentityCore%2A> and set the <xref:Microsoft.AspNetCore.Identity.SignInOptions.RequireConfirmedEmail> property to `true`:
+
+```diff
+- builder.Services.AddIdentityCore<AppUser>()
++ builder.Services.AddIdentityCore<AppUser>(o => o.SignIn.RequireConfirmedEmail = true)
+```
+
+Add the following service registration to set the email sender implementation to `EmailSender` for <xref:Microsoft.AspNetCore.Identity.IEmailSender>:
+
+```csharp
+builder.Services.AddTransient<IEmailSender<AppUser>, EmailSender>();
+```
+
+## Update the client project's account registration response
+
+In the client project's `Register` component (`Components/Identity/Register.razor`), change the message to users on a successful account registration to instruct them to confirm their account. The following example includes a link to trigger Identity on the server to resend the confirmation email.
+
+```diff
+- <div class="alert alert-success">
+-     You successfully registered. Now you can <a href="login">login</a>.
+- </div>
++ <div class="alert alert-success">
++     You successfully registered. You must now confirm your account by clicking 
++     the link in the email that was sent to you. After confirming your account, 
++     you can <a href="login">login</a> to the app. 
++     <a href="resendConfirmationEmail">Resend confirmation email</a>
++ </div>
+```
+
+## Update seed data code to confirm seeded accounts
+
+In the server project's seed data class (`SeedData.cs`), change the code in the `InitializeAsync` method to confirm the seeded accounts so that they don't require confirmation for each test run of the solution:
+
+```diff
+- if (user.Email is not null)
+- {
+-     var appUser = await userManager.FindByEmailAsync(user.Email);
+- 
+-     if (appUser is not null && user.RoleList is not null)
+-     {
+-         await userManager.AddToRolesAsync(appUser, user.RoleList);
+-     }
+- }
++ if (appUser is not null)
++ {
++     if (user.RoleList is not null)
++     {
++         await userManager.AddToRolesAsync(appUser, user.RoleList);
++     }
++ 
++     var token = await userManager.GenerateEmailConfirmationTokenAsync(appUser);
++     await userManager.ConfirmEmailAsync(appUser, token);
++ }
+```
+
+## Password recovery
+
+Password recovery requires the server app to adopt an email provider in order to send password resent codes to users. Therefore, the guidance earlier in this article to enable account confirmation should be followed to enable an email provider.
+
+Password recovery is a two-step process:
+
+1. A POST request is made to the `/forgotPassword` endpoint provided by <xref:Microsoft.AspNetCore.Routing.IdentityApiEndpointRouteBuilderExtensions.MapIdentityApi%2A> in the server project. A message in the UI instructs the user to check their email for a reset code.
+1. A POST request is made to the `/resetPassword` endpoint of the server project with the user's email addres, password reset code, and new password.
+
+The preceding steps are demonstrated by the following implementation guidance for the [sample apps](xref:blazor/security/webassembly/standalone-with-identity/index#sample-apps).
+
+Add the following method signatures to the `IAccountManagement` class (`Identity/IAccountManagement.cs`) in the client project (`BlazorWasmAuth`).
+
+```csharp
+public Task<bool> ForgotPasswordAsync(string email);
+
+public Task<FormResult> ResetPasswordAsync(string email, string resetCode, 
+    string newPassword);
+```
+
+Provide implementations for the preceding methods in the `CookieAuthenticationStateProvider` class (`Identity/CookieAuthenticationStateProvider.cs`):
+
+```csharp
+/// <summary>
+/// Begin the password recovery process by issuing a POST request to the 
+/// '/forgotPassword' endpoint.
+/// </summary>
+/// <param name="email">The user's email address.</param>
+/// <returns>A <see cref="bool"/> indicating success or failure.</returns>
+public async Task<bool> ForgotPasswordAsync(string email)
+{
+    try
+    {
+        // make the request
+        var result = await httpClient.PostAsJsonAsync(
+            "forgotPassword", new
+            {
+                email
+            });
+
+        // successful?
+        if (result.IsSuccessStatusCode)
+        {
+            return true;
+        }
+    }
+    catch { }
+
+    // unknown error
+    return false;
+}
+
+/// <summary>
+/// Reset the user's password by issuing a POST request to the 
+/// '/resetPassword' endpoint.
+/// </summary>
+/// <param name="email">The user's email address.</param>
+/// <param name="resetCode">The user's reset code.</param>
+/// <param name="newPassword">The user's new password.</param>
+/// <returns>The result serialized to a <see cref="FormResult"/>.
+/// </returns>
+public async Task<FormResult> ResetPasswordAsync(string email, string resetCode, 
+    string newPassword)
+{
+    string[] defaultDetail = ["An unknown error prevented resetting the password."];
+
+    try
+    {
+        // make the request
+        var result = await httpClient.PostAsJsonAsync(
+            "resetPassword", new
+            {
+                email,
+                resetCode,
+                newPassword
+            });
+
+        // successful?
+        if (result.IsSuccessStatusCode)
+        {
+            return new FormResult { Succeeded = true };
+        }
+
+        // body should contain details about why it failed
+        var details = await result.Content.ReadAsStringAsync();
+        var problemDetails = JsonDocument.Parse(details);
+        var errors = new List<string>();
+        var errorList = problemDetails.RootElement.GetProperty("errors");
+
+        foreach (var errorEntry in errorList.EnumerateObject())
+        {
+            if (errorEntry.Value.ValueKind == JsonValueKind.String)
+            {
+                errors.Add(errorEntry.Value.GetString()!);
+            }
+            else if (errorEntry.Value.ValueKind == JsonValueKind.Array)
+            {
+                errors.AddRange(
+                    errorEntry.Value.EnumerateArray().Select(
+                        e => e.GetString() ?? string.Empty)
+                    .Where(e => !string.IsNullOrEmpty(e)));
+            }
+        }
+
+        // return the error list
+        return new FormResult
+        {
+            Succeeded = false,
+            ErrorList = problemDetails == null ? defaultDetail : [.. errors]
+        };
+    }
+    catch { }
+
+    // unknown error
+    return new FormResult
+    {
+        Succeeded = false,
+        ErrorList = defaultDetail
+    };
+}
+```
+
+Add the following `ForgotPassword` component to the client project (`BlazorWasmAuth`). Code lines in the following component are shortened for display in this article.
+
+`Components/Identity/ForgotPassword.razor`:
+
+```razor
+@page "/forgot-password"
+@using System.ComponentModel.DataAnnotations
+@using BlazorWasmAuth.Identity
+@inject IAccountManagement Acct
+
+<PageTitle>Forgot your password?</PageTitle>
+
+<h1>Forgot your password?</h1>
+<p>Provide your email address and select the <b>Reset password</b> button.</p>
+<hr />
+<div class="row">
+    <div class="col-md-4">
+        @if (!passwordResetCodeSent)
+        {
+            <EditForm Model="Input" FormName="forgot-password" 
+                OnValidSubmit="OnValidSubmitStep1Async" method="post">
+                <DataAnnotationsValidator />
+                <ValidationSummary class="text-danger" role="alert" />
+
+                <div class="form-floating mb-3">
+                    <InputText @bind-Value="Input.Email" id="Input.Email" 
+                        class="form-control" autocomplete="username" 
+                        aria-required="true" placeholder="name@example.com" />
+                    <label for="Input.Email" class="form-label">
+                        Email
+                    </label>
+                    <ValidationMessage For="() => Input.Email" 
+                        class="text-danger" />
+                </div>
+                <button type="submit" class="w-100 btn btn-lg btn-primary">
+                    Request reset code
+                </button>
+            </EditForm>
+        }
+        else
+        {
+            if (passwordResetSuccess)
+            {
+                if (errors)
+                {
+                    foreach (var error in errorList)
+                    {
+                        <div class="alert alert-danger">@error</div>
+                    }
+                }
+                else
+                {
+                    <div>
+                        Your password was reset. You may <a href="login">login</a> 
+                        to the app with your new password.
+                    </div>
+                }
+            }
+            else
+            {
+                <div>
+                    A password reset code has been sent to your email address. 
+                    Obtain the code from the email for this form.
+                </div>
+                <EditForm Model="Reset" FormName="reset-password" 
+                    OnValidSubmit="OnValidSubmitStep2Async" method="post">
+                    <DataAnnotationsValidator />
+                    <ValidationSummary class="text-danger" role="alert" />
+
+                    <div class="form-floating mb-3">
+                        <InputText @bind-Value="Reset.ResetCode" 
+                            id="Reset.ResetCode" class="form-control" 
+                            autocomplete="username" aria-required="true" />
+                        <label for="Reset.ResetCode" class="form-label">
+                            Reset code
+                        </label>
+                        <ValidationMessage For="() => Reset.ResetCode" 
+                            class="text-danger" />
+                    </div>
+                    <div class="form-floating mb-3">
+                        <InputText type="password" @bind-Value="Reset.NewPassword" 
+                            id="Reset.NewPassword" class="form-control" 
+                            autocomplete="new-password" aria-required="true" 
+                            placeholder="password" />
+                        <label for="Reset.NewPassword" class="form-label">
+                            New Password
+                        </label>
+                        <ValidationMessage For="() => Reset.NewPassword" 
+                            class="text-danger" />
+                    </div>
+                    <div class="form-floating mb-3">
+                        <InputText type="password" @bind-Value="Reset.ConfirmPassword" 
+                            id="Reset.ConfirmPassword" class="form-control" 
+                            autocomplete="new-password" aria-required="true" 
+                            placeholder="password" />
+                        <label for="Reset.ConfirmPassword" class="form-label">
+                            Confirm Password
+                        </label>
+                        <ValidationMessage For="() => Reset.ConfirmPassword" 
+                            class="text-danger" />
+                    </div>
+                    <button type="submit" class="w-100 btn btn-lg btn-primary">
+                        Reset password
+                    </button>
+                </EditForm>
+            }
+        }
+    </div>
+</div>
+
+@code {
+    private bool passwordResetCodeSent;
+    private bool passwordResetSuccess, errors;
+    private string[] errorList = [];
+
+    [SupplyParameterFromForm(FormName = "forgot-password")]
+    private InputModel Input { get; set; } = new();
+
+    [SupplyParameterFromForm(FormName = "reset-password")]
+    private ResetModel Reset { get; set; } = new();
+
+    private async Task OnValidSubmitStep1Async()
+    {
+        passwordResetCodeSent = await Acct.ForgotPasswordAsync(Input.Email);
+    }
+
+    private async Task OnValidSubmitStep2Async()
+    {
+        var result = await Acct.ResetPasswordAsync(Input.Email, Reset.ResetCode, 
+            Reset.NewPassword);
+
+        if (result.Succeeded)
+        {
+            passwordResetSuccess = true;
+
+        }
+        else
+        {
+            errors = true;
+            errorList = result.ErrorList;
+        }
+    }
+
+    private sealed class InputModel
+    {
+        [Required]
+        [EmailAddress]
+        [Display(Name = "Email")]
+        public string Email { get; set; } = string.Empty;
+    }
+
+    private sealed class ResetModel
+    {
+        [Required]
+        [Base64String]
+        public string ResetCode { get; set; } = string.Empty;
+
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at " +
+            "max {1} characters long.", MinimumLength = 6)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Password")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        [Compare("NewPassword", ErrorMessage = "The new password and confirmation " +
+            "password do not match.")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+}
+```
+
+In the `Login` component (`Components/Identity/Login.razor`) of the client project immediately before the closing `</NotAuthorized>` tag, add a forgot password link to reach the `ForgotPassword` component:
+
+```html
+<div>
+    <a href="forgot-password">Forgot password</a>
+</div>
+```
+
+## Email and activity timeout
+
+The default inactivity timeout is 14 days. The following code sets the inactivity timeout to five days with sliding expiration:
+
+```csharp
+builder.Services.ConfigureApplicationCookie(options => {
+    options.ExpireTimeSpan = TimeSpan.FromDays(5);
+    options.SlidingExpiration = true;
+});
+```
+
+## Change all ASP.NET Core Data Protection token lifespans
+
+The following code changes Data Protection tokens' timeout period to three hours:
+
+```csharp
+builder.Services.Configure<DataProtectionTokenProviderOptions>(options =>
+    options.TokenLifespan = TimeSpan.FromHours(3));
+```
+
+The built-in Identity user tokens ([AspNetCore/src/Identity/Extensions.Core/src/TokenOptions.cs](https://github.com/dotnet/aspnetcore/blob/main/src/Identity/Extensions.Core/src/TokenOptions.cs)) have a [one day timeout](https://github.com/dotnet/AspNetCore/blob/main/src/Identity/Core/src/DataProtectionTokenProviderOptions.cs).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+## Change the email token lifespan
+
+The default token lifespan of the [Identity user tokens](https://github.com/dotnet/AspNetCore/blob/main/src/Identity/Extensions.Core/src/TokenOptions.cs) is [one day](https://github.com/dotnet/AspNetCore/blob/main/src/Identity/Core/src/DataProtectionTokenProviderOptions.cs).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+To change the email token lifespan, add a custom <xref:Microsoft.AspNetCore.Identity.DataProtectorTokenProvider%601> and <xref:Microsoft.AspNetCore.Identity.DataProtectionTokenProviderOptions>:
+
+`CustomTokenProvider.cs`:
+
+```csharp
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace BlazorSample;
+
+public class CustomEmailConfirmationTokenProvider<TUser>
+    : DataProtectorTokenProvider<TUser> where TUser : class
+{
+    public CustomEmailConfirmationTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<EmailConfirmationTokenProviderOptions> options,
+        ILogger<DataProtectorTokenProvider<TUser>> logger)
+        : base(dataProtectionProvider, options, logger)
+    {
+    }
+}
+
+public class EmailConfirmationTokenProviderOptions 
+    : DataProtectionTokenProviderOptions
+{
+    public EmailConfirmationTokenProviderOptions()
+    {
+        Name = "EmailDataProtectorTokenProvider";
+        TokenLifespan = TimeSpan.FromHours(4);
+    }
+}
+
+public class CustomPasswordResetTokenProvider<TUser> 
+    : DataProtectorTokenProvider<TUser> where TUser : class
+{
+    public CustomPasswordResetTokenProvider(
+        IDataProtectionProvider dataProtectionProvider,
+        IOptions<PasswordResetTokenProviderOptions> options,
+        ILogger<DataProtectorTokenProvider<TUser>> logger)
+        : base(dataProtectionProvider, options, logger)
+    {
+    }
+}
+
+public class PasswordResetTokenProviderOptions : 
+    DataProtectionTokenProviderOptions
+{
+    public PasswordResetTokenProviderOptions()
+    {
+        Name = "PasswordResetDataProtectorTokenProvider";
+        TokenLifespan = TimeSpan.FromHours(3);
+    }
+}
+```
+
+Configure the services to use the custom token provider in the `Program` file:
+
+```csharp
+builder.Services.AddIdentityCore<AppUser>(options =>
+    {
+        options.SignIn.RequireConfirmedAccount = true;
+        options.Tokens.ProviderMap.Add("CustomEmailConfirmation",
+            new TokenProviderDescriptor(
+                typeof(CustomEmailConfirmationTokenProvider<AppUser>)));
+        options.Tokens.EmailConfirmationTokenProvider = 
+            "CustomEmailConfirmation";
+    })
+    .AddEntityFrameworkStores<ApplicationDbContext>()
+    .AddSignInManager()
+    .AddDefaultTokenProviders();
+
+builder.Services
+    .AddTransient<CustomEmailConfirmationTokenProvider<AppUser>>();
+```
+
+## Enable account confirmation after a site has users
+
+Enabling account confirmation on a site with users locks out all the existing users. Existing users are locked out because their accounts aren't confirmed. To work around existing user lockout, use one of the following approaches:
+
+* Update the database to mark all existing users as confirmed.
+* Confirm existing users. For example, batch-send emails with confirmation links.
+
+## Troubleshoot
+
+If you can't get email working:
+
+* Set a breakpoint in `EmailSender.Execute` to verify `SendEmailAsync` is called.
+* Create a console app to send email using code similar to `EmailSender.Execute` to debug the problem.
+* Review the account email history pages at the email provider's website.
+* Check your spam folder for messages.
+* Try another email alias on a different email provider, such as Microsoft, Yahoo, or Gmail.
+* Try sending to different email accounts.
+
+## Additional resources
+
+* [Mandrill.net (GitHub repository)](https://github.com/feinoujc/Mandrill.net)
+* [Mailchimp developer: Transactional API](https://mailchimp.com/developer/transactional/docs/fundamentals/)

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity/index.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity/index.md
@@ -6,7 +6,7 @@ monikerRange: '>= aspnetcore-8.0'
 ms.author: riande
 ms.custom: mvc
 ms.date: 02/09/2024
-uid: blazor/security/webassembly/standalone-with-identity
+uid: blazor/security/webassembly/standalone-with-identity/index
 ---
 # Secure ASP.NET Core Blazor WebAssembly with ASP.NET Core Identity
 
@@ -86,12 +86,15 @@ At this point, you must provide custom code to parse the <xref:Microsoft.AspNetC
 
 ## Additional Identity scenarios
 
-For additional Identity scenarios provided by the API, see <xref:security/authentication/identity/spa>:
+Scenarios covered by the Blazor documentation set:
+
+* [Account confirmation, password management, and recovery codes](xref:blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery)
+* Two-factor authentication (2FA): *Implementation guidance coming soon!* This work is tracked by [Add 2FA/TOTP coverage to the Standalone+Identity article+sample (`dotnet/AspNetCore.Docs` #33772)](https://github.com/dotnet/AspNetCore.Docs/issues/33772). In the meantime, general information to aid you with a custom implementation is available in <xref:security/authentication/identity/spa#use-the-post-manage2fa-endpoint>.
+
+For information on additional Identity scenarios provided by the API, see <xref:security/authentication/identity/spa>:
 
 * Secure selected endpoints
-* Token authentication
-* Two-factor authentication (2FA)
-* Recovery codes
+* Two-factor authentication (2FA) and recovery codes
 * User info management
 
 ## Use secure authentication flows to maintain sensitive data and credentials

--- a/aspnetcore/release-notes/aspnetcore-8.0.md
+++ b/aspnetcore/release-notes/aspnetcore-8.0.md
@@ -311,7 +311,7 @@ The Blazor documentation hosts a new article and sample app to cover securing a 
 
 For more information, see the following resources:
 
-* <xref:blazor/security/webassembly/standalone-with-identity?view=aspnetcore-8.0&preserve-view=true>
+* <xref:blazor/security/webassembly/standalone-with-identity/index?view=aspnetcore-8.0&preserve-view=true>
 * [What's new with identity in .NET 8 (blog post)](https://devblogs.microsoft.com/dotnet/whats-new-with-identity-in-dotnet-8/#the-blazor-identity-ui)
 
 ### Blazor Server with Yarp routing

--- a/aspnetcore/security/authentication/accconfirm.md
+++ b/aspnetcore/security/authentication/accconfirm.md
@@ -19,7 +19,10 @@ This tutorial shows how to build an ASP.NET Core app with email confirmation and
 
 :::moniker range=">= aspnetcore-8.0"
 
-For Blazor guidance, which adds to or supersedes the guidance in this article, see <xref:blazor/security/server/account-confirmation-and-password-recovery>.
+For Blazor guidance, which adds to or supersedes the guidance in this article, see the following resources:
+
+* <xref:blazor/security/account-confirmation-and-password-recovery>
+* <xref:blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery>
 
 :::moniker-end
 

--- a/aspnetcore/security/authentication/identity-api-authorization.md
+++ b/aspnetcore/security/authentication/identity-api-authorization.md
@@ -15,7 +15,7 @@ uid: security/authentication/identity/spa
 
 [ASP.NET Core Identity](xref:security/authentication/identity) provides APIs that handle authentication, authorization, and identity management. The APIs make it possible to secure endpoints of a Web API backend with cookie-based authentication. A token-based option is available for clients that can't use cookies, but in using this you are responsible for ensuring the tokens are kept secure. We recommend using cookies for browser-based applications, because, by default, the browser automatically handles them without exposing them to JavaScript.
 
-This article shows how to use Identity to secure a Web API backend for SPAs such as Angular, React, and Vue apps. The same backend APIs can be used to secure [Blazor WebAssembly apps](xref:blazor/security/webassembly/standalone-with-identity).
+This article shows how to use Identity to secure a Web API backend for SPAs such as Angular, React, and Vue apps. The same backend APIs can be used to secure [Blazor WebAssembly apps](xref:blazor/security/webassembly/standalone-with-identity/index).
 
 ## Prerequisites
 

--- a/aspnetcore/security/authentication/scaffold-identity.md
+++ b/aspnetcore/security/authentication/scaffold-identity.md
@@ -24,7 +24,7 @@ Although the scaffolder generates the necessary C# code to scaffold Identity int
 
 Inspect the changes after running the Identity scaffolder. We recommend using GitHub or another source control system that shows file changes with a revert changes feature.
 
-Services are required when using [two-factor authentication (2FA)](xref:blazor/security/server/qrcodes-for-authenticator-apps), [account confirmation and password recovery](xref:blazor/security/server/account-confirmation-and-password-recovery), and other security features with Identity. Services or service stubs aren't generated when scaffolding Identity. Services to enable these features must be added manually.
+Services are required when using [two-factor authentication (2FA)](xref:blazor/security/server/qrcodes-for-authenticator-apps), [account confirmation and password recovery](xref:blazor/security/account-confirmation-and-password-recovery), and other security features with Identity. Services or service stubs aren't generated when scaffolding Identity. Services to enable these features must be added manually.
 
 ## Razor Pages and MVC Identity scaffolding
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -608,8 +608,6 @@ items:
                     uid: blazor/security/server/static-server-side-rendering
                   - name: Interactive server-side rendering threats
                     uid: blazor/security/server/interactive-server-side-rendering
-                  - name: Account confirmation and password recovery
-                    uid: blazor/security/server/account-confirmation-and-password-recovery
                   - name: QR code generation
                     uid: blazor/security/server/qrcodes-for-authenticator-apps
                   - name: Additional scenarios
@@ -619,7 +617,11 @@ items:
                   - name: Overview
                     uid: blazor/security/webassembly/index
                   - name: Standalone with Identity
-                    uid: blazor/security/webassembly/standalone-with-identity
+                    items:
+                      - name: Overview
+                        uid: blazor/security/webassembly/standalone-with-identity/index
+                      - name: Account confirmation and password recovery
+                        uid: blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery
                   - name: Standalone with Authentication library
                     uid: blazor/security/webassembly/standalone-with-authentication-library
                   - name: Standalone with Microsoft Accounts
@@ -646,6 +648,8 @@ items:
                 uid: blazor/security/blazor-web-app-entra
               - name: Blazor Web App with OIDC
                 uid: blazor/security/blazor-web-app-oidc
+              - name: Account confirmation and password recovery
+                uid: blazor/security/account-confirmation-and-password-recovery
               - name: Content Security Policy
                 uid: blazor/security/content-security-policy
           - name: State management

--- a/aspnetcore/whats-new/dotnet-AspNetCore.Docs-mod1.md
+++ b/aspnetcore/whats-new/dotnet-AspNetCore.Docs-mod1.md
@@ -13,7 +13,7 @@ Welcome to what's new in the ASP.NET Core docs for January 2024. This article li
 
 ### New articles
 
-- <xref:blazor/security/server/account-confirmation-and-password-recovery>
+- <xref:blazor/security/account-confirmation-and-password-recovery>
 
 ### Updated articles
 
@@ -59,7 +59,7 @@ Welcome to what's new in the ASP.NET Core docs for January 2024. This article li
 - <xref:blazor/security/webassembly/standalone-with-azure-active-directory-b2c> - Content follow-up updates (8.0)
 - <xref:blazor/security/webassembly/standalone-with-microsoft-accounts> - Content follow-up updates (8.0)
 - <xref:blazor/security/webassembly/standalone-with-microsoft-entra-id> - Content follow-up updates (8.0)
-- <xref:blazor/security/webassembly/standalone-with-identity> - Add troubleshooting guidance
+- <xref:blazor/security/webassembly/standalone-with-identity/index> - Add troubleshooting guidance
 - <xref:blazor/security/webassembly/graph-api>
   - Groups/roles article and Graph article updates
   - "Base address" clarifications for `HttpClient`

--- a/aspnetcore/whats-new/dotnet-AspNetCore.Docs-mod2.md
+++ b/aspnetcore/whats-new/dotnet-AspNetCore.Docs-mod2.md
@@ -59,7 +59,7 @@ Welcome to what's new in the ASP.NET Core docs for February 2024. This article l
   - Add WebAssembly (runtime) startup callbacks
   - Blazor Startup - sample environment variable name
   - Startup - manually start Standalone Blazor WebAssembly
-- <xref:blazor/security/webassembly/standalone-with-identity> - Add roles and test user guidance
+- <xref:blazor/security/webassembly/standalone-with-identity/index> - Add roles and test user guidance
 - <xref:blazor/fundamentals/signalr> - [Blazor] SignalR - remove "using System" reminder
 - <xref:blazor/hybrid/class-libraries> - Update 'Blazor Server' references
 - <xref:blazor/host-and-deploy/webassembly>

--- a/aspnetcore/whats-new/dotnet-AspNetCore.Docs-mod3.md
+++ b/aspnetcore/whats-new/dotnet-AspNetCore.Docs-mod3.md
@@ -82,7 +82,7 @@ Welcome to what's new in the ASP.NET Core docs for March 2024. This article list
 - <xref:blazor/components/data-binding> - Blazor - data-binding - event fix
 - <xref:blazor/security/server/interactive-server-side-rendering> - WebSocket compression/CSP and security guidance
 - <xref:blazor/globalization-localization> - Add BWA global Auto approach
-- <xref:blazor/security/webassembly/standalone-with-identity> - WASM+Identity same-site & antiforgery updates
+- <xref:blazor/security/webassembly/standalone-with-identity/index> - WASM+Identity same-site & antiforgery updates
 
 ## Fundamentals
 


### PR DESCRIPTION
Fixes #33771

### Notes

* I'm not excited about the sample app's current avoidance of `EditForms` and DA in the `Login` and `Register` components. I'm going with an `EditForm`+DA here for the new `ForgotPassword` component, and I'll open an issue to update those other two components to use `EditForm`s+DA later.
* There's stuff moving around here because we need to group our articles for the WASM+Identity scenario. There's only ***ONE*** file that you need to look at on the diff ... `aspnetcore/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery.md`.
* There are three sections retained from the BWA version of this article at the bottom. I think they're effective approaches here for the WASM+Identity scenario, but I'm not sure. Let me know if they're OK to keep ...
  * Email and activity timeout
  * Change all ASP.NET Core Data Protection token lifespans
  * Change the email token lifespan
* I don't think that I checked the PW recovery bits in the BWA scenario. That's a separate thing, so I'll open a new issue to confirm that the BWA PW recovery works OOB with the built-in Identity components after account confirmation (i.e., adopting an email provider) is added.