### PR TITLE
MapStaticAssets to migration /2

### DIFF
--- a/aspnetcore/migration/80-90.md
+++ b/aspnetcore/migration/80-90.md
@@ -70,6 +70,22 @@ In the project file, update each [`Microsoft.AspNetCore.*`](https://www.nuget.or
 </ItemGroup>
 ```
 
+## Replace UseStaticFiles with MapStaticAssets
+
+Blazor has different update instructions than Razor Pages and ASP.NET Core MVC.
+
+### Blazor
+
+* Replace [UseStaticFiles](/dotnet/api/microsoft.aspnetcore.builder.staticfileextensions.usestaticfiles) with [MapStaticAssets](/dotnet/api/microsoft.aspnetcore.builder.staticassetsendpointroutebuilderextensions.mapstaticassets) in `Program.cs`
+* Update explicit references to static assets in .razor files to use the `@Assets["asset-path"]` API. This should ***NOT*** be done for the Blazor framework scripts (`*blazor.\*.js*`)
+* Update the root `App.razor` component to include the `<ImportMap />` component in the head.
+
+### Razor Pages and ASP.NET Core MVC
+
+* Replace [UseStaticFiles](/dotnet/api/microsoft.aspnetcore.builder.staticfileextensions.usestaticfiles) with [MapStaticAssets](/dotnet/api/microsoft.aspnetcore.builder.staticassetsendpointroutebuilderextensions.mapstaticassets) in `Program.cs`
+* Chain a call to `.WithStaticAssets` after `MapRazorPages` or `MapControllerRoute` in `Program.cs`. For an example, see the <xref:fundamentals/static-files?view=aspnetcore-9.0&preserve-view=true>
+* Add `<script type="importmap"></script>` to the head of the main layout file.
+
 ## Blazor
 
 [!INCLUDE[](~/migration/80-to-90/includes/blazor.md)]

--- a/aspnetcore/migration/80-90.md
+++ b/aspnetcore/migration/80-90.md
@@ -63,10 +63,10 @@ In the project file, update each [`Microsoft.AspNetCore.*`](https://www.nuget.or
 -   <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.2" />
 -   <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
 -   <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
-+   <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0-preview.1.24081.5" />
-+   <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0-preview.1.24081.2" />
-+   <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0-preview.1.24080.9" />
-+   <PackageReference Include="System.Net.Http.Json" Version="9.0.0-preview.1.24080.9" />
++   <PackageReference Include="Microsoft.AspNetCore.JsonPatch" Version="9.0.0" />
++   <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0" />
++   <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.0" />
++   <PackageReference Include="System.Net.Http.Json" Version="9.0.0" />
 </ItemGroup>
 ```
 

--- a/aspnetcore/migration/80-90.md
+++ b/aspnetcore/migration/80-90.md
@@ -72,15 +72,15 @@ In the project file, update each [`Microsoft.AspNetCore.*`](https://www.nuget.or
 
 ## Replace UseStaticFiles with MapStaticAssets
 
-Blazor has different update instructions than Razor Pages and ASP.NET Core MVC.
+Blazor has different update instructions for `MapStaticAssets` than Razor Pages and ASP.NET Core MVC.
 
-### Blazor
+### Blazor web apps
 
 * Replace [UseStaticFiles](/dotnet/api/microsoft.aspnetcore.builder.staticfileextensions.usestaticfiles) with [MapStaticAssets](/dotnet/api/microsoft.aspnetcore.builder.staticassetsendpointroutebuilderextensions.mapstaticassets) in `Program.cs`
-* Update explicit references to static assets in .razor files to use the `@Assets["asset-path"]` API. This should ***NOT*** be done for the Blazor framework scripts (`*blazor.\*.js*`)
+* Update explicit references to static assets in `.razor` files to use the `@Assets["asset-path"]` API. This should ***NOT*** be done for the Blazor framework scripts (`*blazor.\*.js*`).
 * Update the root `App.razor` component to include the `<ImportMap />` component in the head.
 
-### Razor Pages and ASP.NET Core MVC
+### Razor Pages and ASP.NET Core MVC based apps
 
 * Replace [UseStaticFiles](/dotnet/api/microsoft.aspnetcore.builder.staticfileextensions.usestaticfiles) with [MapStaticAssets](/dotnet/api/microsoft.aspnetcore.builder.staticassetsendpointroutebuilderextensions.mapstaticassets) in `Program.cs`
 * Chain a call to `.WithStaticAssets` after `MapRazorPages` or `MapControllerRoute` in `Program.cs`. For an example, see the <xref:fundamentals/static-files?view=aspnetcore-9.0&preserve-view=true>


### PR DESCRIPTION
Fixes #34000

[Internal ***REVIEW URL***](https://review.learn.microsoft.com/en-us/aspnet/core/migration/80-90?view=aspnetcore-8.0&branch=pr-en-us-34004&tabs=visual-studio#replace-usestaticfiles-with-mapstaticassets)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/80-90.md](https://github.com/dotnet/AspNetCore.Docs/blob/b54d886eaff467bdaed4c88fdb5b52f4b631a073/aspnetcore/migration/80-90.md) | [aspnetcore/migration/80-90](https://review.learn.microsoft.com/en-us/aspnet/core/migration/80-90?branch=pr-en-us-34004) |


<!-- PREVIEW-TABLE-END -->