### PR TITLE
Add a migration scenario for Blazor

### DIFF
--- a/aspnetcore/migration/80-to-90/includes/blazor.md
+++ b/aspnetcore/migration/80-to-90/includes/blazor.md
@@ -34,3 +34,4 @@ In the client project (`.Client`):
   + builder.Services.AddAuthenticationStateDeserialization();
   ```
 
+For more information, see <xref:aspnetcore-9#simplified-authentication-state-serialization-for-blazor-web-apps>.

--- a/aspnetcore/migration/80-to-90/includes/blazor.md
+++ b/aspnetcore/migration/80-to-90/includes/blazor.md
@@ -17,6 +17,12 @@ In the server project:
   +     .AddAuthenticationStateSerialization();
   ```
 
+The API only serializes the server-side name and role claims for access in the browser. To include all claims, set <xref:Microsoft.AspNetCore.Components.WebAssembly.Server.AuthenticationStateSerializationOptions.SerializeAllClaims> to `true`:
+
+```csharp
+.AddAuthenticationStateSerialization(options => options.SerializeAllClaims = true);
+```
+
 In the client project (`.Client`):
 
 * Remove the Persistent Authentication State Provider (`PersistentAuthenticationStateProvider.cs`).
@@ -27,3 +33,4 @@ In the client project (`.Client`):
   - builder.Services.AddSingleton<AuthenticationStateProvider, PersistentAuthenticationStateProvider>();
   + builder.Services.AddAuthenticationStateDeserialization();
   ```
+

--- a/aspnetcore/migration/80-to-90/includes/blazor.md
+++ b/aspnetcore/migration/80-to-90/includes/blazor.md
@@ -1,1 +1,29 @@
-Blazor migration guidance will appear here prior to the release of .NET 9, which is scheduled for November, 2024.
+### Adopt simplified authentication state serialization for Blazor Web Apps
+
+Blazor Web Apps can optionally adopt [simplified authentication state serialization](xref:aspnetcore-9#simplified-authentication-state-serialization-for-blazor-web-apps).
+
+In the server project:
+
+* Remove the Persisting Authentication State Provider (`PersistingAuthenticationStateProvider.cs`).
+
+* Remove the service registration from the `Program` file. Instead, chain a call to <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyRazorComponentsBuilderExtensions.AddAuthenticationStateSerialization%2A> on <xref:Microsoft.Extensions.DependencyInjection.RazorComponentsServiceCollectionExtensions.AddRazorComponents%2A>:
+
+  ```diff
+  - builder.Services.AddScoped<AuthenticationStateProvider, PersistingAuthenticationStateProvider>();
+
+    builder.Services.AddRazorComponents()
+        .AddInteractiveServerComponents()
+        .AddInteractiveWebAssemblyComponents()
+  +     .AddAuthenticationStateSerialization();
+  ```
+
+In the client project (`.Client`):
+
+* Remove the Persistent Authentication State Provider (`PersistentAuthenticationStateProvider.cs`).
+
+* Remove the service registration from the `Program` file. Instead, call <xref:Microsoft.Extensions.DependencyInjection.WebAssemblyAuthenticationServiceCollectionExtensions.AddAuthenticationStateDeserialization%2A> on the service collection:
+
+  ```diff
+  - builder.Services.AddSingleton<AuthenticationStateProvider, PersistentAuthenticationStateProvider>();
+  + builder.Services.AddAuthenticationStateDeserialization();
+  ```


### PR DESCRIPTION
Fixes #34007

cc: @Rick-Anderson ... I'll get any remaining Blazor migration items on here as they come to light in my discussion with Mackinnon.

Mackinnon ... I think outside of the ASP.NET Core-wide changes (TFM, packages, Map Static Assets routing endpoint conventions) that simplified authentication state serialization is the only migration item ... an optional feature but probably a good idea for devs to adopt. Can you think of any others?

BTW ... Although the project templates and Blazor sample apps for 9.0 adopt the latest Bootstrap version, that's a dev task in their own apps that might require other Bootstrap-specific implementation changes, not a MS product, and not on the same release cadence as .NET. Therefore, I'm not placing guidance on updating for latest Bootstrap.