### PR TITLE
Make alternatives 3b (non-DI) and 3c (DI) functionally identical

### DIFF
--- a/aspnetcore/performance/caching/output/samples/7.x/Program.cs
+++ b/aspnetcore/performance/caching/output/samples/7.x/Program.cs
@@ -59,7 +59,7 @@ public class Program
         //<policies3c>
         builder.Services.AddOutputCache(options =>
         {
-            options.AddBasePolicy(builder => 
+            options.AddPolicy("CachePost", builder => 
                 builder.AddPolicy<MyCustomPolicy2>(), true);
         });
         //</policies3c>


### PR DESCRIPTION
Currently, output caching documentation reads as if in order to use DI in a custom `IOutputCachePolicy` consumers must register the policy via `AddBasePolicy(...)`, which is incorrect. This is misleading and may lead consumers to over-cache all endpoints and actions when they only want to override the default policy, while keeping the same behaviour as the default policy which requires the `[OutputCache]` attribute and gives more granular caching control.

The way to apply a policy on all of app's endpoints is already documented separately above: https://learn.microsoft.com/en-us/aspnet/core/performance/caching/output#default-output-caching-policy.

There is currently no issue for this PR. I am not commonly contributing. If I must open one please let me know. If I need to provide additional context please let me know as well.