### PR TITLE
[Blazor] Security overview - SecureMethod correction

### DIFF
--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -451,7 +451,7 @@ You can also supply different content for display if the user isn't authorized w
 }
 ```
 
-Although the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> component controls the visibility of elements based on the user’s authorization status, it does not enforce security on the event handler itself. In the example above, the `HandleClick` method is only associated with a button visible to authorized users, but nothing prevents from invoking this method from other places. To ensure method-level security, implement additional authorization logic within the handler itself or in the relevant API.
+Although the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> component controls the visibility of elements based on the user’s authorization status, it doesn't enforce security on the event handler itself. In the preceding example, the `HandleClick` method is only associated with a button visible to authorized users, but nothing prevents invoking this method from other places. To ensure method-level security, implement additional authorization logic within the handler itself or in the relevant API.
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -439,7 +439,7 @@ You can also supply different content for display if the user isn't authorized w
 <AuthorizeView>
     <Authorized>
         <p>Hello, @context.User.Identity?.Name!</p>
-        <p><button @onclick="SecureMethod">Authorized Only Button</button></p>
+        <p><button @onclick="HandleClick">Authorized Only Button</button></p>
     </Authorized>
     <NotAuthorized>
         <p>You're not authorized.</p>
@@ -447,11 +447,11 @@ You can also supply different content for display if the user isn't authorized w
 </AuthorizeView>
 
 @code {
-    private void SecureMethod() { ... }
+    private void HandleClick() { ... }
 }
 ```
 
-A default event handler for an authorized element, such as the `SecureMethod` method for the `<button>` element in the preceding example, can only be invoked by an authorized user.
+Although the <xref:Microsoft.AspNetCore.Components.Authorization.AuthorizeView> component controls the visibility of elements based on the user’s authorization status, it does not enforce security on the event handler itself. In the example above, the `HandleClick` method is only associated with a button visible to authorized users, but nothing prevents from invoking this method from other places. To ensure method-level security, implement additional authorization logic within the handler itself or in the relevant API.
 
 :::moniker range=">= aspnetcore-8.0"
 


### PR DESCRIPTION
The sample code only demonstrates how to render different content for authorized and unauthorized users. We shouldn't mislead users by naming the button click handler `SecureMethod` or suggesting it's secure in the description below the sample.

Even in server-side Blazor, the method could still be called from other places (either explicitly or through some attack technique), and it doesn't provide any security protection on its own.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/db2aaab0f66fce0cdb0d13dae40b2bc2e57bad76/aspnetcore/blazor/security/index.md) | [aspnetcore/blazor/security/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/index?branch=pr-en-us-34031) |


<!-- PREVIEW-TABLE-END -->