### PR TITLE
.NET 9 migration guidance edit suggestions for MapStaticAssets

### DIFF
--- a/aspnetcore/migration/80-90.md
+++ b/aspnetcore/migration/80-90.md
@@ -72,38 +72,41 @@ In the project file, update each [`Microsoft.AspNetCore.*`](https://www.nuget.or
 
 ## Replace `UseStaticFiles` with `MapStaticAssets`
 
-Blazor has different update instructions for implementing Map Static Assets routing endpoint conventions than ASP.NET Core Razor Pages and MVC.
+Optimize the handling of static files in your web apps by replacing <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> with <xref:Microsoft.AspNetCore.Builder.StaticAssetsEndpointRouteBuilderExtensions.MapStaticAssets%2A> in the app's `Program` file:
+  
+```diff
+- app.UseStaticFiles();
++ app.MapStaticAssets();
+```
+In MVC & Razor Pages apps you additionally need to chain a call to `.WithStaticAssets` after `MapRazorPages` or `MapControllerRoute` in `Program.cs`. For an example, see the <xref:fundamentals/static-files?view=aspnetcore-9.0&preserve-view=true>. 
 
-### Blazor Web App implementation
+ASP.NET Core will automatically fingerprint and precompress your static files at build and publish time and then `MapStaticAssets` will surface the optimized files as endpoints using endpoint routing with appropriate caching headers.
 
-* Replace <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> with <xref:Microsoft.AspNetCore.Builder.StaticAssetsEndpointRouteBuilderExtensions.MapStaticAssets%2A> in the app's `Program` file:
 
-  ```diff
-  - app.UseStaticFiles();
-  + app.MapStaticAssets();
-  ```
 
-* Assets are delivered via the <xref:Microsoft.AspNetCore.Components.ComponentBase.Assets?displayProperty=nameWithType> property, which resolves the fingerprinted URL for a given asset. Update explicit references to static assets in Razor component files (`.razor`) to use `@Assets["{ASSET PATH}"]`, where the `{ASSET PATH}` placeholder is the path to the asset. This should ***NOT*** be done for the Blazor framework scripts (`blazor.*.js`). In the following example, Bootstrap, the Blazor project template app stylesheet (`app.css`), and the [CSS isolation stylesheet](xref:blazor/components/css-isolation) (based on an app's namespace of `BlazorSample`) are linked in a root component, typically the `App` component (`Components/App.razor`):
+To resolve the fingerprinted file names from your app:
 
-  ```razor
-  <link rel="stylesheet" href="@Assets["bootstrap/bootstrap.min.css"]" />
-  <link rel="stylesheet" href="@Assets["app.css"]" />
-  <link rel="stylesheet" href="@Assets["BlazorSample.styles.css"]" />
-  ```
+* In Blazor apps, use the <xref:Microsoft.AspNetCore.Components.ComponentBase.Assets?displayProperty=nameWithType> property. Update explicit references to static assets in Razor component files (`.razor`) to use `@Assets["{ASSET PATH}"]`, where the `{ASSET PATH}` placeholder is the path to the asset. Note that this should ***NOT*** be done for the Blazor framework scripts (`blazor.*.js`). In the following example, Bootstrap, the Blazor project template app stylesheet (`app.css`), and the [CSS isolation stylesheet](xref:blazor/components/css-isolation) (based on an app's namespace of `BlazorSample`) are linked in a root component, typically the `App` component (`Components/App.razor`):
 
-* Add the Import Map component (<xref:Microsoft.AspNetCore.Components.ImportMap>) to the `<head>` content of the app's root component, typically the `App` component (`App.razor`):
+    ```razor
+    <link rel="stylesheet" href="@Assets["bootstrap/bootstrap.min.css"]" />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
+    <link rel="stylesheet" href="@Assets["BlazorSample.styles.css"]" />
+    ```
+    
+* In MVC & Razor Pages apps, the script and link tag helpers will automatically resolve the fingerprinted file names.
 
-  ```razor
-  <ImportMap />
-  ```
+To resolve the fingerprinted file names when importing JavaScript modules, add a generated [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap):
 
+* In Blazor apps, add the (<xref:Microsoft.AspNetCore.Components.ImportMap>) component to the `<head>` content of the app's root component, typically in the `App` component (`App.razor`):
+
+   ```razor
+   <ImportMap />
+   ```
+
+* In MVC & Razor pages apps, add `<script type="importmap"></script>` to the head of the main layout file, which will be updated by the import map tag helper.
+ 
 For more information, see <xref:blazor/fundamentals/static-files>.
-
-### ASP.NET Core Razor Pages and MVC implementation
-
-* Replace <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> with <xref:Microsoft.AspNetCore.Builder.StaticAssetsEndpointRouteBuilderExtensions.MapStaticAssets%2A> in `Program.cs`.
-* Chain a call to `.WithStaticAssets` after `MapRazorPages` or `MapControllerRoute` in `Program.cs`. For an example, see the <xref:fundamentals/static-files?view=aspnetcore-9.0&preserve-view=true>.
-* Add `<script type="importmap"></script>` to the head of the main layout file.
 
 ## Blazor
 

--- a/aspnetcore/migration/80-90.md
+++ b/aspnetcore/migration/80-90.md
@@ -109,7 +109,7 @@ To resolve the fingerprinted file names when importing JavaScript modules, add a
  
 For more information, see the following resources:
 
-* <xref:aspnetcore-9.0#static-asset-delivery-optimization>
+* <xref:aspnetcore-9#static-asset-delivery-optimization>
 * <xref:blazor/fundamentals/static-files>
 
 ## Blazor

--- a/aspnetcore/migration/80-90.md
+++ b/aspnetcore/migration/80-90.md
@@ -78,9 +78,10 @@ Optimize the handling of static files in your web apps by replacing <xref:Micros
 - app.UseStaticFiles();
 + app.MapStaticAssets();
 ```
+
 In MVC & Razor Pages apps you additionally need to chain a call to `.WithStaticAssets` after `MapRazorPages` or `MapControllerRoute` in `Program.cs`. For an example, see the <xref:fundamentals/static-files?view=aspnetcore-9.0&preserve-view=true>. 
 
-ASP.NET Core will automatically fingerprint and precompress your static files at build and publish time and then `MapStaticAssets` will surface the optimized files as endpoints using endpoint routing with appropriate caching headers.
+ASP.NET Core automatically fingerprints and precompresses your static files at build and publish time, and then <xref:Microsoft.AspNetCore.Builder.StaticAssetsEndpointRouteBuilderExtensions.MapStaticAssets%2A> surfaces the optimized files as endpoints using endpoint routing with appropriate caching headers.
 
 
 
@@ -96,7 +97,7 @@ To resolve the fingerprinted file names from your app:
     
 * In MVC & Razor Pages apps, the script and link tag helpers will automatically resolve the fingerprinted file names.
 
-To resolve the fingerprinted file names when importing JavaScript modules, add a generated [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap):
+To resolve the fingerprinted file names when importing JavaScript modules, add a generated [import map](https://developer.mozilla.org/docs/Web/HTML/Element/script/type/importmap):
 
 * In Blazor apps, add the (<xref:Microsoft.AspNetCore.Components.ImportMap>) component to the `<head>` content of the app's root component, typically in the `App` component (`App.razor`):
 
@@ -104,9 +105,12 @@ To resolve the fingerprinted file names when importing JavaScript modules, add a
    <ImportMap />
    ```
 
-* In MVC & Razor pages apps, add `<script type="importmap"></script>` to the head of the main layout file, which will be updated by the import map tag helper.
+* In MVC & Razor pages apps, add `<script type="importmap"></script>` to the head of the main layout file, which is updated by the Import Map Tag Helper.
  
-For more information, see <xref:blazor/fundamentals/static-files>.
+For more information, see the following resources:
+
+* <xref:aspnetcore-9.0#static-asset-delivery-optimization>
+* <xref:blazor/fundamentals/static-files>
 
 ## Blazor
 


### PR DESCRIPTION
I think we want a bit more verbiage around the migration guidance for updating to `MapStaticAssets` so that users understand what they are doing. Proposing some suggestions.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/80-90.md](https://github.com/dotnet/AspNetCore.Docs/blob/90cd8d4a921dcce6a9d908410e6646723b484b52/aspnetcore/migration/80-90.md) | [aspnetcore/migration/80-90](https://review.learn.microsoft.com/en-us/aspnet/core/migration/80-90?branch=pr-en-us-34032) |


<!-- PREVIEW-TABLE-END -->