### PR TITLE
Remove NOTE

### DIFF
--- a/aspnetcore/blazor/components/render-modes.md
+++ b/aspnetcore/blazor/components/render-modes.md
@@ -391,16 +391,7 @@ In the following example, the render mode is set interactive SSR by adding `@ren
 }
 ```
 
-If using the preceding component in a Blazor Web App, place the component in the server project's `Components/Pages` folder&dagger;. The server project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
-
-> [!IMPORTANT]
-> &dagger;If the app adopts global WebAssembly or global Auto rendering via the `Routes` component, individual components that specify interactive SSR (`@rendermode InteractiveServer`) in their component definition file (`.razor`) are *placed in the `.Client` project's `Pages` folder*.
->
-> Placing interactive SSR components in the `.Client` project is counter-intuitive because such components are only rendered on the server.
->
-> If you place an interactive SSR component in the server project's `Components/Pages` folder of a global WebAssembly or Auto app, the component is prerendered normally and briefly displayed in the user's browser. However, the client-side router isn't able to find the component, ultimately resulting in a *404 - Not Found* in the browser.
->
-> Therefore, place interactive SSR components in the `.Client` project's `Pages` folder if the app adopts global WebAssembly or global Auto rendering via the `Routes` component.
+If using the preceding component in a Blazor Web App, place the component in the server project's `Components/Pages` folder. The server project is the solution's project with a name that doesn't end in `.Client`. When the app is running, navigate to `/render-mode-2` in the browser's address bar.
 
 ## Client-side rendering (CSR)
 


### PR DESCRIPTION
Fixes #34041 

Cc: @MackinnonBuck ... We had a discussion a while back pertaining to this situation where components marked for InteractiveSever were placed in the client project. Apparently, I didn't faithfully capture the concept. I'll research further and see if I can figure out how this mistake was made. If u have any recollection of our convo or remarks on the scenario, please place them here.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-modes.md](https://github.com/dotnet/AspNetCore.Docs/blob/a2ed6d51f29f04bac16190a7783e1624f9296338/aspnetcore/blazor/components/render-modes.md) | [aspnetcore/blazor/components/render-modes](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes?branch=pr-en-us-34044) |

<!-- PREVIEW-TABLE-END -->