### PR TITLE
[signalr/dotnet-client.md] Reference FAQ article instead of GitHub readme

### DIFF
--- a/aspnetcore/signalr/dotnet-client.md
+++ b/aspnetcore/signalr/dotnet-client.md
@@ -139,7 +139,7 @@ connection.Closed += error =>
 In order to configure a custom number of reconnect attempts before disconnecting or change the reconnect timing, `WithAutomaticReconnect` accepts an array of numbers representing the delay in milliseconds to wait before starting each reconnect attempt.
 
 ```csharp
-HubConnection connection= new HubConnectionBuilder()
+HubConnection connection = new HubConnectionBuilder()
     .WithUrl(new Uri("http://127.0.0.1:5000/chathub"))
     .WithAutomaticReconnect(new[] { TimeSpan.Zero, TimeSpan.Zero, TimeSpan.FromSeconds(10) })
     .Build();
@@ -231,7 +231,7 @@ The `InvokeAsync` method returns a `Task` which completes when the server method
 The `SendAsync` method returns a `Task` which completes when the message has been sent to the server. No return value is provided since this `Task` doesn't wait until the server method completes. Any exceptions thrown on the client while sending the message produce a faulted `Task`. Use `await` and `try...catch` syntax to handle send errors.
 
 > [!NOTE]
-> Calling hub methods from a client is only supported when using the Azure SignalR Service in *Default* mode. For more information, see [Frequently Asked Questions (azure-signalr GitHub repository)](https://github.com/Azure/azure-signalr/blob/dev/docs/faq.md#what-is-the-meaning-of-service-mode-defaultserverlessclassic-how-can-i-choose).
+> Calling hub methods from a client is only supported when using the Azure SignalR Service in *Default* mode. For more information, see [Frequently Asked Questions](/azure/azure-signalr/signalr-resource-faq).
 
 ## Call client methods from hub
 

--- a/aspnetcore/signalr/dotnet-client/sample/SignalRChat/Hubs/ChatHub.cs
+++ b/aspnetcore/signalr/dotnet-client/sample/SignalRChat/Hubs/ChatHub.cs
@@ -8,7 +8,7 @@ namespace SignalRChat.Hubs
         #region snippet_SendMessage
         public async Task SendMessage(string user, string message)
         {
-            await Clients.All.SendAsync("ReceiveMessage", user,message);
+            await Clients.All.SendAsync("ReceiveMessage", user, message);
         }
         #endregion
     }


### PR DESCRIPTION
I changed FAQ link to reference [article](https://learn.microsoft.com/en-us/azure/azure-signalr/signalr-resource-faq) instead of readme on [GitHub](https://github.com/Azure/azure-signalr/blob/dev/docs/faq.md#what-is-the-meaning-of-service-mode-defaultserverlessclassic-how-can-i-choose).
Minor code improvements in `dotnet-client.md`.

Fixes #34092

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/signalr/dotnet-client.md](https://github.com/dotnet/AspNetCore.Docs/blob/98c07dc66ded7431dba1b8b6be8d857f5a8fd5e0/aspnetcore/signalr/dotnet-client.md) | [ASP.NET Core SignalR .NET Client](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/dotnet-client?branch=pr-en-us-34047) |

<!-- PREVIEW-TABLE-END -->