### PR TITLE
Fix reference source cross-links

### DIFF
--- a/aspnetcore/blazor/components/prerendering-and-integration.md
+++ b/aspnetcore/blazor/components/prerendering-and-integration.md
@@ -21,7 +21,7 @@ zone_pivot_groups: blazor-hosting-models
 This article explains Razor component integration scenarios for Blazor apps, including prerendering of Razor components on the server.
 
 > [!IMPORTANT]
-> Framework changes across ASP.NET Core releases led to different sets of instructions in this article. Before using this article's guidance, confirm that the document version selector on this page matches the version of ASP.NET Core that you intend to use for your app.
+> Framework changes across ASP.NET Core releases led to different sets of instructions in this article. Before using this article's guidance, confirm that the document version selector at the top of this article matches the version of ASP.NET Core that you intend to use for your app.
 
 :::moniker range=">= aspnetcore-7.0"
 

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -1735,7 +1735,7 @@ For more information, see <xref:blazor/js-interop/index#javascript-interop-calls
 ## Additional resources
 
 * <xref:blazor/js-interop/call-javascript-from-dotnet>
-* [`InteropComponent.razor` example (`dotnet/AspNetCore` GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/5.0`), use the **Switch branches or tags** dropdown list to select the branch.
+* [`InteropComponent.razor` example (`dotnet/AspNetCore` GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/{VERSION}`, where the `{VERSION}` placeholder is the release version), use the **Switch branches or tags** dropdown list to select the branch. For a branch that no longer exists, use the **Tags** tab to find the API (for example, `v7.0.0`).
 * [Interaction with the DOM](xref:blazor/js-interop/index#interaction-with-the-dom)
 * [Blazor samples GitHub repository (`dotnet/blazor-samples`)](https://github.com/dotnet/blazor-samples) ([how to download](xref:blazor/fundamentals/index#sample-apps))
 * <xref:blazor/fundamentals/handle-errors#javascript-interop> (*JavaScript interop* section)

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -1696,7 +1696,7 @@ For more information, see <xref:blazor/js-interop/index#javascript-interop-calls
 ## Additional resources
 
 * <xref:blazor/js-interop/call-dotnet-from-javascript>
-* [`InteropComponent.razor` example (`dotnet/AspNetCore` GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/5.0`), use the **Switch branches or tags** dropdown list to select the branch.
+* [`InteropComponent.razor` example (`dotnet/AspNetCore` GitHub repository `main` branch)](https://github.com/dotnet/AspNetCore/blob/main/src/Components/test/testassets/BasicTestApp/InteropComponent.razor): The `main` branch represents the product unit's current development for the next release of ASP.NET Core. To select the branch for a different release (for example, `release/{VERSION}`, where the `{VERSION}` placeholder is the release version), use the **Switch branches or tags** dropdown list to select the branch. For a branch that no longer exists, use the **Tags** tab to find the API (for example, `v7.0.0`).
 * [Blazor samples GitHub repository (`dotnet/blazor-samples`)](https://github.com/dotnet/blazor-samples) ([how to download](xref:blazor/fundamentals/index#sample-apps))
 * <xref:blazor/fundamentals/handle-errors#javascript-interop> (*JavaScript interop* section)
 * [Threat mitigation: JavaScript functions invoked from .NET](xref:blazor/security/server/interactive-server-side-rendering#javascript-functions-invoked-from-net)

--- a/aspnetcore/blazor/progressive-web-app.md
+++ b/aspnetcore/blazor/progressive-web-app.md
@@ -120,15 +120,16 @@ In the app's `wwwroot/index.html` file:
 
 :::moniker range="< aspnetcore-8.0"
 
-* Navigate to the ASP.NET Core GitHub repository at the following URL, which links to the `release/6.0` branch reference source and assets. If you're using a version of ASP.NET Core later than 6.0, change the document version selector to see the updated guidance for this section. Select the release that you're working with from the **Switch branches or tags** dropdown list that applies to your app.
+* Navigate to the ASP.NET Core GitHub repository at the following URL, which links to the `v7.0.0` tag reference source and assets. If you're using a version of ASP.NET Core later than 7.0, change the document version selector at the top of this article to see the updated guidance for this section. Select the release that you're working with from the **Switch branches or tags** dropdown list that applies to your app.
 
-  [Blazor WebAssembly project template `wwwroot` folder](https://github.com/dotnet/aspnetcore/tree/release/6.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
+  [Blazor WebAssembly project template `wwwroot` folder (`v7.0.0` tag)](https://github.com/dotnet/aspnetcore/tree/v7.0.0/src/ProjectTemplates/Web.ProjectTemplates/content/ComponentsWebAssembly-CSharp/Client/wwwroot)
 
   [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
   From the source `wwwroot` folder either in the app that you created or from the reference assets in the `dotnet/aspnetcore` GitHub repository, copy the following files into the app's `wwwroot` folder:
 
   * `favicon.png`
+  * `icon-192.png`
   * `icon-512.png`
   * `manifest.json`
   * `service-worker.js`
@@ -141,6 +142,7 @@ In the app's `wwwroot/index.html` file:
   ```html
   <link href="manifest.json" rel="manifest" />
   <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
+  <link rel="apple-touch-icon" sizes="192x192" href="icon-192.png" />
   ```
 
 :::moniker-end


### PR DESCRIPTION
Fixes #34060

BTW @Rick-Anderson @wadepickett @tdykstra ...

I'm finding just a few NIT problems in the Blazor node for reference source links. For example, the `release/7.0` branch was dropped, but those assets can be obtained via the `v7.0.0` ***tag*** (**Tags** tab of **Switch branches or tags**).

When I search the whole repo, I see a number of remarks tied to reference source links that are pegged to old framework versions. I'm not performing an analysis on them, so perhaps they're fine, but it seems like a concern. For example, making a current-release remark about API but linking all the way back to the 3.1 or 6.0 reference source 😨. Idk if you want to open an issue to investigate ref source cross-linking.

The Blazor docs will be resolved with my work this morning. I found links with `release/3.1`, `release/5.0`, `release/6.0`, `release/7.0`, and `release/8.0`. However, I noticed near the end of my work that I could just get away with searching `release/`. It brings up a couple of dozen unrelated results, but it's quicker to just skim past them than make all of those separate searches. Too late for me 😄, but it might save you some ⌚.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/prerendering-and-integration.md](https://github.com/dotnet/AspNetCore.Docs/blob/840264c1405c5abdaf65931cfaaadd543a4f84ec/aspnetcore/blazor/components/prerendering-and-integration.md) | [aspnetcore/blazor/components/prerendering-and-integration](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/prerendering-and-integration?branch=pr-en-us-34062) |
| [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/840264c1405c5abdaf65931cfaaadd543a4f84ec/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md) | [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?branch=pr-en-us-34062) |
| [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md](https://github.com/dotnet/AspNetCore.Docs/blob/840264c1405c5abdaf65931cfaaadd543a4f84ec/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md) | [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?branch=pr-en-us-34062) |
| [aspnetcore/blazor/progressive-web-app.md](https://github.com/dotnet/AspNetCore.Docs/blob/840264c1405c5abdaf65931cfaaadd543a4f84ec/aspnetcore/blazor/progressive-web-app.md) | [aspnetcore/blazor/progressive-web-app](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/progressive-web-app?branch=pr-en-us-34062) |

<!-- PREVIEW-TABLE-END -->