### PR TITLE
Add breaking changes docs

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -63,6 +63,13 @@
       "url": "https://github.com/dotnet/AspNetCore.Docs.Samples",
       "branch": "main",
       "branch_mapping": {}
+    },
+    {
+      "path_to_root": "_razor",
+      "url": "https://github.com/dotnet/razor",
+      "branch": "main",
+      "include_in_build": true,
+      "branch_mapping": {}
     }
   ],
   "branch_target_mapping": {

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -51,12 +51,10 @@
     },
     "fileMetadata": {
       "author": {
-        "whats-new/**/**.md": "rick-anderson",
-        "_razor/docs/*.md": "rick-anderson"
+        "whats-new/**/**.md": "rick-anderson"
       },
       "ms.author": {
-        "whats-new/**/**.md": "riande",
-        "../_razor/docs/*.md": "riande"
+        "whats-new/**/**.md": "riande"
       },
       "ms.subservice": {
         "introduction-to-aspnet-core.md": "index-page",
@@ -94,14 +92,6 @@
       },
       "recommendations": {
         "**/tutorials/**/**.md": "false"
-      },
-      "title": {
-        "../_razor/docs/Compiler Breaking Changes - DotNet 8.md": "Razor compiler breaking changes since .NET 8",
-        "_razor/docs/Compiler Breaking Changes - DotNet 9.md": "Razor compiler breaking changes since .NET 9"            
-      },
-      "description": {
-        "../_razor/docs/Compiler Breaking Changes - DotNet 8.md": "Learn about any breaking changes since the initial release of .NET 8",
-        "_razor/docs/Compiler Breaking Changes - DotNet 9.md": "Learn about any breaking changes since the initial release of .NET 9"
       }
     },
     "template": [],

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -6,6 +6,16 @@
         "exclude": [ "**/includes/**", "***/license.md", "**/obj/**", "***/readme.md", "**/sample/**", "**/samples/**", "_site/**" ], 
         "group": "group1", 
         "src": "."
+      },
+      {
+        "files": [
+            "Compiler Breaking Changes - DotNet 8.md",
+            "Compiler Breaking Changes - DotNet 9.md"
+        ],
+        "exclude": [],
+        "group": "group1", 
+        "src": "../_razor/docs",
+        "dest": "_razor/docs"
       }
     ],
     "resource": [
@@ -41,10 +51,12 @@
     },
     "fileMetadata": {
       "author": {
-        "whats-new/**/**.md": "rick-anderson"
+        "whats-new/**/**.md": "rick-anderson",
+        "_razor/docs/*.md": "rick-anderson"
       },
       "ms.author": {
-        "whats-new/**/**.md": "riande"
+        "whats-new/**/**.md": "riande",
+        "../_razor/docs/*.md": "riande"
       },
       "ms.subservice": {
         "introduction-to-aspnet-core.md": "index-page",
@@ -82,6 +94,14 @@
       },
       "recommendations": {
         "**/tutorials/**/**.md": "false"
+      },
+      "title": {
+        "../_razor/docs/Compiler Breaking Changes - DotNet 8.md": "Razor compiler breaking changes since .NET 8",
+        "_razor/docs/Compiler Breaking Changes - DotNet 9.md": "Razor compiler breaking changes since .NET 9"            
+      },
+      "description": {
+        "../_razor/docs/Compiler Breaking Changes - DotNet 8.md": "Learn about any breaking changes since the initial release of .NET 8",
+        "_razor/docs/Compiler Breaking Changes - DotNet 9.md": "Learn about any breaking changes since the initial release of .NET 9"
       }
     },
     "template": [],

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -797,6 +797,10 @@ items:
             uid: mvc/controllers/filters
           - name: Razor SDK
             uid: razor-pages/sdk
+          - name: Razor breaking changes since .NET 8
+            href: ../_razor/docs/Compiler%20Breaking%20Changes%20-%20DotNet%208.md
+          - name: Razor breaking changes since .NET 9
+            href: ../_razor/docs/Compiler%20Breaking%20Changes%20-%20DotNet%209.md
           - name: View components
             uid: mvc/views/view-components
           - name: View compilation


### PR DESCRIPTION
Fixes #33996

Add the configuration and TOC changes for publishing the breaking changes articles to the razor compiler.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/toc.yml](https://github.com/dotnet/AspNetCore.Docs/blob/774aed08f39a9ba4ef1c586b1ba4ba68f0d2fe0f/aspnetcore/toc.yml) | [aspnetcore/toc](https://review.learn.microsoft.com/en-us/aspnet/core/toc?branch=pr-en-us-34063) |


<!-- PREVIEW-TABLE-END -->