### PR TITLE
Removing mention of .NET 10 in .NET 9 release notes

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/blazor.md
@@ -218,11 +218,3 @@ The <xref:Microsoft.AspNetCore.Components.Forms.InputNumber%601> component now s
     }
 }
 ```
-
-### Multiple Blazor Web Apps per server project
-
-<!-- UPDATE 10.0 Confirm or update -->
-
-Support for multiple Blazor Web Apps per server project is under consideration for .NET 10 in late 2025.
-
-For more information, see [Support for multiple Blazor Web apps per server project (`dotnet/aspnetcore` #52216)](https://github.com/dotnet/aspnetcore/issues/52216).


### PR DESCRIPTION
Removing mention of .NET 10 from the .NET 9 release notes. We'll announce what's on the .NET 10 roadmap once we're further along with planning. 