### PR TITLE
Small change to 'splatting' explanation

### DIFF
--- a/aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters.md
+++ b/aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters.md
@@ -12,7 +12,7 @@ uid: blazor/components/attribute-splatting
 
 [!INCLUDE[](~/includes/not-latest-version.md)]
 
-Components can capture and render additional attributes in addition to the component's declared parameters. Additional attributes can be captured in a dictionary and then *splatted* onto an element when the component is rendered using the [`@attributes`](xref:mvc/views/razor#attributes) Razor directive attribute. This scenario is useful for defining a component that produces a markup element that supports a variety of customizations. For example, it can be tedious to define attributes separately for an `<input>` that supports many parameters.
+Components can capture and render additional attributes in addition to the component's declared parameters. Additional attributes can be captured in a dictionary and then applied to an element, calling *splatting*, when the component is rendered using the [`@attributes`](xref:mvc/views/razor#attributes) Razor directive attribute. This scenario is useful for defining a component that produces a markup element that supports a variety of customizations. For example, it can be tedious to define attributes separately for an `<input>` that supports many parameters.
 
 ## Attribute splatting
 


### PR DESCRIPTION
Fixes #34069

"Splatting" was already explained (including by example), but I'll make a change that should improve it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters.md](https://github.com/dotnet/AspNetCore.Docs/blob/a9b85ef04c4f31538318db221af2c66f3c91cb59/aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters.md) | [aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/splat-attributes-and-arbitrary-parameters?branch=pr-en-us-34071) |

<!-- PREVIEW-TABLE-END -->