### PR TITLE
[Blazor] splat-attributes-and-arbitrary-parameters.md - typo

### DIFF
--- a/aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters.md
+++ b/aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters.md
@@ -12,7 +12,7 @@ uid: blazor/components/attribute-splatting
 
 [!INCLUDE[](~/includes/not-latest-version.md)]
 
-Components can capture and render additional attributes in addition to the component's declared parameters. Additional attributes can be captured in a dictionary and then applied to an element, calling *splatting*, when the component is rendered using the [`@attributes`](xref:mvc/views/razor#attributes) Razor directive attribute. This scenario is useful for defining a component that produces a markup element that supports a variety of customizations. For example, it can be tedious to define attributes separately for an `<input>` that supports many parameters.
+Components can capture and render additional attributes in addition to the component's declared parameters. Additional attributes can be captured in a dictionary and then applied to an element, called *splatting*, when the component is rendered using the [`@attributes`](xref:mvc/views/razor#attributes) Razor directive attribute. This scenario is useful for defining a component that produces a markup element that supports a variety of customizations. For example, it can be tedious to define attributes separately for an `<input>` that supports many parameters.
 
 ## Attribute splatting
 


### PR DESCRIPTION
"calling splatting" => "called splatting"

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters.md](https://github.com/dotnet/AspNetCore.Docs/blob/6009cd7c401ddf0a5308e98c29e2bf3b8a31363a/aspnetcore/blazor/components/splat-attributes-and-arbitrary-parameters.md) | [ASP.NET Core Blazor attribute splatting and arbitrary parameters](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/splat-attributes-and-arbitrary-parameters?branch=pr-en-us-34074) |

<!-- PREVIEW-TABLE-END -->