### PR TITLE
Update not-latest-version.md

### DIFF
--- a/aspnetcore/includes/not-latest-version.md
+++ b/aspnetcore/includes/not-latest-version.md
@@ -1,17 +1,17 @@
-:::moniker range="< aspnetcore-8.0"
+:::moniker range="< aspnetcore-9.0"
 > [!NOTE]
-> This isn't the latest version of this article. For the current release, see the [.NET 8 version of this article](?view=aspnetcore-8.0&preserve-view=true).
+> This isn't the latest version of this article. For the current release, see the [.NET 9 version of this article](?view=aspnetcore-9.0&preserve-view=true).
 :::moniker-end
 
 :::moniker range="= aspnetcore-7.0 || = aspnetcore-5.0 || = aspnetcore-3.0 || = aspnetcore-3.1 || = aspnetcore-2.0"
 [!INCLUDE[](~/includes/out-of-support.md)]
 :::moniker-end
 
-:::moniker range="> aspnetcore-8.0"
+:::moniker range="> aspnetcore-9.0"
 > [!IMPORTANT]
 > This information relates to a pre-release product that may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
 >
-> For the current release, see the [.NET 8 version of this article](?view=aspnetcore-8.0&preserve-view=true).
+> For the current release, see the [.NET 9 version of this article](?view=aspnetcore-9.0&preserve-view=true).
 :::moniker-end
 
 <!--


### PR DESCRIPTION
The preview notice is showing for 9.0, which is the default doc load now.