### PR TITLE
Add a not-latest-version INCLUDE

### DIFF
--- a/aspnetcore/includes/not-latest-version-without-not-supported-content.md
+++ b/aspnetcore/includes/not-latest-version-without-not-supported-content.md
@@ -11,11 +11,19 @@
 :::moniker-end
 
 <!--
-Include this file at the top of articles. When a new version is released,
-it might be necessary to temporarily comment out the current version
-moniker range section until the new moniker is created.
-Markdown to include this file:
-[!INCLUDE[](~/includes/not-latest-version-without-not-supported-content.md)]
+Include either this file or 'not-latest-version.md' at the top of articles.
 
-This version of the file doesn't include the not-supported-version content.
+'not-latest-version.md': Includes not-supported content.
+'not-latest-version-without-not-supported-content.md' (this file): Doesn't include not-supported content.
+
+Use this file in articles that target >=8.0 until 9.0 reaches EOL, and then update those
+articles to use 'not-latest-version.md'. For articles that target >=7.0, 'not-latest-version.md'
+can be used without creating a zone/file moniker range mismatch error.
+
+When a new version is released, it might be necessary to temporarily comment out the current version
+moniker range section until the new moniker is created.
+
+Markdown to include this file:
+
+[!INCLUDE[](~/includes/not-latest-version-without-not-supported-content.md)]
 -->

--- a/aspnetcore/includes/not-latest-version-without-not-supported-content.md
+++ b/aspnetcore/includes/not-latest-version-without-not-supported-content.md
@@ -1,0 +1,21 @@
+:::moniker range="< aspnetcore-9.0"
+> [!NOTE]
+> This isn't the latest version of this article. For the current release, see the [.NET 9 version of this article](?view=aspnetcore-9.0&preserve-view=true).
+:::moniker-end
+
+:::moniker range="> aspnetcore-9.0"
+> [!IMPORTANT]
+> This information relates to a pre-release product that may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
+>
+> For the current release, see the [.NET 9 version of this article](?view=aspnetcore-9.0&preserve-view=true).
+:::moniker-end
+
+<!--
+Include this file at the top of articles. When a new version is released,
+it might be necessary to temporarily comment out the current version
+moniker range section until the new moniker is created.
+Markdown to include this file:
+[!INCLUDE[](~/includes/not-latest-version-without-not-supported-content.md)]
+
+This version of the file doesn't include the not-supported-version content.
+-->

--- a/aspnetcore/includes/not-latest-version.md
+++ b/aspnetcore/includes/not-latest-version.md
@@ -15,9 +15,20 @@
 :::moniker-end
 
 <!--
-Include this file at the top of articles. When a new version is released,
-it might be necessary to temporarily comment out the  current version
-moniker range section until the new moniker is created.
+Include either this file or 'not-latest-version-without-not-supported-content.md' at the top 
+of articles.
+
+'not-latest-version.md' (this file): Includes not-supported content.
+'not-latest-version-without-not-supported-content.md': Doesn't include not-supported content.
+
+Use this file in articles that target >=7.0. For articles that target >=8.0 prior to 9.0
+reaching EOL, 'not-latest-version-without-not-supported-content.md' must be used to avoid
+a zone/file moniker range mismatch error.
+
+When a new version is released, it might be necessary to temporarily comment out the current 
+version moniker range section until the new moniker is created.
+
 Markdown to include this file:
+
 [!INCLUDE[](~/includes/not-latest-version.md)]
 -->


### PR DESCRIPTION
Fixes #34100

This version of the file doesn't include the not-supported content.

After this goes in, I'll update my Blazor PR to use this file, which only addresses the new Blazor articles at 8.0 that were versioned >=8.0 at the file level.