### PR TITLE
Fix `@bind:after` description

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -158,7 +158,7 @@ Razor attribute binding is case-sensitive:
 
 :::moniker range=">= aspnetcore-7.0"
 
-To execute asynchronous logic after binding, use `@bind:after="{EVENT}"` with a DOM event for the `{EVENT}` placeholder. An assigned C# method isn't executed until the bound value is assigned synchronously.
+To execute asynchronous logic after binding, use `@bind:after="{DELEGATE}"`, where the `{DELEGATE}` placeholder is a C# delegate (method). An assigned C# delegate isn't executed until the bound value is assigned synchronously.
 
 Using an [event callback parameter (`EventCallback`/`EventCallback<T>`)](xref:blazor/components/event-handling#eventcallback) with `@bind:after` isn't supported. Instead, pass a method that returns an <xref:System.Action> or <xref:System.Threading.Tasks.Task> to `@bind:after`.
 


### PR DESCRIPTION
Fixes #34127

Thanks @willdean! 🚀 ... I'll hold it for sec while you check out the update. I'm not going to wait for the product unit on this one. I agree with your suggestion for the change.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/data-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/451eb67f2ffc4bd65e46871c647fb2d48346dbbb/aspnetcore/blazor/components/data-binding.md) | [aspnetcore/blazor/components/data-binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?branch=pr-en-us-34128) |

<!-- PREVIEW-TABLE-END -->