### PR TITLE
Update 7.0 migration guidance

### DIFF
--- a/aspnetcore/migration/60-70.md
+++ b/aspnetcore/migration/60-70.md
@@ -82,8 +82,6 @@ To adopt all of the [new 7.0 features for Blazor apps](xref:aspnetcore-7#blazor)
 * Create a new 7.0 Blazor project from one of the Blazor project templates. For more information, see <xref:blazor/tooling>.
 * Move the app's components and code to the 7.0 app making modifications to adopt the new 7.0 features.
 
-<!-- HOLD: See https://github.com/dotnet/AspNetCore.Docs/issues/27848
-
 ### Simplify component parameter binding
 
 In prior Blazor releases, binding across multiple components required binding to properties with `get`/`set` accessors.
@@ -111,22 +109,10 @@ In .NET 7, you can use the new `@bind:get` and `@bind:set` modifiers to support 
     @bind-GrandchildMessage:set="ChildMessageChanged" />
 ```
 
-> [!IMPORTANT]
-> The `@bind:get` and `@bind:set` features are receiving further updates at this time. To take advantage of the latest updates, confirm that you've installed the [latest SDK](https://dotnet.microsoft.com/download/dotnet/7.0).
->
-> Using an event callback parameter (`[Parameter] public EventCallback<string> ValueChanged { get; set; }`) isn't supported. Instead, pass an <xref:System.Action>-returning or <xref:System.Threading.Tasks.Task>-returning method to `@bind:set`.
->
-> For more information, see the following resources:
->
-> * [Blazor `@bind:after` not working on .NET 7 RTM release (dotnet/aspnetcore #44957)](https://github.com/dotnet/aspnetcore/issues/44957)
-> * [`BindGetSetAfter701` sample app (javiercn/BindGetSetAfter701 GitHub repository)](https://github.com/javiercn/BindGetSetAfter701)
-
 For more information, see the following content in the *Data binding* article:
 
 * [Introduction](xref:blazor/components/data-binding?view=aspnetcore-7.0)
 * [Bind across more than two components](xref:blazor/components/data-binding?view=aspnetcore-7.0#bind-across-more-than-two-components)
-
--->
 
 ### Migrate unmarshalled JavaScript interop
 
@@ -138,7 +124,7 @@ For more information, see <xref:blazor/js-interop/import-export-interop>.
 
 The support for authentication in Blazor WebAssembly apps changed to rely on [navigation history state](xref:blazor/fundamentals/routing?view=aspnetcore-7.0#navigation-history-state) instead of query strings in the URL. As a result, passing the return URL through the query string fails to redirect back to the original page after a successful login in .NET 7.
 
-The following example demonstrates **the prior redirection approach for apps that target .NET 6 or earlier**, which is based on a redirect URL (`?returnUrl=`) with <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A>:
+The following example demonstrates **the prior redirection approach for apps that target .NET 6 or earlier** in `RedirectToLogin.razor`, which is based on a redirect URL (`?returnUrl=`) with <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A>:
 
 ```razor
 @inject NavigationManager Navigation
@@ -152,7 +138,7 @@ The following example demonstrates **the prior redirection approach for apps tha
 }
 ```
 
-The following example demonstrates **the new redirection approach for apps that target .NET 7 or later**, which is based on [navigation history state](xref:blazor/fundamentals/routing?view=aspnetcore-7.0#navigation-history-state) with <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.NavigationManagerExtensions.NavigateToLogin%2A>:
+The following example demonstrates **the new redirection approach for apps that target .NET 7 or later** in `RedirectToLogin.razor`, which is based on [navigation history state](xref:blazor/fundamentals/routing?view=aspnetcore-7.0#navigation-history-state) with <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.NavigationManagerExtensions.NavigateToLogin%2A>:
 
 ```razor
 @inject NavigationManager Navigation
@@ -186,7 +172,7 @@ The following example demonstrates **the prior approach** in `Shared/LoginDispla
 }
 ```
 
-The following example demonstrates **the new approach** that calls <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.NavigationManagerExtensions.NavigateToLogout%2A>. The injection (`@inject`) of the <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.SignOutSessionStateManager> is removed from the component's directives at the top of the file, and the `BeginLogOut` method is updated to the following code:
+The following example demonstrates **the new approach** in `Shared/LoginDisplay.razor` that calls <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.NavigationManagerExtensions.NavigateToLogout%2A>. The injection (`@inject`) of the <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.SignOutSessionStateManager> is removed from the component's directives at the top of the file, and the `BeginLogOut` method is updated to the following code:
 
 ```razor
 @code{


### PR DESCRIPTION
Fixes #34143

Thanks @dougclutter! 🚀 

... and I missed enabling a section on `@bind:get`/`@bind:set` modifiers for binding. It was commented out at the time because there was a bug in the framework at release. The bug was fixed in a patch later. I enabled the [new content in the 7.0 version of the binding article](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?view=aspnetcore-7.0#bind-across-more-than-two-components) when the patch landed, but I failed to enable it in this article.

This type of mistake likely won't happen again because now I use an approach to track content that I need to address during release. I place an HTML comment into the markdown to flag items like this. In this case, I would've placed something like "UPDATE 7.0 - Enable this when patched" with the product unit issue link in the comment. Then, this comment (and all of the other 7.0 items to address in articles) for the 7.0 release come up in a simple repo search of "UPDATE 7.0". That's what I do these days, and it's been working very well for the last couple of releases.

Thanks again for the issue!

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/60-70.md](https://github.com/dotnet/AspNetCore.Docs/blob/7624112d2a2a122e31327265e2227db92bfa44ab/aspnetcore/migration/60-70.md) | [aspnetcore/migration/60-70](https://review.learn.microsoft.com/en-us/aspnet/core/migration/60-70?branch=pr-en-us-34146) |

<!-- PREVIEW-TABLE-END -->