### PR TITLE
JS interop/circuit disposal updates

### DIFF
--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -142,6 +142,8 @@ The following `JsCollocation2` component's `OnAfterRenderAsync` method loads a J
 }
 ```
 
+In the preceding example, <xref:Microsoft.JSInterop.JSDisconnectedException> is trapped during module disposal in case Blazor's SignalR circuit is lost. If the preceding code is used in a Blazor WebAssembly app, there's no SignalR connection to lose, so you can remove the `try`-`catch` block and leave the line that disposes the module (`await module.DisposeAsync();`). For more information, see <xref:blazor/js-interop/index#javascript-interop-calls-without-a-circuit>.
+
 `{PATH}/JsCollocation2.razor.js`:
 
 ```javascript

--- a/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
+++ b/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
@@ -47,14 +47,10 @@ When working with <xref:Microsoft.JSInterop.IJSObjectReference> in ASP.NET Core 
     {
         if (module is not null)
         {
-            try
-            {
-                await module.DisposeAsync();
-            }
-            catch (JSDisconnectedException)
-            {
-            }
+            await module.DisposeAsync();
         }
     }
 }
 ```
+
+In the preceding example, a <xref:Microsoft.JSInterop.JSDisconnectedException> isn't trapped during module disposal because there's no Blazor-SignalR circuit in a Blazor WebAssembly app to lose. For more information, see <xref:blazor/js-interop/index#javascript-interop-calls-without-a-circuit>.

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -582,6 +582,7 @@ In the preceding example:
 * `JS` is an injected <xref:Microsoft.JSInterop.IJSRuntime> instance. <xref:Microsoft.JSInterop.IJSRuntime> is registered by the Blazor framework.
 * The variable name `dotNetHelper` is arbitrary and can be changed to any preferred name.
 * The component must explicitly dispose of the <xref:Microsoft.JSInterop.DotNetObjectReference> to permit garbage collection and prevent a memory leak.
+* <xref:Microsoft.JSInterop.JSDisconnectedException> is trapped during module disposal in case Blazor's SignalR circuit is lost. If the preceding code is used in a Blazor WebAssembly app, there's no SignalR connection to lose, so you can remove the `try`-`catch` block and leave the line that disposes the module (`await module.DisposeAsync();`). For more information, see <xref:blazor/js-interop/index#javascript-interop-calls-without-a-circuit>.
 
 `CallDotNetExampleOneHelper.razor.js`:
 

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -167,6 +167,8 @@ export function addHandlers() {
 }
 ```
 
+In the preceding example, <xref:Microsoft.JSInterop.JSDisconnectedException> is trapped during module disposal in case Blazor's SignalR circuit is lost. If the preceding code is used in a Blazor WebAssembly app, there's no SignalR connection to lose, so you can remove the `try`-`catch` block and leave the line that disposes the module (`await module.DisposeAsync();`). For more information, see <xref:blazor/js-interop/index#javascript-interop-calls-without-a-circuit>.
+
 For more information, see the following resources:
 
 * <xref:blazor/js-interop/javascript-location>
@@ -276,6 +278,8 @@ In the following example, the `DOMCleanup` component:
     }
 }
 ```
+
+In the preceding example, <xref:Microsoft.JSInterop.JSDisconnectedException> is trapped during module disposal in case Blazor's SignalR circuit is lost. If the preceding code is used in a Blazor WebAssembly app, there's no SignalR connection to lose, so you can remove the `try`-`catch` block and leave the line that disposes the module (`await module.DisposeAsync();`). For more information, see <xref:blazor/js-interop/index#javascript-interop-calls-without-a-circuit>.
 
 In the following example, the `MutationObserver` callback is executed each time a DOM change occurs. Execute your cleanup code when the `if` statement confirms that the target element (`cleanupDiv`) was removed (`if (targetRemoved) { ... }`). It's important to disconnect and delete the `MutationObserver` to avoid a memory leak after your cleanup code executes.
 

--- a/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
@@ -193,7 +193,7 @@ JS isolation provides the following benefits:
 * Imported JS no longer pollutes the global namespace.
 * Consumers of a library and components aren't required to import the related JS.
 
-In server-side scenarios, trap <xref:Microsoft.JSInterop.JSDisconnectedException> if loss of Blazor's SignalR circuit prevents a JS interop call from disposing a module, which results in an unhandled exception. Blazor WebAssembly apps don't use a SignalR connection, so there's no need to trap <xref:Microsoft.JSInterop.JSDisconnectedException> in Blazor WebAssembly apps for module disposal.
+In server-side scenarios, always trap <xref:Microsoft.JSInterop.JSDisconnectedException> in case loss of Blazor's SignalR circuit prevents a JS interop call from disposing a module, which results in an unhandled exception. Blazor WebAssembly apps don't use a SignalR connection, so there's no need to trap <xref:Microsoft.JSInterop.JSDisconnectedException> in Blazor WebAssembly apps for module disposal.
 
 For more information, see the following resources:
 

--- a/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
@@ -193,7 +193,7 @@ JS isolation provides the following benefits:
 * Imported JS no longer pollutes the global namespace.
 * Consumers of a library and components aren't required to import the related JS.
 
-Trap <xref:Microsoft.JSInterop.JSDisconnectedException> in potential cases where loss of Blazor's SignalR circuit prevents a JS interop call from disposing a module, which results an unhandled exception.
+In server-side scenarios, trap <xref:Microsoft.JSInterop.JSDisconnectedException> if loss of Blazor's SignalR circuit prevents a JS interop call from disposing a module, which results in an unhandled exception. Blazor WebAssembly apps don't use a SignalR connection, so there's no need to trap <xref:Microsoft.JSInterop.JSDisconnectedException> in Blazor WebAssembly apps for module disposal.
 
 For more information, see the following resources:
 

--- a/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
@@ -193,7 +193,7 @@ JS isolation provides the following benefits:
 * Imported JS no longer pollutes the global namespace.
 * Consumers of a library and components aren't required to import the related JS.
 
-In server-side scenarios, always trap <xref:Microsoft.JSInterop.JSDisconnectedException> in case loss of Blazor's SignalR circuit prevents a JS interop call from disposing a module, which results in an unhandled exception. Blazor WebAssembly apps don't use a SignalR connection, so there's no need to trap <xref:Microsoft.JSInterop.JSDisconnectedException> in Blazor WebAssembly apps for module disposal.
+In server-side scenarios, always trap <xref:Microsoft.JSInterop.JSDisconnectedException> in case loss of Blazor's SignalR circuit prevents a JS interop call from disposing a module, which results in an unhandled exception. Blazor WebAssembly apps don't use a SignalR connection during JS interop, so there's no need to trap <xref:Microsoft.JSInterop.JSDisconnectedException> in Blazor WebAssembly apps for module disposal.
 
 For more information, see the following resources:
 


### PR DESCRIPTION
Addresses #34126

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0bc5c3466b890da45efe647157ecfcdde07cdc1/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md) | [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?branch=pr-en-us-34178) |
| [aspnetcore/blazor/javascript-interoperability/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0bc5c3466b890da45efe647157ecfcdde07cdc1/aspnetcore/blazor/javascript-interoperability/index.md) | [aspnetcore/blazor/javascript-interoperability/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/index?branch=pr-en-us-34178) |
| [aspnetcore/blazor/javascript-interoperability/location-of-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0bc5c3466b890da45efe647157ecfcdde07cdc1/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md) | [aspnetcore/blazor/javascript-interoperability/location-of-javascript](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/location-of-javascript?branch=pr-en-us-34178) |


<!-- PREVIEW-TABLE-END -->