### PR TITLE
Update links

### DIFF
--- a/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
+++ b/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md
@@ -19,7 +19,7 @@ This document focuses on using Visual Studio 2022 or later to create and use [pu
 For the most current and detailed information on:
 
 * Publishing with Visual studio, see [Overview of Visual Studio Publish](/visualstudio/deployment/publish-overview)
-* MSBuild, see [MSBuild](/visualstudio/msbuild/msbuild-introduction)
+* MSBuild, see [MSBuild](/visualstudio/msbuild/msbuild)
 * Publishing with MSBuild, see [Microsoft.NET.Sdk.Publish](https://github.com/dotnet/sdk/tree/main/src/WebSdk#microsoftnetsdkpublish)
 
 The `dotnet new mvc` command produces a project file containing the following root-level [\<Project> element](/visualstudio/msbuild/project-element-msbuild):

--- a/aspnetcore/release-notes/aspnetcore-9/includes/signalrActivities.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/signalrActivities.md
@@ -32,6 +32,6 @@ The SignalR ActivitySource named `Microsoft.AspNetCore.SignalR.Client` emits eve
 * The .NET SignalR client has an `ActivitySource` named `Microsoft.AspNetCore.SignalR.Client`. Hub invocations now create a client span. Note that other SignalR clients, such as the JavaScript client, don't support tracing. This feature will be added to more clients in future releases.
 * Hub invocations on the client and server support [context propagation](https://opentelemetry.io/docs/concepts/context-propagation/). Propagating the trace context enables true distributed tracing. It's now possible to see invocations flow from the client to the server and back.
 
-Here's how these new activities look in the [.NET Aspire dashboard](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/overview?tabs=bash#standalone-mode):
+Here's how these new activities look in the [.NET Aspire dashboard](/dotnet/aspire/fundamentals/dashboard/overview?tabs=bash#standalone-mode):
 
 ![SignalR distributed tracing in Aspire dashboard](~/release-notes/aspnetcore-9/_static/signalr-distributed-tracing-aspire-dashboard.png) 


### PR DESCRIPTION
We're getting build warnings on these.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/visual-studio-publish-profiles.md](https://github.com/dotnet/AspNetCore.Docs/blob/5c459ecf2fd19c6eddabc82d8d0e052931e51637/aspnetcore/host-and-deploy/visual-studio-publish-profiles.md) | [aspnetcore/host-and-deploy/visual-studio-publish-profiles](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/visual-studio-publish-profiles?branch=pr-en-us-34190) |

<!-- PREVIEW-TABLE-END -->