### PR TITLE
QuickGrid empty rows and border styling

### DIFF
--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -138,6 +138,63 @@ To provide a UI for pagination, add a [`Paginator` component](xref:Microsoft.Asp
 
 In the running app, page through the items using a rendered `Paginator` component.
 
+QuickGrid renders additional empty rows to fill in the final page of data when used with a `Paginator` component. In .NET 9 or later, empty data cells (`<td></td>`) are added to the empty rows. The empty rows are intended to facilitate rendering the QuickGrid with stable row height and styling across all pages. You can apply styles to the rows using [CSS isolation](xref:blazor/components/css-isolation) by wrapping the `QuickGrid` component in a wrapper element, such as a `<div>`, and applying a row style with `::deep` [pseudo-elements](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements):
+
+```css
+::deep tr {
+    height: 2em;
+}
+```
+
+:::moniker range=">= aspnetcore-9.0"
+
+<!-- UPDATE 10.0 Check on https://github.com/dotnet/aspnetcore/issues/59078 to see
+                 if an empty row template feature is added that will result in an 
+                 update the following content for >=10.0. -->
+
+In .NET 9 or later, Bootstrap styling adds a bottom border to empty row data cells, which results in a UI artifact. To remove the border styling of the empty cells on these rows, use [CSS isolation](xref:blazor/components/css-isolation).
+
+Consider the following QuickGrid placed in the app's `Index` component. The `QuickGrid` component has a wrapper `<div>` element, which permits you to apply `::deep` [pseudo-elements](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements) to the QuickGrid.
+
+`Index.razor`:
+
+```razor
+<div>
+    <QuickGrid ... Pagination="pagination">
+        ...
+    </QuickGrid>
+</div>
+
+<Paginator State="pagination" />
+
+@code {
+    private PaginationState pagination = new PaginationState { ItemsPerPage = 10 };
+
+    ...
+}
+```
+
+In the following isolated CSS styles:
+
+* Row cells populated with data are displayed.
+* Empty row data cells aren't displayed, which avoids empty row cell borders rendering per the Bootstrap style.
+
+`Index.razor.css`:
+
+```css
+::deep tr:has(> td:not(:empty)) > td {
+    display: table-cell;
+}
+
+::deep td:empty {
+    display: none;
+}
+```
+
+:::moniker-end
+
+For more information on using `::deep` [pseudo-elements](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements) with CSS isolation, see <xref:blazor/components/css-isolation#child-component-support>.
+
 ## Custom attributes and styles
 
 QuickGrid also supports passing custom attributes and style classes (<xref:Microsoft.AspNetCore.Components.QuickGrid.QuickGrid%601.Class%2A>) to the rendered table element:

--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -152,27 +152,7 @@ QuickGrid renders additional empty rows to fill in the final page of data when u
                  if an empty row template feature is added that will result in an 
                  update the following content for >=10.0. -->
 
-In .NET 9 or later, Bootstrap styling adds a bottom border to empty row data cells, which results in a UI artifact. To remove the border styling of the empty cells on these rows, use [CSS isolation](xref:blazor/components/css-isolation).
-
-Consider the following QuickGrid placed in the app's `Index` component. The `QuickGrid` component has a wrapper `<div>` element, which permits you to apply `::deep` [pseudo-elements](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements) to the QuickGrid.
-
-`Index.razor`:
-
-```razor
-<div>
-    <QuickGrid ... Pagination="pagination">
-        ...
-    </QuickGrid>
-</div>
-
-<Paginator State="pagination" />
-
-@code {
-    private PaginationState pagination = new PaginationState { ItemsPerPage = 10 };
-
-    ...
-}
-```
+If you prefer to hide the empty rows rendered by the `QuickGrid`, you may do so using CSS styling to hide the empty data cell in rows that that don't contain any data.
 
 In the following isolated CSS styles:
 

--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -146,20 +146,12 @@ QuickGrid renders additional empty rows to fill in the final page of data when u
 }
 ```
 
-:::moniker range=">= aspnetcore-9.0"
-
-<!-- UPDATE 10.0 Check on https://github.com/dotnet/aspnetcore/issues/59078 to see
-                 if an empty row template feature is added that will result in an 
-                 update the following content for >=10.0. -->
-
-If you prefer to hide the empty rows rendered by the `QuickGrid`, you may do so using CSS styling to hide the empty data cell in rows that that don't contain any data.
-
-In the following isolated CSS styles:
+To hide the empty row data cells rendered by the QuickGrid, use CSS styling. In the following isolated CSS styles:
 
 * Row cells populated with data are displayed.
-* Empty row data cells aren't displayed, which avoids empty row cell borders rendering per the Bootstrap style.
+* Empty row data cells aren't displayed, which avoids empty row cell borders from rendering per Bootstrap styling.
 
-`Index.razor.css`:
+`{COMPONENT}.razor.css`:
 
 ```css
 ::deep tr:has(> td:not(:empty)) > td {
@@ -170,8 +162,6 @@ In the following isolated CSS styles:
     display: none;
 }
 ```
-
-:::moniker-end
 
 For more information on using `::deep` [pseudo-elements](https://developer.mozilla.org/docs/Web/CSS/Pseudo-elements) with CSS isolation, see <xref:blazor/components/css-isolation#child-component-support>.
 


### PR DESCRIPTION
Fixes #34211

This includes the border fix, if you wish to keep it. I'll track the empty data row template PU issue, possibly for .NET 10, which will lead to >=10 modifications to that part of the coverage here.

Do you want the movie dB tutorial to include the border workaround for empty rows?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/quickgrid.md](https://github.com/dotnet/AspNetCore.Docs/blob/7232da59853a689f3bdecceb621e8a6f7b2821bc/aspnetcore/blazor/components/quickgrid.md) | [aspnetcore/blazor/components/quickgrid](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/quickgrid?branch=pr-en-us-34214) |


<!-- PREVIEW-TABLE-END -->