### PR TITLE
Remove Nowin WebSocket sample

### DIFF
--- a/aspnetcore/fundamentals/owin.md
+++ b/aspnetcore/fundamentals/owin.md
@@ -90,58 +90,6 @@ app.UseOwin(pipeline =>
 });
 ```
 
-<a name="hosting-on-owin"></a>
-
-## Run ASP.NET Core on an OWIN-based server and use its WebSockets support
-
-Another example of how OWIN-based servers' features can be leveraged by ASP.NET Core is access to features like WebSockets. The .NET OWIN web server used in the previous example has support for WebSockets built in, which can be leveraged by an ASP.NET Core application. The example below shows a simple web app that supports WebSockets and echoes back everything sent to the server through WebSockets.
-
-```csharp
-public class Startup
-{
-    public void Configure(IApplicationBuilder app)
-    {
-        app.Use(async (context, next) =>
-        {
-            if (context.WebSockets.IsWebSocketRequest)
-            {
-                WebSocket webSocket = await context.WebSockets.AcceptWebSocketAsync();
-                await EchoWebSocket(webSocket);
-            }
-            else
-            {
-                await next();
-            }
-        });
-
-        app.Run(context =>
-        {
-            return context.Response.WriteAsync("Hello World");
-        });
-    }
-
-    private async Task EchoWebSocket(WebSocket webSocket)
-    {
-        byte[] buffer = new byte[1024];
-        WebSocketReceiveResult received = await webSocket.ReceiveAsync(
-            new ArraySegment<byte>(buffer), CancellationToken.None);
-
-        while (!webSocket.CloseStatus.HasValue)
-        {
-            // Echo anything we receive
-            await webSocket.SendAsync(new ArraySegment<byte>(buffer, 0, received.Count), 
-                received.MessageType, received.EndOfMessage, CancellationToken.None);
-
-            received = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), 
-                CancellationToken.None);
-        }
-
-        await webSocket.CloseAsync(webSocket.CloseStatus.Value, 
-            webSocket.CloseStatusDescription, CancellationToken.None);
-    }
-}
-```
-
 ## OWIN environment
 
 You can construct an OWIN environment using the `HttpContext`.


### PR DESCRIPTION
I would prefer to revert https://github.com/dotnet/AspNetCore.Docs/pull/19693, because by moving the Nowin sample, we removed any documentation on how to run ASP.NET Core using an OWIN server. But if we decide that isn't an important enough scenario to still document, since we don't know of any supported OWIN servers that run outside of .NET Framework, the "Run ASP.NET Core on an OWIN-based server and use its WebSockets support" section makes no sense. All it shows is bog standard WebSocket code. The only thing interesting about it was the code to make it work on Nowin which is thankfully still in the [sample directory](https://github.com/dotnet/AspNetCore.Docs/tree/9771604bd406c2415514f09a890d972b5ffb9a5f/aspnetcore/fundamentals/owin/sample/src/NowinWebSockets).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/owin.md](https://github.com/dotnet/AspNetCore.Docs/blob/9d585fc0a0f1982a4b4d0d3e4610db2a141601a3/aspnetcore/fundamentals/owin.md) | [aspnetcore/fundamentals/owin](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/owin?branch=pr-en-us-34221) |

<!-- PREVIEW-TABLE-END -->