### PR TITLE
Add important notes on HybridCache limitations and behavior

### DIFF
--- a/aspnetcore/performance/caching/hybrid.md
+++ b/aspnetcore/performance/caching/hybrid.md
@@ -148,7 +148,8 @@ For more information, see the [HybridCache serialization sample app](https://git
 
 By default `HybridCache` uses <xref:System.Runtime.Caching.MemoryCache> for its primary cache storage. Cache entries are stored in-process, so each server has a separate cache that is lost whenever the server process is restarted. For secondary out-of-process storage, such as Redis or SQL Server, `HybridCache` uses [the configured `IDistributedCache` implementation](xref:performance/caching/distributed), if any. But even without an `IDistributedCache`implementation, the `HybridCache` service still provides in-process caching and [stampede protection](https://en.wikipedia.org/wiki/Cache_stampede).
 
-**Note:** When invalidating the cache by key or by tags, it will be invalidated in the current node and in the secondary out-of-process storage. However, the in-memory cache on other nodes will not be affected.
+> [!NOTE]
+> When invalidating cache entries by key or by tags, they are invalidated in the current server and in the secondary out-of-process storage. However, the in-memory cache in other servers isn't affected.
 
 ## Optimize performance
 

--- a/aspnetcore/performance/caching/hybrid.md
+++ b/aspnetcore/performance/caching/hybrid.md
@@ -73,6 +73,9 @@ When an entry is removed, it is removed from both the primary and secondary cach
 
 ## Remove cache entries by tag
 
+> [!IMPORTANT]
+> This feature is still under development. If you try to remove entries by tag, you will notice that it won't cause any effect yet.
+
 Tags can be used to group cache entries and invalidate them together.
 
 Set tags when calling `GetOrCreateAsync`, as shown in the following example:
@@ -144,6 +147,8 @@ For more information, see the [HybridCache serialization sample app](https://git
 ## Cache storage
 
 By default `HybridCache` uses <xref:System.Runtime.Caching.MemoryCache> for its primary cache storage. Cache entries are stored in-process, so each server has a separate cache that is lost whenever the server process is restarted. For secondary out-of-process storage, such as Redis or SQL Server, `HybridCache` uses [the configured `IDistributedCache` implementation](xref:performance/caching/distributed), if any. But even without an `IDistributedCache`implementation, the `HybridCache` service still provides in-process caching and [stampede protection](https://en.wikipedia.org/wiki/Cache_stampede).
+
+**Note:** When invalidating the cache by key or by tags, it will be invalidated in the current node and in the secondary out-of-process storage. However, the in-memory cache on other nodes will not be affected.
 
 ## Optimize performance
 

--- a/aspnetcore/performance/caching/hybrid.md
+++ b/aspnetcore/performance/caching/hybrid.md
@@ -74,7 +74,7 @@ When an entry is removed, it is removed from both the primary and secondary cach
 ## Remove cache entries by tag
 
 > [!IMPORTANT]
-> This feature is still under development. If you try to remove entries by tag, you will notice that it won't cause any effect yet.
+> This feature is still under development. If you try to remove entries by tag, you will notice that it doesn't have any effect.
 
 Tags can be used to group cache entries and invalidate them together.
 


### PR DESCRIPTION
Fixes #34250

- Added a note indicating that removing cache entries by tag is still under development and is currently non-functional.

- Clarified that cache invalidation by key or tags affects only the current node and secondary storage, but not other nodes' in-memory cache.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/caching/hybrid.md](https://github.com/dotnet/AspNetCore.Docs/blob/08192e0acf12e12d978fdfde62a1f472456aabcf/aspnetcore/performance/caching/hybrid.md) | [HybridCache library in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/caching/hybrid?branch=pr-en-us-34224) |


<!-- PREVIEW-TABLE-END -->