### PR TITLE
[Blazor] State management - StateHasChanged+InvokeAsync

### DIFF
--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -791,7 +791,7 @@ When implementing custom state storage, a useful approach is to adopt [cascading
 
 ## Troubleshoot
 
-When using a custom state management service where you want to support state modifications from outside Blazor's synchronization context (for example from a timer or a background service), all consuming components must wrap the `StateHasChanged` call in <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType>. This ensures the change notification is handled on the renderer's synchronization context.
+When using a custom state management service where you want to support state modifications from outside Blazor's synchronization context (for example from a timer or a background service), all consuming components must wrap the <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> call in <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType>. This ensures the change notification is handled on the renderer's synchronization context.
 
 When the state management service doesn't call <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> on Blazor's synchronization context, the following error is thrown:
 

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -791,7 +791,7 @@ When implementing custom state storage, a useful approach is to adopt [cascading
 
 ## Troubleshoot
 
-When using a custom state management service, if you want to support state modifications from outside Blazor's synchronization context (for example from a timer or a background service), all consuming components must wrap the `StateHasChanged` call in <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType>. This ensures the change notification is handled on the renderer's synchronization context.
+When using a custom state management service where you want to support state modifications from outside Blazor's synchronization context (for example from a timer or a background service), all consuming components must wrap the `StateHasChanged` call in <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType>. This ensures the change notification is handled on the renderer's synchronization context.
 
 When the state management service doesn't call <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> on Blazor's synchronization context, the following error is thrown:
 

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -791,7 +791,7 @@ When implementing custom state storage, a useful approach is to adopt [cascading
 
 ## Troubleshoot
 
-In a custom state management service, a callback invoked outside of Blazor's synchronization context must wrap the logic of the callback in <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType> to move it onto the renderer's synchronization context.
+When using a custom state management service, if you want to support state modifications from outside Blazor's synchronization context (for example from a timer or a background service), all consuming components must wrap the `StateHasChanged` call in <xref:Microsoft.AspNetCore.Components.ComponentBase.InvokeAsync%2A?displayProperty=nameWithType>. This ensures the change notification is handled on the renderer's synchronization context.
 
 When the state management service doesn't call <xref:Microsoft.AspNetCore.Components.ComponentBase.StateHasChanged%2A> on Blazor's synchronization context, the following error is thrown:
 


### PR DESCRIPTION
> In a custom state management service, a callback invoked outside of Blazor's synchronization context must wrap the logic of the callback in [ComponentBase.InvokeAsync](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.components.componentbase.invokeasync) to move it onto the renderer's synchronization context.

There isn’t a straightforward way to use `ComponentBase.InvokeAsync` directly in a custom state management service. Instead, each component subscribed to the `OnChange` event must handle it by wrapping the `StateHasChanged` call in `InvokeAsync`. This means the responsibility for ensuring synchronization with Blazor’s rendering context falls on the components themselves.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/state-management.md](https://github.com/dotnet/AspNetCore.Docs/blob/e53ac22800db1f532ccf6d29cbe4fb5ee6c0ba56/aspnetcore/blazor/state-management.md) | [aspnetcore/blazor/state-management](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/state-management?branch=pr-en-us-34237) |


<!-- PREVIEW-TABLE-END -->