### PR TITLE
[Blazor] Debug - missing *

### DIFF
--- a/aspnetcore/blazor/debug.md
+++ b/aspnetcore/blazor/debug.md
@@ -386,7 +386,7 @@ The additional options in the following table only apply to **hosted Blazor WebA
 *The guidance in this section applies debugging Blazor WebAssembly apps in:*
 
 * ***Google Chrome*** *running on Windows or macOS.*
-* ***Microsoft Edge** *running on Windows.*
+* ***Microsoft Edge*** *running on Windows.*
 
 1. Run the app in a command shell with `dotnet watch` (or `dotnet run`).
 1. Launch a browser and navigate to the app's URL.


### PR DESCRIPTION
styling

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/debug.md](https://github.com/dotnet/AspNetCore.Docs/blob/b9d8c73998dfe028e4cd3a7a1da9cf2a977a6d38/aspnetcore/blazor/debug.md) | [Debug ASP.NET Core apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/debug?branch=pr-en-us-34240) |

<!-- PREVIEW-TABLE-END -->