### PR TITLE
[Blazor] webassembly-lazy-load-assemblies.md - Forms package already referenced

### DIFF
--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -339,10 +339,6 @@ Add an ASP.NET Core class library project to the solution:
 * Visual Studio: Right-click the solution file in **Solution Explorer** and select **Add** > **New project**. From the dialog of new project types, select **Razor Class Library**. Name the project `GrantImaharaRobotControls`. Do **not** select the **Support pages and view** checkbox.
 * Visual Studio Code/.NET CLI: Execute `dotnet new razorclasslib -o GrantImaharaRobotControls` from a command prompt. The `-o|--output` option creates a folder and names the project `GrantImaharaRobotControls`.
 
-The example component presented later in this section uses a [Blazor form](xref:blazor/forms/index). In the RCL project, add the [`Microsoft.AspNetCore.Components.Forms`](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.Forms) package to the project.
-
-[!INCLUDE[](~/includes/package-reference.md)]
-
 Create a `HandGesture` class in the RCL with a `ThumbUp` method that hypothetically makes a robot perform a thumbs-up gesture. The method accepts an argument for the axis, `Left` or `Right`, as an [`enum`](/dotnet/csharp/language-reference/builtin-types/enum). The method returns `true` on success.
 
 `HandGesture.cs`:

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -336,7 +336,7 @@ Create a standalone Blazor WebAssembly app to demonstrate lazy loading of a Razo
 
 Add an ASP.NET Core class library project to the solution: 
 
-* Visual Studio: Right-click the solution file in **Solution Explorer** and select **Add** > **New project**. From the dialog of new project types, select **Razor Class Library**. Name the project `GrantImaharaRobotControls`. Do **not** select the **Support pages and view** checkbox.
+* Visual Studio: Right-click the solution file in **Solution Explorer** and select **Add** > **New project**. From the dialog of new project types, select **Razor Class Library**. Name the project `GrantImaharaRobotControls`. Do **not** select the **Support pages and views** checkbox.
 * Visual Studio Code/.NET CLI: Execute `dotnet new razorclasslib -o GrantImaharaRobotControls` from a command prompt. The `-o|--output` option creates a folder and names the project `GrantImaharaRobotControls`.
 
 Create a `HandGesture` class in the RCL with a `ThumbUp` method that hypothetically makes a robot perform a thumbs-up gesture. The method accepts an argument for the axis, `Left` or `Right`, as an [`enum`](/dotnet/csharp/language-reference/builtin-types/enum). The method returns `true` on success.


### PR DESCRIPTION
The `Microsoft.AspNetCore.Components.Forms` package is already transitively referenced by `Microsoft.AspNetCore.Components.Web` package (which is included in the RCL template). No need to add explicit reference to `Forms` package.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/webassembly-lazy-load-assemblies.md](https://github.com/dotnet/AspNetCore.Docs/blob/e2a24fd658a0bebf94855c5264b3cf84bcdfd8d4/aspnetcore/blazor/webassembly-lazy-load-assemblies.md) | [Lazy load assemblies in ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-lazy-load-assemblies?branch=pr-en-us-34242) |


<!-- PREVIEW-TABLE-END -->