### PR TITLE
[Blazor] Lazy loading - Complete example - Prevent repeated loads

### DIFF
--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -658,10 +658,10 @@ The assembly is assigned to <xref:Microsoft.AspNetCore.Components.Routing.Router
         {
             if ((args.Path == "robot") && !grantImaharaRobotControlsAssemblyLoaded)
             {
-                grantImaharaRobotControlsAssemblyLoaded = true;
                 var assemblies = await AssemblyLoader.LoadAssembliesAsync(
                     new[] { "GrantImaharaRobotControls.{FILE EXTENSION}" });
                 lazyLoadedAssemblies.AddRange(assemblies);
+                grantImaharaRobotControlsAssemblyLoaded = true;
             }
         }
         catch (Exception ex)

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -604,10 +604,10 @@ The assembly is assigned to <xref:Microsoft.AspNetCore.Components.Routing.Router
         {
             if ((args.Path == "robot") && !grantImaharaRobotControlsAssemblyLoaded)
             {
-                grantImaharaRobotControlsAssemblyLoaded = true;
                 var assemblies = await AssemblyLoader.LoadAssembliesAsync(
                     new[] { "GrantImaharaRobotControls.{FILE EXTENSION}" });
                 lazyLoadedAssemblies.AddRange(assemblies);
+                grantImaharaRobotControlsAssemblyLoaded = true;
             }
         }
         catch (Exception ex)

--- a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
+++ b/aspnetcore/blazor/webassembly-lazy-load-assemblies.md
@@ -596,13 +596,15 @@ The assembly is assigned to <xref:Microsoft.AspNetCore.Components.Routing.Router
 
 @code {
     private List<Assembly> lazyLoadedAssemblies = new();
+    private bool grantImaharaRobotControlsAssemblyLoaded;
 
     private async Task OnNavigateAsync(NavigationContext args)
     {
         try
         {
-            if (args.Path == "robot")
+            if ((args.Path == "robot") && !grantImaharaRobotControlsAssemblyLoaded)
             {
+                grantImaharaRobotControlsAssemblyLoaded = true;
                 var assemblies = await AssemblyLoader.LoadAssembliesAsync(
                     new[] { "GrantImaharaRobotControls.{FILE EXTENSION}" });
                 lazyLoadedAssemblies.AddRange(assemblies);
@@ -648,13 +650,15 @@ The assembly is assigned to <xref:Microsoft.AspNetCore.Components.Routing.Router
 
 @code {
     private List<Assembly> lazyLoadedAssemblies = new List<Assembly>();
+    private bool grantImaharaRobotControlsAssemblyLoaded;
 
     private async Task OnNavigateAsync(NavigationContext args)
     {
         try
         {
-            if (args.Path == "robot")
+            if ((args.Path == "robot") && !grantImaharaRobotControlsAssemblyLoaded)
             {
+                grantImaharaRobotControlsAssemblyLoaded = true;
                 var assemblies = await AssemblyLoader.LoadAssembliesAsync(
                     new[] { "GrantImaharaRobotControls.{FILE EXTENSION}" });
                 lazyLoadedAssemblies.AddRange(assemblies);


### PR DESCRIPTION
Even though repeated calls to `AssemblyLoader.LoadAssembliesAsync()` don't download the assembly multiple times or throw exception:  
- They still trigger asynchronous calls to JavaScript.  
- The `<Navigating>` content is rendered in the meantime, causing unnecessary UI flickering when navigating to the lazy-loaded area repeatedly.  
- The `lazyLoadedAssemblies` collection gets populated with duplicate entries.  

Therefore, lazy-loading should be guarded with an "already loaded" flag.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/webassembly-lazy-load-assemblies.md](https://github.com/dotnet/AspNetCore.Docs/blob/6d848125dd50a3e46c68b1ffc5b3243c5815803a/aspnetcore/blazor/webassembly-lazy-load-assemblies.md) | [aspnetcore/blazor/webassembly-lazy-load-assemblies](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-lazy-load-assemblies?branch=pr-en-us-34243) |


<!-- PREVIEW-TABLE-END -->