### PR TITLE
[Blazor] Performance - Change detection - set parameters only

### DIFF
--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -35,7 +35,7 @@ The last two steps of the preceding sequence continue recursively down the compo
 
 To prevent rendering recursion into a particular subtree, use either of the following approaches:
 
-* Ensure that the *set* parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
+* Ensure that the **set** parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
   * To accept nonprimitive parameter values, such as complex custom model types, event callbacks, or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
   * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -35,7 +35,7 @@ The last two steps of the preceding sequence continue recursively down the compo
 
 To prevent rendering recursion into a particular subtree, use either of the following approaches:
 
-* Ensure that child component parameters are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
+* Ensure that the *set* parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
   * To accept nonprimitive parameter values, such as complex custom model types, event callbacks, or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
   * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -33,9 +33,9 @@ At runtime, components exist in a hierarchy. A root component (the first compone
 
 The last two steps of the preceding sequence continue recursively down the component hierarchy. In many cases, the entire subtree is rerendered. Events targeting high-level components can cause expensive rerendering because every component below the high-level component must rerender.
 
-:::moniker range=">= aspnetcore-9.0"
-
 To prevent rendering recursion into a particular subtree, use either of the following approaches:
+
+:::moniker range=">= aspnetcore-9.0"
 
 * Ensure that the set parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
@@ -45,8 +45,6 @@ To prevent rendering recursion into a particular subtree, use either of the foll
 :::moniker-end
 
 :::moniker range="< aspnetcore-9.0"
-
-To prevent rendering recursion into a particular subtree, use either of the following approaches:
 
 * Ensure that the set parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -37,7 +37,7 @@ The last two steps of the preceding sequence continue recursively down the compo
 
 To prevent rendering recursion into a particular subtree, use either of the following approaches:
 
-* Ensure that the **set** parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
+* Ensure that the set parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
   * To accept nonprimitive parameter values, such as complex custom model types, or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
   * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -39,7 +39,7 @@ To prevent rendering recursion into a particular subtree, use either of the foll
 
 * Ensure that the set parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
-  * To accept nonprimitive parameter values, such as complex custom model types, or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
+  * To accept nonprimitive parameter values, such as complex custom model types or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
   * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.
  
 :::moniker-end

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -48,7 +48,7 @@ To prevent rendering recursion into a particular subtree, use either of the foll
 
 To prevent rendering recursion into a particular subtree, use either of the following approaches:
 
-* Ensure that the **set** parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
+* Ensure that the set parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
   * To accept nonprimitive parameter values, such as complex custom model types, event callbacks, or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
   * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.

--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -33,12 +33,27 @@ At runtime, components exist in a hierarchy. A root component (the first compone
 
 The last two steps of the preceding sequence continue recursively down the component hierarchy. In many cases, the entire subtree is rerendered. Events targeting high-level components can cause expensive rerendering because every component below the high-level component must rerender.
 
+:::moniker range=">= aspnetcore-9.0"
+
+To prevent rendering recursion into a particular subtree, use either of the following approaches:
+
+* Ensure that the **set** parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
+* Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
+  * To accept nonprimitive parameter values, such as complex custom model types, or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
+  * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.
+ 
+:::moniker-end
+
+:::moniker range="< aspnetcore-9.0"
+
 To prevent rendering recursion into a particular subtree, use either of the following approaches:
 
 * Ensure that the **set** parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
   * To accept nonprimitive parameter values, such as complex custom model types, event callbacks, or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
   * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.
+ 
+:::moniker-end
 
 The following airline flight search tool example uses private fields to track the necessary information to detect changes. The previous inbound flight identifier (`prevInboundFlightId`) and previous outbound flight identifier (`prevOutboundFlightId`) track information for the next potential component update. If either of the flight identifiers change when the component's parameters are set in [`OnParametersSet`](xref:blazor/components/lifecycle#after-parameters-are-set-onparameterssetasync), the component is rerendered because `shouldRender` is set to `true`. If `shouldRender` evaluates to `false` after checking the flight identifiers, an expensive rerender is avoided:
 


### PR DESCRIPTION
1. When I think back to what wasn’t entirely clear to me and I had to test and look up in the source code - the whole condition for primitive types in change detection applies to the parameters **used (set)** in a specific place, not to the component **having** non-primitive parameters.
2. Starting net9 EventCallbacks are included in change detection.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/performance.md](https://github.com/dotnet/AspNetCore.Docs/blob/b79fd5034b4902ee7429e140f1aedf21c6fa2a00/aspnetcore/blazor/performance.md) | [ASP.NET Core Blazor performance best practices](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/performance?branch=pr-en-us-34281) |


<!-- PREVIEW-TABLE-END -->