### PR TITLE
[Blazor] Performance - IsFixed=true for `this` explanation

### DIFF
--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -35,23 +35,10 @@ The last two steps of the preceding sequence continue recursively down the compo
 
 To prevent rendering recursion into a particular subtree, use either of the following approaches:
 
-:::moniker range=">= aspnetcore-9.0"
-
-* Ensure that the set parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
-* Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
-  * To accept nonprimitive parameter values, such as complex custom model types or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
-  * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.
- 
-:::moniker-end
-
-:::moniker range="< aspnetcore-9.0"
-
-* Ensure that the set parameters of child components are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. Only the parameters that are explicitly set on the component are considered for change detection. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
+* Ensure that child component parameters are of primitive immutable types, such as `string`, `int`, `bool`, `DateTime`, and other similar types. The built-in logic for detecting changes automatically skips rerendering if the primitive immutable parameter values haven't changed. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
 * Override <xref:Microsoft.AspNetCore.Components.ComponentBase.ShouldRender%2A>:
   * To accept nonprimitive parameter values, such as complex custom model types, event callbacks, or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
   * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.
- 
-:::moniker-end
 
 The following airline flight search tool example uses private fields to track the necessary information to detect changes. The previous inbound flight identifier (`prevInboundFlightId`) and previous outbound flight identifier (`prevOutboundFlightId`) track information for the next potential component update. If either of the flight identifiers change when the component's parameters are set in [`OnParametersSet`](xref:blazor/components/lifecycle#after-parameters-are-set-onparameterssetasync), the component is rerendered because `shouldRender` is set to `true`. If `shouldRender` evaluates to `false` after checking the flight identifiers, an expensive rerender is avoided:
 
@@ -261,7 +248,7 @@ The [`CascadingValue` component](xref:blazor/components/cascading-values-and-par
 
 Setting `IsFixed` to `true` improves performance if there are a large number of other components that receive the cascaded value. Wherever possible, set `IsFixed` to `true` on cascaded values. You can set `IsFixed` to `true` when the supplied value doesn't change over time.
 
-Where a component passes `this` as a cascaded value, `IsFixed` can also be set to `true`:
+Where a component passes `this` as a cascaded value, `IsFixed` can also be set to `true`, because `this` never changes during the component's lifecycle:
 
 ```razor
 <CascadingValue Value="this" IsFixed="true">


### PR DESCRIPTION
relates to re-rendering discussed above in the article

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/performance.md](https://github.com/dotnet/AspNetCore.Docs/blob/5445e7b325a0463a0ca6b7532feaea42ecdd9dcc/aspnetcore/blazor/performance.md) | [ASP.NET Core Blazor performance best practices](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/performance?branch=pr-en-us-34292) |

<!-- PREVIEW-TABLE-END -->