### PR TITLE
[Blazor] Performance - Event callbacks in RenderFragments

### DIFF
--- a/aspnetcore/blazor/performance.md
+++ b/aspnetcore/blazor/performance.md
@@ -195,7 +195,7 @@ public static RenderFragment SayHello = @<h1>Hello!</h1>;
 }
 ```
 
-The preceding approach reuses rendering logic without per-component overhead. However, the approach doesn't permit refreshing the subtree of the UI independently, nor does it have the ability to skip rendering the subtree of the UI when its parent renders because there's no component boundary. Assignment to a <xref:Microsoft.AspNetCore.Components.RenderFragment> delegate is only supported in Razor component files (`.razor`), and [event callbacks](xref:blazor/components/event-handling#eventcallback) aren't supported.
+The preceding approach reuses rendering logic without per-component overhead. However, the approach doesn't permit refreshing the subtree of the UI independently, nor does it have the ability to skip rendering the subtree of the UI when its parent renders because there's no component boundary. Assignment to a <xref:Microsoft.AspNetCore.Components.RenderFragment> delegate is only supported in Razor component files (`.razor`).
 
 For a non-static field, method, or property that can't be referenced by a field initializer, such as `TitleTemplate` in the following example, use a property instead of a field for the <xref:Microsoft.AspNetCore.Components.RenderFragment>:
 


### PR DESCRIPTION
I'm not sure what was meant by "event callbacks aren't supported" in this context.

This code with event callback works as expected:
```razor
@page "/counter"
@using Microsoft.Extensions.Logging
@inject ILogger<Counter> Logger

@MyRenderFragment

@code {
	private RenderFragment? MyRenderFragment => @<button @onclick="HandleValidSubmit">Submit</button>;

	private void HandleValidSubmit()
	{
		Logger.LogInformation("HandleValidSubmit called");
	}
}
```

(Don't worry, this is my last PR for today. 😇)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/performance.md](https://github.com/dotnet/AspNetCore.Docs/blob/aef6f508c6b6ced745a461b5fa46faf324392a4c/aspnetcore/blazor/performance.md) | [ASP.NET Core Blazor performance best practices](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/performance?branch=pr-en-us-34293) |

<!-- PREVIEW-TABLE-END -->