### PR TITLE
Drop Xamarin from Blazor articles

### DIFF
--- a/aspnetcore/blazor/hybrid/index.md
+++ b/aspnetcore/blazor/hybrid/index.md
@@ -80,12 +80,7 @@ When dynamically changing the app culture at runtime, the app must be reloaded t
 
 .NET's resource system supports embedding localized images (as blobs) into an app, but Blazor Hybrid can't display the embedded images in Razor components at this time. Even if a user reads an image's bytes into a <xref:System.IO.Stream> using <xref:System.Resources.ResourceManager>, the framework doesn't currently support rendering the retrieved image in a Razor component.
 
-[A platform-specific approach to include localized images](/xamarin/xamarin-forms/user-interface/images#local-images) is a feature of .NET's resource system, but a Razor component's browser elements in a .NET MAUI Blazor Hybrid app aren't able to interact with such images.
-
-For more information, see the following resources:
-
-* [Xamarin.Forms String and Image Localization](/xamarin/xamarin-forms/app-fundamentals/localization/): The guidance generally applies to Blazor Hybrid apps. Not every scenario is supported at this time.
-* [Blazor Image component to display images that are not accessible through HTTP endpoints (dotnet/aspnetcore #25274)](https://github.com/dotnet/aspnetcore/issues/25274)
+For more information, see [Blazor Image component to display images that are not accessible through HTTP endpoints (dotnet/aspnetcore #25274)](https://github.com/dotnet/aspnetcore/issues/25274)
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/hybrid/index.md
+++ b/aspnetcore/blazor/hybrid/index.md
@@ -80,7 +80,10 @@ When dynamically changing the app culture at runtime, the app must be reloaded t
 
 .NET's resource system supports embedding localized images (as blobs) into an app, but Blazor Hybrid can't display the embedded images in Razor components at this time. Even if a user reads an image's bytes into a <xref:System.IO.Stream> using <xref:System.Resources.ResourceManager>, the framework doesn't currently support rendering the retrieved image in a Razor component.
 
-For more information, see [Blazor Image component to display images that are not accessible through HTTP endpoints (dotnet/aspnetcore #25274)](https://github.com/dotnet/aspnetcore/issues/25274)
+For more information, see the following resources:
+
+* [Localization (.NET MAUI documentation)](/dotnet/maui/fundamentals/localization)
+* [Blazor Image component to display images that are not accessible through HTTP endpoints (dotnet/aspnetcore #25274)](https://github.com/dotnet/aspnetcore/issues/25274)
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/hybrid/security/index.md
+++ b/aspnetcore/blazor/hybrid/security/index.md
@@ -36,7 +36,7 @@ After authentication is added to a .NET MAUI, WPF, or Windows Forms app and user
 
 :::zone pivot="maui"
 
-.NET MAUI apps use [Xamarin.Essentials: Web Authenticator](/xamarin/essentials/web-authenticator): The `WebAuthenticator` class allows the app to initiate browser-based authentication flows that listen for a callback to a specific URL registered with the app.
+.NET MAUI apps use the `WebAuthenticator` class to initiate browser-based authentication flows that listen for a callback to a specific URL registered with the app.
 
 For additional guidance, see the following resources:
 
@@ -574,7 +574,7 @@ After authentication is added to a .NET MAUI, WPF, or Windows Forms app and user
 
 :::zone pivot="maui"
 
-.NET MAUI apps use [Xamarin.Essentials: Web Authenticator](/xamarin/essentials/web-authenticator): The `WebAuthenticator` class allows the app to initiate browser-based authentication flows that listen for a callback to a specific URL registered with the app.
+.NET MAUI apps use the `WebAuthenticator` class to initiate browser-based authentication flows that listen for a callback to a specific URL registered with the app.
 
 For additional guidance, see the following resources:
 

--- a/aspnetcore/blazor/hybrid/tutorials/maui.md
+++ b/aspnetcore/blazor/hybrid/tutorials/maui.md
@@ -117,7 +117,7 @@ In the **Create a Default Android Device** window, select the **Create** button:
 Wait for Visual Studio to download, unzip, and create an Android Emulator. When the Android phone emulator is ready, select the **Start** button.
 
 > [!NOTE]
-> [Enable hardware acceleration](/xamarin/android/get-started/installation/android-emulator/hardware-acceleration) to improve the performance of the Android emulator.
+> [Enable hardware acceleration](/dotnet/maui/android/emulator/hardware-acceleration) to improve the performance of the Android emulator.
 
 Close the **Android Device Manager** window. Wait until the emulated phone window appears, the Android OS loads, and the home screen appears.
 
@@ -132,7 +132,7 @@ In the Visual Studio toolbar, select the **:::no-loc text="Pixel 5 - {VERSION}":
 
 Visual Studio builds the project and deploys the app to the emulator.
 
-Starting the emulator, loading the emulated phone and OS, and deploying and running the app can take several minutes depending on the speed of the system and whether or not [hardware acceleration](/xamarin/android/get-started/installation/android-emulator/hardware-acceleration) is enabled. You can monitor the progress of the deployment by inspecting Visual Studio's status bar at the bottom of the UI. The **Ready** indicator receives a checkmark and the emulator's deployment and app loading indicators disappear when the app is running:
+Starting the emulator, loading the emulated phone and OS, and deploying and running the app can take several minutes depending on the speed of the system and whether or not [hardware acceleration](/dotnet/maui/android/emulator/hardware-acceleration) is enabled. You can monitor the progress of the deployment by inspecting Visual Studio's status bar at the bottom of the UI. The **Ready** indicator receives a checkmark and the emulator's deployment and app loading indicators disappear when the app is running:
 
 During deployment:
 

--- a/aspnetcore/blazor/index.md
+++ b/aspnetcore/blazor/index.md
@@ -182,7 +182,7 @@ For apps that require third-party JavaScript libraries and access to browser API
 
 ## Code sharing and .NET Standard
 
-Blazor implements the [.NET Standard](/dotnet/standard/net-standard), which enables Blazor projects to reference libraries that conform to .NET Standard specifications. .NET Standard is a formal specification of .NET APIs that are common across .NET implementations. .NET Standard class libraries can be shared across different .NET platforms, such as Blazor, .NET Framework, .NET Core, Xamarin, Mono, and Unity.
+Blazor implements the [.NET Standard](/dotnet/standard/net-standard), which enables Blazor projects to reference libraries that conform to .NET Standard specifications. .NET Standard is a formal specification of .NET APIs that are common across .NET implementations. .NET Standard class libraries can be shared across different .NET platforms, such as Blazor, .NET Framework, .NET Core, .NET Multi-platform App UI (.NET MAUI), Mono, and Unity.
 
 APIs that aren't applicable inside of a web browser (for example, accessing the file system, opening a socket, and threading) throw a <xref:System.PlatformNotSupportedException>.
 


### PR DESCRIPTION
Fixes #34325

@wadepickett ... Had a few minutes to knock this out now 🤜😵. This resolves it for the "blazor" node articles. 

No review necessary. I found the replacement links; or in one case, the link was already there below the Xamarin remark, so I only had to remove the Xamarin cross-link.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/4217eff73aae79d92dc352fff952039b05717d64/aspnetcore/blazor/hybrid/index.md) | [aspnetcore/blazor/hybrid/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/index?branch=pr-en-us-34328) |
| [aspnetcore/blazor/hybrid/security/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/4217eff73aae79d92dc352fff952039b05717d64/aspnetcore/blazor/hybrid/security/index.md) | [aspnetcore/blazor/hybrid/security/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/security/index?branch=pr-en-us-34328) |
| [aspnetcore/blazor/hybrid/tutorials/maui.md](https://github.com/dotnet/AspNetCore.Docs/blob/4217eff73aae79d92dc352fff952039b05717d64/aspnetcore/blazor/hybrid/tutorials/maui.md) | [aspnetcore/blazor/hybrid/tutorials/maui](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/tutorials/maui?branch=pr-en-us-34328) |
| [aspnetcore/blazor/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/4217eff73aae79d92dc352fff952039b05717d64/aspnetcore/blazor/index.md) | [aspnetcore/blazor/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/index?branch=pr-en-us-34328) |

<!-- PREVIEW-TABLE-END -->