### PR TITLE
[Blazor] synchronous-js-interop-call-js.md - fully synchronous code sample

### DIFF
--- a/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
+++ b/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
@@ -38,7 +38,7 @@ When working with <xref:Microsoft.JSInterop.IJSObjectReference> in ASP.NET Core 
         {
             var jsInProcess = (IJSInProcessRuntime)JS;
             module = await jsInProcess.Invoke<IJSInProcessObjectReference>("import", 
-            "./scripts.js");
+                "./scripts.js");
             var value = module.Invoke<string>("javascriptFunctionIdentifier");
         }
     }

--- a/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
+++ b/aspnetcore/blazor/includes/js-interop/synchronous-js-interop-call-js.md
@@ -24,7 +24,7 @@ When working with <xref:Microsoft.JSInterop.IJSObjectReference> in ASP.NET Core 
 
 ```razor
 @inject IJSRuntime JS
-@implements IAsyncDisposable
+@implements IDisposable
 
 ...
 
@@ -36,18 +36,20 @@ When working with <xref:Microsoft.JSInterop.IJSObjectReference> in ASP.NET Core 
     {
         if (firstRender)
         {
-            module = await JS.InvokeAsync<IJSInProcessObjectReference>("import", 
+            var jsInProcess = (IJSInProcessRuntime)JS;
+            module = await jsInProcess.Invoke<IJSInProcessObjectReference>("import", 
             "./scripts.js");
+            var value = module.Invoke<string>("javascriptFunctionIdentifier");
         }
     }
 
     ...
 
-    async ValueTask IAsyncDisposable.DisposeAsync()
+    void IDisposable.Dispose()
     {
         if (module is not null)
         {
-            await module.DisposeAsync();
+            await module.Dispose();
         }
     }
 }


### PR DESCRIPTION
1. When mentioning `IJSInProcessObjectReference`, we should demonstrate its usage in the sample, not just retrieve it. I’ve added the line `var value = module.Invoke<string>("javascriptFunctionIdentifier");` to address this.

2. When discussing the performance benefits of synchronous WASM calls over asynchronous code (as this file is part of the Blazor Performance article), the entire sample should be synchronous for consistency.