### PR TITLE
State preservation (common provider) updates

### DIFF
--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -517,4 +517,4 @@ The following `ExampleTabSet` component uses the `TabSet` component, which conta
 ## Additional resources
 
 * [Generic type support: Explicit generic types based on ancestor components](xref:blazor/components/generic-type-support#explicit-generic-types-based-on-ancestor-components)
-* [State management: Factor out the state preservation to a common location](xref:blazor/state-management?pivots=server#factor-out-the-state-preservation-to-a-common-location)
+* [State management: Factor out state preservation to a common provider](xref:blazor/state-management?pivots=server#factor-out-state-preservation-to-a-common-provider)

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -405,7 +405,7 @@ If many components rely on browser-based storage, implementing state provider co
 
 In the following example of a `CounterStateProvider` component, counter data is persisted to `sessionStorage`, and it handles the loading phase by not rendering its child content until state loading is complete.
 
-The `CounterStateProvider` component works in both server-side (Blazor Web Apps and Blazor Server) and Blazor WebAssembly apps. In server-side apps, the component deals with prerendering by not loading state until after component rendering in the [`OnAfterRenderAsync` lifecycle method](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync), which doesn't execute during prerendering.
+The `CounterStateProvider` component deals with prerendering by not loading state until after component rendering in the [`OnAfterRenderAsync` lifecycle method](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync), which doesn't execute during prerendering.
 
 The approach in this section isn't capable of triggering rerendering of multiple subscribed components on the same page. If one subscribed component changes the state, it rerenders and can display the updated state, but a different component on the same page displaying that state displays stale data until its own next rerender. Therefore, the approach described in this section is best suited to using state in a single component on the page.
 

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -399,11 +399,17 @@ else
 
 :::moniker-end
 
-### Factor out the state preservation to a common location
+### Factor out state preservation to a common provider
 
 If many components rely on browser-based storage, implementing state provider code many times creates code duplication. One option for avoiding code duplication is to create a *state provider parent component* that encapsulates the state provider logic. Child components can work with persisted data without regard to the state persistence mechanism.
 
-In the following example of a `CounterStateProvider` component, counter data is persisted to `sessionStorage`:
+In the following example of a `CounterStateProvider` component, counter data is persisted to `sessionStorage`, and it handles the loading phase by not rendering its child content until state loading is complete.
+
+The `CounterStateProvider` component works in both server-side (Blazor Web Apps and Blazor Server) and Blazor WebAssembly apps. In server-side apps, the component deals with prerendering by not loading state until after component rendering in the [`OnAfterRenderAsync` lifecycle method](xref:blazor/components/lifecycle#after-component-render-onafterrenderasync), which doesn't execute during prerendering.
+
+The approach in this section isn't capable of triggering rerendering of multiple subscribed components on the same page. If one subscribed component changes the state, it rerenders and can display the updated state, but a different component on the same page displaying that state displays stale data until its own next rerender. Therefore, the approach described in this section is best suited to using state in a single component on the page.
+
+`CounterStateProvider.razor`:
 
 :::moniker range=">= aspnetcore-5.0"
 
@@ -430,15 +436,26 @@ else
 
     public int CurrentCount { get; set; }
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            isLoaded = true;
+            await LoadStateAsync();
+            StateHasChanged();
+        }
+    }
+
+    private async Task LoadStateAsync()
     {
         var result = await ProtectedSessionStore.GetAsync<int>("count");
         CurrentCount = result.Success ? result.Value : 0;
-        isLoaded = true;
+        isConnected = true;
     }
 
-    public async Task SaveChangesAsync()
+    public async Task IncrementCount()
     {
+        CurrentCount++;
         await ProtectedSessionStore.SetAsync("count", CurrentCount);
     }
 }
@@ -471,14 +488,25 @@ else
 
     public int CurrentCount { get; set; }
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        CurrentCount = await ProtectedSessionStore.GetAsync<int>("count");
-        isLoaded = true;
+        if (firstRender)
+        {
+            isLoaded = true;
+            await LoadStateAsync();
+            StateHasChanged();
+        }
     }
 
-    public async Task SaveChangesAsync()
+    private async Task LoadStateAsync()
     {
+        CurrentCount = await ProtectedSessionStore.GetAsync<int>("count");
+        isConnected = true;
+    }
+
+    public async Task IncrementCount()
+    {
+        CurrentCount++;
         await ProtectedSessionStore.SetAsync("count", CurrentCount);
     }
 }
@@ -488,8 +516,6 @@ else
 
 > [!NOTE]
 > For more information on <xref:Microsoft.AspNetCore.Components.RenderFragment>, see <xref:blazor/components/index#child-content-render-fragments>.
-
-The `CounterStateProvider` component handles the loading phase by not rendering its child content until state loading is complete.
 
 :::moniker range=">= aspnetcore-8.0"
 
@@ -541,16 +567,13 @@ Wrapped components receive and can modify the persisted counter state. The follo
     {
         if (CounterStateProvider is not null)
         {
-            CounterStateProvider.CurrentCount++;
-            await CounterStateProvider.SaveChangesAsync();
+            await CounterStateProvider.IncrementCount();
         }
     }
 }
 ```
 
 The preceding component isn't required to interact with `ProtectedBrowserStorage`, nor does it deal with a "loading" phase.
-
-To deal with prerendering as described earlier, `CounterStateProvider` can be amended so that all of the components that consume the counter data automatically work with prerendering. For more information, see the [Handle prerendering](#handle-prerendering) section.
 
 In general, the *state provider parent component* pattern is recommended:
 

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -469,7 +469,7 @@ else
 @using Microsoft.AspNetCore.ProtectedBrowserStorage
 @inject ProtectedSessionStorage ProtectedSessionStore
 
-@if (isLoaded)
+@if (isConnected)
 {
     <CascadingValue Value="this">
         @ChildContent
@@ -481,7 +481,7 @@ else
 }
 
 @code {
-    private bool isLoaded;
+    private bool isConnected;
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }
@@ -492,7 +492,7 @@ else
     {
         if (firstRender)
         {
-            isLoaded = true;
+            isConnected = true;
             await LoadStateAsync();
             StateHasChanged();
         }


### PR DESCRIPTION
Addresses #34236

@hakenr ... Let's see if we can make some progress with obvious problems in the section just to get the ball rolling.

I placed some 🦖 ***RexHacks!™*** 🙈 on here to at least improve things while the thrust of your main suggestion is discussed on the issue.

Three goals of this ...

* Change the section heading to say what this is. The state provider is in the "common location," so I'm seeing if the heading as "*Factor out state preservation to a common provider*" works.
* Discuss the prerendering situation and update the code to deal with it.
* Explicitly call out that this isn't good for multiple components that modify/render the state on the same page.

BTW ... I don't speak to getting access to state from a provider ***during prerendering***, which is something to consider at least remarking on. Given the backing storage, should the article include a line to the effect ...

> For state management during prerendering, choose a different storage mechanism and access state in an earlier lifecycle method.

Simple enough. Does that approach to covering it make sense? 🤔

If we get this polished up and place it in the article, then your issue is about adding a ***new section***, perhaps entitled, "*Factor out state preservation to a common location*," which is basically the old title of this section.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/cascading-values-and-parameters.md](https://github.com/dotnet/AspNetCore.Docs/blob/6f526abe36d7baa8e18d3a816c228803ae091c53/aspnetcore/blazor/components/cascading-values-and-parameters.md) | [aspnetcore/blazor/components/cascading-values-and-parameters](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/cascading-values-and-parameters?branch=pr-en-us-34337) |
| [aspnetcore/blazor/state-management.md](https://github.com/dotnet/AspNetCore.Docs/blob/6f526abe36d7baa8e18d3a816c228803ae091c53/aspnetcore/blazor/state-management.md) | [aspnetcore/blazor/state-management](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/state-management?branch=pr-en-us-34337) |


<!-- PREVIEW-TABLE-END -->