### PR TITLE
Remove logger step

### DIFF
--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity/qrcodes-for-authenticator-apps.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity/qrcodes-for-authenticator-apps.md
@@ -160,16 +160,6 @@ At the top of the `CookieAuthenticationStateProvider.cs` file, add a `using` sta
 using System.Text.Json.Serialization;
 ```
 
-Inject an `ILogger<CookieAuthenticationStateProvider>` to log exceptions in the class:
-
-```diff
-- public class CookieAuthenticationStateProvider(IHttpClientFactory httpClientFactory) 
--     : AuthenticationStateProvider, IAccountManagement
-+ public class CookieAuthenticationStateProvider(IHttpClientFactory httpClientFactory, 
-+     ILogger<CookieAuthenticationStateProvider> logger) 
-+     : AuthenticationStateProvider, IAccountManagement
-```
-
 In the <xref:System.Text.Json.JsonSerializerOptions>, add the <xref:System.Text.Json.JsonSerializerOptions.DefaultIgnoreCondition> option set to <xref:System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull?displayProperty=nameWithType>, which avoids serializing null properties:
 
 ```diff


### PR DESCRIPTION
Fixes #34348

Rolled into the sample apps on https://github.com/dotnet/blazor-samples/pull/402.

No need to update the overview, as this part of the cookie auth state provider isn't shown or mentioned.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/webassembly/standalone-with-identity/qrcodes-for-authenticator-apps.md](https://github.com/dotnet/AspNetCore.Docs/blob/ec2546db5b135ea15fa47c95b83fbac39a18df06/aspnetcore/blazor/security/webassembly/standalone-with-identity/qrcodes-for-authenticator-apps.md) | [aspnetcore/blazor/security/webassembly/standalone-with-identity/qrcodes-for-authenticator-apps](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-identity/qrcodes-for-authenticator-apps?branch=pr-en-us-34349) |

<!-- PREVIEW-TABLE-END -->