### PR TITLE
[Blazor] state-management.md - isConnected vs. isLoaded

### DIFF
--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -450,7 +450,7 @@ else
     {
         var result = await ProtectedSessionStore.GetAsync<int>("count");
         CurrentCount = result.Success ? result.Value : 0;
-        isConnected = true;
+        isLoaded = true;
     }
 
     public async Task IncrementCount()
@@ -469,7 +469,7 @@ else
 @using Microsoft.AspNetCore.ProtectedBrowserStorage
 @inject ProtectedSessionStorage ProtectedSessionStore
 
-@if (isConnected)
+@if (isLoaded)
 {
     <CascadingValue Value="this">
         @ChildContent
@@ -481,7 +481,7 @@ else
 }
 
 @code {
-    private bool isConnected;
+    private bool isLoaded;
 
     [Parameter]
     public RenderFragment ChildContent { get; set; }
@@ -492,7 +492,7 @@ else
     {
         if (firstRender)
         {
-            isConnected = true;
+            isLoaded = true;
             await LoadStateAsync();
             StateHasChanged();
         }
@@ -501,7 +501,7 @@ else
     private async Task LoadStateAsync()
     {
         CurrentCount = await ProtectedSessionStore.GetAsync<int>("count");
-        isConnected = true;
+        isLoaded = true;
     }
 
     public async Task IncrementCount()


### PR DESCRIPTION
In the first example, there’s no `isConnected` field.  
I think the `isConnected` must have sneaked in by copy-pasting from another section and doesn’t make sense here.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/state-management.md](https://github.com/dotnet/AspNetCore.Docs/blob/3b42cc413888627336e945438ed6b8149b6d4f07/aspnetcore/blazor/state-management.md) | [ASP.NET Core Blazor state management](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/state-management?branch=pr-en-us-34353) |

<!-- PREVIEW-TABLE-END -->