### PR TITLE
Add section on middleware by app type

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -29,17 +29,7 @@ Request delegates are configured using <xref:Microsoft.AspNetCore.Builder.RunExt
 
 ## The role of middleware by app type
 
-:::moniker range=">= aspnetcore-8.0"
-
 Blazor Web Apps, Razor Pages, and MVC process browser requests on the server with middleware. The guidance in this article applies to these types of apps.
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-8.0"
-
-Razor Pages, MVC, Blazor Server, and the server-side project of a hosted Blazor WebAssembly solution process browser requests on the server with middleware. The guidance in this article applies to these types of apps.
-
-:::moniker-end
 
 Standalone Blazor WebAssembly apps run entirely on the client and don't process requests with a middleware pipeline. The guidance in this article doesn't apply to standalone Blazor WebAssembly apps.
 

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -27,6 +27,22 @@ Request delegates are configured using <xref:Microsoft.AspNetCore.Builder.RunExt
 
 <xref:migration/http-modules> explains the difference between request pipelines in ASP.NET Core and ASP.NET 4.x and provides additional middleware samples.
 
+## The role of middleware by app type
+
+:::moniker range=">= aspnetcore-8.0"
+
+Blazor Web Apps, Razor Pages, and MVC process browser requests on the server with middleware. The guidance in this article applies to these types of apps.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
+Razor Pages, MVC, Blazor Server, and the server-side project of a hosted Blazor WebAssembly solution process browser requests on the server with middleware. The guidance in this article applies to these types of apps.
+
+:::moniker-end
+
+Standalone Blazor WebAssembly apps run entirely on the client and don't process requests with a middleware pipeline. The guidance in this article doesn't apply to standalone Blazor WebAssembly apps.
+
 ## Middleware code analysis
 
 ASP.NET Core includes many compiler platform analyzers that inspect application code for quality. For more information, see <xref:diagnostics/code-analysis>

--- a/aspnetcore/fundamentals/middleware/index/includes/index3-7.md
+++ b/aspnetcore/fundamentals/middleware/index/includes/index3-7.md
@@ -13,6 +13,12 @@ Request delegates are configured using <xref:Microsoft.AspNetCore.Builder.RunExt
 
 <xref:migration/http-modules> explains the difference between request pipelines in ASP.NET Core and ASP.NET 4.x and provides additional middleware samples.
 
+## The role of middleware by app type
+
+Razor Pages, MVC, Blazor Server, and the server-side project of a hosted Blazor WebAssembly solution process browser requests on the server with middleware. The guidance in this article applies to these types of apps.
+
+Standalone Blazor WebAssembly apps run entirely on the client and don't process requests with a middleware pipeline. The guidance in this article doesn't apply to standalone Blazor WebAssembly apps.
+
 ## Middleware code analysis
 
 ASP.NET Core includes many compiler platform analyzers that inspect application code for quality. For more information, see <xref:diagnostics/code-analysis>


### PR DESCRIPTION
Fixes #34382
Addresses #34356

Notes

* There are other options for the section heading. I recommend using "app type" language over "web UI" language.
* The rest of this article probably only requires minimal changes. The RP-based example in one of the sections requires minimal changes. I think the changes there can probably make the pipeline agnostic to app type.
* BTW ... Static Files Middleware was never addressed in this article for >=8.0. I guess that's tracked by some other issue ... just mentioning it FYI in case it isn't tracked somewhere.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/middleware/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/64b82acab1e084a77c7c4a54a75a3ab98dfd4369/aspnetcore/fundamentals/middleware/index.md) | [aspnetcore/fundamentals/middleware/index](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/index?branch=pr-en-us-34383) |


<!-- PREVIEW-TABLE-END -->