### PR TITLE
Pull new sample code

### DIFF
--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -50,7 +50,7 @@ Add the following script after the Blazor script ([location of the Blazor start 
 @code {
     private string? result;
 
-    public async void ShowPrompt()
+    public async Task ShowPrompt()
     {
         result = await JS.InvokeAsync<string>(
             "showPrompt1", "What's your name?");

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -5,7 +5,7 @@ description: Learn how to invoke .NET methods from JavaScript functions in Blazo
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 11/12/2024
+ms.date: 12/17/2024
 uid: blazor/js-interop/call-dotnet-from-javascript
 ---
 # Call .NET methods from JavaScript functions in ASP.NET Core Blazor

--- a/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md
@@ -757,7 +757,7 @@ public class GenericType<TValue>
     }
 
     [JSInvokable]
-    public async void UpdateAsync(TValue newValue)
+    public async Task UpdateAsync(TValue newValue)
     {
         await Task.Yield();
         Value = newValue;


### PR DESCRIPTION
Fixes #34360

Thanks @ScarletKuro! 🚀 ... Thus far, this takes care of the last Blazor sample code from the samples repo (changing the date of the article pulls the new code). I'll make a sweep now to determine if there are any in-text examples to address.

**UPDATE**: Found a couple of more NITs.

WRT the coverage on "support" for returning a task in the *Event Handling* article, it's really just this one line ...

> * Asynchronous delegate event handlers that return a <xref:System.Threading.Tasks.Task> is supported.

I'll talk to the product unit about that in 25Q1. It will be tracked by my UE Tracking issue, so it won't get lost.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/207cb58e9419ea325732682bf9ed14da3996fc6b/aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript.md) | [aspnetcore/blazor/javascript-interoperability/call-dotnet-from-javascript](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-dotnet-from-javascript?branch=pr-en-us-34386) |


<!-- PREVIEW-TABLE-END -->