### PR TITLE
Start Blazor circuit with custom URL

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1470,7 +1470,7 @@ Prevent automatically starting the app by adding `autostart="false"` to the Blaz
 + </script>
 ```
 
-Add the following to the `Program` file:
+Add the following <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> call with the `/signalr` path to the middleware processing pipeline in the server app's `Program` file:
 
 ```csharp
 app.MapBlazorHub("/signalr");

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1456,9 +1456,9 @@ Use a <xref:Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler> to c
 
 ## Start the SignalR circuit at a different URL
 
-In the `App` component (`App.razor`):
+To start the SignalR circuit at a different URL:
 
-* Prevent automatically starting the app by adding `autostart="false"` to the Blazor script tag.
+* Prevent automatically starting the app by adding `autostart="false"` to the Blazor `<script>` tag ([location of the Blazor start script](xref:blazor/project-structure#location-of-the-blazor-script)).
 * Establish the circuit URL manually using `Blazor.start`.
 
 The following example uses the path `/signalr`:

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1452,6 +1452,33 @@ Use a <xref:Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler> to c
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-8.0"
+
+## Start the SignalR circuit at a different URL
+
+In the `App` component (`App.razor`), change the Blazor Web App script to prevent automatically starting the app and establish the circuit URL manually. The following example uses the path `/signalr`:
+
+
+```diff
+- <script src="_framework/blazor.web.js"></script>
++ <script src="_framework/blazor.web.js" autostart="false"></script>
++ <script>
++   Blazor.start({
++     circuit: {
++       configureSignalR: builder => builder.withUrl("/signalr")
++     },
++   });
++ </script>
+```
+
+Add the following to the `Program` file:
+
+```csharp
+app.MapBlazorHub("/signalr");
+```
+
+:::moniker-end
+
 ## `IHttpContextAccessor`/`HttpContext` in Razor components
 
 [!INCLUDE[](~/blazor/security/includes/httpcontext.md)]

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1452,11 +1452,13 @@ Use a <xref:Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler> to c
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-8.0"
-
 ## Start the SignalR circuit at a different URL
 
-Prevent automatically starting the app by adding `autostart="false"` to the Blazor `<script>` tag ([location of the Blazor start script](xref:blazor/project-structure#location-of-the-blazor-script)). Manually establish the circuit URL using `Blazor.start`. The following example uses the path `/signalr`:
+Prevent automatically starting the app by adding `autostart="false"` to the Blazor `<script>` tag ([location of the Blazor start script](xref:blazor/project-structure#location-of-the-blazor-script)). Manually establish the circuit URL using `Blazor.start`. The following examples use the path `/signalr`.
+
+:::moniker range=">= aspnetcore-9.0"
+
+Blazor Web Apps:
 
 ```diff
 - <script src="_framework/blazor.web.js"></script>
@@ -1470,13 +1472,40 @@ Prevent automatically starting the app by adding `autostart="false"` to the Blaz
 + </script>
 ```
 
-Add the following <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> call with the hub path to the middleware processing pipeline in the server app's `Program` file:
+Blazor Server:
+
+:::moniker-end
+
+```diff
+- <script src="_framework/blazor.server.js"></script>
++ <script src="_framework/blazor.server.js" autostart="false"></script>
++ <script>
++   Blazor.start({
++     configureSignalR: builder => builder.withUrl("/signalr")
++   });
++ </script>
+```
+
+Add the following <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> call with the hub path to the middleware processing pipeline in the server app's `Program` file.
+
+:::moniker range=">= aspnetcore-9.0"
+
+Blazor Web Apps:
 
 ```csharp
 app.MapBlazorHub("/signalr");
 ```
 
+Blazor Server:
+
 :::moniker-end
+
+Leave the existing call to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> in the file and add a new call to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> with the path:
+
+```diff
+app.MapBlazorHub();
++ app.MapBlazorHub("/signalr");
+```
 
 ## `IHttpContextAccessor`/`HttpContext`
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1456,12 +1456,7 @@ Use a <xref:Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler> to c
 
 ## Start the SignalR circuit at a different URL
 
-To start the SignalR circuit at a different URL:
-
-* Prevent automatically starting the app by adding `autostart="false"` to the Blazor `<script>` tag ([location of the Blazor start script](xref:blazor/project-structure#location-of-the-blazor-script)).
-* Establish the circuit URL manually using `Blazor.start`.
-
-The following example uses the path `/signalr`:
+Prevent automatically starting the app by adding `autostart="false"` to the Blazor `<script>` tag ([location of the Blazor start script](xref:blazor/project-structure#location-of-the-blazor-script)). Establish the circuit URL manually using `Blazor.start`. The following example uses the path `/signalr`:
 
 ```diff
 - <script src="_framework/blazor.web.js"></script>

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1456,8 +1456,12 @@ Use a <xref:Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler> to c
 
 ## Start the SignalR circuit at a different URL
 
-In the `App` component (`App.razor`), change the Blazor Web App script to prevent automatically starting the app and establish the circuit URL manually. The following example uses the path `/signalr`:
+In the `App` component (`App.razor`):
 
+* Prevent automatically starting the app by adding `autostart="false"` to the Blazor script tag.
+* Establish the circuit URL manually using `Blazor.start`.
+
+The following example uses the path `/signalr`:
 
 ```diff
 - <script src="_framework/blazor.web.js"></script>

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1456,7 +1456,7 @@ Use a <xref:Microsoft.AspNetCore.Components.Server.Circuits.CircuitHandler> to c
 
 Prevent automatically starting the app by adding `autostart="false"` to the Blazor `<script>` tag ([location of the Blazor start script](xref:blazor/project-structure#location-of-the-blazor-script)). Manually establish the circuit URL using `Blazor.start`. The following examples use the path `/signalr`.
 
-:::moniker range=">= aspnetcore-9.0"
+:::moniker range=">= aspnetcore-8.0"
 
 Blazor Web Apps:
 
@@ -1488,7 +1488,7 @@ Blazor Server:
 
 Add the following <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> call with the hub path to the middleware processing pipeline in the server app's `Program` file.
 
-:::moniker range=">= aspnetcore-9.0"
+:::moniker range=">= aspnetcore-8.0"
 
 Blazor Web Apps:
 


### PR DESCRIPTION
Fixes #34403

Thanks @pablosantosluaces! 🚀 ... I figured out the Blazor Server approach based on your BWA code and included the proper versioning for the section.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/signalr.md](https://github.com/dotnet/AspNetCore.Docs/blob/a90fee2d363e498b774447f25c4556602630ecd4/aspnetcore/blazor/fundamentals/signalr.md) | [aspnetcore/blazor/fundamentals/signalr](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/signalr?branch=pr-en-us-34404) |


<!-- PREVIEW-TABLE-END -->