### PR TITLE
doc(grpc): fix formatting

### DIFF
--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample8/GrpcGreeter/appsettings.Development.json
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample8/GrpcGreeter/appsettings.Development.json
@@ -2,8 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-      ,"Microsoft.AspNetCore.Hosting": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.Hosting": "Information",
       "Microsoft.AspNetCore.Routing.EndpointMiddleware": "Information"
     }
   }


### PR DESCRIPTION
While completing the [gRPC tutorial](https://learn.microsoft.com/en-us/aspnet/core/tutorials/grpc/grpc-start?view=aspnetcore-9.0&tabs=visual-studio-code#test-the-grpc-client-with-the-grpc-greeter-service) I noticed this formatting nit.