### PR TITLE
Prohibition on `<script>` tags for modules

### DIFF
--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -97,7 +97,7 @@ A Blazor WebAssembly app built as a [Progressive Web App (PWA)](xref:blazor/prog
 
 The Blazor script handles:
 
-* Downloading the .NET runtime, Razor components, and the component's dependencies.
+* Downloading the .NET runtime, Razor components, and dependencies.
 * Initialization of the runtime.
 
 The size of the published app, its *payload size*, is a critical performance factor for an app's usability. A large app takes a relatively long time to download to a browser, which diminishes the user experience. Blazor WebAssembly optimizes payload size to reduce download times:

--- a/aspnetcore/blazor/hosting-models.md
+++ b/aspnetcore/blazor/hosting-models.md
@@ -98,7 +98,7 @@ A Blazor WebAssembly app built as a [Progressive Web App (PWA)](xref:blazor/prog
 The Blazor script handles:
 
 * Downloading the .NET runtime, Razor components, and dependencies.
-* Initialization of the runtime.
+* Runtime initialization.
 
 The size of the published app, its *payload size*, is a critical performance factor for an app's usability. A large app takes a relatively long time to download to a browser, which diminishes the user experience. Blazor WebAssembly optimizes payload size to reduce download times:
 

--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -153,7 +153,7 @@ export function showPrompt2(message) {
 ```
 
 > [!IMPORTANT]
-> Don't place a `<script>` tag for `JsCollocation2.razor.js` after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script). The module is loaded automatically and cached. Adding a `<script>` tag results in the module not loading correctly.
+> Don't place a `<script>` tag for `JsCollocation2.razor.js` after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script) because the module is loaded and cached automatically. Adding a `<script>` tag prevents the module from loading.
 
 Use of scripts and modules for collocated JS in a Razor class library (RCL) is only supported for Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface. If you're implementing [JavaScript `[JSImport]`/`[JSExport]` interop](xref:blazor/js-interop/import-export-interop), see <xref:blazor/js-interop/import-export-interop#razor-class-library-rcl-collocated-js-is-unsupported>.
 

--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -153,7 +153,7 @@ export function showPrompt2(message) {
 ```
 
 > [!IMPORTANT]
-> Don't place a `<script>` tag for `JsCollocation2.razor.js` after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script) because the module is loaded and cached automatically. Adding a `<script>` tag prevents the module from loading.
+> Don't place a `<script>` tag for `JsCollocation2.razor.js` after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script) because the module is loaded and cached automatically when the [dynamic `import()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import) is invoked.
 
 Use of scripts and modules for collocated JS in a Razor class library (RCL) is only supported for Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface. If you're implementing [JavaScript `[JSImport]`/`[JSExport]` interop](xref:blazor/js-interop/import-export-interop), see <xref:blazor/js-interop/import-export-interop#razor-class-library-rcl-collocated-js-is-unsupported>.
 

--- a/aspnetcore/blazor/includes/js-interop/js-collocation.md
+++ b/aspnetcore/blazor/includes/js-interop/js-collocation.md
@@ -152,6 +152,9 @@ export function showPrompt2(message) {
 }
 ```
 
+> [!IMPORTANT]
+> Don't place a `<script>` tag for `JsCollocation2.razor.js` after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script). The module is loaded automatically and cached. Adding a `<script>` tag results in the module not loading correctly.
+
 Use of scripts and modules for collocated JS in a Razor class library (RCL) is only supported for Blazor's JS interop mechanism based on the <xref:Microsoft.JSInterop.IJSRuntime> interface. If you're implementing [JavaScript `[JSImport]`/`[JSExport]` interop](xref:blazor/js-interop/import-export-interop), see <xref:blazor/js-interop/import-export-interop#razor-class-library-rcl-collocated-js-is-unsupported>.
 
 For scripts or modules provided by a Razor class library (RCL) using <xref:Microsoft.JSInterop.IJSRuntime>-based JS interop, the following path is used:

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -623,6 +623,7 @@ In the preceding example:
   * The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
   * The `{SCRIPT PATH AND FILE NAME (.js)}` placeholder is the path and file name under `wwwroot`.
 * Disposes the <xref:Microsoft.JSInterop.IJSObjectReference> for [garbage collection](xref:blazor/components/lifecycle#asynchronous-iasyncdisposable) in <xref:System.IAsyncDisposable.DisposeAsync%2A?displayProperty=nameWithType>.
+* Don't place a `<script>` tag for the script after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script). The module is loaded automatically and cached. Adding a `<script>` tag results in the module not loading correctly.
 
 Dynamically importing a module requires a network request, so it can only be achieved asynchronously by calling <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A>.
 

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -623,7 +623,7 @@ In the preceding example:
   * The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
   * The `{SCRIPT PATH AND FILE NAME (.js)}` placeholder is the path and file name under `wwwroot`.
 * Disposes the <xref:Microsoft.JSInterop.IJSObjectReference> for [garbage collection](xref:blazor/components/lifecycle#asynchronous-iasyncdisposable) in <xref:System.IAsyncDisposable.DisposeAsync%2A?displayProperty=nameWithType>.
-* Don't place a `<script>` tag for the script after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script). The module is loaded automatically and cached. Adding a `<script>` tag results in the module not loading correctly.
+* Don't place a `<script>` tag for the script after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script) because the module is loaded and cached automatically. Adding a `<script>` tag prevents the module from loading.
 
 Dynamically importing a module requires a network request, so it can only be achieved asynchronously by calling <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A>.
 

--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -623,7 +623,7 @@ In the preceding example:
   * The path segment for the current directory (`./`) is required in order to create the correct static asset path to the JS file.
   * The `{SCRIPT PATH AND FILE NAME (.js)}` placeholder is the path and file name under `wwwroot`.
 * Disposes the <xref:Microsoft.JSInterop.IJSObjectReference> for [garbage collection](xref:blazor/components/lifecycle#asynchronous-iasyncdisposable) in <xref:System.IAsyncDisposable.DisposeAsync%2A?displayProperty=nameWithType>.
-* Don't place a `<script>` tag for the script after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script) because the module is loaded and cached automatically. Adding a `<script>` tag prevents the module from loading.
+* Don't place a `<script>` tag for the script after the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script) because the module is loaded and cached automatically when the [dynamic `import()`](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import) is invoked.
 
 Dynamically importing a module requires a network request, so it can only be achieved asynchronously by calling <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A>.
 

--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -538,7 +538,7 @@ The project structure of the client-side app in a hosted Blazor Webassembly solu
 
 The Blazor script, which is served from an embedded resource in the ASP.NET Core shared framework, handles:
 
-* Downloading the .NET runtime, Razor components, and the component's dependencies.
+* Downloading the .NET runtime, Razor components, and dependencies.
 * Initialization of the runtime.
 
 :::moniker range=">= aspnetcore-8.0"

--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -536,7 +536,10 @@ The project structure of the client-side app in a hosted Blazor Webassembly solu
 
 ## Location of the Blazor script
 
-The Blazor script is served from an embedded resource in the ASP.NET Core shared framework.
+The Blazor script, which is served from an embedded resource in the ASP.NET Core shared framework, handles:
+
+* Downloading the .NET runtime, Razor components, and the component's dependencies.
+* Initialization of the runtime.
 
 :::moniker range=">= aspnetcore-8.0"
 

--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -539,7 +539,7 @@ The project structure of the client-side app in a hosted Blazor Webassembly solu
 The Blazor script, which is served from an embedded resource in the ASP.NET Core shared framework, handles:
 
 * Downloading the .NET runtime, Razor components, and dependencies.
-* Initialization of the runtime.
+* Runtime initialization.
 
 :::moniker range=">= aspnetcore-8.0"
 


### PR DESCRIPTION
Fixes #34414

Thanks @gregoryagu! 🚀 ... I won't merge this until tomorrow morning (Friday) to give you a chance to review it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hosting-models.md](https://github.com/dotnet/AspNetCore.Docs/blob/dbb863e45c81eeaec222de05c3eed5ed77e24ab3/aspnetcore/blazor/hosting-models.md) | [aspnetcore/blazor/hosting-models](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hosting-models?branch=pr-en-us-34432) |
| [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md](https://github.com/dotnet/AspNetCore.Docs/blob/dbb863e45c81eeaec222de05c3eed5ed77e24ab3/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md) | [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?branch=pr-en-us-34432) |


<!-- PREVIEW-TABLE-END -->