### PR TITLE
Fix misspelled word

### DIFF
--- a/aspnetcore/fundamentals/index/samples/9.0/BlazorWebAppMovies/Components/Pages/Weather.razor
+++ b/aspnetcore/fundamentals/index/samples/9.0/BlazorWebAppMovies/Components/Pages/Weather.razor
@@ -19,7 +19,7 @@ else
             <tr>
                 <th>Date</th>
                 <th aria-label="Temperature in Celsius">Temp. (C)</th>
-                <th aria-label="Temperature in Farenheit">Temp. (F)</th>
+                <th aria-label="Temperature in Fahrenheit">Temp. (F)</th>
                 <th>Summary</th>
             </tr>
         </thead>

--- a/aspnetcore/fundamentals/openapi/overview.md
+++ b/aspnetcore/fundamentals/openapi/overview.md
@@ -7,7 +7,6 @@ monikerRange: '>= aspnetcore-6.0'
 ms.date: 8/02/2024
 uid: fundamentals/openapi/overview
 ---
-
 # OpenAPI support in ASP.NET Core API apps
 
 [!INCLUDE[](~/includes/not-latest-version.md)]

--- a/aspnetcore/fundamentals/openapi/samples/9.x/AspireApp1/AspireApp1.Web/Components/Pages/Weather.razor
+++ b/aspnetcore/fundamentals/openapi/samples/9.x/AspireApp1/AspireApp1.Web/Components/Pages/Weather.razor
@@ -21,7 +21,7 @@ else
             <tr>
                 <th>Date</th>
                 <th aria-label="Temperature in Celsius">Temp. (C)</th>
-                <th aria-label="Temperature in Farenheit">Temp. (F)</th>
+                <th aria-label="Temperature in Fahrenheit">Temp. (F)</th>
                 <th>Summary</th>
             </tr>
         </thead>


### PR DESCRIPTION
Fixes #34438

Rick (and Wade, you're on as the MS author of one of the articles/samples) ...

The PU didn't backport the spelling fix (it's 10.0+), and the new Aspire 10.0 sample won't likely be created for some time. However, I think we should go ahead and fix this now for 9.0+ and not sweat versioning the change. It's not going to be particularly noticeable that we have it spelled correctly ***here***, and it will avoid devs opening issues ***for us***. 😆

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/overview.md](https://github.com/dotnet/AspNetCore.Docs/blob/aecc14bd46c3570071c3f861575f6315708ecf7e/aspnetcore/fundamentals/openapi/overview.md) | [aspnetcore/fundamentals/openapi/overview](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/overview?branch=pr-en-us-34439) |


<!-- PREVIEW-TABLE-END -->