### PR TITLE
Update README.md - remove link to unmonitored feedback repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This repository contains the [ASP.NET Core documentation](https://learn.microsoft.com/aspnet/core/introduction-to-aspnet-core). See the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/dotnet/AspNetCore.Docs/issues) if you would like to help.
 
-To provide comments and suggestions on [learn.microsoft.com](https://learn.microsoft.com) site functionality, open an issue in the [`MicrosoftDocs/feedback` GitHub repository](https://github.com/MicrosoftDocs/feedback).
-
 ASP.NET 4.x documentation changes are made in the [`dotnet/AspNetDocs` GitHub repository](https://github.com/dotnet/AspNetDocs).
 
 ## How to open an issue


### PR DESCRIPTION
This link needs to be removed, the Feedback repo has not been the standard site feedback channel for over three years.