### PR TITLE
Enhance the Options config example

### DIFF
--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -339,29 +339,39 @@ builder.Services.Configure<OptionsExample>(
     builder.Configuration.GetSection("OptionsExample"));
 ```
 
-To retreive the settings in a class file with the [`[Inject]` attribute](xref:Microsoft.AspNetCore.Components.InjectAttribute):
+The following Razor component retrieves the settings with the [`@inject`](xref:mvc/views/razor#inject) directive or [`[Inject]` attribute](xref:Microsoft.AspNetCore.Components.InjectAttribute).
 
-```csharp
-using Microsoft.Extensions.Options;
-
-...
-
-[Inject]
-public IOptions<OptionsExample>? OptionsExample { get; set; }
-```
-
-To retrieve the settings in a Razor component with the [`@inject`](xref:mvc/views/razor#inject) directive:
+`Options.razor`:
 
 ```razor
+@page "/options"
 @using Microsoft.Extensions.Options
-@inject IOptions<OptionsExample>? OptionsExample
+@inject IOptions<OptionsExample>? OptionsExample1
 
-...
+<h1>Options</h1>
+
+<h2>
+    &commat;inject approach
+</h2>
 
 <ul>
-    <li>@OptionsExample?.Value.Option1</li>
-    <li>@OptionsExample?.Value.Option2</li>
+    <li>@OptionsExample1?.Value.Option1</li>
+    <li>@OptionsExample1?.Value.Option2</li>
 </ul>
+
+<h2>
+    [Inject] approach
+</h2>
+
+<ul>
+    <li>@OptionsExample2?.Value.Option1</li>
+    <li>@OptionsExample2?.Value.Option2</li>
+</ul>
+
+@code {
+    [Inject]
+    public IOptions<OptionsExample>? OptionsExample2 { get; set; }
+}
 ```
 
 Not all of the ASP.NET Core Options features are supported in Razor components. For example, <xref:Microsoft.Extensions.Options.IOptionsSnapshot%601> and <xref:Microsoft.Extensions.Options.IOptionsMonitor%601> configuration is supported, but recomputing option values for these interfaces isn't supported outside of reloading the app by either requesting the app in a new browser tab or selecting the browser's reload button. Merely calling [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes-statehaschanged) doesn't update snapshot or monitored option values when the underlying configuration changes.

--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -315,9 +315,53 @@ For more information on how background updates are handled by PWAs, see <xref:bl
 
 Example:
 
+`OptionsExample.cs`:
+
 ```csharp
-builder.Services.Configure<MyOptions>(
-    builder.Configuration.GetSection("MyOptions"));
+public class OptionsExample
+{
+    public string? Option1 { get; set; }
+    public string? Option2 { get; set; }
+}
+```
+
+In `appsettings.json`:
+
+```json
+"OptionsExample": {
+  "Option1": "Option1 Value",
+  "Option2": "Option2 Value"
+}
+```
+
+```csharp
+builder.Services.Configure<OptionsExample>(
+    builder.Configuration.GetSection("OptionsExample"));
+```
+
+To retreive the settings in a class file with the [`[Inject]` attribute](xref:Microsoft.AspNetCore.Components.InjectAttribute):
+
+```csharp
+using Microsoft.Extensions.Options;
+
+...
+
+[Inject]
+public IOptions<MyOptions> MyOptions { get; set; }
+```
+
+To retrieve the settings in a Razor component with the [`@inject`](xref:mvc/views/razor#inject) directive:
+
+```razor
+@using Microsoft.Extensions.Options
+@inject IOptions<OptionsExample> OptionsExample
+
+...
+
+<ul>
+    <li>@OptionsExample.Value.Option1</li>
+    <li>@OptionsExample.Value.Option2</li>
+</ul>
 ```
 
 Not all of the ASP.NET Core Options features are supported in Razor components. For example, <xref:Microsoft.Extensions.Options.IOptionsSnapshot%601> and <xref:Microsoft.Extensions.Options.IOptionsMonitor%601> configuration is supported, but recomputing option values for these interfaces isn't supported outside of reloading the app by either requesting the app in a new browser tab or selecting the browser's reload button. Merely calling [`StateHasChanged`](xref:blazor/components/lifecycle#state-changes-statehaschanged) doesn't update snapshot or monitored option values when the underlying configuration changes.

--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -347,7 +347,7 @@ using Microsoft.Extensions.Options;
 ...
 
 [Inject]
-public IOptions<MyOptions> MyOptions { get; set; }
+public IOptions<OptionsExample> OptionsExample { get; set; }
 ```
 
 To retrieve the settings in a Razor component with the [`@inject`](xref:mvc/views/razor#inject) directive:

--- a/aspnetcore/blazor/fundamentals/configuration.md
+++ b/aspnetcore/blazor/fundamentals/configuration.md
@@ -347,20 +347,20 @@ using Microsoft.Extensions.Options;
 ...
 
 [Inject]
-public IOptions<OptionsExample> OptionsExample { get; set; }
+public IOptions<OptionsExample>? OptionsExample { get; set; }
 ```
 
 To retrieve the settings in a Razor component with the [`@inject`](xref:mvc/views/razor#inject) directive:
 
 ```razor
 @using Microsoft.Extensions.Options
-@inject IOptions<OptionsExample> OptionsExample
+@inject IOptions<OptionsExample>? OptionsExample
 
 ...
 
 <ul>
-    <li>@OptionsExample.Value.Option1</li>
-    <li>@OptionsExample.Value.Option2</li>
+    <li>@OptionsExample?.Value.Option1</li>
+    <li>@OptionsExample?.Value.Option2</li>
 </ul>
 ```
 


### PR DESCRIPTION
Fixes #34458

Thanks @gregoryagu! 🚀 ... How about this? It includes getting rid of the "MY" naming. I've been dropping "MY"-named things around here for years, and here's yet another one 😩 to get rid of.

The reason that this wasn't fleshed out in the first place is simply that the Blazor doc set is an ***add-on*** doc set. All of this is covered by the cross-linked *Options* article in the main doc set. However, it is nice to show the Razor component piece, and it may as well add the other pieces to make it work.

There's an effort underway to make the main doc set's *Fundamentals* node articles emphasize Razor component/Blazor examples. That's on-going work.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/configuration.md](https://github.com/dotnet/AspNetCore.Docs/blob/7341bab9c0c96908c4084e8fa490a279e6c3d105/aspnetcore/blazor/fundamentals/configuration.md) | [aspnetcore/blazor/fundamentals/configuration](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/configuration?branch=pr-en-us-34459) |


<!-- PREVIEW-TABLE-END -->