### PR TITLE
Make QuickGrid section "Display name support" use correct way to determine display name

### DIFF
--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -297,7 +297,7 @@ However, managing column titles (names) from bound model properties is usually a
 public DateTime ReleaseDate { get; set; }
 ```
 
-To enable the `QuickGrid` component to use the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> property, subclass <xref:Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn`2>, either in the component or in a separate class. Call the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.GetName%2A> method to return the localized <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> value if an unlocalized <xref:System.ComponentModel.DisplayNameAttribute.DisplayName> doesn't hold the value:
+To enable the `QuickGrid` component to use the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> property, subclass <xref:Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn`2>, either in the component or in a separate class. Call the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.GetName%2A> method to return the localized <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> value if an unlocalized <xref:System.ComponentModel.DisplayNameAttribute.DisplayName> ([`[DisplayName]` attribute](xref:System.ComponentModel.DisplayNameAttribute)) doesn't hold the value:
 
 ```csharp
 public class DisplayNameColumn<TGridItem, TProp> : PropertyColumn<TGridItem, TProp>

--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -297,7 +297,7 @@ However, managing column titles (names) from bound model properties is usually a
 public DateTime ReleaseDate { get; set; }
 ```
 
-To enable the `QuickGrid` component to use the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType>, subclass <xref:Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn`2> either in the component or in a separate class:
+To enable the `QuickGrid` component to use the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> property, subclass <xref:Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn`2>, either in the component or in a separate class. Call the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.GetName%2A> method to return the localized <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> value:
 
 ```csharp
 public class DisplayNameColumn<TGridItem, TProp> : PropertyColumn<TGridItem, TProp>

--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -297,7 +297,7 @@ However, managing column titles (names) from bound model properties is usually a
 public DateTime ReleaseDate { get; set; }
 ```
 
-To enable the `QuickGrid` component to use the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> property, subclass <xref:Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn`2>, either in the component or in a separate class. Call the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.GetName%2A> method to return the localized <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> value if <xref:System.ComponentModel.DisplayNameAttribute.DisplayName> doesn't hold the value:
+To enable the `QuickGrid` component to use the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> property, subclass <xref:Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn`2>, either in the component or in a separate class. Call the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.GetName%2A> method to return the localized <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> value if an unlocalized <xref:System.ComponentModel.DisplayNameAttribute.DisplayName> doesn't hold the value:
 
 ```csharp
 public class DisplayNameColumn<TGridItem, TProp> : PropertyColumn<TGridItem, TProp>

--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -309,7 +309,7 @@ public class DisplayNameColumn<TGridItem, TProp> : PropertyColumn<TGridItem, TPr
             var memberInfo = memberExpression.Member;
             Title = 
                 memberInfo.GetCustomAttribute<DisplayNameAttribute>().DisplayName ??
-                memberInfo.GetCustomAttribute<DisplayAttribute>().Name ??
+                memberInfo.GetCustomAttribute<DisplayAttribute>().GetName() ??
                 memberInfo.Name;
         }
 

--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -297,7 +297,7 @@ However, managing column titles (names) from bound model properties is usually a
 public DateTime ReleaseDate { get; set; }
 ```
 
-To enable the `QuickGrid` component to use the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> property, subclass <xref:Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn`2>, either in the component or in a separate class. Call the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.GetName%2A> method to return the localized <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> value:
+To enable the `QuickGrid` component to use the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> property, subclass <xref:Microsoft.AspNetCore.Components.QuickGrid.PropertyColumn`2>, either in the component or in a separate class. Call the <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.GetName%2A> method to return the localized <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.Name?displayProperty=nameWithType> value if <xref:System.ComponentModel.DisplayNameAttribute.DisplayName> doesn't hold the value:
 
 ```csharp
 public class DisplayNameColumn<TGridItem, TProp> : PropertyColumn<TGridItem, TProp>


### PR DESCRIPTION
See <https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.displayattribute.name?view=net-8.0#remarks> which reads

> Do not use this property to get the value of the [Name](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.displayattribute.name?view=net-8.0) property. Use the [GetName](https://learn.microsoft.com/en-us/dotnet/api/system.componentmodel.dataannotations.displayattribute.getname?view=net-8.0) method instead.

I think using `.Name` instead of `.GetName()` would return the resource key / non-localized version.

Note: I didn't verify the fix in a minimal project.

@guardrex 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/quickgrid.md](https://github.com/dotnet/AspNetCore.Docs/blob/c3d023c3a3209672a38d1b2990efc873cdb5ab71/aspnetcore/blazor/components/quickgrid.md) | [aspnetcore/blazor/components/quickgrid](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/quickgrid?branch=pr-en-us-34479) |


<!-- PREVIEW-TABLE-END -->