### PR TITLE
Draft: Update Blazor supported localization scenarios

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -22,6 +22,8 @@ A limited set of ASP.NET Core's localization features are supported:
 
 <span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> are supported in Blazor apps.
 
+<span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> Localized validation messages in [forms validation using DataAnnotations](<xref:blazor/forms/validation#data-annotations-validator-component-and-custom-validation>) if <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.ResourceType?displayProperty=nameWithType> and <xref:System.ComponentModel.DataAnnotations.ValidationAttribute.ErrorMessageResourceType?displayProperty=nameWithType> are set explicitly are also supported in Blazor apps.
+
 <span aria-hidden="true">❌</span><span class="visually-hidden">Not supported:</span> <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer>, <xref:Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer>, and [Data Annotations localization](xref:fundamentals/localization#dataannotations-localization) are ASP.NET Core MVC features and *not supported* in Blazor apps.
 
 This article describes how to use Blazor's globalization and localization features based on:

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -22,9 +22,9 @@ A limited set of ASP.NET Core's localization features are supported:
 
 <span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> are supported in Blazor apps.
 
-<span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> Localized validation messages in [forms validation using DataAnnotations](<xref:blazor/forms/validation#data-annotations-validator-component-and-custom-validation>) if <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.ResourceType?displayProperty=nameWithType> and <xref:System.ComponentModel.DataAnnotations.ValidationAttribute.ErrorMessageResourceType?displayProperty=nameWithType> are set explicitly are also supported in Blazor apps.
+<span aria-hidden="true">❌</span><span class="visually-hidden">Not supported:</span> <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer>, <xref:Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer>, and data annotations via [Localization Middleware](xref:fundamentals/localization#dataannotations-localization) are ASP.NET Core MVC features and *not supported* in Blazor apps.
 
-<span aria-hidden="true">❌</span><span class="visually-hidden">Not supported:</span> <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer>, <xref:Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer>, and [Data Annotations localization middleware](xref:fundamentals/localization#dataannotations-localization) are ASP.NET Core MVC features and *not supported* in Blazor apps.
+For Blazor apps, localized validation messages for [forms validation using data annotations](<xref:blazor/forms/validation#data-annotations-validator-component-and-custom-validation>) is supported if <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.ResourceType?displayProperty=nameWithType> and <xref:System.ComponentModel.DataAnnotations.ValidationAttribute.ErrorMessageResourceType?displayProperty=nameWithType> are implemented.
 
 This article describes how to use Blazor's globalization and localization features based on:
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -22,7 +22,7 @@ A limited set of ASP.NET Core's localization features are supported:
 
 <span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> <xref:Microsoft.Extensions.Localization.IStringLocalizer> and <xref:Microsoft.Extensions.Localization.IStringLocalizer%601> are supported in Blazor apps.
 
-<span aria-hidden="true">❌</span><span class="visually-hidden">Not supported:</span> <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer>, <xref:Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer>, and data annotations via [Localization Middleware](xref:fundamentals/localization#dataannotations-localization) are ASP.NET Core MVC features and *not supported* in Blazor apps.
+<span aria-hidden="true">❌</span><span class="visually-hidden">Not supported:</span> <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer> and <xref:Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer> are ASP.NET Core MVC features and *not supported* in Blazor apps.
 
 For Blazor apps, localized validation messages for [forms validation using data annotations](<xref:blazor/forms/validation#data-annotations-validator-component-and-custom-validation>) is supported if <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.ResourceType?displayProperty=nameWithType> and <xref:System.ComponentModel.DataAnnotations.ValidationAttribute.ErrorMessageResourceType?displayProperty=nameWithType> are implemented.
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -24,7 +24,7 @@ A limited set of ASP.NET Core's localization features are supported:
 
 <span aria-hidden="true">✔️</span><span class="visually-hidden">Supported:</span> Localized validation messages in [forms validation using DataAnnotations](<xref:blazor/forms/validation#data-annotations-validator-component-and-custom-validation>) if <xref:System.ComponentModel.DataAnnotations.DisplayAttribute.ResourceType?displayProperty=nameWithType> and <xref:System.ComponentModel.DataAnnotations.ValidationAttribute.ErrorMessageResourceType?displayProperty=nameWithType> are set explicitly are also supported in Blazor apps.
 
-<span aria-hidden="true">❌</span><span class="visually-hidden">Not supported:</span> <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer>, <xref:Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer>, and [Data Annotations localization](xref:fundamentals/localization#dataannotations-localization) are ASP.NET Core MVC features and *not supported* in Blazor apps.
+<span aria-hidden="true">❌</span><span class="visually-hidden">Not supported:</span> <xref:Microsoft.AspNetCore.Mvc.Localization.IHtmlLocalizer>, <xref:Microsoft.AspNetCore.Mvc.Localization.IViewLocalizer>, and [Data Annotations localization middleware](xref:fundamentals/localization#dataannotations-localization) are ASP.NET Core MVC features and *not supported* in Blazor apps.
 
 This article describes how to use Blazor's globalization and localization features based on:
 


### PR DESCRIPTION
@guardrex Probably there's a more concise and/or nicer way to express this in the docs, but I found it confusing to read

> Not supported: [...] Data Annotations localization [...]

despite code like this

```csharp
[Required(ErrorMessageResourceName = nameof(Resources.Strings.RequiredAttribute_ValidationError), ErrorMessageResourceType = typeof(Resources.Strings))]
[Display(Name = "Street", ResourceType = typeof(Resources.ViewModels.BaseAddressViewModel))]
public string? Street { get; set; }
```

works great with

```razor
<EditForm Model="Model" OnValidSubmit="HandleSubmit">
    <DataAnnotationsValidator />
    <ValidationSummary />
    ...
</EditForm>
```

and e.g. [`UseRequestLocalization`](https://learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?view=aspnetcore-9.0#server-side-localization).

Also, resource localization in general (while not an ASP.NET Core feature), by just accessing a strongly typed property in a generated resource class in code e.g. `Resources.Strings.RequiredAttribute_ValidationError` works.

Or is this in some subtle way unsupported? If so, wouldn't `CultureInfo.CurrentCulture` in the [demo component](https://learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?view=aspnetcore-9.0#demonstration-component) be equally unsupported?

What afaik doesn't work regarding DataAnnotations localization is Mvc's [middleware component](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.dependencyinjection.mvcdataannotationsmvcbuilderextensions.adddataannotationslocalization?view=aspnetcore-9.0) that removes the need to be as verbose as `[Required(ErrorMessageResourceName = nameof(Resources.Strings.RequiredAttribute_ValidationError), ErrorMessageResourceType = typeof(Resources.Strings))]` (or deriving).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/globalization-localization.md](https://github.com/dotnet/AspNetCore.Docs/blob/f64abea0817b9f243bef41efece456333548d310/aspnetcore/blazor/globalization-localization.md) | [aspnetcore/blazor/globalization-localization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?branch=pr-en-us-34481) |


<!-- PREVIEW-TABLE-END -->