### PR TITLE
Fix inaccurate code snippet highlighting

### DIFF
--- a/aspnetcore/fundamentals/index.md
+++ b/aspnetcore/fundamentals/index.md
@@ -71,7 +71,7 @@ The request handling pipeline is composed as a series of middleware components. 
 
 By convention, a middleware component is added to the pipeline by invoking a `Use{Feature}` extension method. The use of methods named `Use{Feature}` to add middleware to an app is illustrated in the following code:
 
-:::code language="csharp" source="~/fundamentals/index/samples/9.0/BlazorWebAppMovies/Program.cs" id="snippet_middleware" highlight="24-26,29,32":::
+:::code language="csharp" source="~/fundamentals/index/samples/9.0/BlazorWebAppMovies/Program.cs" id="snippet_middleware" highlight="26-28,30,32":::
 
 For more information, see <xref:fundamentals/middleware/index>.
 


### PR DESCRIPTION
From my understanding, only the lines of code containing `Use{Feature}` method should be highlighted, so that's what I fixed.

Fixes #34516

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/c8390ab37bfcaff8467ed6ba4e4366ad0de6c5c0/aspnetcore/fundamentals/index.md) | [ASP.NET Core fundamentals overview](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/index?branch=pr-en-us-34506) |

<!-- PREVIEW-TABLE-END -->