### PR TITLE
Replace file destination instructions for OpenAPI build-time documentation so projects can build correctly 

### DIFF
--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -160,7 +160,7 @@ By default, the generated OpenAPI document will be emitted to the application's 
 
 ```xml
 <PropertyGroup>
-  <OpenApiDocumentsDirectory>./</OpenApiDocumentsDirectory>
+  <OpenApiDocumentsDirectory>.</OpenApiDocumentsDirectory>
 </PropertyGroup>
 ```
 

--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -164,7 +164,7 @@ By default, the generated OpenAPI document will be emitted to the application's 
 </PropertyGroup>
 ```
 
-The value of `OpenApiDocumentsDirectory` is resolved relative to the project file. Using the `./` value above will emit the OpenAPI document in the same directory as the project file.
+The value of `OpenApiDocumentsDirectory` is resolved relative to the project file. Using the `.` value above will emit the OpenAPI document in the same directory as the project file.
 
 #### Modifying the output file name
 


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #34508

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #34508

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/c73bb059531ba49dc75718c6a8aa31c61b38d2f5/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md) | [Generate OpenAPI documents](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?branch=pr-en-us-34509) |


<!-- PREVIEW-TABLE-END -->