### PR TITLE
Enhance location of `<script>` tags coverage

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
+++ b/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md
@@ -39,7 +39,7 @@ Inline JavaScript isn't recommended for Blazor apps. We recommend using [JS coll
 
 :::moniker range=">= aspnetcore-8.0"
 
-Only place a `<script>` tag in a component file (`.razor`) if the component is guaranteed to adopt [static server-side rendering (static SSR)](xref:blazor/fundamentals/index#client-and-server-rendering-concepts) because the `<script>` tag can't be updated dynamically. Placing a `<script>` tag in a component file doesn't produce a compile-time warning or error, but script loading behavior might not match your expectations in components that adopt an interactive render mode.
+Only place a `<script>` tag in a component file (`.razor`) if the component is guaranteed to adopt [static server-side rendering (static SSR)](xref:blazor/fundamentals/index#client-and-server-rendering-concepts) without [enhanced navigation](xref:blazor/fundamentals/routing#enhanced-navigation-and-form-handling). Placing a `<script>` tag in a component file doesn't produce a compile-time warning or error, but script loading behavior might not match your expectations in components that adopt an interactive render mode or static SSR with enhanced navigation.
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #34371

@hakenr ... This generalizes the reason ('the tag can't be updated dynamically') to just a recommendation not to place the tag and specifies the condition (static SSR w/o enhanced nav). I feel good about this update. How do you feel about it?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/location-of-javascript.md](https://github.com/dotnet/AspNetCore.Docs/blob/f5f419e699c4fabd8fe5499a69698381a86d2669/aspnetcore/blazor/javascript-interoperability/location-of-javascript.md) | [aspnetcore/blazor/javascript-interoperability/location-of-javascript](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/location-of-javascript?branch=pr-en-us-34528) |

<!-- PREVIEW-TABLE-END -->