### PR TITLE
update MongoDB controller based API tutorial to v9

### DIFF
--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -35,15 +35,11 @@ In this tutorial, you learn how to:
 
 # [Visual Studio](#tab/visual-studio)
 
-[!INCLUDE[](~/includes/net-prereqs-vs-8.0.md)]
+[!INCLUDE[](~/includes/net-prereqs-vs-9.0.md)]
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-[!INCLUDE[](~/includes/net-prereqs-vsc-8.0.md)]
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-[!INCLUDE[](~/includes/net-prereqs-mac-8.0.md)]
+[!INCLUDE[](~/includes/net-prereqs-vsc-9.0.md)]
 
 ---
 
@@ -151,7 +147,11 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 1. Go to **File** > **New** > **Project**.
 1. Select the **ASP.NET Core Web API** project type, and select **Next**.
 1. Name the project *BookStoreApi*, and select **Next**.
-1. Select the **.NET 8.0 (Long Term support)** framework and select **Create**.
+1. In the **Additional information** dialog:
+  * Confirm the **Framework** is **.NET 9.0 (Standard Term Support)**.
+  * Confirm the checkbox for **Use controllers** is checked.
+  * Confirm the checkbox for **Enable OpenAPI support** is checked.
+  * Select **Create**.
 1. In the **Package Manager Console** window, navigate to the project root. Run the following command to install the .NET driver for MongoDB:
 
    ```powershell
@@ -163,7 +163,7 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 1. Run the following commands in a command shell:
 
    ```dotnetcli
-   dotnet new webapi -o BookStoreApi
+   dotnet new webapi -o BookStoreApi --use-controllers
    code BookStoreApi
    ```
 
@@ -175,17 +175,6 @@ Use the previously installed MongoDB Shell in the following steps to create a da
    ```dotnetcli
    dotnet add package MongoDB.Driver
    ```
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-1. Select **File** > **New Project...**.
-1. Select **Web and Console** > **App** from the sidebar.
-1. Select the **ASP.NET Core** > **API** C# project template, and select **Next**.
-1. Select **.NET 8.0** from the **Target Framework** drop-down list, and select **Next**.
-1. Enter *BookStoreApi* for the **Project Name**, and select **Create**.
-1. In the **Solution** pad, right-click the project's **Dependencies** node and select **Manage NuGet Packages**.
-1. Enter *MongoDB.Driver* in the search box, select the *MongoDB.Driver* package, and select **Add Package**.
-1. Select the **Accept** button in the **License Acceptance** dialog.
 
 ---
 

--- a/aspnetcore/tutorials/first-mongo-app/includes/first-mongo-app8.md
+++ b/aspnetcore/tutorials/first-mongo-app/includes/first-mongo-app8.md
@@ -177,7 +177,7 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 1. Add a *Models* directory to the project root.
 1. Add a `Book` class to the *Models* directory with the following code:
 
-   :::code language="csharp" source="first-mongo-app/samples_snapshot/6.x/Book.cs":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples_snapshot/6.x/Book.cs":::
 
    In the preceding class, the `Id` property is:
 
@@ -191,48 +191,48 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 
 1. Add the following database configuration values to `appsettings.json`:
 
-   :::code language="json" source="first-mongo-app/samples/6.x/BookStoreApi/appsettings.json" highlight="2-6":::
+   :::code language="json" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/appsettings.json" highlight="2-6":::
 
 1. Add a `BookStoreDatabaseSettings` class to the *Models* directory with the following code:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Models/BookStoreDatabaseSettings.cs":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Models/BookStoreDatabaseSettings.cs":::
 
    The preceding `BookStoreDatabaseSettings` class is used to store the `appsettings.json` file's `BookStoreDatabase` property values. The JSON and C# property names are named identically to ease the mapping process.
 
 1. Add the following highlighted code to `Program.cs`:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_BookStoreDatabaseSettings" highlight="4-5":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_BookStoreDatabaseSettings" highlight="4-5":::
 
    In the preceding code, the configuration instance to which the `appsettings.json` file's `BookStoreDatabase` section binds is registered in the Dependency Injection (DI) container. For example, the `BookStoreDatabaseSettings` object's `ConnectionString` property is populated with the `BookStoreDatabase:ConnectionString` property in `appsettings.json`.
 
 1. Add the following code to the top of `Program.cs` to resolve the `BookStoreDatabaseSettings` reference:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_UsingModels":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_UsingModels":::
 
 ## Add a CRUD operations service
 
 1. Add a *Services* directory to the project root.
 1. Add a `BooksService` class to the *Services* directory with the following code:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_File":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_File":::
 
    In the preceding code, a `BookStoreDatabaseSettings` instance is retrieved from DI via constructor injection. This technique provides access to the `appsettings.json` configuration values that were added in the [Add a configuration model](#add-a-configuration-model) section.
 
 1. Add the following highlighted code to `Program.cs`:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_BooksService" highlight="7":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_BooksService" highlight="7":::
 
    In the preceding code, the `BooksService` class is registered with DI to support constructor injection in consuming classes. The singleton service lifetime is most appropriate because `BooksService` takes a direct dependency on `MongoClient`. Per the official [Mongo Client reuse guidelines](https://mongodb.github.io/mongo-csharp-driver/2.14/reference/driver/connecting/#re-use), `MongoClient` should be registered in DI with a singleton service lifetime.
 
 1. Add the following code to the top of `Program.cs` to resolve the `BooksService` reference:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_UsingServices":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_UsingServices":::
 
 The `BooksService` class uses the following `MongoDB.Driver` members to run CRUD operations against the database:
 
 * [MongoClient](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/T_MongoDB_Driver_MongoClient.htm): Reads the server instance for running database operations. The constructor of this class is provided in the MongoDB connection string:
 
-  :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_ctor" highlight="4-5":::
+  :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_ctor" highlight="4-5":::
 
 * [IMongoDatabase](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/T_MongoDB_Driver_IMongoDatabase.htm): Represents the Mongo database for running operations. This tutorial uses the generic [GetCollection\<TDocument>(collection)](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/M_MongoDB_Driver_IMongoDatabase_GetCollection__1.htm) method on the interface to gain access to data in a specific collection. Run CRUD operations against the collection after this method is called. In the `GetCollection<TDocument>(collection)` method call:
 
@@ -250,7 +250,7 @@ The `BooksService` class uses the following `MongoDB.Driver` members to run CRUD
 
 Add a `BooksController` class to the *Controllers* directory with the following code:
 
-:::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Controllers/BooksController.cs":::
+:::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Controllers/BooksController.cs":::
 
 The preceding web API controller:
 
@@ -306,19 +306,19 @@ To satisfy the preceding requirements, make the following changes:
 
 1. In `Program.cs`, chain the following highlighted code on to the `AddControllers` method call:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_AddControllers" highlight="10-11":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_AddControllers" highlight="10-11":::
 
    With the preceding change, property names in the web API's serialized JSON response match their corresponding property names in the CLR object type. For example, the `Book` class's `Author` property serializes as `Author` instead of `author`.
 
 1. In `Models/Book.cs`, annotate the `BookName` property with the [`[JsonPropertyName]`](xref:System.Text.Json.Serialization.JsonPropertyNameAttribute) attribute:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Models/Book.cs" id="snippet_BookName" highlight="2":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Models/Book.cs" id="snippet_BookName" highlight="2":::
 
    The `[JsonPropertyName]` attribute's value of `Name` represents the property name in the web API's serialized JSON response.
 
 1. Add the following code to the top of `Models/Book.cs` to resolve the `[JsonProperty]` attribute reference:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Models/Book.cs" id="snippet_UsingSystemTextJsonSerialization":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Models/Book.cs" id="snippet_UsingSystemTextJsonSerialization":::
 
 1. Repeat the steps defined in the [Test the web API](#test-the-web-api) section. Notice the difference in JSON property names.
 

--- a/aspnetcore/tutorials/first-mongo-app/includes/first-mongo-app8.md
+++ b/aspnetcore/tutorials/first-mongo-app/includes/first-mongo-app8.md
@@ -1,21 +1,4 @@
----
-title: Create a web API with ASP.NET Core and MongoDB
-author: wadepickett
-<!-- author: prkhandelwal -->
-description: This tutorial demonstrates how to create an ASP.NET Core web API using a MongoDB NoSQL database.
-monikerRange: '>= aspnetcore-3.1'
-ms.author: wpickett
-ms.custom: mvc, engagement-fy23
-ms.date: 04/17/2024
-uid: tutorials/first-mongo-app
----
-# Create a web API with ASP.NET Core and MongoDB
-
-[!INCLUDE[](~/includes/not-latest-version.md)]
-
-By [Pratik Khandelwal](https://twitter.com/K2Prk) and [Scott Addie](https://twitter.com/Scott_Addie)
-
-:::moniker range=">= aspnetcore-9.0"
+:::moniker range="= aspnetcore-8.0"
 
 This tutorial creates a web API that runs Create, Read, Update, and Delete (CRUD) operations on a [MongoDB](https://www.mongodb.com/what-is-mongodb) NoSQL database.
 
@@ -351,11 +334,3 @@ To satisfy the preceding requirements, make the following changes:
 * [Create a web API with ASP.NET Core](/training/modules/build-web-api-aspnet-core/)
 
 :::moniker-end
-
-[!INCLUDE[](~/tutorials/first-mongo-app/includes/first-mongo-app8.md)]
-
-[!INCLUDE[](~/tutorials/first-mongo-app/includes/first-mongo-app7.md)]
-
-[!INCLUDE[](~/tutorials/first-mongo-app/includes/first-mongo-app6.md)]
-
-[!INCLUDE[](~/tutorials/first-mongo-app/includes/first-mongo-app3-5.md)]


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #34317

This PR "archives" the current docs in a new v8 page (copy-paste), and updates the current docs for ASP.NET 9.
Because Minimal API's have become the default, I updated the setup steps to use the controller-based API (similar to https://learn.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?view=aspnetcore-9.0&tabs=visual-studio-code). 
It also removes the MAC setup for v9 because it isn't supported anymore and I noticed other docs also removed it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mongo-app.md](https://github.com/dotnet/AspNetCore.Docs/blob/2981ee78be96b348d934f6bf8a1ebc2e3b655c8b/aspnetcore/tutorials/first-mongo-app.md) | [Create a web API with ASP.NET Core and MongoDB](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mongo-app?branch=pr-en-us-34529) |


<!-- PREVIEW-TABLE-END -->