### PR TITLE
fix role access descriptions in authorization documentation

### DIFF
--- a/aspnetcore/security/authorization/roles.md
+++ b/aspnetcore/security/authorization/roles.md
@@ -59,8 +59,8 @@ Access to an action can be limited by applying additional role authorization att
 
 In the preceding `ControlAllPanelController` controller:
 
-* Members of the `Administrator` role or the `PowerUser` role can access the controller and the `ShutDown` action.
-* Only members of the `Administrator` role can access the `SetTime` action.
+* Members of the `Administrator` role or the `PowerUser` role can access the controller and the `SetTime` action.
+* Only members of the `Administrator` role can access the `ShutDown` action.
 
 A controller can be secured but allow anonymous, unauthenticated access to individual actions:
 
@@ -138,8 +138,8 @@ If multiple attributes are applied at the controller and action levels, ***all**
 
 In the preceding `ControlAllPanelController` controller:
 
-* Members of the `Administrator` role or the `PowerUser` role can access the controller and the `SetTime` action.
-* Only members of the `Administrator` role can access the `ShutDown` action.
+* Members of the `Administrator` role can access the controller and the `SetTime` action.
+* Only members of the `Administrator` **and** the `PowerUser` role can access the `ShutDown` action.
 
 You can also lock down a controller but allow anonymous, unauthenticated access to individual actions.
 


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #34525

Updates the description to match the example.
I also noticed the description was wrong for `< 6` versions.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authorization/roles.md](https://github.com/dotnet/AspNetCore.Docs/blob/a5845bc802976f20174b46326c488e4fa55552ad/aspnetcore/security/authorization/roles.md) | [Role-based authorization in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authorization/roles?branch=pr-en-us-34533) |

<!-- PREVIEW-TABLE-END -->