### PR TITLE
Move MapOpenApi() Inside the IsDevelopment() block for consistency wi…

### DIFF
--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -5,7 +5,7 @@ description: Learn how to generate and customize OpenAPI documents in an ASP.NET
 ms.author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.custom: mvc
-ms.date: 12/11/2024
+ms.date: 01/23/2025
 uid: fundamentals/openapi/aspnetcore-openapi
 ---
 # Generate OpenAPI documents
@@ -48,7 +48,7 @@ The following code:
 * Adds OpenAPI services using the <xref:Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions.AddOpenApi%2A> extension method on the app builder's service collection.
 * Maps an endpoint for viewing the OpenAPI document in JSON format with the <xref:Microsoft.AspNetCore.Builder.OpenApiEndpointRouteBuilderExtensions.MapOpenApi%2A> extension method on the app.
 
-[!code-csharp[](~/fundamentals/openapi/samples/9.x/WebMinOpenApi/Program.cs?name=snippet_first&highlight=3,7)]
+[!code-csharp[](~/fundamentals/openapi/samples/9.x/WebMinOpenApi/Program.cs?name=snippet_first&highlight=3,9)]
 
 Launch the app and navigate to `https://localhost:<port>/openapi/v1.json` to view the generated OpenAPI document.
 

--- a/aspnetcore/fundamentals/openapi/samples/9.x/WebMinOpenApi/Program.cs
+++ b/aspnetcore/fundamentals/openapi/samples/9.x/WebMinOpenApi/Program.cs
@@ -3,7 +3,6 @@
 //#define DOCUMENTtransformer1
 //#define DOCUMENTtransformer2
 #define DOCUMENTtransformerUse999
-//#define DEFAULT
 //#define FIRST
 //#define OPENAPIWITHSCALAR
 //#define MAPOPENAPIWITHCACHING
@@ -80,7 +79,10 @@ builder.Services.AddOpenApi(options =>
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 app.MapGet("/", () => "Hello world!");
 
@@ -107,7 +109,10 @@ builder.Services.AddOpenApi(options =>
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 app.MapGet("/", () => "Hello world!");
 
@@ -161,7 +166,10 @@ builder.Services.AddOpenApi(options =>
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 app.MapGet("/", () => "Hello world!");
 
@@ -189,7 +197,10 @@ builder.Services.AddOpenApi("public");
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 app.MapGet("/world", () => "Hello world!")
     .WithGroupName("internal");
@@ -253,7 +264,10 @@ builder.Services.AddOpenApi(options => {
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 app.MapGet("/", () => new Body { Amount = 1.1m });
 
@@ -343,8 +357,11 @@ var app = builder.Build();
 
 app.UseOutputCache();
 
-app.MapOpenApi()
-    .CacheOutput();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi()
+        .CacheOutput();
+}
 
 app.MapGet("/", () => "Hello world!");
 
@@ -366,7 +383,10 @@ builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 if (app.Environment.IsDevelopment())
 {
@@ -387,7 +407,10 @@ builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 app.MapGet("/", () => "Hello world!");
 
@@ -420,7 +443,10 @@ builder.Services.AddOpenApi(options =>
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 app.MapGet("/", () => "Hello world!");
 
@@ -474,7 +500,10 @@ builder.Services.AddOpenApi(options =>
 
 var app = builder.Build();
 
-app.MapOpenApi();
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
 
 app.MapGet("/", () => "Hello world!");
 

--- a/aspnetcore/fundamentals/openapi/samples/9.x/WebMinOpenApi/Program.cs
+++ b/aspnetcore/fundamentals/openapi/samples/9.x/WebMinOpenApi/Program.cs
@@ -386,10 +386,6 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
-}
-
-if (app.Environment.IsDevelopment())
-{
     app.MapScalarApiReference();
 }
 

--- a/aspnetcore/fundamentals/openapi/samples/9.x/WebMinOpenApi/Program.cs
+++ b/aspnetcore/fundamentals/openapi/samples/9.x/WebMinOpenApi/Program.cs
@@ -279,9 +279,10 @@ builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
-app.MapOpenApi();
 if (app.Environment.IsDevelopment())
 {
+    app.MapOpenApi();
+    
     app.UseSwaggerUI(options =>
     {
         options.SwaggerEndpoint("/openapi/v1.json", "v1");


### PR DESCRIPTION
Fixes #34571

…th templates and other docs

The default template with .NET 9 has MapOpenApi() inside the IsDevelopment block. Many examples on MS Learn also have it inside due to limit information exposure. 

Move inside to minimize potential for confusion to devs.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/aabdd2a46ed4b42596b12b7ec4ab88aff074a35c/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md) | [aspnetcore/fundamentals/openapi/aspnetcore-openapi](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?branch=pr-en-us-34541) |

<!-- PREVIEW-TABLE-END -->