### PR TITLE
Update examples in anti-request-forgery documentation to use a consistent domain format

### DIFF
--- a/aspnetcore/security/anti-request-forgery.md
+++ b/aspnetcore/security/anti-request-forgery.md
@@ -40,7 +40,7 @@ In addition to the scenario where the user selects the button to submit the form
 
 These alternative scenarios don't require any action or input from the user other than initially visiting the malicious site.
 
-Using HTTPS doesn't prevent a CSRF attack. The malicious site can send an `https://www.good-banking-site.com/` request as easily as it can send an insecure request.
+Using HTTPS doesn't prevent a CSRF attack. The malicious site can send `https://www.good-banking-site.example.com/` a request just as easily as it can send an insecure request.
 
 Some attacks target endpoints that respond to GET requests, in which case an image tag can be used to perform the action. This form of attack is common on forum sites that permit images but block JavaScript. Apps that change state on GET requests, where variables or resources are altered, are vulnerable to malicious attacks. **GET requests that change state are insecure. A best practice is to never change state on a GET request.**
 
@@ -359,7 +359,7 @@ In addition to the scenario where the user selects the button to submit the form
 
 These alternative scenarios don't require any action or input from the user other than initially visiting the malicious site.
 
-Using HTTPS doesn't prevent a CSRF attack. The malicious site can send an `https://www.good-banking-site.com/` request just as easily as it can send an insecure request.
+Using HTTPS doesn't prevent a CSRF attack. The malicious site can send `https://www.good-banking-site.example.com/` a request just as easily as it can send an insecure request.
 
 Some attacks target endpoints that respond to GET requests, in which case an image tag can be used to perform the action. This form of attack is common on forum sites that permit images but block JavaScript. Apps that change state on GET requests, where variables or resources are altered, are vulnerable to malicious attacks. **GET requests that change state are insecure. A best practice is to never change state on a GET request.**
 
@@ -635,7 +635,7 @@ In addition to the scenario where the user selects the button to submit the form
 
 These alternative scenarios don't require any action or input from the user other than initially visiting the malicious site.
 
-Using HTTPS doesn't prevent a CSRF attack. The malicious site can send an `https://www.good-banking-site.com/` request just as easily as it can send an insecure request.
+Using HTTPS doesn't prevent a CSRF attack. The malicious site can send `https://www.good-banking-site.example.com/` a request just as easily as it can send an insecure request.
 
 Some attacks target endpoints that respond to GET requests, in which case an image tag can be used to perform the action. This form of attack is common on forum sites that permit images but block JavaScript. Apps that change state on GET requests, where variables or resources are altered, are vulnerable to malicious attacks. **GET requests that change state are insecure. A best practice is to never change state on a GET request.**
 
@@ -887,7 +887,7 @@ In addition to the scenario where the user selects the button to submit the form
 
 These alternative scenarios don't require any action or input from the user other than initially visiting the malicious site.
 
-Using HTTPS doesn't prevent a CSRF attack. The malicious site can send an `https://www.good-banking-site.com/` request just as easily as it can send an insecure request.
+Using HTTPS doesn't prevent a CSRF attack. The malicious site can send `https://www.good-banking-site.example.com/` a request just as easily as it can send an insecure request.
 
 Some attacks target endpoints that respond to GET requests, in which case an image tag can be used to perform the action. This form of attack is common on forum sites that permit images but block JavaScript. Apps that change state on GET requests, where variables or resources are altered, are vulnerable to malicious attacks. **GET requests that change state are insecure. A best practice is to never change state on a GET request.**
 

--- a/aspnetcore/security/anti-request-forgery/samples_snapshot/vulnerable-form.html
+++ b/aspnetcore/security/anti-request-forgery/samples_snapshot/vulnerable-form.html
@@ -1,5 +1,5 @@
 <h1>Congratulations! You're a Winner!</h1>
-<form action="https://good-banking-site.com/api/account" method="post">
+<form action="https://www.good-banking-site.example.com/api/account" method="post">
     <input type="hidden" name="Transaction" value="withdraw" />
     <input type="hidden" name="Amount" value="1000000" />
     <input type="submit" value="Click to collect your prize!" />


### PR DESCRIPTION
Fixes #34565
Fixes #34557



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/anti-request-forgery.md](https://github.com/dotnet/AspNetCore.Docs/blob/8b74cf3c922f0cba4a64ac1b5b8e65043ea34a53/aspnetcore/security/anti-request-forgery.md) | [Prevent Cross-Site Request Forgery (XSRF/CSRF) attacks in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/anti-request-forgery?branch=pr-en-us-34568) |

<!-- PREVIEW-TABLE-END -->