### PR TITLE
FirstMVC: Correct f12 image for search.md

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/search.md
+++ b/aspnetcore/tutorials/first-mvc-app/search.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Part 7 of tutorial series on ASP.NET Core MVC.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 07/24/2024
+ms.date: 01/26/2025
 uid: tutorials/first-mvc-app/search
 ---
 
@@ -98,7 +98,7 @@ The following image shows the Chrome browser Developer tools with the **Network*
 
 The **Network** and **Payload** tabs are selected to view form data:
 
-![Network and Payload tabs of Chrome browser Developer Tools showing form data](~/tutorials/first-mvc-app/search/_static/9/f12_general90.png)
+![Network and Payload tabs of Chrome browser Developer Tools showing form data](~/tutorials/first-mvc-app/search/_static/9/f12_form90.png)
 
 You can see the search parameter and [XSRF](xref:security/anti-request-forgery) token in the request body. Note, as mentioned in the previous tutorial, the [Form Tag Helper](xref:mvc/views/working-with-forms) generates an [XSRF](xref:security/anti-request-forgery) antiforgery token. We're not modifying data, so we don't need to validate the token in the controller method.
 


### PR DESCRIPTION
Fixes #34567

This line:
`![Network and Payload tabs of Chrome browser Developer Tools showing form data](~/tutorials/first-mvc-app/search/_static/9/f12_general90.png)`

should point to a different image that was already available:

`![Network and Payload tabs of Chrome browser Developer Tools showing form data](~/tutorials/first-mvc-app/search/_static/9/f12_form90.png)`



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mvc-app/search.md](https://github.com/dotnet/AspNetCore.Docs/blob/883273906f9ed35729495be0935fb635cf4da926/aspnetcore/tutorials/first-mvc-app/search.md) | [aspnetcore/tutorials/first-mvc-app/search](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/search?branch=pr-en-us-34569) |

<!-- PREVIEW-TABLE-END -->