### PR TITLE
update grpc-start to .NET 9

### DIFF
--- a/aspnetcore/includes/run-the-app9.0.md
+++ b/aspnetcore/includes/run-the-app9.0.md
@@ -1,0 +1,29 @@
+# [Visual Studio](#tab/visual-studio)
+
+* Press Ctrl+F5 to run without the debugger.
+
+  [!INCLUDE[](~/includes/trustCertVS.md)]
+
+  Visual Studio:
+
+  * Starts [Kestrel](xref:fundamentals/servers/index#kestrel) server.
+  * Launches a browser.
+  * Navigates to `http://localhost:port`, such as `http://localhost:7042`.
+    * *port*: A randomly assigned port number for the app.
+    * `localhost`: The standard hostname for the local computer. Localhost only serves web requests from the local computer.
+
+# [Visual Studio Code](#tab/visual-studio-code)
+
+  [!INCLUDE[](~/includes/trustCertVSC.md)]
+
+* Press **Ctrl-F5** to run without the debugger.
+
+  Visual Studio Code:
+
+  * Starts [Kestrel](xref:fundamentals/servers/index#kestrel) server.
+  * Launches a browser.
+  * Navigates to `http://localhost:port`, such as `http://localhost:7042`.
+    * *port*: A randomly assigned port number for the app.
+    * `localhost`: The standard hostname for the local computer. Localhost only serves web requests from the local computer.
+
+---

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: wpickett
-ms.date: 01/30/2024
+ms.date: 01/30/2025
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -218,7 +218,7 @@ The Greeter client is created by:
 
 The Greeter client calls the asynchronous `SayHello` method. The result of the `SayHello` call is displayed:
 
-[!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Program.cs?name=snippet&highlight=4-7)]
+[!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Program.cs?name=snippet&highlight=4-6)]
 
 ## Test the gRPC client with the gRPC Greeter service
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -39,7 +39,7 @@ In this tutorial, you:
 * In the **Create a new project** dialog, search for `gRPC`. Select **ASP.NET Core gRPC Service** and select **Next**.
 * In the **Configure your new project** dialog, enter `GrpcGreeter` for **Project name**. It's important to name the project *GrpcGreeter* so the namespaces match when you copy and paste code.
 * Select **Next**.
-* In the **Additional information** dialog, select **.NET 8.0 (Standard Term Support)** and then select **Create**.
+* In the **Additional information** dialog, select **.NET 9.0 (Standard Term Support)** and then select **Create**.
 
 # [Visual Studio Code](#tab/visual-studio-code)
 

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: wpickett
-ms.date: 08/30/2023
+ms.date: 01/30/2024
 uid: tutorials/grpc/grpc-start
 ---
 # Tutorial: Create a gRPC client and server in ASP.NET Core

--- a/aspnetcore/tutorials/grpc/grpc-start.md
+++ b/aspnetcore/tutorials/grpc/grpc-start.md
@@ -23,15 +23,11 @@ In this tutorial, you:
 
 # [Visual Studio](#tab/visual-studio)
 
-[!INCLUDE[](~/includes/net-prereqs-vs-8.0.md)]
+[!INCLUDE[](~/includes/net-prereqs-vs-9.0.md)]
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-[!INCLUDE[](~/includes/net-prereqs-vsc-8.0.md)]
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-[!INCLUDE[](~/includes/net-prereqs-mac-8.0.md)]
+[!INCLUDE[](~/includes/net-prereqs-vsc-9.0.md)]
 
 ---
 
@@ -43,13 +39,13 @@ In this tutorial, you:
 * In the **Create a new project** dialog, search for `gRPC`. Select **ASP.NET Core gRPC Service** and select **Next**.
 * In the **Configure your new project** dialog, enter `GrpcGreeter` for **Project name**. It's important to name the project *GrpcGreeter* so the namespaces match when you copy and paste code.
 * Select **Next**.
-* In the **Additional information** dialog, select **.NET 8.0 (Long Term Support)** and then select **Create**.
+* In the **Additional information** dialog, select **.NET 8.0 (Standard Term Support)** and then select **Create**.
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
 The tutorial assumes familiarity with VS Code. For more information, see [Getting started with VS Code](https://code.visualstudio.com/docs).
 
-* Select **New Terminal** from the **Terminal** menu to open the [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal).
+* Select **New Terminal** from the **Terminal** menu to open the [integrated terminal](https://code.visualstudio.com/docs/terminal/basics).
 * Change to the directory (`cd`) that will contain the project.
 * Run the following commands:
 
@@ -64,19 +60,11 @@ The tutorial assumes familiarity with VS Code. For more information, see [Gettin
 
 [!INCLUDE[](~/includes/vscode-trust-authors-add-assets.md)]
 
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-* Start Visual Studio 2022 for Mac and select **File** > **New Project**.
-* In the **Choose a template for your new project** dialog, select **Web and Console** > **App** > **gRPC Service** and select **Continue**.
-* Select **.NET 8.0** for the target framework and select **Continue**.
-* Name the project **GrpcGreeter**. It's important to name the project *GrpcGreeter* so the namespaces match when you copy and paste code.
-* Select **Continue**.
-
 ---
 
 ### Run the service
  
-[!INCLUDE[](~/includes/run-the-app6.0.md)]
+[!INCLUDE[](~/includes/run-the-app9.0.md)]
 
 The logs show the service listening on `https://localhost:<port>`, where `<port>` is the localhost port number randomly assigned when the project is created and set in `Properties/launchSettings.json`.
 
@@ -110,11 +98,11 @@ info: Microsoft.Hosting.Lifetime[0]
 * Open a second instance of Visual Studio and select **New Project**.
 * In the **Create a new project** dialog, select **Console App**, and select **Next**.
 * In the **Project name** text box, enter **GrpcGreeterClient** and select **Next**.
-* In the **Additional information** dialog, select **.NET 8.0 (Long Term Support)** and then select **Create**.
+* In the **Additional information** dialog, select **.NET 9.0 (Standard Term Support)** and then select **Create**.
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
-* Open the [integrated terminal](https://code.visualstudio.com/docs/editor/integrated-terminal).
+* Open the [integrated terminal](https://code.visualstudio.com/docs/terminal/basics).
 * Change directories (`cd`) to a folder for the project.
 * Run the following commands:
 
@@ -124,14 +112,6 @@ info: Microsoft.Hosting.Lifetime[0]
   ```
 
 [!INCLUDE[](~/includes/vscode-trust-authors-add-assets.md)]
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-* In Visual Studio 2022 for Mac select **File** > **Add** > **Project...**.
-* In the **Choose a template for your new project** dialog, select **Web and Console** > **App** > **Console Application**, and select **Continue**.
-* Select **.NET 8.0** for the target framework, and select **Continue**.
-* Name the project **GrpcGreeterClient**. It's important to name the project *GrpcGreeterClient* so the namespaces match when you copy and paste code.
-* Select **Continue**.
 
 ---
 
@@ -177,15 +157,6 @@ dotnet add GrpcGreeterClient.csproj package Google.Protobuf
 dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 ```
 
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-* Right-click **GrpcGreeterClient** project in the **Solution Pad** and select **Manage NuGet Packages**.
-* Enter **Grpc.Net.Client** in the search box.
-* Select the **Grpc.Net.Client** package from the results pane and select **Add Package**.
-* In **Select Projects** select **OK**.
-* If the **License Acceptance** dialog appears, select **Accept** if you agree to the license terms.
-* Repeat for `Google.Protobuf` and `Grpc.Tools`.
-
 ---
 
 ### Add greet.proto
@@ -207,10 +178,6 @@ dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 # [Visual Studio Code](#tab/visual-studio-code)
 
   Select the `GrpcGreeterClient.csproj` file.
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
-
-  Right-click the project and select **Edit Project File**.
 
   ---
 
@@ -236,7 +203,7 @@ dotnet add GrpcGreeterClient.csproj package Grpc.Tools
 
 * Update the gRPC client `Program.cs` file with the following code.
 
-  [!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample8/GrpcGreeterClient/Program.cs?name=snippet2&highlight=6)]
+  [!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Program.cs?name=snippet2&highlight=5)]
 
 * In the preceding highlighted code, replace the localhost port number `7042` with the `HTTPS` port number specified in `Properties/launchSettings.json` within the `GrpcGreeter` service project.
 
@@ -247,29 +214,24 @@ The Greeter client is created by:
 * Instantiating a `GrpcChannel` containing the information for creating the connection to the gRPC service.
 * Using the `GrpcChannel` to construct the Greeter client:
 
-[!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample8/GrpcGreeterClient/Program.cs?name=snippet&highlight=1-3)]
+[!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Program.cs?name=snippet&highlight=1-3)]
 
 The Greeter client calls the asynchronous `SayHello` method. The result of the `SayHello` call is displayed:
 
-[!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample8/GrpcGreeterClient/Program.cs?name=snippet&highlight=4-7)]
+[!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Program.cs?name=snippet&highlight=4-7)]
 
 ## Test the gRPC client with the gRPC Greeter service
 
 Update the `appsettings.Development.json` file by adding the following highlighted lines:
 
-[!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample8/GrpcGreeter/appsettings.Development.json?highlight=6-7)]
+[!code-csharp[](~/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/appsettings.Development.json?highlight=6-7)]
 
 # [Visual Studio](#tab/visual-studio)
 
-* In the Greeter service, press `Ctrl+F5` to start the server without the debugger.
-* In the `GrpcGreeterClient` project, press `Ctrl+F5` to start the client without the debugger.
+* In the `GrpcGreeter` service project, press `Ctrl+F5` to start the server without the debugger.
+* In the `GrpcGreeterClient` console project, press `Ctrl+F5` to start the client without the debugger.
 
 # [Visual Studio Code](#tab/visual-studio-code)
-
-* Start the Greeter service.
-* Start the client.
-
-# [Visual Studio for Mac](#tab/visual-studio-mac)
 
 * Start the Greeter service.
 * Start the client.
@@ -295,13 +257,13 @@ info: Microsoft.Hosting.Lifetime[0]
 info: Microsoft.Hosting.Lifetime[0]
       Content root path: C:\GH\aspnet\docs\4\Docs\aspnetcore\tutorials\grpc\grpc-start\sample\GrpcGreeter
 info: Microsoft.AspNetCore.Hosting.Diagnostics[1]
-      Request starting HTTP/2 POST https://localhost:<port>/Greet.Greeter/SayHello application/grpc
+      Request starting HTTP/2 POST https://localhost:<port>/greet.Greeter/SayHello application/grpc
 info: Microsoft.AspNetCore.Routing.EndpointMiddleware[0]
-      Executing endpoint 'gRPC - /Greet.Greeter/SayHello'
+      Executing endpoint 'gRPC - /greet.Greeter/SayHello'
 info: Microsoft.AspNetCore.Routing.EndpointMiddleware[1]
-      Executed endpoint 'gRPC - /Greet.Greeter/SayHello'
+      Executed endpoint 'gRPC - /greet.Greeter/SayHello'
 info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
-      Request finished in 78.32260000000001ms 200 application/grpc
+      Request finished HTTP/2 POST https://localhost:7042/greet.Greeter/SayHello - 200 - application/grpc 40.4615ms
 ```
 
 > [!NOTE]

--- a/aspnetcore/tutorials/grpc/grpc-start/includes/grpc-start8.md
+++ b/aspnetcore/tutorials/grpc/grpc-start/includes/grpc-start8.md
@@ -1,15 +1,4 @@
----
-title: Create a .NET Core gRPC client and server in ASP.NET Core
-author: jamesnk
-description: This tutorial shows how to create a gRPC Service and gRPC client on ASP.NET Core. Learn how to create a gRPC Service project, edit a proto file, and add a duplex streaming call.
-monikerRange: '>= aspnetcore-3.0'
-ms.author: wpickett
-ms.date: 08/30/2023
-uid: tutorials/grpc/grpc-start
----
-# Tutorial: Create a gRPC client and server in ASP.NET Core
-
-:::moniker range=">= aspnetcore-9.0"
+:::moniker range="= aspnetcore-8.0"
 This tutorial shows how to create a .NET Core [gRPC](xref:grpc/index) client and an ASP.NET Core gRPC Server. At the end, you'll have a gRPC client that communicates with the gRPC Greeter service.
 
 In this tutorial, you:
@@ -315,13 +304,3 @@ info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
 * <xref:grpc/migration>
 
 :::moniker-end
-
-[!INCLUDE[](~/tutorials/grpc/grpc-start/includes/grpc-start8.md)]
-
-[!INCLUDE[](~/tutorials/grpc/grpc-start/includes/grpc-start7.md)]
-
-[!INCLUDE[](~/tutorials/grpc/grpc-start/includes/grpc-start6.md)]
-
-[!INCLUDE[](~/tutorials/grpc/grpc-start/includes/grpc-start5.md)]
-
-[!INCLUDE[](~/tutorials/grpc/grpc-start/includes/grpc-start3.md)]

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/GrpcGreeter.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/GrpcGreeter.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.64.0" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/Program.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/Program.cs
@@ -1,0 +1,14 @@
+using GrpcGreeter.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.AddGrpc();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+app.MapGrpcService<GreeterService>();
+app.MapGet("/", () => "Communication with gRPC endpoints must be made through a gRPC client. To learn how to create a client, visit: https://go.microsoft.com/fwlink/?linkid=2086909");
+
+app.Run();

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/Protos/greet.proto
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/Protos/greet.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "GrpcGreeter";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings.
+message HelloReply {
+  string message = 1;
+}

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/Services/GreeterService.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/Services/GreeterService.cs
@@ -1,0 +1,23 @@
+using Grpc.Core;
+using GrpcGreeter;
+
+namespace GrpcGreeter.Services;
+
+#region snippet
+public class GreeterService : Greeter.GreeterBase
+{
+    private readonly ILogger<GreeterService> _logger;
+    public GreeterService(ILogger<GreeterService> logger)
+    {
+        _logger = logger;
+    }
+
+    public override Task<HelloReply> SayHello(HelloRequest request, ServerCallContext context)
+    {
+        return Task.FromResult(new HelloReply
+        {
+            Message = "Hello " + request.Name
+        });
+    }
+}
+#endregion

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/appsettings.Development.json
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/appsettings.Development.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.Hosting": "Information",
+      "Microsoft.AspNetCore.Routing.EndpointMiddleware": "Information"
+    }
+  }
+}

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/appsettings.json
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeter/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Kestrel": {
+    "EndpointDefaults": {
+      "Protocols": "Http2"
+    }
+  }
+}

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/GrpcGreeterClient.csproj
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/GrpcGreeterClient.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.29.3" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.67.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.69.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="Protos\greet.proto" GrpcServices="Client" />
+  </ItemGroup>
+</Project>

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Program.cs
@@ -1,0 +1,15 @@
+﻿#region snippet2
+using Grpc.Net.Client;
+using GrpcGreeterClient;
+
+#region snippet
+// The port number must match the port of the gRPC server.
+using var channel = GrpcChannel.ForAddress("https://localhost:7042");
+var client = new Greeter.GreeterClient(channel);
+var reply = await client.SayHelloAsync(
+    new HelloRequest { Name = "GreeterClient" });
+Console.WriteLine("Greeting: " + reply.Message);
+Console.WriteLine("Press any key to exit...");
+Console.ReadKey();
+#endregion
+#endregion

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Protos/greet.proto
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/GrpcGreeterClient/Protos/greet.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option csharp_namespace = "GrpcGreeterClient";
+
+package greet;
+
+// The greeting service definition.
+service Greeter {
+  // Sends a greeting
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+// The request message containing the user's name.
+message HelloRequest {
+  string name = 1;
+}
+
+// The response message containing the greetings.
+message HelloReply {
+  string message = 1;
+}

--- a/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/readme.md
+++ b/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/readme.md
@@ -1,0 +1,23 @@
+---
+page_type: sample
+description: "Sample projects for a gRPC Service and gRPC client on ASP.NET Core."
+languages:
+- csharp
+products:
+- dotnet-core
+- aspnet-core
+- vs
+urlFragment: create-grpc-client
+---
+
+# Create a gRPC client and server in ASP.NET Core 9
+
+This sample demonstrates a .NET Core [gRPC](https://grpc.io/docs/guides/) client and an ASP.NET Core gRPC Server.
+
+For a tutorial on this sample see [Tutorial: Create a gRPC client and server in ASP.NET Core](https://learn.microsoft.com/aspnet/core/tutorials/grpc/grpc-start?view=aspnetcore-9.0)
+
+### Docs help & next steps for gRPC
+
+* [Introduction to gRPC on ASP.NET Core](https://learn.microsoft.com/aspnet/core/grpc/)
+* [gRPC services with C#](https://learn.microsoft.com/aspnet/core/grpc/basics/)
+* [Migrating gRPC services from C-core to ASP.NET Core](https://learn.microsoft.com/aspnet/core/grpc/migration/)


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Closes #34560

This PR:

- Moves the existing .NET 8 docs to its separate file
- Updates the current article to .NET 9
  - Removes instructions for Mac
  - Updates references to .NET 9
  - Updates VS code terminal link to new link (the old one gets redirected to this one)
  - Updates logs
- Adds .NET 9 sample
  - Removes unused using
  - The issue #34560 mentions removing `using GrpcGreeterClient`, but this is required 
![image](https://github.com/user-attachments/assets/98104439-5163-4c64-95a0-1ce43ad768d5)
    

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/grpc/grpc-start.md](https://github.com/dotnet/AspNetCore.Docs/blob/cd474da29da2717efff1ac446aa53018b2f0ecc8/aspnetcore/tutorials/grpc/grpc-start.md) | [aspnetcore/tutorials/grpc/grpc-start](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/grpc/grpc-start?branch=pr-en-us-34603) |
| [aspnetcore/tutorials/grpc/grpc-start/sample/sample9/readme.md](https://github.com/dotnet/AspNetCore.Docs/blob/cd474da29da2717efff1ac446aa53018b2f0ecc8/aspnetcore/tutorials/grpc/grpc-start/sample/sample9/readme.md) | [aspnetcore/tutorials/grpc/grpc-start/sample/sample9/readme](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/grpc/grpc-start/sample/sample9/readme?branch=pr-en-us-34603) |


<!-- PREVIEW-TABLE-END -->