### PR TITLE
fix markdown for configure-jwt-bearer-authentication page

### DIFF
--- a/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
+++ b/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
@@ -125,7 +125,7 @@ JWT bearer tokens should be fully validated in an API. The following should be v
 *  Audience claim with the expected value.
 *  Token expiration.
 
-The following claims are required for OAuth 2.0 access tokens: `iss`, `exp`, `aud`, `sub`, `client_id`, `iat, and `jti`.
+The following claims are required for OAuth 2.0 access tokens: `iss`, `exp`, `aud`, `sub`, `client_id`, `iat`, and `jti`.
 
 If any of these claims or values are incorrect, the API should return a 401 response.
 


### PR DESCRIPTION
This is fixing a markdown issue, https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-jwt-bearer-authentication?view=aspnetcore-9.0#implementing-jwt-bearer-token-authentication
![image](https://github.com/user-attachments/assets/7102d0cf-e8d6-429f-8ab0-423c90d054bc)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/configure-jwt-bearer-authentication.md](https://github.com/dotnet/AspNetCore.Docs/blob/d263228ff1bd90baee1f417949f8bef5f7a207eb/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md) | [Configure JWT bearer authentication in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-jwt-bearer-authentication?branch=pr-en-us-34608) |

<!-- PREVIEW-TABLE-END -->