### PR TITLE
Update configure-jwt-bearer-authentication so that code matches docs

### DIFF
--- a/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
+++ b/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
@@ -188,7 +188,7 @@ var requireAuthPolicy = new AuthorizationPolicyBuilder()
 	.Build();
 
 builder.Services.AddAuthorizationBuilder()
-	.SetFallbackPolicy(requireAuthPolicy);
+	.SetDefaultPolicy(requireAuthPolicy);
 ```
 
 The [Authorize](/dotnet/api/microsoft.aspnetcore.authorization.authorizeattribute) attribute can also be used to force the authentication. If multiple schemes are used, the bearer scheme generally needs to be set as the default authentication scheme or specified via `[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme])`.


### PR DESCRIPTION
The docs mentioned `SetDefaultPolicy ` so the code should match as well. https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-jwt-bearer-authentication?view=aspnetcore-9.0#forcing-the-bearer-authentication

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/configure-jwt-bearer-authentication.md](https://github.com/dotnet/AspNetCore.Docs/blob/830ead1b987aee50b99ec1f80be74742ef3a9e49/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md) | [Configure JWT bearer authentication in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-jwt-bearer-authentication?branch=pr-en-us-34609) |

<!-- PREVIEW-TABLE-END -->