### PR TITLE
include AOT support in v9 moniker

### DIFF
--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -227,7 +227,7 @@ In order to restrict these code paths from being invoked by the build-time gener
 
 :::code language="csharp" source="~/fundamentals/openapi/samples/9.x/AspireApp1/AspireApp1.Web/Program.cs" highlight="5-8":::
 
-<!--keep-->[AddServiceDefaults](https://source.dot.net/#TestingAppHost1.ServiceDefaults/Extensions.cs,0f0d863053754768,references) Adds common .NET Aspire services such as service discovery, resilience, health checks, and OpenTelemetry.
+[AddServiceDefaults](https://source.dot.net/#TestingAppHost1.ServiceDefaults/Extensions.cs,0f0d863053754768,references)<!--keep--> adds common .NET Aspire services such as service discovery, resilience, health checks, and OpenTelemetry.
 
 ## Trimming and Native AOT
 

--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -229,8 +229,6 @@ In order to restrict these code paths from being invoked by the build-time gener
 
 <!--keep-->[AddServiceDefaults](https://source.dot.net/#TestingAppHost1.ServiceDefaults/Extensions.cs,0f0d863053754768,references) Adds common .NET Aspire services such as service discovery, resilience, health checks, and OpenTelemetry.
 
-:::moniker-end
-
 ## Trimming and Native AOT
 
 OpenAPI in ASP.NET Core supports trimming and native AOT. The following steps create and publish an OpenAPI app with trimming and native AOT:
@@ -262,5 +260,7 @@ Publish the app.
 ```console
 dotnet publish
 ```
+
+:::moniker-end
 
 [!INCLUDE[](~/fundamentals/openapi/includes/aspnetcore-openapi6-8.md)]


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Closes #34510

As the issue points out the section about Native AOT is also showing on `< aspnetcore-9.0` pages (at the top of the page).
This PR moves the section within the `>= aspnetcore-9.0` moniker range, as it was [released in v9.0](https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-9.0?view=aspnetcore-9.0#microsoftaspnetcoreopenapi-supports-trimming-and-native-aot)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/218aa5ed593eb83eda42fffbead4e7fc68e7a0c4/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md) | [Generate OpenAPI documents](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?branch=pr-en-us-34613) |


<!-- PREVIEW-TABLE-END -->