### PR TITLE
Document request variables in .http files

### DIFF
--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -237,7 +237,7 @@ If you want to refer to the response of a named request, you need to manually tr
 
 ### Example request variable usage
 
-For example, suppose your HTTP file has a request that authenticates the caller, and you name it `login`. The response body is a JSON document that contains the bearer token in a property named `token`. In subsequent requests, you want to pass in this bearer token in an `Authorization` header. The following syntax does all this:
+For example, suppose your HTTP file has a request that authenticates the caller, and you name it `login`. The response body is a JSON document that contains the bearer token in a property named `token`. In subsequent requests, you want to pass in this bearer token in an `Authorization` header. The following example does this:
 
 ```http 
 #@name login

--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -195,9 +195,24 @@ In the preceding example, the `$shared` environment defines the `HostAddress` va
 You can pass values from one HTTP request to another within the same HTTP file.
 
 1. Create a named variable that represents a request by using the syntax `#@name`.
-1. In other requests in the same HTTP file use the variable name to refer to the request.
+1. In subsequent requests in the same HTTP file use the variable name to refer to the request.
+1. Use the following syntax to extract the specific part of the response that you want.
 
-For example, suppose you have a request that authenticates the caller, so you name it `login`. In subsequent requests, pass in the bearer token in an Authorization header by using the syntax `{{login.response.body.$.token}}`. The following example shows how to do this:
+   ```http
+   {{requestVariable.(response|request).(body|headers).(*|JSONPath|XPath|Header Name)}}.
+   ```
+
+   You can extract values from the request itself or from the response to it. For either request or response, you can extract values from the body or the headers. For the body:
+
+   * `*` extracts the entire response body.
+   * For JSON responses, use JSONPath to extract a specific property or attribute.
+   * For XML responses, use XPath to extract a specific property or attribute.
+
+   Header names are case-insensitive.
+
+### Example
+
+For example, suppose your HTTP file has a request that authenticates the caller, so you name it `login`. The response body is a JSON document that contains the bearer token in a property named `token`. In subsequent requests, you want to pass in this bearer token in an `Authorization` header. The following syntax does this:
 
 ```http 
 #@name login
@@ -217,61 +232,14 @@ Authorization: Bearer {{login.response.body.$.token}}
 ### 
 ```
 
-Once the named request is sent, you can access values from its response in any subsequent request within the same file. Use JSONPath to query  JSONin the , similar to XPath for XML. It allows you to navigate and extract data from JSON documents.
+The syntax `{{login.response.body.$.token}}` extracts the bearer token:
 
-### Explanation
-
+- **`login`**: Is the request variable.
 - **`response`**: Refers to the HTTP response object.
 - **`body`**: Refers to the body of the HTTP response.
 - **`$`**: Represents the root element of the JSON document in the response body.
 - **`token`**: Refers to the specific property within the JSON document.
 
-The reference syntax of a request variable is a bit more complex than other kinds of custom variables. The request variable reference syntax follows {{requestName.(response|request).(body|headers).(*|JSONPath|XPath|Header Name)}}. You have two reference part choices of the response or request: body and headers. For body part, you can use * to reference the full response body, and for JSON and XML responses, you can use JSONPath and XPath to extract specific property or attribute. For example, if a JSON response returns body {"id": "mock"}, you can set the JSONPath part to $.id to reference the id. For headers part, you can specify the header name to extract the header value. Additionally, the header name is case-insensitive.
-
-If the JSONPath or XPath of body, or Header Name of headers can't be resolved, the plain text of variable reference will be sent instead. And in this case, diagnostic information will be displayed to help you to inspect this. And you can also hover over the request variables to view the actual resolved value.
-
-Below is a sample of request variable definitions and references in an http file.
-
-
-@baseUrl = https://example.com/api
-
-# @name login
-POST {{baseUrl}}/api/login HTTP/1.1
-Content-Type: application/x-www-form-urlencoded
-
-name=foo&password=bar
-
-###
-
-@authToken = {{login.response.headers.X-AuthToken}}
-
-# @name createComment
-POST {{baseUrl}}/comments HTTP/1.1
-Authorization: {{authToken}}
-Content-Type: application/json
-
-{
-    "content": "fake content"
-}
-
-###
-
-@commentId = {{createComment.response.body.$.id}}
-
-# @name getCreatedComment
-GET {{baseUrl}}/comments/{{commentId}} HTTP/1.1
-Authorization: {{authToken}}
-
-###
-
-# @name getReplies
-GET {{baseUrl}}/comments/{{commentId}}/replies HTTP/1.1
-Accept: application/xml
-
-###
-
-# @name getFirstReply
-GET {{baseUrl}}/comments/{{commentId}}/replies/{{getReplies.response.body.//reply[1]/@id}}### Example
 
 Given a JSON response body like this:
 

--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -198,7 +198,7 @@ You can pass values from one HTTP request to another within the same `.http` fil
 
    ```http
    # @name login
-   https://contosol..com/api/login HTTP/1.1   
+   https://contoso.com/api/login HTTP/1.1   
    ```
 
    ```http

--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -231,7 +231,7 @@ You can pass values from one HTTP request to another within the same `.http` fil
 
    When `headers` is selected, a header name extracts the entire header. Header names are case-insensitive.
 
-  Example: `{{login.response.headers.Location}}`
+   Example: `{{login.response.headers.Location}}`
 
 If you want to refer to the response of a named request, you need to manually trigger the named request to retrieve its response first. When you extract values from the response, you'll get the latest response if the request has been sent more than once.
 

--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -192,27 +192,42 @@ In the preceding example, the `$shared` environment defines the `HostAddress` va
 
 ## Request variables
 
-You can pass values from one HTTP request to another within the same HTTP file.
+You can pass values from one HTTP request to another within the same `.http` file.
 
-1. Create a named variable that represents a request by using the syntax `#@name`.
-1. In subsequent requests in the same HTTP file use the variable name to refer to the request.
+1. Create a single-line comment located just before a request URL to name the following request. For example, the following lines show alternative ways to name the request `login`:
+
+   ```http
+   # @name login
+   https://contosol..com/api/login HTTP/1.1   
+   ```
+
+   ```http
+   // @name login
+   https://contosol..com/api/login HTTP/1.1
+   ```
+
+1. In subsequent requests in the same HTTP file use the request name to refer to the request.
 1. Use the following syntax to extract the specific part of the response that you want.
 
    ```http
-   {{requestVariable.(response|request).(body|headers).(*|JSONPath|XPath|Header Name)}}.
+   {{<request name>.(response|request).(body|headers).(*|JSONPath|XPath|Header Name)}}.
    ```
 
-   You can extract values from the request itself or from the response to it. For either request or response, you can extract values from the body or the headers. For the body:
+   You can extract values from the request itself or from the response to it (`request|response`). For either request or response, you can extract values from the body or the headers (`body|headers`). 
+
+   For the body (`*|JSONPath|XPath`):
 
    * `*` extracts the entire response body.
-   * For JSON responses, use JSONPath to extract a specific property or attribute.
-   * For XML responses, use XPath to extract a specific property or attribute.
+   * For JSON responses, use [JSONPath](https://www.rfc-editor.org/rfc/rfc9535.html) to extract a specific property or attribute.
+   * For XML responses, use [XPath](https://www.w3schools.com/xml/xpath_syntax.asp) to extract a specific property or attribute.
 
-   Header names are case-insensitive.
+   Header name extracts the entire header. Header names are case-insensitive.
 
-### Example
+If you want to refer to the response of a named request, you need to manually trigger the named request to retrieve its response first. When you extract from the response, you'll get the latest response if the request has been sent more than once.
 
-For example, suppose your HTTP file has a request that authenticates the caller, so you name it `login`. The response body is a JSON document that contains the bearer token in a property named `token`. In subsequent requests, you want to pass in this bearer token in an `Authorization` header. The following syntax does this:
+### Example request variable usage
+
+For example, suppose your HTTP file has a request that authenticates the caller, and you name it `login`. The response body is a JSON document that contains the bearer token in a property named `token`. In subsequent requests, you want to pass in this bearer token in an `Authorization` header. The following syntax does all this:
 
 ```http 
 #@name login
@@ -232,43 +247,15 @@ Authorization: Bearer {{login.response.body.$.token}}
 ### 
 ```
 
-The syntax `{{login.response.body.$.token}}` extracts the bearer token:
+The syntax `{{login.response.body.$.token}}` represents the bearer token:
 
-- **`login`**: Is the request variable.
-- **`response`**: Refers to the HTTP response object.
-- **`body`**: Refers to the body of the HTTP response.
-- **`$`**: Represents the root element of the JSON document in the response body.
-- **`token`**: Refers to the specific property within the JSON document.
+**`login`**: Is the request name.
+**`response`**: Refers to the HTTP response object.
+**`body`**: Refers to the body of the HTTP response.
+**`$`**: Represents the root element of the JSON document in the response body.
+**`token`**: Refers to the specific property within the JSON document.
 
-
-Given a JSON response body like this:
-
-```json
-
-
-{
-
-
-  "token": "abc123",
-  "user": {
-    "id": 1,
-    "name": "John Doe"
-  }
-}
-```
-
-The expression `{{login.response.body.$.token}}` would extract the value `"abc123"`.
-
-### Reference Documentation
-
-For more information on JSONPath syntax and what can come after `response.` or `body.`, you can refer to the following resources:
-
-- **JSONPath Syntax**: [JSONPath - XPath for JSON](https://goessner.net/articles/JsonPath/)
-- **HTTP File Syntax in Visual Studio Code**: [REST Client Extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
-
-These resources provide detailed information on how to use JSONPath to navigate and extract data from JSON documents, as well as how to use the REST Client extension in Visual Studio Code to work with HTTP files.
-
- This approach reduces error-prone manual steps. Without using request variables you would need to manually extract the token from the login response and include it in the header of subsequent requests. With the HTTP Request Variables feature, this process is automated.
+Without using request variables you would need to manually extract the token from the login response and include it in the header of subsequent requests. Request variables enable you to automate this process.
 
 ## User-specific environment files
 

--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -259,11 +259,11 @@ Authorization: Bearer {{login.response.body.$.token}}
 
 The syntax `{{login.response.body.$.token}}` represents the bearer token:
 
-**`login`**: Is the request name.
-**`response`**: Refers to the HTTP response object.
-**`body`**: Refers to the body of the HTTP response.
-**`$`**: Represents the root element of the JSON document in the response body.
-**`token`**: Refers to the specific property within the JSON document.
+* **`login`**: Is the request name.
+* **`response`**: Refers to the HTTP response object.
+* **`body`**: Refers to the body of the HTTP response.
+* **`$`**: Represents the root element of the JSON document in the response body.
+* **`token`**: Refers to the specific property within the JSON document.
 
 Without using request variables you would need to manually extract the token from the login response and include it in the header of subsequent requests. Request variables enable you to automate this process.
 

--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -210,20 +210,30 @@ You can pass values from one HTTP request to another within the same `.http` fil
 1. Use the following syntax to extract the specific part of the response that you want.
 
    ```http
-   {{<request name>.(response|request).(body|headers).(*|JSONPath|XPath|Header Name)}}.
+   {{<request name>.(response|request).(body|headers).(*|JSONPath|XPath|<header name>)}}.
    ```
 
-   You can extract values from the request itself or from the response to it (`request|response`). For either request or response, you can extract values from the body or the headers (`body|headers`). 
+   This syntax lets you extract values from the request itself or from the response to it (`request|response`). For either request or response, you can extract values from the body or the headers (`body|headers`). 
 
-   For the body (`*|JSONPath|XPath`):
+   When `body` is selected, the `*|JSONPath|XPath` part of the syntax applies:
 
    * `*` extracts the entire response body.
+
+     Example: `{{login.response.body.*}}`
+
    * For JSON responses, use [JSONPath](https://www.rfc-editor.org/rfc/rfc9535.html) to extract a specific property or attribute.
+
+     Example: `{{login.response.body.$.token}}`
+
    * For XML responses, use [XPath](https://www.w3schools.com/xml/xpath_syntax.asp) to extract a specific property or attribute.
 
-   Header name extracts the entire header. Header names are case-insensitive.
+     Example: `{{login.response.body./token}}`
 
-If you want to refer to the response of a named request, you need to manually trigger the named request to retrieve its response first. When you extract from the response, you'll get the latest response if the request has been sent more than once.
+   When `headers` is selected, a header name extracts the entire header. Header names are case-insensitive.
+
+  Example: `{{login.response.headers.Location}}`
+
+If you want to refer to the response of a named request, you need to manually trigger the named request to retrieve its response first. When you extract values from the response, you'll get the latest response if the request has been sent more than once.
 
 ### Example request variable usage
 

--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -203,7 +203,7 @@ You can pass values from one HTTP request to another within the same `.http` fil
 
    ```http
    // @name login
-   https://contosol..com/api/login HTTP/1.1
+   https://contoso.com/api/login HTTP/1.1
    ```
 
 1. In subsequent requests in the same HTTP file use the request name to refer to the request.


### PR DESCRIPTION
Fixes #34607
Fixes #33729 
Fixes #32668 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/http-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/770007e92a7d375ea171bc0f3609c3fe275d07ca/aspnetcore/test/http-files.md) | [Use .http files in Visual Studio 2022](https://review.learn.microsoft.com/en-us/aspnet/core/test/http-files?branch=pr-en-us-34617) |


<!-- PREVIEW-TABLE-END -->