### PR TITLE
QuickGrid RowClass parameter

### DIFF
--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -191,6 +191,34 @@ QuickGrid also supports passing custom attributes and style classes (<xref:Micro
 <QuickGrid Items="..." custom-attribute="value" Class="custom-class">
 ```
 
+:::moniker range=">= aspnetcore-10.0"
+
+## Style a table row based on the row item
+
+<!-- UPDATE 10.0 API cross-link -->
+
+Apply a stylesheet class to a row of the grid based on the row item using the `RowClass` parameter.
+
+In the following example:
+
+* A row item is represented by the `Person` [record](/dotnet/csharp/language-reference/builtin-types/record). The `Person` record includes a `FirstName` property.
+* The `HighlightJulie` method applies the `highlight` class styles to any row where the person's first name is "`Julie`."
+
+```razor
+<QuickGrid ... RowClass="HighlightJulie">
+    ...
+</QuickGrid>
+
+@code {
+    private record Person(int PersonId, string FirstName, string LastName);
+
+    private string HighlightJulie(Person person) =>
+        person.FirstName == "Julie" ? "highlight" : null;
+}
+```
+
+:::moniker-end
+
 ## Entity Framework Core (EF Core) data source
 
 Use the factory pattern to resolve an EF Core database context that provides data to a `QuickGrid` component. For more information on why the factory pattern is recommended, see <xref:blazor/blazor-ef-core>.


### PR DESCRIPTION
Fixes #34658

@danroth27 ... The PU PR looks like it has a NIT 😈. The record there is ...

```csharp
record Person(int PersonId, string firstName, string lastName, DateOnly BirthDate);
```

Cross-ref: https://github.com/dotnet/aspnetcore/pull/59901/files

... and the [C# record guidance](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record) never does that given that these are properties, thus they should be Pascal case, which I'm going to do on this PR for the doc example.

Do you want me to open a PU issue to update the `SampleQuickGridComponent` component?

**UPDATE (2/11)**: I'm going to go ahead with this. Let me know if you have a change request. 👂 It will be added to the *What's New* article on a separate PR shortly.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/quickgrid.md](https://github.com/dotnet/AspNetCore.Docs/blob/4cea66c43cc6f21df81e296151fc7e1d47f31c3f/aspnetcore/blazor/components/quickgrid.md) | [aspnetcore/blazor/components/quickgrid](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/quickgrid?branch=pr-en-us-34664) |

<!-- PREVIEW-TABLE-END -->