### PR TITLE
add example to modify headers in Minimal APIs

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -5,7 +5,7 @@ description: Provides an overview of minimal APIs in ASP.NET Core
 ms.author: wpickett
 content_well_notification: AI-contribution
 monikerRange: '>= aspnetcore-6.0'
-ms.date: 10/23/2023
+ms.date: 02/07/2024
 uid: fundamentals/minimal-apis
 ai-usage: ai-assisted
 ---

--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -171,6 +171,22 @@ app.MapGet("/download", () => Results.File("myfile.text"));
 
 [!INCLUDE [results-helpers](~/fundamentals/minimal-apis/includes/results-helpers.md)]
 
+### Modifying Headers
+
+Use the `HttpResponse` object to modify response headers:
+
+```csharp
+app.MapGet("/", (HttpContext context) => {
+    // Set a custom header
+    context.Response.Headers["X-Custom-Header"] = "CustomValue";
+
+    // Set a known header
+    context.Response.Headers.CacheControl = $"public,max-age=3600";
+
+    return "Hello World";
+});
+```
+
 ### Customizing results
 
 Applications can control responses by implementing a custom <xref:Microsoft.AspNetCore.Http.IResult> type. The following code is an example of an HTML result type:

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs
@@ -46,7 +46,14 @@ public class Program
         // <snippet_10>
         app.MapGet("/download", () => Results.File("myfile.text"));
         // </snippet_10>
-
+        // <snippet_12>
+        app.MapGet("/problem", () =>
+        {
+            var extensions = new List<KeyValuePair<string, object?>> { new("test", "value") };
+            return TypedResults.Problem("This is an error with extensions", 
+                                                        extensions: extensions);
+        });
+        // </snippet_12>
         app.Run();
     }
     // <snippet_11>

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -195,6 +195,22 @@ Here's an example of a filter that uses one of these interfaces:
 
 For more information, see [Filters in Minimal API apps](xref:fundamentals/minimal-apis/min-api-filters) and [IResult implementation types](xref:fundamentals/minimal-apis/test-min-api#iresult-implementation-types).
 
+## Modifying Headers
+
+Use the `HttpResponse` object to modify response headers:
+
+```csharp
+app.MapGet("/", (HttpContext context) => {
+    // Set a custom header
+    context.Response.Headers["X-Custom-Header"] = "CustomValue";
+
+    // Set a known header
+    context.Response.Headers.CacheControl = $"public,max-age=3600";
+
+    return "Hello World";
+});
+```
+
 ## Customizing responses
 
 Applications can control responses by implementing a custom <xref:Microsoft.AspNetCore.Http.IResult> type. The following code is an example of an HTML result type:

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -146,6 +146,10 @@ The following sections demonstrate the usage of the common result helpers.
 
 The preceding example returns a 500 status code.
 
+#### Problem and ValidationProblem
+
+:::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_12":::
+
 #### Text
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_08":::

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -4,7 +4,7 @@ author: brunolins16
 description: Learn how to create responses for minimal APIs in ASP.NET Core.
 ms.author: brolivei
 monikerRange: '>= aspnetcore-7.0'
-ms.date: 06/04/2024
+ms.date: 02/07/2025
 uid: fundamentals/minimal-apis/responses
 ---
 


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #34471 

- Adds an example on how to modify headers to quick reference and create response pages
- Adds example on Problem details in the create response page, which was added in v9 https://learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-9.0?view=aspnetcore-9.0#problem-and-validationproblem-result-types-support-construction-with-ienumerablekeyvaluepairstring-object-values

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis.md](https://github.com/dotnet/AspNetCore.Docs/blob/881e4de1598b39d1d7b38fc2eaa38c61d495b056/aspnetcore/fundamentals/minimal-apis.md) | [aspnetcore/fundamentals/minimal-apis](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis?branch=pr-en-us-34666) |
| [aspnetcore/fundamentals/minimal-apis/responses.md](https://github.com/dotnet/AspNetCore.Docs/blob/881e4de1598b39d1d7b38fc2eaa38c61d495b056/aspnetcore/fundamentals/minimal-apis/responses.md) | [aspnetcore/fundamentals/minimal-apis/responses](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/responses?branch=pr-en-us-34666) |


<!-- PREVIEW-TABLE-END -->