### PR TITLE
Update 80-90.md

### DIFF
--- a/aspnetcore/migration/80-90.md
+++ b/aspnetcore/migration/80-90.md
@@ -72,6 +72,8 @@ In the project file, update each [`Microsoft.AspNetCore.*`](https://www.nuget.or
 
 ## Replace `UseStaticFiles` with `MapStaticAssets`
 
+Warning: It's recommended not to remove ```app.UseStaticFiles();``` but add ```app.MapStaticAssets();``` after it. Because it will cause an error if you load static files without the Assets feature.
+
 Optimize the handling of static files in your web apps by replacing <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> with <xref:Microsoft.AspNetCore.Builder.StaticAssetsEndpointRouteBuilderExtensions.MapStaticAssets%2A> in the app's `Program` file:
   
 ```diff


### PR DESCRIPTION
Warn dev not to remove ```app.UseStaticFiles();``` because it will cause an error if you load static files without the Assets feature.


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/80-90.md](https://github.com/dotnet/AspNetCore.Docs/blob/89732a98a964520335f625e25c64466f9257f1a7/aspnetcore/migration/80-90.md) | [Migrate from ASP.NET Core in .NET 8 to ASP.NET Core in .NET 9](https://review.learn.microsoft.com/en-us/aspnet/core/migration/80-90?branch=pr-en-us-34740) |

<!-- PREVIEW-TABLE-END -->