### PR TITLE
Remove semi-duplicated code-block from YARP documentation

### DIFF
--- a/aspnetcore/fundamentals/servers/yarp/direct-forwarding.md
+++ b/aspnetcore/fundamentals/servers/yarp/direct-forwarding.md
@@ -134,29 +134,6 @@ internal class CustomTransformer : HttpTransformer
 }
 ```
 
-```C#
-private class CustomTransformer : HttpTransformer
-{
-    public override async ValueTask TransformRequestAsync(HttpContext httpContext,
-        HttpRequestMessage proxyRequest, string destinationPrefix, CancellationToken cancellationToken)
-    {
-        // Copy all request headers
-        await base.TransformRequestAsync(httpContext, proxyRequest, destinationPrefix, cancellationToken);
-
-        // Customize the query string:
-        var queryContext = new QueryTransformContext(httpContext.Request);
-        queryContext.Collection.Remove("param1");
-        queryContext.Collection["area"] = "xx2";
-
-        // Assign the custom uri. Be careful about extra slashes when concatenating here. RequestUtilities.MakeDestinationAddress is a safe default.
-        proxyRequest.RequestUri = RequestUtilities.MakeDestinationAddress("https://example.com", httpContext.Request.Path, queryContext.QueryString);
-
-        // Suppress the original request header, use the one from the destination Uri.
-        proxyRequest.Headers.Host = null;
-    }
-}
-```
-
 There are also [extension methods](xref:Microsoft.AspNetCore.Builder.DirectForwardingIEndpointRouteBuilderExtensions) available that simplify the mapping of IHttpForwarder to endpoints.
 
 ```C#


### PR DESCRIPTION
The CustomTransformer class is included twice in the example, once as an internal and once as a private class.  The corresponding sample project only has the internal, and I therefor propose to remove the private class definition



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/yarp/direct-forwarding.md](https://github.com/dotnet/AspNetCore.Docs/blob/b15de89dbb33f63608ea50d5679684c1c098b4a3/aspnetcore/fundamentals/servers/yarp/direct-forwarding.md) | [YARP Direct Forwarding](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/yarp/direct-forwarding?branch=pr-en-us-34751) |

<!-- PREVIEW-TABLE-END -->