### PR TITLE
Hosted WASM notice for security articles

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -379,7 +379,7 @@ The preceding example sets the base address with `builder.HostEnvironment.BaseAd
 The most common use cases for using the client's own base address are:
 
 * The client project (`.Client`) of a Blazor Web App (.NET 8 or later) makes web API calls from WebAssembly components or code that runs on the client in WebAssembly to APIs in the server app.
-* The client project (**:::no-loc text="Client":::**) of a hosted Blazor WebAssembly app makes web API calls to the server project (**:::no-loc text="Server":::**). Note that the hosted Blazor WebAssembly project template is no longer available in .NET 8 or later. However, hosted Blazor WebAssembly apps remain supported for .NET 8.
+* The client project (**:::no-loc text="Client":::**) of a hosted Blazor WebAssembly app makes web API calls to the server project (**:::no-loc text="Server":::**). Note that the Hosted Blazor WebAssembly project template is no longer available in .NET 8 or later. However, hosted Blazor WebAssembly apps remain supported for .NET 8.
 
 If you're calling an external web API (not in the same URL space as the client app), set the URI to the web API's base address. The following example sets the base address of the web API to `https://localhost:5001`, where a separate web API app is running and ready to respond to requests from the client app:
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -115,7 +115,7 @@ Using the `environment` property overrides the environment set by the [`Blazor-E
 
 The preceding approach sets the client's environment without changing the `Blazor-Environment` header's value, nor does it change the server project's console logging of the startup environment for a Blazor Web App that has adopted global Interactive WebAssembly rendering.
 
-To log the environment to the console in either a standalone Blazor WebAssembly project or the `.Client` project of a Blazor Web App, place the following C# code in the `Program` file after the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created with <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType> and before the line that builds and runs the project (`await builder.Build().RunAsync();`):
+To log the environment to the console in either a standalone Blazor WebAssembly app or the `.Client` project of a Blazor Web App, place the following C# code in the `Program` file after the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created with <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType> and before the line that builds and runs the project (`await builder.Build().RunAsync();`):
 
 ```csharp
 Console.WriteLine(

--- a/aspnetcore/blazor/security/includes/hosted-blazor-webassembly-notice.md
+++ b/aspnetcore/blazor/security/includes/hosted-blazor-webassembly-notice.md
@@ -1,0 +1,2 @@
+> [!IMPORTANT]
+> The Hosted Blazor WebAssembly project template was removed from the framework with the release of .NET 8 (November, 2023). The guidance in this article is only supported for .NET 7 or earlier. Hosted Blazor WebAssembly apps that are upgraded each release continue to receive product support. Alternatively, refactor the app into either a standalone Blazor WebAssembly app or a Blazor Web App.

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -10,6 +10,8 @@ uid: blazor/security/webassembly/hosted-with-azure-active-directory-b2c
 ---
 # Secure a hosted ASP.NET Core Blazor WebAssembly app with Azure Active Directory B2C
 
+[!INCLUDE[](~/blazor/security/includes/hosted-blazor-webassembly-notice.md)]
+
 This article explains how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Azure Active Directory (AAD) B2C](/azure/active-directory-b2c/overview) for authentication.
 
 For additional security scenario coverage after reading this article, see <xref:blazor/security/webassembly/additional-scenarios>.

--- a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md
@@ -10,6 +10,8 @@ uid: blazor/security/webassembly/hosted-with-identity-server
 ---
 # Secure a hosted ASP.NET Core Blazor WebAssembly app with Identity Server
 
+[!INCLUDE[](~/blazor/security/includes/hosted-blazor-webassembly-notice.md)]
+
 This article explains how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Duende Identity Server](https://docs.duendesoftware.com) to authenticate users and API calls.
 
 :::moniker range=">= aspnetcore-6.0"

--- a/aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id.md
@@ -10,6 +10,8 @@ uid: blazor/security/webassembly/hosted-with-microsoft-entra-id
 ---
 # Secure a hosted ASP.NET Core Blazor WebAssembly app with Microsoft Entra ID
 
+[!INCLUDE[](~/blazor/security/includes/hosted-blazor-webassembly-notice.md)]
+
 This article explains how to create a [hosted Blazor WebAssembly solution](xref:blazor/hosting-models#blazor-webassembly) that uses [Microsoft Entra ID (ME-ID)](https://azure.microsoft.com/services/active-directory/) for authentication. This article focuses on a single tenant app with a single tenant Azure app registration.
 
 This article doesn't cover a *multi-tenant ME-ID registration*. For more information, see [Making your application multi-tenant](/entra/identity-platform/howto-convert-app-to-be-multi-tenant).

--- a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles-net-5-to-7.md
+++ b/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles-net-5-to-7.md
@@ -11,8 +11,10 @@ zone_pivot_groups: blazor-groups-and-roles
 ---
 # Microsoft Entra (ME-ID) groups, Administrator Roles, and App Roles (.NET 5 to .NET 7)
 
-> [!NOTE]
+> [!IMPORTANT]
 > This isn't the latest version of this article. For the current ASP.NET Core release, see the latest version of <xref:blazor/security/webassembly/meid-groups-roles>.
+
+[!INCLUDE[](~/blazor/security/includes/hosted-blazor-webassembly-notice.md)]
 
 This article explains how to configure Blazor WebAssembly to use Microsoft Entra ID groups and roles.
 

--- a/aspnetcore/blazor/tooling.md
+++ b/aspnetcore/blazor/tooling.md
@@ -65,7 +65,7 @@ Select **Next**.
 :::moniker range=">= aspnetcore-8.0"
 
   > [!NOTE]
-  > The hosted Blazor WebAssembly project template isn't available in ASP.NET Core 8.0 or later. To create a hosted Blazor WebAssembly app, a **Framework** option earlier than .NET 8.0 must be selected with the **ASP.NET Core Hosted** checkbox.
+  > The Hosted Blazor WebAssembly project template isn't available in ASP.NET Core 8.0 or later. To create a hosted Blazor WebAssembly app, a **Framework** option earlier than .NET 8.0 must be selected with the **ASP.NET Core Hosted** checkbox.
 
 :::moniker-end
 
@@ -329,7 +329,7 @@ Create a new project:
   ```
 
   > [!NOTE]
-  > The hosted Blazor WebAssembly project template isn't available in ASP.NET Core 8.0 or later. To create a hosted Blazor WebAssembly app using a .NET 8.0 or later SDK, pass the `-f|--framework` option with a 7.0 target framework (`net7.0`):
+  > The Hosted Blazor WebAssembly project template isn't available in ASP.NET Core 8.0 or later. To create a hosted Blazor WebAssembly app using a .NET 8.0 or later SDK, pass the `-f|--framework` option with a 7.0 target framework (`net7.0`):
   >
   > ```dotnet cli
   > dotnet new blazorwasm -o BlazorApp -ho -f net7.0


### PR DESCRIPTION
Fixes #34742

Thanks @sussexrick! 🚀 ... and I've added a tracking item to take a closer look at content organization for securely calling a web API. In the meantime, see the links that I placed on the issue, especially the *Additional scenarios* article for WASM in the *Security and Identity* node. What I might end up doing is adding security coverage on the basics of calling a web API securely to the *Call web API* article and either cross-link to relevant existing samples and/or update one or more of the existing samples for that article to include security.

Pinging Dan to see if the INCLUDE language is what we'd like to say about hosted WASM at this point. This INCLUDE is only for the four relevant security articles that either completely focus on hosted WASM (three of them) or have hosted WASM coverage (one of them).

BTW Dan WRT conventions ... This PR is also going to adjust a few sneaky instances 😈 that don't conform to a convention that I've used. "Standalone" and "Hosted" (uppercase) are for use when specifically referring to a project template. I'll use "standalone" and "hosted" (lowercase) when referring to an app/project.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/call-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/edcf728e025493dbd3161ac27f8ac69d9edccb1a/aspnetcore/blazor/call-web-api.md) | [aspnetcore/blazor/call-web-api](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/call-web-api?branch=pr-en-us-34753) |
| [aspnetcore/blazor/fundamentals/environments.md](https://github.com/dotnet/AspNetCore.Docs/blob/edcf728e025493dbd3161ac27f8ac69d9edccb1a/aspnetcore/blazor/fundamentals/environments.md) | [aspnetcore/blazor/fundamentals/environments](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/environments?branch=pr-en-us-34753) |
| [aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md](https://github.com/dotnet/AspNetCore.Docs/blob/edcf728e025493dbd3161ac27f8ac69d9edccb1a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md) | [aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/hosted-with-azure-active-directory-b2c?branch=pr-en-us-34753) |
| [aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md](https://github.com/dotnet/AspNetCore.Docs/blob/edcf728e025493dbd3161ac27f8ac69d9edccb1a/aspnetcore/blazor/security/webassembly/hosted-with-identity-server.md) | [aspnetcore/blazor/security/webassembly/hosted-with-identity-server](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/hosted-with-identity-server?branch=pr-en-us-34753) |
| [aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id.md](https://github.com/dotnet/AspNetCore.Docs/blob/edcf728e025493dbd3161ac27f8ac69d9edccb1a/aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id.md) | [aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/hosted-with-microsoft-entra-id?branch=pr-en-us-34753) |
| [aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles-net-5-to-7.md](https://github.com/dotnet/AspNetCore.Docs/blob/edcf728e025493dbd3161ac27f8ac69d9edccb1a/aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles-net-5-to-7.md) | [aspnetcore/blazor/security/webassembly/microsoft-entra-id-groups-and-roles-net-5-to-7](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/microsoft-entra-id-groups-and-roles-net-5-to-7?branch=pr-en-us-34753) |
| [aspnetcore/blazor/tooling.md](https://github.com/dotnet/AspNetCore.Docs/blob/edcf728e025493dbd3161ac27f8ac69d9edccb1a/aspnetcore/blazor/tooling.md) | [aspnetcore/blazor/tooling](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tooling?branch=pr-en-us-34753) |

<!-- PREVIEW-TABLE-END -->