### PR TITLE
Correct naming and output for build-time generated OpenAPI documents

### DIFF
--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -175,11 +175,11 @@ dotnet add package Microsoft.Extensions.ApiDescription.Server
 ```
 ---
 
-Upon installation, this package will automatically generate the Open API document(s) associated with the application during build and populate them into the application's output directory.
+Upon installation, this package will automatically generate the Open API document(s) associated with the application during build and populate them into the application's output directory. The OpenAPI document name is per default `{ProjectName}.json`. If multiple documents are registered, then it is post-fixed with the document name - unless the document name is `v1`. E.g., `{ProjectName}_{DocumentName}.json`.
 
 ```cli
 $ dotnet build
-$ cat bin/Debug/net9.0/{ProjectName}.json
+$ cat {ProjectName}/obj/{ProjectName}.json
 ```
 
 ### Customizing build-time document generation


### PR DESCRIPTION
The documentation in the edited section does not correspond to the observed behaviour.

Reusing another [minimal reproduction repository](https://github.com/thygesteffensen/OpenApiMinimal), adding another document or changing the document name to a name that is not `v1`, will output a OpenAPI document at build-time as described in changes here :) 


Fixes #34803

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/daf84ec73b1c793c71359267a2bb823398e0d787/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md) | [Generate OpenAPI documents](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?branch=pr-en-us-34755) |

<!-- PREVIEW-TABLE-END -->