### PR TITLE
Do not show unnecessary steps for creating AOT-compatible OpenAPI application when running in .NET 10

### DIFF
--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -239,7 +239,9 @@ Create a new ASP.NET Core Web API (Native AOT) project.
 dotnet new webapiaot
 ```
 
-:::moniker range="< aspnetcore-10.0"
+:::moniker-end
+
+:::moniker range="= aspnetcore-9.0"
 
 Add the Microsoft.AspNetCore.OpenAPI package.
 
@@ -257,14 +259,12 @@ var app = builder.Build();
 + app.MapOpenApi();
 ```
 
-:::moniker end
+:::moniker-end
 
 Publish the app.
 
 ```console
 dotnet publish
 ```
-
-:::moniker-end
 
 [!INCLUDE[](~/fundamentals/openapi/includes/aspnetcore-openapi6-8.md)]

--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -239,10 +239,12 @@ Create a new ASP.NET Core Web API (Native AOT) project.
 dotnet new webapiaot
 ```
 
+:::moniker range="< aspnetcore-10.0"
+
 Add the Microsoft.AspNetCore.OpenAPI package.
 
 ```console
-dotnet add package Microsoft.AspNetCore.OpenApi --prerelease
+dotnet add package Microsoft.AspNetCore.OpenApi
 ```
 
 Update `Program.cs` to enable generating OpenAPI documents.
@@ -254,6 +256,8 @@ var app = builder.Build();
 
 + app.MapOpenApi();
 ```
+
+:::moniker end
 
 Publish the app.
 


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

I have also removed the `--preview` flag as it seems unnecessary. It's not necessary to add a preview package to get OpenAPI to be AOT compatible in .NET 9.

Fixes #34756

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/b3d952d12a585714fb67cfaa9f7808d555a3fbac/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md) | [Generate OpenAPI documents](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?branch=pr-en-us-34757) |


<!-- PREVIEW-TABLE-END -->