### PR TITLE
Improve title for overview of Identity external login

### DIFF
--- a/aspnetcore/security/authentication/social/index.md
+++ b/aspnetcore/security/authentication/social/index.md
@@ -1,13 +1,13 @@
 ---
-title: Facebook and Google authentication in ASP.NET Core
+title: Using external login providers with Identity in ASP.NET Core
 author: rick-anderson
-description: Create an ASP.NET Core app using OAuth 2.0 with external authentication providers such as Facebook, Twitter, Google, and Microsoft.
+description: Create an ASP.NET Core app using Identity with external authentication providers such as Facebook, Twitter, Google, and Microsoft.
 ms.author: riande
 ms.custom: mvc
 ms.date: 03/07/2022
 uid: security/authentication/social/index
 ---
-# Facebook, Google, and external provider authentication in ASP.NET Core
+# External provider authentication in ASP.NET Core Identity
 
 By [Valeriy Novytskyy](https://github.com/01binary) and [Rick Anderson](https://twitter.com/RickAndMSFT)
 


### PR DESCRIPTION
The title of "Facebook and Google authentication in ASP.NET Core" is particularly bad considering this is the overview for using Identity any external login provider. And while this is already under "ASP.NET Core Identity" in the TOC, I still think it's worth calling out this is demonstrating external login with "Identity" in the title, because it is possible to use external login without identity as demonstrated in https://learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication?view=aspnetcore-9.0.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/social/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/56e4d220e36a5c82645cb08575ac1844a2d3fa2a/aspnetcore/security/authentication/social/index.md) | [aspnetcore/security/authentication/social/index](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/social/index?branch=pr-en-us-34776) |

<!-- PREVIEW-TABLE-END -->