### PR TITLE
First MVC: Ensure command run at project directory for VSC

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model.md
@@ -61,6 +61,8 @@ Build the project as a check for compiler errors.
 
 # [Visual Studio Code](#tab/visual-studio-code)
 
+Open a command window in the project directory. The project directory is the directory that contains the `Program.cs` and `.csproj` files.
+
 [!INCLUDE[](~/includes/add-EF-NuGet-SQLite-CLI-9.md)]
 
 In Visual Studio Code, press <kbd>Ctrl</kbd>+<kbd>F5</kbd> to run the app without debugging.

--- a/aspnetcore/tutorials/first-mvc-app/adding-model.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-model.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Part 4 of tutorial series on ASP.NET Core MVC.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 07/24/2024
+ms.date: 2/20/2025
 uid: tutorials/first-mvc-app/adding-model
 ---
 


### PR DESCRIPTION
Fixes #32720

Clarified the command window is opened in the project directory.   The last time we said to do that was in a previous tutorial in this series. By the time folks got to this step they were accidentally moving from that directory before running the EF install commands.

I am not adding this to the Add NuGet Packages include instead since in some tutorials we just get through instructing to navigate to the project directory in previous steps.

Go right to the section edited section for internal review: https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?view=aspnetcore-9.0&branch=pr-en-us-34777&tabs=visual-studio-code#add-nuget-packages

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mvc-app/adding-model.md](https://github.com/dotnet/AspNetCore.Docs/blob/bc8aca8e49bf05a4b58da3660c1adcd2c29086a3/aspnetcore/tutorials/first-mvc-app/adding-model.md) | [aspnetcore/tutorials/first-mvc-app/adding-model](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-model?branch=pr-en-us-34777) |

<!-- PREVIEW-TABLE-END -->