### PR TITLE
Cascading values+params for state management

### DIFF
--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -195,8 +195,7 @@ The type's <xref:System.ComponentModel.PropertyChangedEventHandler> (`HandleProp
 In the `Program` file&dagger;, `NotifyingDalek` is passed to create a <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601> with an initial `Unit` value of 888 units:
 
 ```csharp
-builder.Services.AddNotifyingCascadingValue<NotifyingDalek>(
-    new NotifyingDalek() { Units = 888 });
+builder.Services.AddNotifyingCascadingValue(new NotifyingDalek() { Units = 888 });
 ```
 
 > [!NOTE]

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -98,7 +98,7 @@ Calling <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601.NotifyCha
 
 In the following example:
 
-* `NotifyingDalek` implements <xref:System.ComponentModel.INotifyPropertyChanged> to notify clients that a property value has changed. When the `Units` property is set, the <xref:System.ComponentModel.PropertyChangedEventHandler> (`PropertyChanged`) is invoked.
+* `NotifyingDalek` implements <xref:System.ComponentModel.INotifyPropertyChanged> to notify clients that a property value has changed. When the `Units` property is set, the <xref:System.ComponentModel.PropertyChangedEventHandler> (`PropertyChanged`) is invoked. Keep in mind for production code that any change in state (any property value change of the class) causes all subscribed components to rerender, regardless of which part of the state they use. We recommend creating granular classes, cascading them separately with specific subscriptions to ensure that only components subscribed to a specific portion of the application state are affected by changes.
 * The `SetUnitsToOneThousand` method can be triggered by subscribers to set `Units` to 1,000 with a simulated processing delay.
 
 `NotifyingDalek.cs`:

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -170,7 +170,7 @@ public class NotifyingCascadingValueSource<T> : IDisposable where T : INotifyPro
 
     private void OnValuePropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        source.NotifyChangedAsync();
+        _ = source.NotifyChangedAsync();
     }
 
     public CascadingValueSource<T> Source => source;

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -75,7 +75,7 @@ The following `Daleks` component displays the cascaded values.
 
 :::moniker range=">= aspnetcore-8.0"
 
-In the following example, `Dalek` is registered as a cascading value using [`CascadingValueSource<T>`](xref:Microsoft.AspNetCore.Components.CascadingValueSource%601), where `<T>` is the type. The `isFixed` flag indicates whether the value is fixed. If false, all recipients are subscribed for update notifications, which are issued by calling <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601.NotifyChangedAsync%2A>. Subscriptions create overhead and reduce performance, so set `isFixed` to `true` if the value doesn't change.
+In the following example, `Dalek` is registered as a cascading value using [`CascadingValueSource<T>`](xref:Microsoft.AspNetCore.Components.CascadingValueSource%601), where `<T>` is the type. The `isFixed` flag indicates whether the value is fixed. If false, all recipients are subscribed for update notifications. Subscriptions create overhead and reduce performance, so set `isFixed` to `true` if the value doesn't change.
 
 ```csharp
 builder.Services.AddCascadingValue(sp =>
@@ -93,6 +93,160 @@ builder.Services.AddCascadingValue(sp =>
 > Treat required services separately from cascading values, registering them separately from the cascaded type.
 >
 > Avoid using <xref:Microsoft.Extensions.DependencyInjection.CascadingValueServiceCollectionExtensions.AddCascadingValue%2A> to register a component type as a cascading value. Instead, wrap the `<Router>...</Router>` in the `Routes` component (`Components/Routes.razor`) with the component and adopt global interactive server-side rendering (interactive SSR). For an example, see the [`CascadingValue` component](#cascadingvalue-component) section.
+
+Calling <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601.NotifyChangedAsync%2A> to issue update notifications can be used to signal multiple Razor component subscribers that a cascading value has changed. Notifications aren't possible for subscribers that adopt static server-side rendering (static SSR), so subscribers must adopt an interactive render mode. 
+
+In the following example:
+
+* `NotifyingDalek` implements <xref:System.ComponentModel.INotifyPropertyChanged> to notify clients that a property value has changed. When the `Units` property is set, the <xref:System.ComponentModel.PropertyChangedEventHandler> (`PropertyChanged`) is invoked.
+* The `SetUnitsToOneThousand` method can be triggered by subscribers to set `Units` to 1,000 with a simulated processing delay.
+* Because the <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601>'s type in this example is a class type, you can meet virtually any state management feature specification requirement. However, subscriptions create overhead and reduce performance, so benchmark the performance of this approach in your app and compare it to other [state management approaches](xref:blazor/state-management) before adopting it in a production app with constrained processing and memory resources.
+
+`NotifyingDalek.cs`:
+
+```csharp
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+public class NotifyingDalek : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private int units;
+
+    public int Units
+    {
+        get => units;
+        set
+        {
+            if (units != value)
+            {
+                units = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+
+    protected virtual void OnPropertyChanged(
+        [CallerMemberName] string? propertyName = default)
+            => PropertyChanged?.Invoke(this, new(propertyName));
+
+    public async Task SetUnitsToOneThousand()
+    {
+        // Simulate a three second delay in processing
+        await Task.Delay(3000);
+
+        Units = 1000;
+    }
+}
+```
+
+The following `CascadingValueSourceFactory` has a `CreateNotifying` method to create a <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601> from a type that implements <xref:System.ComponentModel.INotifyPropertyChanged>.
+
+`CascadingValueSourceFactory.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Components;
+using System.ComponentModel;
+
+public static class CascadingValueSourceFactory
+{
+    public static CascadingValueSource<T> CreateNotifying<T>(
+        T value, bool isFixed = false) where T : INotifyPropertyChanged
+    {
+        var source = new CascadingValueSource<T>(value, isFixed);
+
+        value.PropertyChanged += (sender, args) => source.NotifyChangedAsync();
+
+        return source;
+    }
+}
+```
+
+The type's <xref:System.ComponentModel.PropertyChangedEventHandler> (`PropertyChanged`) calls the <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601>'s <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601.NotifyChangedAsync%2A> method to notify subscribers that the cascading value has changed. The <xref:System.Threading.Tasks.Task> is discarded when calling <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601.NotifyChangedAsync%2A> because the call only represents the duration of the dispatch to the synchronous context. Exceptions are handled internally by dispatching them to the renderer within the context of whichever component threw when receiving the update. This is the same way that exceptions are processed with a <xref:Microsoft.AspNetCore.Components.CascadingValue%601>, which isn't notified about exceptions that happen inside notification recipients.
+
+In the `Program` file&dagger;, `NotifyingDalek` is created as a <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601> with an initial `Unit` value of 888 units:
+
+```csharp
+builder.Services.AddCascadingValue(
+    s => CascadingValueSourceFactory.CreateNotifying(new NotifyingDalek() { Units = 888 }));
+```
+
+> [!NOTE]
+> &dagger;For Blazor Web App solutions consisting of server and client (`.Client`) projects:
+>
+> * The preceding `NotifyingDalek.cs` and `CascadingValueSourceFactory.cs` files are placed in the `.Client` project.
+> * The preceding code is placed into the `Program` file of *both* projects.
+
+The following component is used to demonstrate how changing the value of `NotifyingDalek.Units` notifies subscribers.
+
+`Daleks.razor`:
+
+```razor
+<h2>Daleks component</h2>
+
+<div>
+    <b>Dalek Units:</b> @Dalek?.Units
+</div>
+
+<div>
+    <label>
+        <span style="font-weight:bold">New Unit Count:</span>
+        <input @bind="dalekCount" />
+    </label>
+    <button @onclick="Update">Update</button>
+</div>
+
+<div>
+    <button @onclick="SetOneThousandUnits">Set Units to 1,000</button>
+</div>
+
+<p>
+    Dalek© <a href="https://www.imdb.com/name/nm0622334/">Terry Nation</a><br>
+    Doctor Who© <a href="https://www.bbc.co.uk/programmes/b006q2x0">BBC</a>
+</p>
+
+@code {
+    private int dalekCount;
+
+    [CascadingParameter]
+    public NotifyingDalek? Dalek { get; set; }
+
+    private void Update()
+    {
+        if (Dalek is not null)
+        {
+            Dalek.Units = dalekCount;
+            dalekCount = 0;
+        }
+    }
+
+    private async Task SetOneThousandUnits()
+    {
+        if (Dalek is not null)
+        {
+            await Dalek.SetUnitsToOneThousand();
+        }
+    }
+}
+```
+
+To demonstrate multiple subscriber notifications, the following `DaleksMain` component renders three `Daleks` components. When the unit count (`Units`) of one `Dalek` component is updated, the other two `Dalek` component subscribers are updated.
+
+`DaleksMain.razor`:
+
+```razor
+@page "/daleks-main"
+
+<PageTitle>Daleks Main</PageTitle>
+
+<h1>Daleks Main</h1>
+
+<Daleks />
+
+<Daleks />
+
+<Daleks />
+```
 
 :::moniker-end
 

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -98,8 +98,10 @@ Calling <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601.NotifyCha
 
 In the following example:
 
-* `NotifyingDalek` implements <xref:System.ComponentModel.INotifyPropertyChanged> to notify clients that a property value has changed. When the `Units` property is set, the <xref:System.ComponentModel.PropertyChangedEventHandler> (`PropertyChanged`) is invoked. Keep in mind for production code that any change in state (any property value change of the class) causes all subscribed components to rerender, regardless of which part of the state they use. We recommend creating granular classes, cascading them separately with specific subscriptions to ensure that only components subscribed to a specific portion of the application state are affected by changes.
+* `NotifyingDalek` implements <xref:System.ComponentModel.INotifyPropertyChanged> to notify clients that a property value has changed. When the `Units` property is set, the <xref:System.ComponentModel.PropertyChangedEventHandler> (`PropertyChanged`) is invoked.
 * The `SetUnitsToOneThousand` method can be triggered by subscribers to set `Units` to 1,000 with a simulated processing delay.
+
+Keep in mind for production code that any change in state (any property value change of the class) causes all subscribed components to rerender, regardless of which part of the state they use. We recommend creating granular classes, cascading them separately with specific subscriptions to ensure that only components subscribed to a specific portion of the application state are affected by changes.
 
 `NotifyingDalek.cs`:
 

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -180,8 +180,6 @@ public static class CascadingApplicationStateServiceCollectionExtensions
             _ = NotifyChangedAsync();
         }
 
-        public CascadingValueSource<T> Source => source;
-
         public void Dispose()
         {
             value.PropertyChanged -= HandlePropertyChanged;
@@ -202,7 +200,7 @@ builder.Services.AddCascadingApplicationState<NotifyingDalek>(
 > [!NOTE]
 > &dagger;For Blazor Web App solutions consisting of server and client (`.Client`) projects:
 >
-> * The preceding `NotifyingDalek.cs` and `CascadingValueSourceFactory.cs` files are placed in the `.Client` project.
+> * The preceding `NotifyingDalek.cs` and `CascadingValueServiceCollectionExtensions.cs` files are placed in the `.Client` project.
 > * The preceding code is placed into the `Program` file of *both* projects.
 
 The following component is used to demonstrate how changing the value of `NotifyingDalek.Units` notifies subscribers.

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -139,9 +139,9 @@ public class NotifyingDalek : INotifyPropertyChanged
 }
 ```
 
-The following `CascadingValueServiceCollectionExtensions` creates a <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601> from a type that implements <xref:System.ComponentModel.INotifyPropertyChanged>.
+The following `CascadingStateServiceCollectionExtensions` creates a <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601> from a type that implements <xref:System.ComponentModel.INotifyPropertyChanged>.
 
-`CascadingValueServiceCollectionExtensions.cs`:
+`CascadingStateServiceCollectionExtensions.cs`:
 
 ```csharp
 using System.ComponentModel;
@@ -149,25 +149,25 @@ using Microsoft.AspNetCore.Components;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
-public static class CascadingApplicationStateServiceCollectionExtensions
+public static class CascadingStateServiceCollectionExtensions
 {
-    public static IServiceCollection AddCascadingApplicationState<T>(
+    public static IServiceCollection AddCascadingStateNotifier<T>(
         this IServiceCollection serviceCollection, T value, bool isFixed = false)
         where T : INotifyPropertyChanged
     {
         return serviceCollection.AddCascadingValue<T>(services =>
         {
-            return new ApplicationStateCascadingValueSource<T>(value, isFixed);
+            return new CascadingStateValueSource<T>(value, isFixed);
         });
     }
 
-    private sealed class ApplicationStateCascadingValueSource<T>
+    private sealed class CascadingStateValueSource<T>
         : CascadingValueSource<T>, IDisposable where T : INotifyPropertyChanged
     {
         private readonly T value;
         private readonly CascadingValueSource<T> source;
 
-        public ApplicationStateCascadingValueSource(T value, bool isFixed = false)
+        public CascadingStateValueSource(T value, bool isFixed = false)
             : base(value, isFixed = false)
         {
             this.value = value;
@@ -193,15 +193,15 @@ The type's <xref:System.ComponentModel.PropertyChangedEventHandler> (`HandleProp
 In the `Program` file&dagger;, `NotifyingDalek` is passed to create a <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601> with an initial `Unit` value of 888 units:
 
 ```csharp
-builder.Services.AddCascadingApplicationState<NotifyingDalek>(
+builder.Services.AddCascadingStateNotifier<NotifyingDalek>(
     new NotifyingDalek() { Units = 888 });
 ```
 
 > [!NOTE]
 > &dagger;For Blazor Web App solutions consisting of server and client (`.Client`) projects:
 >
-> * The preceding `NotifyingDalek.cs` and `CascadingValueServiceCollectionExtensions.cs` files are placed in the `.Client` project.
-> * The preceding code is placed into the `Program` file of *both* projects.
+> * The preceding `NotifyingDalek.cs` and `CascadingStateServiceCollectionExtensions.cs` files are placed in the `.Client` project.
+> * The preceding code is placed into each project's `Program` file.
 
 The following component is used to demonstrate how changing the value of `NotifyingDalek.Units` notifies subscribers.
 
@@ -275,6 +275,8 @@ To demonstrate multiple subscriber notifications, the following `DaleksMain` com
 ```
 
 Because the <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601>'s type in this example (`NotifyingDalek`) is a class type, you can meet virtually any state management feature specification requirement. However, subscriptions create overhead and reduce performance, so benchmark the performance of this approach in your app and compare it to other [state management approaches](xref:blazor/state-management) before adopting it in a production app with constrained processing and memory resources.
+
+Any change in state (any property value change of the class) causes all subscribed components to rerender, regardless of which part of the state that they use. **Avoid creating a single large class representing the entire global application state.** Instead, create granular classes and cascade them separately with specific subscriptions to cascading parameters, ensuring that only components subscribed to a specific portion of the application state are affected by changes.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -99,7 +99,7 @@ Calling <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601.NotifyCha
 In the following example:
 
 * `NotifyingDalek` implements <xref:System.ComponentModel.INotifyPropertyChanged> to notify clients that a property value has changed. When the `Units` property is set, the <xref:System.ComponentModel.PropertyChangedEventHandler> (`PropertyChanged`) is invoked.
-* The `SetUnitsToOneThousand` method can be triggered by subscribers to set `Units` to 1,000 with a simulated processing delay.
+* The `SetUnitsToOneThousandAsync` method can be triggered by subscribers to set `Units` to 1,000 with a simulated processing delay.
 
 Keep in mind for production code that any change in state (any property value change of the class) causes all subscribed components to rerender, regardless of which part of the state they use. We recommend creating granular classes, cascading them separately with specific subscriptions to ensure that only components subscribed to a specific portion of the application state are affected by changes.
 
@@ -153,13 +153,13 @@ namespace Microsoft.Extensions.DependencyInjection;
 
 public static class CascadingStateServiceCollectionExtensions
 {
-    public static IServiceCollection AddCascadingStateNotifier<T>(
+    public static IServiceCollection AddNotifyingCascadingValue<T>(
         this IServiceCollection services, T state, bool isFixed = false)
         where T : INotifyPropertyChanged
     {
-        return serviceCollection.AddCascadingValue<T>(sp =>
+        return services.AddCascadingValue(sp =>
         {
-            return new CascadingStateValueSource<T>(value, isFixed);
+            return new CascadingStateValueSource<T>(state, isFixed);
         });
     }
 
@@ -172,7 +172,7 @@ public static class CascadingStateServiceCollectionExtensions
         public CascadingStateValueSource(T state, bool isFixed = false)
             : base(state, isFixed = false)
         {
-            this.state= state;
+            this.state = state;
             source = new CascadingValueSource<T>(state, isFixed);
             this.state.PropertyChanged += HandlePropertyChanged;
         }
@@ -195,7 +195,7 @@ The type's <xref:System.ComponentModel.PropertyChangedEventHandler> (`HandleProp
 In the `Program` file&dagger;, `NotifyingDalek` is passed to create a <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601> with an initial `Unit` value of 888 units:
 
 ```csharp
-builder.Services.AddCascadingStateNotifier<NotifyingDalek>(
+builder.Services.AddNotifyingCascadingValue<NotifyingDalek>(
     new NotifyingDalek() { Units = 888 });
 ```
 

--- a/aspnetcore/blazor/components/cascading-values-and-parameters.md
+++ b/aspnetcore/blazor/components/cascading-values-and-parameters.md
@@ -157,7 +157,7 @@ public static class CascadingStateServiceCollectionExtensions
         this IServiceCollection services, T state, bool isFixed = false)
         where T : INotifyPropertyChanged
     {
-        return services.AddCascadingValue(sp =>
+        return services.AddCascadingValue<T>(sp =>
         {
             return new CascadingStateValueSource<T>(state, isFixed);
         });

--- a/aspnetcore/blazor/state-management.md
+++ b/aspnetcore/blazor/state-management.md
@@ -61,6 +61,7 @@ Common locations exist for persisting state:
 * [URL](#url-server)
 * [Browser storage](#browser-storage-server)
 * [In-memory state container service](#in-memory-state-container-service)
+* [Cascading values and parameters](#cascading-values-and-parameters)
 
 <h2 id="server-side-storage-server">Server-side storage</h2>
 
@@ -620,7 +621,8 @@ Common locations exist for persisting state:
 * [Server-side storage](#server-side-storage-wasm)
 * [URL](#url-wasm)
 * [Browser storage](#browser-storage-wasm)
-* [In-memory state container service](#in-memory-state-container-service) 
+* [In-memory state container service](#in-memory-state-container-service)
+* [Cascading values and parameters](#cascading-values-and-parameters)
 
 <h2 id="server-side-storage-wasm">Server-side storage</h2>
 
@@ -804,6 +806,16 @@ services.AddScoped<StateContainer>();
 ```
 
 The preceding components implement <xref:System.IDisposable>, and the `OnChange` delegates are unsubscribed in the `Dispose` methods, which are called by the framework when the components are disposed. For more information, see <xref:blazor/components/lifecycle#component-disposal-with-idisposable-and-iasyncdisposable>.
+
+## Cascading values and parameters
+
+Use [cascading values and parameters](xref:blazor/components/cascading-values-and-parameters) to manage state by flowing data from an ancestor Razor component to descendent components.
+
+:::moniker range=">= aspnetcore-8.0"
+
+Root-level cascading values with a <xref:Microsoft.AspNetCore.Components.CascadingValueSource%601> permit Razor component subscriber notifications of changed cascading values. For more information and a working example, see the `NotifyingDalek` example in <xref:blazor/components/cascading-values-and-parameters#root-level-cascading-values>.
+
+:::moniker-end
 
 ## Additional approaches
 


### PR DESCRIPTION
Fixes #34236

Thanks @hakenr! 🎷 ... This is probably a bit rough in spots. If you have time to look, I'll address your feedback before pinging a PU engineer. If you're busy, no worries ... I'll get one of them on here early next week to put an 👁️ on this.

**UPDATE (Monday, 2/24)**: I pinged to ask if either Illona or Ondrej are available to take a look. If they're busy, I'll hit up either Pavel or Marek to look.

### Notes

* Add a `CascadingValueSource<T>` with notifications (`INotifyPropertyChanged`/`NotifyChangedAsync`) approach to the *Cascading values and parameters* article. The basis for the example is code provided by @kzu on https://github.com/dotnet/aspnetcore/issues/53257 (***Thanks @kzu!*** 🎸) . Sanderson said it's supported at https://github.com/dotnet/aspnetcore/issues/53257#issuecomment-1904282397, but he also commented elsewhere that "In practice it's extremely rare for people to want to do `INotifyPropertyChanged` with Blazor." However, that might be because it isn't documented (until now ***here*** 😄).

* I favor placing this coverage because it's easy to understand/implement and flexible/powerful with a class type. I demo both setting a property value directly and having a method in the class that updates a property. An app can process state quite easily using this approach. I make sure to call out that there's a perf hit and to be careful with this approach.

* Add a short section to the *State Management* article mentioning cascading values and parameters generally. For >=8.0, cross-link the root-level cascading value/`CascadingValueSource<T>` /`INotifyPropertyChanged`/`NotifyChangedAsync` approach.

* WRT ... 

  > the entire State Management page could simply be a list of approaches with links to other pages that explain each feature in detail

  My initial concern is simply that explaining the features and explaining state management using the features *in one spot* is problematic because state management is a more advanced use case for the two or three scenarios here where this idea applies. For root-level cascading values with notifications, this approach seems to work well because the use case is a state management approach. I've made a tracking item entry for this idea to look at it again later.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/cascading-values-and-parameters.md](https://github.com/dotnet/AspNetCore.Docs/blob/2d49bcb6a90a84eb8f3f0425cdb9cdafb7c4a445/aspnetcore/blazor/components/cascading-values-and-parameters.md) | [aspnetcore/blazor/components/cascading-values-and-parameters](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/cascading-values-and-parameters?branch=pr-en-us-34779) |
| [aspnetcore/blazor/state-management.md](https://github.com/dotnet/AspNetCore.Docs/blob/2d49bcb6a90a84eb8f3f0425cdb9cdafb7c4a445/aspnetcore/blazor/state-management.md) | [aspnetcore/blazor/state-management](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/state-management?branch=pr-en-us-34779) |


<!-- PREVIEW-TABLE-END -->