### PR TITLE
`NavigateTo` no longer scrolls to the top

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -29,3 +29,11 @@ For more information, see the following resources:
 The [`[Route]` attribute](xref:Microsoft.AspNetCore.Components.RouteAttribute) now supports route syntax highlighting to help visualize the structure of the route template:
 
 ![Route template pattern for the Order ID is highlighted in a method that maps endpoints](~/release-notes/aspnetcore-10/_static/route-template-highlighting.png)
+
+<!-- PREVIEW 2
+
+### `NavigateTo` no longer scrolls to the top for same-page navigations
+
+Previously, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> scrolled to the top of the page for same-page navigations. This behavior has been changed in .NET 10 so that the browser no longer scrolls to the top of the page when navigating to the same page. This means the viewport no longer is reset when making updates to the address for the current page, such as changing the query string or fragment.
+
+-->

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -34,6 +34,6 @@ The [`[Route]` attribute](xref:Microsoft.AspNetCore.Components.RouteAttribute) n
 
 ### `NavigateTo` no longer scrolls to the top for same-page navigations
 
-Previously, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> scrolled to the top of the page for same-page navigations. This behavior has been changed in .NET 10 so that the browser no longer scrolls to the top of the page when navigating to the same page. This means the viewport no longer is reset when making updates to the address for the current page, such as changing the query string or fragment.
+Previously, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> scrolled to the top of the page for same-page navigations. This behavior has been changed in .NET 10 so that the browser no longer scrolls to the top of the page when navigating to the same page. This means the viewport is no longer reset when making updates to the address for the current page, such as changing the query string or fragment.
 
 -->


### PR DESCRIPTION
Fixes #34789
Addresses #34729

We don't need to call this incremental behavioral improvement out in the articles because we never commented on it in detail in the first place. All we've ever said about the scroll position is that (emphasis added) ...

> Blazor's enhanced navigation and form handling avoid the need for a full-page reload and preserves more of the page state, so pages load faster, *usually without losing the user's scroll position on the page*.

... and never remarked on it at all for `NavigateTo` coverage in the *Routing* article ... or anywhere else for that matter.

Therefore, we only need to mention this in the *What's New* article.

This will remain commented out until Preview 2 releases.