### PR TITLE
Factor out a mention of 'hosting model'

### DIFF
--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -20,7 +20,7 @@ This article describes the files and folders that make up a Blazor app generated
 
 Blazor Web App project template: `blazor`
 
-The Blazor Web App project template provides a single starting point for using Razor components (`.razor`) to build any style of web UI, both server-side rendered and client-side rendered. It combines the strengths of the existing Blazor Server and Blazor WebAssembly hosting models with server-side rendering, streaming rendering, enhanced navigation and form handling, and the ability to add interactivity using either Blazor Server or Blazor WebAssembly on a per-component basis.
+The Blazor Web App project template provides a single starting point for using Razor components (`.razor`) to build any style of web UI, both server-side rendered and client-side rendered. It combines the strengths of Blazor Server and Blazor WebAssembly with server-side and client-side rendering, streaming rendering, enhanced navigation and form handling, and the ability to add interactivity using either Blazor Server or Blazor WebAssembly on a per-component basis.
 
 If both client-side rendering (CSR) and interactive server-side rendering (interactive SSR) are selected on app creation, the project template uses the Interactive Auto render mode. The automatic rendering mode initially uses interactive SSR while the .NET app bundle and runtime are downloaded to the browser. After the .NET WebAssembly runtime is activated, rendering switches to CSR.
 


### PR DESCRIPTION
Fixes #34801

Thanks @S-Nakib! 🚀 ... I've factored out the single mention of "hosting model" here. It isn't really incorrect to use it, even when referring to Blazor Web Apps, but we are favoring "render mode" language these days. Here, I can just revise this to "with server-side and client-side rendering" to resolve the issue.