### PR TITLE
Improve EF Core breaking change coverage

### DIFF
--- a/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
@@ -119,6 +119,27 @@ Paste all of the following commands at the prompt (`>`) of the **Terminal**. Whe
 
 When you paste multiple commands, all of the commands execute except the last one. The last command doesn't execute until you press <kbd>Enter</kbd> on the keyboard.
 
+:::moniker range=">= aspnetcore-10.0 < aspnetcore-9.0"
+
+```dotnetcli
+dotnet tool install --global dotnet-aspnet-codegenerator
+dotnet tool install --global dotnet-ef
+dotnet add package Microsoft.EntityFrameworkCore.SQLite
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package Microsoft.EntityFrameworkCore.Tools
+dotnet add package Microsoft.AspNetCore.Components.QuickGrid
+dotnet add package Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter
+dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
+```
+
+> [!IMPORTANT]
+> After the first eight commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
+
+:::moniker-end
+
+:::moniker range="= aspnetcore-9.0"
+
 ```dotnetcli
 dotnet tool install --global dotnet-aspnet-codegenerator
 dotnet tool install --global dotnet-ef
@@ -135,18 +156,22 @@ dotnet add package Microsoft.EntityFrameworkCore.Design
 > [!IMPORTANT]
 > After the first nine commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
 
-> [!NOTE]
-> The preceding commands are .NET CLI commands, and .NET CLI commands are executed when entered at a [PowerShell](/powershell/) prompt, which is the default command shell of the VS Code **Terminal**.
-
-Open the app's project file (`BlazorWebAppMovies.csproj`). Drop the `<IncludeAssets>` and `<PrivateAssets>` from the `Microsoft.EntityFrameworkCore.Design` package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
+Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
 
 ```diff
-- <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
--   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
--   <PrivateAssets>all</PrivateAssets>
-- </PackageReference>
-+ <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
+  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  <PrivateAssets>all</PrivateAssets>
++ <Publish>true</Publish>
+</PackageReference>
 ```
+
+The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The change to the package reference can be reverted in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
+
+:::moniker-end
+
+> [!NOTE]
+> The preceding commands are .NET CLI commands, and .NET CLI commands are executed when entered at a [PowerShell](/powershell/) prompt, which is the default command shell of the VS Code **Terminal**.
 
 Save the project file.
 
@@ -175,6 +200,27 @@ Paste all of the following commands  at the prompt (`>`) of the command shell. W
 
 When you paste multiple commands, all of the commands execute except the last one. The last command doesn't execute until you press <kbd>Enter</kbd> on the keyboard.
 
+:::moniker range=">= aspnetcore-10.0 < aspnetcore-9.0"
+
+```dotnetcli
+dotnet tool install --global dotnet-aspnet-codegenerator
+dotnet tool install --global dotnet-ef
+dotnet add package Microsoft.EntityFrameworkCore.SQLite
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package Microsoft.EntityFrameworkCore.Tools
+dotnet add package Microsoft.AspNetCore.Components.QuickGrid
+dotnet add package Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter
+dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
+```
+
+> [!IMPORTANT]
+> After the first eight commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
+
+:::moniker-end
+
+:::moniker range="= aspnetcore-9.0"
+
 ```dotnetcli
 dotnet tool install --global dotnet-aspnet-codegenerator
 dotnet tool install --global dotnet-ef
@@ -191,15 +237,19 @@ dotnet add package Microsoft.EntityFrameworkCore.Design
 > [!IMPORTANT]
 > After the first nine commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
 
-Open the app's project file (`BlazorWebAppMovies.csproj`). Drop the `<IncludeAssets>` and `<PrivateAssets>` from the `Microsoft.EntityFrameworkCore.Design` package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
+Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
 
 ```diff
-- <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
--   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
--   <PrivateAssets>all</PrivateAssets>
-- </PackageReference>
-+ <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}" />
+<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
+  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  <PrivateAssets>all</PrivateAssets>
++ <Publish>true</Publish>
+</PackageReference>
 ```
+
+The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The change to the package reference can be reverted in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
+
+:::moniker-end
 
 Save the project file.
 


### PR DESCRIPTION
Fixes #34775

Thanks @kemundos! 🚀 ... The updates here will now address the [EF Core tools breaking change](https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools) better and will solve this for everyone going forward for the .NET 9 version of the tutorial. I've versioned it to drop out at .NET 10 or later, when they'll have it fixed in the tooling.