### PR TITLE
Update EF Core tooling breaking change

### DIFF
--- a/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
@@ -134,36 +134,32 @@ dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
 > [!IMPORTANT]
 > After the first eight commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
 
-:::moniker range=">= aspnetcore-9.0 < aspnetcore-10.0"
+:::moniker range=">= aspnetcore-9.0"
 
-<!-- UPDATE 10.0 - Update the first bullet. -->
+<!-- UPDATE 10.0 - Remove this when the 9.0.300 SDK lands. -->
 
 > [!IMPORTANT]
-> If using the .NET 9 SDK, a breaking change in EF Core tooling prevents scaffolding from executing with the following exception:
+> A breaking change in EF Core tooling for .NET SDK 9.0.200 prevents scaffolding from executing with the following exception:
 >
 > > :::no-loc text="Could not load file or assembly 'Microsoft.EntityFrameworkCore.Design, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.":::
 > 
-> Adopt ***either*** of the following approaches:
+> To resolve the error until the .NET SDK 9.0.300 is released, add a package reference to the app for the [`Microsoft.EntityFrameworkCore.Design`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design) NuGet package:
 >
-> * Use a .NET SDK for [.NET 10](https://dotnet.microsoft.com/download/dotnet/10.0) or later. .NET 10 is currently in preview and is secheduled for release in November, 2025. If you obtain and use the .NET 10 SDK for this tutorial, you can leave the app targeting .NET 9.
->
-> * Add a package reference to the app for the [`Microsoft.EntityFrameworkCore.Design`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design) NuGet package:
->
->   ```dotnetcli
->   dotnet add package Microsoft.EntityFrameworkCore.Design
->   ```
+> ```dotnetcli
+> dotnet add package Microsoft.EntityFrameworkCore.Design
+> ```
 > 
->   Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
+> Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
 >
->   ```diff
->   <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
->     <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
->     <PrivateAssets>all</PrivateAssets>
->   + <Publish>true</Publish>
->   </PackageReference>
->   ```
+> ```diff
+> <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
+>   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+>   <PrivateAssets>all</PrivateAssets>
+> + <Publish>true</Publish>
+> </PackageReference>
+>  ```
 >
->   The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The entire package reference can be removed in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
+> The preceding changes are a workaround for a breaking change in .NET 9.0.200 EF Core tooling. This workaround won't be required for .NET SDK 9.0.300 or later, when the entire package reference can be removed from the app. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
 
 :::moniker-end
 
@@ -197,36 +193,32 @@ Paste all of the following commands  at the prompt (`>`) of the command shell. W
 
 When you paste multiple commands, all of the commands execute except the last one. The last command doesn't execute until you press <kbd>Enter</kbd> on the keyboard.
 
-:::moniker range=">= aspnetcore-9.0 < aspnetcore-10.0"
+:::moniker range=">= aspnetcore-9.0"
 
-<!-- UPDATE 10.0 - Update the first bullet. -->
+<!-- UPDATE 10.0 - Remove this when the 9.0.300 SDK lands. -->
 
 > [!IMPORTANT]
-> If using the .NET 9 SDK, a breaking change in EF Core tooling prevents scaffolding from executing with the following exception:
+> A breaking change in EF Core tooling for .NET SDK 9.0.200 prevents scaffolding from executing with the following exception:
 >
 > > :::no-loc text="Could not load file or assembly 'Microsoft.EntityFrameworkCore.Design, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.":::
 > 
-> Adopt ***either*** of the following approaches:
+> To resolve the error until the .NET SDK 9.0.300 is released, add a package reference to the app for the [`Microsoft.EntityFrameworkCore.Design`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design) NuGet package:
 >
-> * Use a .NET SDK for [.NET 10](https://dotnet.microsoft.com/download/dotnet/10.0) or later. .NET 10 is currently in preview and is secheduled for release in November, 2025. If you obtain and use the .NET 10 SDK for this tutorial, you can leave the app targeting .NET 9.
->
-> * Add a package reference to the app for the [`Microsoft.EntityFrameworkCore.Design`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design) NuGet package:
->
->   ```dotnetcli
->   dotnet add package Microsoft.EntityFrameworkCore.Design
->   ```
+> ```dotnetcli
+> dotnet add package Microsoft.EntityFrameworkCore.Design
+> ```
 > 
->   Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
+> Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
 >
->   ```diff
->   <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
->     <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
->     <PrivateAssets>all</PrivateAssets>
->   + <Publish>true</Publish>
->   </PackageReference>
->   ```
+> ```diff
+> <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
+>   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+>   <PrivateAssets>all</PrivateAssets>
+> + <Publish>true</Publish>
+> </PackageReference>
+>  ```
 >
->   The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The entire package reference can be removed in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
+> The preceding changes are a workaround for a breaking change in .NET 9.0.200 EF Core tooling. This workaround won't be required for .NET SDK 9.0.300 or later, when the entire package reference can be removed from the app. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
@@ -163,7 +163,7 @@ dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
 >   </PackageReference>
 >   ```
 >
->   The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The change to the package reference can be reverted in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
+>   The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The entire package reference can be removed in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
 
 :::moniker-end
 
@@ -197,73 +197,36 @@ Paste all of the following commands  at the prompt (`>`) of the command shell. W
 
 When you paste multiple commands, all of the commands execute except the last one. The last command doesn't execute until you press <kbd>Enter</kbd> on the keyboard.
 
-:::moniker range=">= aspnetcore-10.0"
-
-```dotnetcli
-dotnet tool install --global dotnet-aspnet-codegenerator
-dotnet tool install --global dotnet-ef
-dotnet add package Microsoft.EntityFrameworkCore.SQLite
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer
-dotnet add package Microsoft.EntityFrameworkCore.Tools
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter
-dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
-```
-
-> [!IMPORTANT]
-> After the first eight commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
-
-:::moniker-end
-
 :::moniker range=">= aspnetcore-9.0 < aspnetcore-10.0"
 
-```dotnetcli
-dotnet tool install --global dotnet-aspnet-codegenerator
-dotnet tool install --global dotnet-ef
-dotnet add package Microsoft.EntityFrameworkCore.SQLite
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer
-dotnet add package Microsoft.EntityFrameworkCore.Tools
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter
-dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
-dotnet add package Microsoft.EntityFrameworkCore.Design
-```
+<!-- UPDATE 10.0 - Update the first bullet. -->
 
 > [!IMPORTANT]
-> After the first nine commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
-
-Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
-
-```diff
-<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
-  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-  <PrivateAssets>all</PrivateAssets>
-+ <Publish>true</Publish>
-</PackageReference>
-```
-
-The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The change to the package reference can be reverted in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-9.0"
-
-```dotnetcli
-dotnet tool install --global dotnet-aspnet-codegenerator
-dotnet tool install --global dotnet-ef
-dotnet add package Microsoft.EntityFrameworkCore.SQLite
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer
-dotnet add package Microsoft.EntityFrameworkCore.Tools
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter
-dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
-```
-
-> [!IMPORTANT]
-> After the first eight commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
+> If using the .NET 9 SDK, a breaking change in EF Core tooling prevents scaffolding from executing with the following exception:
+>
+> > :::no-loc text="Could not load file or assembly 'Microsoft.EntityFrameworkCore.Design, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.":::
+> 
+> Adopt ***either*** of the following approaches:
+>
+> * Use a .NET SDK for [.NET 10](https://dotnet.microsoft.com/download/dotnet/10.0) or later. .NET 10 is currently in preview and is secheduled for release in November, 2025. If you obtain and use the .NET 10 SDK for this tutorial, you can leave the app targeting .NET 9.
+>
+> * Add a package reference to the app for the [`Microsoft.EntityFrameworkCore.Design`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design) NuGet package:
+>
+>   ```dotnetcli
+>   dotnet add package Microsoft.EntityFrameworkCore.Design
+>   ```
+> 
+>   Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
+>
+>   ```diff
+>   <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
+>     <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+>     <PrivateAssets>all</PrivateAssets>
+>   + <Publish>true</Publish>
+>   </PackageReference>
+>   ```
+>
+>   The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The entire package reference can be removed in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
@@ -119,8 +119,6 @@ Paste all of the following commands at the prompt (`>`) of the **Terminal**. Whe
 
 When you paste multiple commands, all of the commands execute except the last one. The last command doesn't execute until you press <kbd>Enter</kbd> on the keyboard.
 
-:::moniker range=">= aspnetcore-10.0"
-
 ```dotnetcli
 dotnet tool install --global dotnet-aspnet-codegenerator
 dotnet tool install --global dotnet-ef
@@ -135,57 +133,37 @@ dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
 
 > [!IMPORTANT]
 > After the first eight commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
-
-:::moniker-end
 
 :::moniker range=">= aspnetcore-9.0 < aspnetcore-10.0"
 
-```dotnetcli
-dotnet tool install --global dotnet-aspnet-codegenerator
-dotnet tool install --global dotnet-ef
-dotnet add package Microsoft.EntityFrameworkCore.SQLite
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer
-dotnet add package Microsoft.EntityFrameworkCore.Tools
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter
-dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
-dotnet add package Microsoft.EntityFrameworkCore.Design
-```
+<!-- UPDATE 10.0 - Update the first bullet. -->
 
 > [!IMPORTANT]
-> After the first nine commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
-
-Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
-
-```diff
-<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
-  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-  <PrivateAssets>all</PrivateAssets>
-+ <Publish>true</Publish>
-</PackageReference>
-```
-
-The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The change to the package reference can be reverted in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-9.0"
-
-```dotnetcli
-dotnet tool install --global dotnet-aspnet-codegenerator
-dotnet tool install --global dotnet-ef
-dotnet add package Microsoft.EntityFrameworkCore.SQLite
-dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
-dotnet add package Microsoft.EntityFrameworkCore.SqlServer
-dotnet add package Microsoft.EntityFrameworkCore.Tools
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid
-dotnet add package Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter
-dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
-```
-
-> [!IMPORTANT]
-> After the first eight commands execute, make sure that you press <kbd>Enter</kbd> on the keyboard to execute the last command.
+> If using the .NET 9 SDK, a breaking change in EF Core tooling prevents scaffolding from executing with the following exception:
+>
+> > :::no-loc text="Could not load file or assembly 'Microsoft.EntityFrameworkCore.Design, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.":::
+> 
+> Adopt ***either*** of the following approaches:
+>
+> * Use a .NET SDK for .NET 10 or later. .NET 10 is currently in preview and is secheduled for release in November, 2025.
+>
+> * Add a package reference to the app for the [`Microsoft.EntityFrameworkCore.Design`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design) NuGet package:
+>
+> ```dotnetcli
+> dotnet add package Microsoft.EntityFrameworkCore.Design
+> ```
+> 
+> Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
+>
+> ```diff
+> <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
+>   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+>   <PrivateAssets>all</PrivateAssets>
+> + <Publish>true</Publish>
+> </PackageReference>
+> ```
+>
+> The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The change to the package reference can be reverted in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
@@ -145,25 +145,25 @@ dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
 > 
 > Adopt ***either*** of the following approaches:
 >
-> * Use a .NET SDK for .NET 10 or later. .NET 10 is currently in preview and is secheduled for release in November, 2025.
+> * Use a .NET SDK for [.NET 10](https://dotnet.microsoft.com/download/dotnet/10.0) or later. .NET 10 is currently in preview and is secheduled for release in November, 2025. If you obtain and use the .NET 10 SDK for this tutorial, you can leave the app targeting .NET 9.
 >
 > * Add a package reference to the app for the [`Microsoft.EntityFrameworkCore.Design`](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Design) NuGet package:
 >
-> ```dotnetcli
-> dotnet add package Microsoft.EntityFrameworkCore.Design
-> ```
+>   ```dotnetcli
+>   dotnet add package Microsoft.EntityFrameworkCore.Design
+>   ```
 > 
-> Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
+>   Open the app's project file (`BlazorWebAppMovies.csproj`). Mark the `Microsoft.EntityFrameworkCore.Design` assembly reference as publishable by adding `<Publish>true</Publish>` to the package reference. In the following example, the `{VERSION}` placeholder is the package's version and remains unchanged: 
 >
-> ```diff
-> <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
->   <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
->   <PrivateAssets>all</PrivateAssets>
-> + <Publish>true</Publish>
-> </PackageReference>
-> ```
+>   ```diff
+>   <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="{VERSION}">
+>     <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+>     <PrivateAssets>all</PrivateAssets>
+>   + <Publish>true</Publish>
+>   </PackageReference>
+>   ```
 >
-> The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The change to the package reference can be reverted in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
+>   The preceding update to the package reference is a workaround for a breaking change in .NET 9 EF Core tooling. The change to the package reference can be reverted in apps that are eventually updated to .NET 10 or later. For more information, see [Breaking changes in EF Core 9 (EF9)](/ef/core/what-is-new/ef-core-9.0/breaking-changes#microsoftentityframeworkcoredesign-not-found-when-using-ef-tools).
 
 :::moniker-end
 


### PR DESCRIPTION
Addresses #34775

Let's see if this looks better. I think with a minor update to this approach at 10.0 to remove the remark about .NET 10's release (and to update the link so that it just points to the downloads page at https://dotnet.microsoft.com/download), this is a better way to handle a tooling breaking change that will be patched for 10.0. ***Maybe!*** 🤔 ... best to sleep on it for sure 🛌💤.

cc: @Rick-Anderson @tdykstra ... Discussed further with Wade offline. I'm looking at a different approach here for this because this really is a temporary tooling (SDK) problem.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tutorials/movie-database-app/part-2.md](https://github.com/dotnet/AspNetCore.Docs/blob/5a97559abdeffc48dc2d1e4c1e0f918d90286721/aspnetcore/blazor/tutorials/movie-database-app/part-2.md) | [aspnetcore/blazor/tutorials/movie-database-app/part-2](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/movie-database-app/part-2?branch=pr-en-us-34814) |


<!-- PREVIEW-TABLE-END -->