### PR TITLE
Add context to introductory remarks

### DIFF
--- a/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
+++ b/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md
@@ -12,7 +12,7 @@ uid: blazor/components/render-outside-of-aspnetcore
 
 [!INCLUDE[](~/includes/not-latest-version-without-not-supported-content.md)]
 
-Razor components can be rendered outside of the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for generating email content, generating static site content, or for building a content templating engine.
+[Razor components](xref:blazor/components/index), which are self-contained portions of user interface (UI) with processing logic used in [ASP.NET Core Blazor](xref:blazor/index), can be rendered outside of the context of an HTTP request. You can render Razor components as HTML directly to a string or stream independently of the ASP.NET Core hosting environment. This is convenient for scenarios where you want to generate HTML fragments, such as for generating email content, generating static site content, or for building a content templating engine.
 
 In the following example, a Razor component is rendered to an HTML string from a console app:
 


### PR DESCRIPTION
Fixes #34188

Thanks @dipique! 🚀 ... I'm adding context to the first line of the article, including a cross-link for "Razor components" to the Razor components *Overview* article and a link to the Blazor landing page of the doc set. That should clarify things:

* Razor components are for Blazor.
* The *Overview* article describes the relationship between Razor components and other "Razor"-named things in .NET.

Thanks for the issue. This should help folks who land in the doc set from Internet search.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md](https://github.com/dotnet/AspNetCore.Docs/blob/122dbe7b4fa7953a398005110d6e753db4b5be62/aspnetcore/blazor/components/render-components-outside-of-aspnetcore.md) | [aspnetcore/blazor/components/render-components-outside-of-aspnetcore](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/render-components-outside-of-aspnetcore?branch=pr-en-us-34826) |

<!-- PREVIEW-TABLE-END -->