### PR TITLE
Updates inside `OnInitializedAsync` not streamed for POSTs

### DIFF
--- a/aspnetcore/blazor/forms/index.md
+++ b/aspnetcore/blazor/forms/index.md
@@ -78,7 +78,9 @@ In the preceding `StarshipPlainForm` component:
 
 Blazor enhances page navigation and form handling by intercepting the request in order to apply the response to the existing DOM, preserving as much of the rendered form as possible. The enhancement avoids the need to fully load the page and provides a much smoother user experience, similar to a single-page app (SPA), although the component is rendered on the server. For more information, see <xref:blazor/fundamentals/routing#enhanced-navigation-and-form-handling>.
 
-[Streaming rendering](xref:blazor/components/rendering#streaming-rendering) is supported for plain HTML forms. Note that when `POST`ing a form, only DOM updates inside the form's handlers, e.g. `@onsubmit`, are streamed. Updates inside `OnInitializedAsync` are only streamed for `GET` requests. See [#50994](https://github.com/dotnet/aspnetcore/issues/50994) for more information.
+<!-- UPDATE 11.0 - Check the PU issue (backlogged as of 2/27/25 -->
+
+[Streaming rendering](xref:blazor/components/rendering#streaming-rendering) is supported for plain HTML forms. Note that when `POST`ing a form, only DOM updates inside the form's handlers are streamed (for example, `@onsubmit`). Updates inside `OnInitializedAsync` are only streamed for `GET` requests. For more information, see [Allow streaming the loading phase of POST responses (`dotnet/aspnetcore` #50994)](https://github.com/dotnet/aspnetcore/issues/50994).
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
@@ -124,7 +126,9 @@ In the preceding `Starship1` component:
 
 Blazor enhances page navigation and form handling for <xref:Microsoft.AspNetCore.Components.Forms.EditForm> components. For more information, see <xref:blazor/fundamentals/routing#enhanced-navigation-and-form-handling>.
 
-[Streaming rendering](xref:blazor/components/rendering#streaming-rendering) is supported for <xref:Microsoft.AspNetCore.Components.Forms.EditForm>. Note that when `POST`ing a form, only DOM updates inside the form's handlers, e.g. `OnValidSubmit`, are streamed. Updates inside `OnInitializedAsync` are only streamed for `GET` requests. See [#50994](https://github.com/dotnet/aspnetcore/issues/50994) for more information.
+<!-- UPDATE 11.0 - Check the PU issue (backlogged as of 2/27/25 -->
+
+[Streaming rendering](xref:blazor/components/rendering#streaming-rendering) is supported for <xref:Microsoft.AspNetCore.Components.Forms.EditForm>. Note that when `POST`ing a form, only DOM updates inside the form's handlers are streamed (for example, `OnValidSubmit`). Updates inside `OnInitializedAsync` are only streamed for `GET` requests. For more information, see [Allow streaming the loading phase of POST responses (`dotnet/aspnetcore` #50994)](https://github.com/dotnet/aspnetcore/issues/50994).
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 

--- a/aspnetcore/blazor/forms/index.md
+++ b/aspnetcore/blazor/forms/index.md
@@ -78,7 +78,7 @@ In the preceding `StarshipPlainForm` component:
 
 Blazor enhances page navigation and form handling by intercepting the request in order to apply the response to the existing DOM, preserving as much of the rendered form as possible. The enhancement avoids the need to fully load the page and provides a much smoother user experience, similar to a single-page app (SPA), although the component is rendered on the server. For more information, see <xref:blazor/fundamentals/routing#enhanced-navigation-and-form-handling>.
 
-[Streaming rendering](xref:blazor/components/rendering#streaming-rendering) is supported for plain HTML forms.
+[Streaming rendering](xref:blazor/components/rendering#streaming-rendering) is supported for plain HTML forms. Note that when `POST`ing a form, only DOM updates inside the form's handlers, e.g. `@onsubmit`, are streamed. Updates inside `OnInitializedAsync` are only streamed for `GET` requests. See [#50994](https://github.com/dotnet/aspnetcore/issues/50994) for more information.
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
@@ -124,7 +124,7 @@ In the preceding `Starship1` component:
 
 Blazor enhances page navigation and form handling for <xref:Microsoft.AspNetCore.Components.Forms.EditForm> components. For more information, see <xref:blazor/fundamentals/routing#enhanced-navigation-and-form-handling>.
 
-[Streaming rendering](xref:blazor/components/rendering#streaming-rendering) is supported for <xref:Microsoft.AspNetCore.Components.Forms.EditForm>.
+[Streaming rendering](xref:blazor/components/rendering#streaming-rendering) is supported for <xref:Microsoft.AspNetCore.Components.Forms.EditForm>. Note that when `POST`ing a form, only DOM updates inside the form's handlers, e.g. `OnValidSubmit`, are streamed. Updates inside `OnInitializedAsync` are only streamed for `GET` requests. See [#50994](https://github.com/dotnet/aspnetcore/issues/50994) for more information.
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 


### PR DESCRIPTION
Related: <https://github.com/dotnet/aspnetcore/issues/50994>

I was about to open an issue about this because I thought it was a bug before I found <https://github.com/dotnet/aspnetcore/issues/50994> and then thought it might be worth to mention this in the docs.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/dd4f8cc255314a9bd87710665b90b924fafec4bc/aspnetcore/blazor/forms/index.md) | [aspnetcore/blazor/forms/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/index?branch=pr-en-us-34828) |


<!-- PREVIEW-TABLE-END -->