### PR TITLE
Reconnect UI component

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -524,7 +524,7 @@ If reconnection succeeds, user state is often lost. Custom code can be added to 
 To create UI elements that track reconnection state, the following table describes:
 
 * A set of `components-reconnect-*` CSS classes (**Css class** column) that are set or unset by Blazor on an element with an `id` of `components-reconnect-modal`.
-* The `components-reconnect-state-changed` event value (**Event** column) that indicates a reconnection status change.
+* A `components-reconnect-state-changed` event (**Event** column) that indicates a reconnection status change.
 
 | CSS class | Event | Indicates&hellip; |
 | --- | --- | --- |
@@ -541,6 +541,26 @@ When the reconnection state change is `rejected`, the server was reached but ref
 * A crash in the server-side circuit occurs.
 * The client is disconnected long enough for the server to drop the user's state. Instances of the user's components are disposed.
 * The server is restarted, or the app's worker process is recycled.
+
+The developer adds an event listener on the reconnect modal element to monitor and react to reconnection state changes, as seen in the following example:
+
+```javascript
+const reconnectModal = document.getElementById("components-reconnect-modal");
+reconnectModal.addEventListener("components-reconnect-state-changed", 
+  handleReconnectStateChanged);
+
+function handleReconnectStateChanged(event) {
+  if (event.detail.state === "show") {
+    reconnectModal.showModal();
+  } else if (event.detail.state === "hide") {
+    reconnectModal.close();
+  } else if (event.detail.state === "failed") {
+    Blazor.reconnect();
+  } else if (event.detail.state === "rejected") {
+    location.reload();
+  }
+}
+```
 
 An element with an `id` of `components-reconnect-max-retries` displays the maximum number of reconnect retries:
 
@@ -560,7 +580,7 @@ An element with an `id` of `components-seconds-to-next-attempt` displays the num
 <span id="components-seconds-to-next-attempt"></span>
 ```
 
-The Blazor Web App project template includes a `ReconnectModal` component (`Components/Layout/ReconnectModal.razor`) with collocated stylesheet and JavaScript files (`ReconnectModal.razor.css`, `ReconnectModal.razor.js`) that can be customized as needed. These files can be examined in the ASP.NET Core reference source or by inspecting an app created from the Blazor Web App project template with Interactive WebAssembly or Interactive Auto rendering enabled:
+The Blazor Web App project template includes a `ReconnectModal` component (`Components/Layout/ReconnectModal.razor`) with collocated stylesheet and JavaScript files (`ReconnectModal.razor.css`, `ReconnectModal.razor.js`) that can be customized as needed. These files can be examined in the ASP.NET Core reference source or by inspecting an app created from the Blazor Web App project template. The component is added to the project when the project is created in Visual Studio with **Interactive render mode** set to **Server** or **Auto** or created with the .NET CLI with the option `--interactivity server` (default) or `--interactivity auto`.
 
 * [`ReconnectModal` component](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor)
 * [Stylesheet file](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.css)

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -553,7 +553,7 @@ Additional CSS classes to further control the style of rendered elements is desc
 | --- | --- | --- |
 | `components-reconnect-first-attempt-visible` | `retrying` | The first retry attempt. |
 | `components-reconnect-repeated-attempt-visible` | `retrying` | Subsequent retry attempts. |
-| `components-reconnect-failed-visible` | `failed`/`rejected` | Reconnection attempts that have failed or been rejected. |
+| `components-reconnect-failed-visible` | `failed` | A failed reconnection attempt. |
 
 An element with an `id` of `components-reconnect-max-retries` displays the maximum number of reconnect retries:
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -521,39 +521,26 @@ If reconnection succeeds, user state is often lost. Custom code can be added to 
 
 :::moniker range=">= aspnetcore-10.0"
 
-Customize the UI and reconnection behavior in the `ReconnectModal` component (`Components/Layout/ReconnectModal.razor`), its collocated stylesheet file (`ReconnectModal.razor.css`), and its collocated JavaScript file (`ReconnectModal.razor.js`). These files can be examined in the ASP.NET Core reference source or by inspecting an app created from the Blazor Web App project template with Interactive WebAssembly or Interactive Auto rendering enabled:
+To create UI elements that track reconnection state, the following table describes:
 
-* [`ReconnectModal` component](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor)
-* [Stylesheet file](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.css)
-* [JavaScript file](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js)
-
-[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
-
-The `components-reconnect-state-changed` event indicates a reconnection status change:
-
-* `show`: The reconnection modal is shown.
-* `hide`: The reconnection model is closed.
-* `retrying`: Reconnect attempts are in progress.
-* `failed`: A reconnection attempt failed.
-* `rejected`: A reconnection attempt was received by the server but rejected.
-
-The following table describes the CSS classes applied to the `components-reconnect-modal` element. The **Event** column represents the value of the matching `components-reconnect-state-changed` JavaScript event.
+* A set of `components-reconnect-*` CSS classes (**Css class** column) that are set or unset by Blazor on an element with an `id` of `components-reconnect-modal`.
+* The `components-reconnect-state-changed` event value (**Event** column) that indicates a reconnection status change.
 
 | CSS class | Event | Indicates&hellip; |
 | --- | --- | --- |
-| `components-reconnect-show` | `show` | A lost connection. The client is attempting to reconnect. Show the modal. |
-| `components-reconnect-hide` | `hide` | An active connection is re-established to the server. Hide the modal. |
+| `components-reconnect-show` | `show` | A lost connection. The client is attempting to reconnect. The reconnection modal is shown. |
+| `components-reconnect-hide` | `hide` | An active connection is re-established to the server. The reconnection model is closed. |
 | `components-reconnect-retrying` | `retrying` | The client is attempting to reconnect. |
-| `components-reconnect-failed` | `failed` | Reconnection failed, probably due to a network failure. To attempt reconnection, call `Blazor.reconnect()` in JavaScript. |
-| `components-reconnect-rejected` | `rejected` | Reconnection rejected. The server was reached but refused the connection, and the user's state on the server is lost. To reload the app, call `location.reload()` in JavaScript. This connection state may result when:<ul><li>A crash in the server-side circuit occurs.</li><li>The client is disconnected long enough for the server to drop the user's state. Instances of the user's components are disposed.</li><li>The server is restarted, or the app's worker process is recycled.</li></ul> |
+| `components-reconnect-failed` | `failed` | Reconnection failed, probably due to a network failure. |
+| `components-reconnect-rejected` | `rejected` | Reconnection rejected. |
 
-Additional CSS classes to further control the style of rendered elements is described in the following table. The **Event** column represents the value of the matching `components-reconnect-state-changed` JavaScript event.
+When the reconnection state change in `components-reconnect-state-changed` is `failed`, call `Blazor.reconnect()` in JavaScript to attempt reconnection.
 
-| CSS class | Event | Displayed on&hellip; |
-| --- | --- | --- |
-| `components-reconnect-first-attempt-visible` | `retrying` | The first retry attempt. |
-| `components-reconnect-repeated-attempt-visible` | `retrying` | Subsequent retry attempts. |
-| `components-reconnect-failed-visible` | `failed` | A failed reconnection attempt. |
+When the reconnection state change is `rejected`, the server was reached but refused the connection, and the user's state on the server is lost. To reload the app, call `location.reload()` in JavaScript. This connection state may result when:
+
+* A crash in the server-side circuit occurs.
+* The client is disconnected long enough for the server to drop the user's state. Instances of the user's components are disposed.
+* The server is restarted, or the app's worker process is recycled.
 
 An element with an `id` of `components-reconnect-max-retries` displays the maximum number of reconnect retries:
 
@@ -572,6 +559,14 @@ An element with an `id` of `components-seconds-to-next-attempt` displays the num
 ```html
 <span id="components-seconds-to-next-attempt"></span>
 ```
+
+The Blazor Web App project template includes a `ReconnectModal` component (`Components/Layout/ReconnectModal.razor`) with collocated stylesheet and JavaScript files (`ReconnectModal.razor.css`, `ReconnectModal.razor.js`) that can be customized as needed. These files can be examined in the ASP.NET Core reference source or by inspecting an app created from the Blazor Web App project template with Interactive WebAssembly or Interactive Auto rendering enabled:
+
+* [`ReconnectModal` component](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor)
+* [Stylesheet file](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.css)
+* [JavaScript file](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js)
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
 :::moniker-end
 

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -666,6 +666,8 @@ The following table describes the CSS classes applied to the `components-reconne
 | `components-reconnect-failed`   | Reconnection failed, probably due to a network failure. To attempt reconnection, call `window.Blazor.reconnect()` in JavaScript. |
 | `components-reconnect-rejected` | Reconnection rejected. The server was reached but refused the connection, and the user's state on the server is lost. To reload the app, call `location.reload()` in JavaScript. This connection state may result when:<ul><li>A crash in the server-side circuit occurs.</li><li>The client is disconnected long enough for the server to drop the user's state. Instances of the user's components are disposed.</li><li>The server is restarted, or the app's worker process is recycled.</li></ul> |
 
+:::moniker-end
+
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-10.0"
 
 Customize the delay before the reconnection UI appears by setting the `transition-delay` property in the site's CSS for the modal element. The following example sets the transition delay from 500 ms (default) to 1,000 ms (1 second).

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -519,7 +519,63 @@ If reconnection fails, the user is instructed to retry or reload the page:
 
 If reconnection succeeds, user state is often lost. Custom code can be added to any component to save and reload user state across connection failures. For more information, see <xref:blazor/state-management>.
 
-:::moniker range=">= aspnetcore-8.0"
+:::moniker range=">= aspnetcore-10.0"
+
+Customize the UI and reconnection behavior in the `ReconnectModal` component (`Components/Layout/ReconnectModal.razor`), its collocated stylesheet file (`ReconnectModal.razor.css`), and its collocated JavaScript file (`ReconnectModal.razor.js`). These files can be examined in the ASP.NET Core reference source or by inspecting an app created from the Blazor Web App project template with Interactive WebAssembly or Interactive Auto rendering enabled:
+
+* [`ReconnectModal` component](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor)
+* [Stylesheet file](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.css)
+* [JavaScript file](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Layout/ReconnectModal.razor.js)
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+The `components-reconnect-state-changed` event indicates a reconnection status change:
+
+* `show`: The reconnection modal is shown.
+* `hide`: The reconnection model is closed.
+* `retrying`: Reconnect attempts are in progress.
+* `failed`: A reconnection attempt has failed.
+* `rejected`: A reconnection attempt was received but rejected.
+
+The following table describes the CSS classes applied to the `components-reconnect-modal` element. The **Event** column represents the value of the matching `components-reconnect-state-changed` JavaScript event.
+
+| CSS class | Event | Indicates&hellip; |
+| --- | --- | --- |
+| `components-reconnect-show` | `show` | A lost connection. The client is attempting to reconnect. Show the modal. |
+| `components-reconnect-hide` | `hide` | An active connection is re-established to the server. Hide the modal. |
+| `components-reconnect-retrying` | `retrying` | The client is attempting to reconnect. |
+| `components-reconnect-failed` | `failed` | Reconnection failed, probably due to a network failure. To attempt reconnection, call `Blazor.reconnect()` in JavaScript. |
+| `components-reconnect-rejected` | `rejected` | Reconnection rejected. The server was reached but refused the connection, and the user's state on the server is lost. To reload the app, call `location.reload()` in JavaScript. This connection state may result when:<ul><li>A crash in the server-side circuit occurs.</li><li>The client is disconnected long enough for the server to drop the user's state. Instances of the user's components are disposed.</li><li>The server is restarted, or the app's worker process is recycled.</li></ul> |
+
+Additional CSS classes to further control the style of rendered elements is described in the following table. The **Event** column represents the value of the matching `components-reconnect-state-changed` JavaScript event.
+
+| CSS class | Event | Indicates&hellip; |
+| --- | --- | --- |
+| `components-reconnect-first-attempt-visible` | `retrying` | Displayed on the first retry attempt. |
+| `components-reconnect-repeated-attempt-visible` | `retrying` | Displayed on the subsequent retry attempts. |
+| `components-reconnect-failed-visible` | `failed`/`rejected` | Displayed when reconnection attempts have failed or a reconnection attempt has been rejected. |
+
+To display the maximum number of reconnect retries, define an element with an `id` of `components-reconnect-max-retries`:
+
+```html
+<span id="components-reconnect-max-retries"></span>
+```
+
+To display the current reconnect attempt, define an element with an `id` of `components-reconnect-current-attempt`:
+
+```html
+<span id="components-reconnect-current-attempt"></span>
+```
+
+To display the number of seconds to the next reconnection attempt, define an element with an `id` of `components-seconds-to-next-attempt`:
+
+```html
+<span id="components-seconds-to-next-attempt"></span>
+```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
 
 To customize the UI, define a single element with an `id` of `components-reconnect-modal` in the `<body>` element content. The following example places the element in the `App` component.
 
@@ -551,6 +607,8 @@ To customize the UI, define a single element with an `id` of `components-reconne
 
 :::moniker-end
 
+:::moniker range="< aspnetcore-10.0"
+
 ```cshtml
 <div id="components-reconnect-modal">
     Connection lost.<br>Attempting to reconnect...
@@ -562,7 +620,9 @@ To customize the UI, define a single element with an `id` of `components-reconne
 
 Add the following CSS styles to the site's stylesheet.
 
-:::moniker range=">= aspnetcore-8.0"
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
 
 `wwwroot/app.css`:
 
@@ -573,6 +633,8 @@ Add the following CSS styles to the site's stylesheet.
 `wwwroot/css/site.css`:
 
 :::moniker-end
+
+:::moniker range="< aspnetcore-10.0"
 
 ```css
 #components-reconnect-modal {
@@ -604,13 +666,13 @@ The following table describes the CSS classes applied to the `components-reconne
 | `components-reconnect-failed`   | Reconnection failed, probably due to a network failure. To attempt reconnection, call `window.Blazor.reconnect()` in JavaScript. |
 | `components-reconnect-rejected` | Reconnection rejected. The server was reached but refused the connection, and the user's state on the server is lost. To reload the app, call `location.reload()` in JavaScript. This connection state may result when:<ul><li>A crash in the server-side circuit occurs.</li><li>The client is disconnected long enough for the server to drop the user's state. Instances of the user's components are disposed.</li><li>The server is restarted, or the app's worker process is recycled.</li></ul> |
 
-:::moniker range=">= aspnetcore-5.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-10.0"
 
 Customize the delay before the reconnection UI appears by setting the `transition-delay` property in the site's CSS for the modal element. The following example sets the transition delay from 500 ms (default) to 1,000 ms (1 second).
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-8.0"
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
 
 `wwwroot/app.css`:
 
@@ -622,7 +684,7 @@ Customize the delay before the reconnection UI appears by setting the `transitio
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-5.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-10.0"
 
 ```css
 #components-reconnect-modal {

--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -534,8 +534,8 @@ The `components-reconnect-state-changed` event indicates a reconnection status c
 * `show`: The reconnection modal is shown.
 * `hide`: The reconnection model is closed.
 * `retrying`: Reconnect attempts are in progress.
-* `failed`: A reconnection attempt has failed.
-* `rejected`: A reconnection attempt was received but rejected.
+* `failed`: A reconnection attempt failed.
+* `rejected`: A reconnection attempt was received by the server but rejected.
 
 The following table describes the CSS classes applied to the `components-reconnect-modal` element. The **Event** column represents the value of the matching `components-reconnect-state-changed` JavaScript event.
 
@@ -549,25 +549,25 @@ The following table describes the CSS classes applied to the `components-reconne
 
 Additional CSS classes to further control the style of rendered elements is described in the following table. The **Event** column represents the value of the matching `components-reconnect-state-changed` JavaScript event.
 
-| CSS class | Event | Indicates&hellip; |
+| CSS class | Event | Displayed on&hellip; |
 | --- | --- | --- |
-| `components-reconnect-first-attempt-visible` | `retrying` | Displayed on the first retry attempt. |
-| `components-reconnect-repeated-attempt-visible` | `retrying` | Displayed on the subsequent retry attempts. |
-| `components-reconnect-failed-visible` | `failed`/`rejected` | Displayed when reconnection attempts have failed or a reconnection attempt has been rejected. |
+| `components-reconnect-first-attempt-visible` | `retrying` | The first retry attempt. |
+| `components-reconnect-repeated-attempt-visible` | `retrying` | Subsequent retry attempts. |
+| `components-reconnect-failed-visible` | `failed`/`rejected` | Reconnection attempts that have failed or been rejected. |
 
-To display the maximum number of reconnect retries, define an element with an `id` of `components-reconnect-max-retries`:
+An element with an `id` of `components-reconnect-max-retries` displays the maximum number of reconnect retries:
 
 ```html
 <span id="components-reconnect-max-retries"></span>
 ```
 
-To display the current reconnect attempt, define an element with an `id` of `components-reconnect-current-attempt`:
+An element with an `id` of `components-reconnect-current-attempt` displays the current reconnect attempt:
 
 ```html
 <span id="components-reconnect-current-attempt"></span>
 ```
 
-To display the number of seconds to the next reconnection attempt, define an element with an `id` of `components-seconds-to-next-attempt`:
+An element with an `id` of `components-seconds-to-next-attempt` displays the number of seconds to the next reconnection attempt:
 
 ```html
 <span id="components-seconds-to-next-attempt"></span>

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -36,14 +36,14 @@ The [`[Route]` attribute](xref:Microsoft.AspNetCore.Components.RouteAttribute) n
 
 Previously, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> scrolled to the top of the page for same-page navigations. This behavior has been changed in .NET 10 so that the browser no longer scrolls to the top of the page when navigating to the same page. This means the viewport is no longer reset when making updates to the address for the current page, such as changing the query string or fragment.
 
-### Reconnection UI component added to the Blazor Web App template
+### Reconnection UI component added to the Blazor Web App project template
 
-The Blazor Web App project template now includes a `ReconnectModal` component, including collocated stylesheet and JavaScript files, for improved developer control over the reconnection UI when the client loses the WebSocket connection to the server. The component isn't required to inline styles programatically, so it doesn't violate stricter Content Security Policy (CSP) settings for the `style-src` policy, thus avoiding CSP violations that faced the reconnection UI in prior releases.
+The Blazor Web App project template now includes a `ReconnectModal` component, including collocated stylesheet and JavaScript files, for improved developer control over the reconnection UI when the client loses the WebSocket connection to the server. The component isn't required to inline styles programatically, so it doesn't violate stricter Content Security Policy (CSP) settings for the `style-src` policy, thus avoiding CSP violations that occurred with the reconnection UI in prior releases.
 
 New reconnection UI features:
 
-* Apart from indicating the reconnection state by setting a specific CSS class on the element with the `components-reconnect-modal` ID, it also dispatches a custom event in `components-reconnect-state-changed` that can be listened for on the modal element.
-* The new reconnection state `retrying` is indicated by both a CSS class and the custom event, so that code can better differentiate the stages of the reconnection process.
+* Apart from indicating the reconnection state by setting a specific CSS class on the reconnection UI element, the new `components-reconnect-state-changed` event is dispatched for reconnection state changes.
+* Code can better differentiate the stages of the reconnection process with the new reconnection state "`retrying`," indicated by both the CSS class and the new event.
 
 For more information, see <xref:blazor/fundamentals/signalr?view=aspnetcore-10.0#reflect-the-server-side-connection-state-in-the-ui>.
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -36,4 +36,15 @@ The [`[Route]` attribute](xref:Microsoft.AspNetCore.Components.RouteAttribute) n
 
 Previously, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2A?displayProperty=nameWithType> scrolled to the top of the page for same-page navigations. This behavior has been changed in .NET 10 so that the browser no longer scrolls to the top of the page when navigating to the same page. This means the viewport is no longer reset when making updates to the address for the current page, such as changing the query string or fragment.
 
+### Reconnection UI component added to the Blazor Web App template
+
+The Blazor Web App project template now includes a `ReconnectModal` component, including collocated stylesheet and JavaScript files, for improved developer control over the reconnection UI when the client loses the WebSocket connection to the server. The component isn't required to inline styles programatically, so it doesn't violate stricter Content Security Policy (CSP) settings for the `style-src` policy, thus avoiding CSP violations that faced the reconnection UI in prior releases.
+
+New reconnection UI features:
+
+* Apart from indicating the reconnection state by setting a specific CSS class on the element with the `components-reconnect-modal` ID, it also dispatches a custom event in `components-reconnect-state-changed` that can be listened for on the modal element.
+* The new reconnection state `retrying` is indicated by both a CSS class and the custom event, so that code can better differentiate the stages of the reconnection process.
+
+For more information, see <xref:blazor/fundamentals/signalr?view=aspnetcore-10.0#reflect-the-server-side-connection-state-in-the-ui>.
+
 -->

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -38,7 +38,7 @@ Previously, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2
 
 ### Reconnection UI component added to the Blazor Web App project template
 
-The Blazor Web App project template now includes a `ReconnectModal` component, including collocated stylesheet and JavaScript files, for improved developer control over the reconnection UI when the client loses the WebSocket connection to the server. The component isn't required to inline styles programatically, so it doesn't violate stricter Content Security Policy (CSP) settings for the `style-src` policy, thus avoiding CSP violations that occurred with the reconnection UI in prior releases.
+The Blazor Web App project template now includes a `ReconnectModal` component, including collocated stylesheet and JavaScript files, for improved developer control over the reconnection UI when the client loses the WebSocket connection to the server. The component doesn't insert styles programmatically, so it doesn't violate stricter Content Security Policy (CSP) settings for the `style-src` policy. In prior releases, the default reconnection UI was created by the framework in a way that could cause CSP violations. Note that the default reconnection UI is still used as fallback when the app doesn't define the reconnection UI, such as by using the project template's `ReconnectModal` component or a similar custom component.
 
 New reconnection UI features:
 


### PR DESCRIPTION
Fixes #34813

## Notes

* I'm versioning all of the 10.0 or later content into one moniker range, and I'm disabling all of the existing content for <10.0. In the past, I broke up coverage into multiple moniker ranges because parts of the coverage changed (e.g., filenames, file locations).
* I'm using our standard approach for cross-linking reference source. I link the `main` branch, and I include the [guidance on selecting the correct release branch/tag](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/includes/aspnetcore-repo-ref-source-links.md).

## ❓Questions❓ 

* Are the existing images still accurate? ***If not,*** I'll make a tracking note to snap and place new shots on Preview 2 release day because I'm not on nightly releases (*yet* anyway 😄).
  * https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/blazor/fundamentals/signalr/_static/reconnection-ui-90-or-later.png
  * https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/blazor/fundamentals/signalr/_static/retry-ui-90-or-later.png
* The rejected scenario is a bit confusing: What does the `ReconnectModel` component display in that scenario? There's no such class (element marked with) "`components-reconnect-rejected-visible`," and doesn't `components-reconnect-failed-visible` go to `display: none` on a rejection? I don't see any styles for `components-reconnect-rejected` when it's applied to the dialog.
* Are there any *gotchas* 😈 to call out?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/signalr.md](https://github.com/dotnet/AspNetCore.Docs/blob/9091b6cc12f041a14a322760323e71acb11697af/aspnetcore/blazor/fundamentals/signalr.md) | [aspnetcore/blazor/fundamentals/signalr](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/signalr?branch=pr-en-us-34842) |


<!-- PREVIEW-TABLE-END -->