### PR TITLE
mention queue limit can be set to 0

### DIFF
--- a/aspnetcore/performance/rate-limit.md
+++ b/aspnetcore/performance/rate-limit.md
@@ -44,7 +44,7 @@ The preceding code:
 * Calls `AddFixedWindowLimiter` to create a fixed window limiter with a policy name of `"fixed"` and sets:
 * <xref:System.Threading.RateLimiting.FixedWindowRateLimiterOptions.PermitLimit> to 4 and the time <xref:System.Threading.RateLimiting.FixedWindowRateLimiterOptions.Window> to 12. A maximum of 4 requests per each 12-second window are allowed.
 * <xref:System.Threading.RateLimiting.FixedWindowRateLimiterOptions.QueueProcessingOrder> to <xref:System.Threading.RateLimiting.QueueProcessingOrder.OldestFirst>.
-* <xref:System.Threading.RateLimiting.FixedWindowRateLimiterOptions.QueueLimit> to 2.
+* <xref:System.Threading.RateLimiting.FixedWindowRateLimiterOptions.QueueLimit> to 2 (set this to 0 to disable the queueing mechanism).
 * Calls [UseRateLimiter](/dotnet/api/microsoft.aspnetcore.builder.ratelimiterapplicationbuilderextensions.useratelimiter) to enable rate limiting.
 
 Apps should use [Configuration](xref:fundamentals/configuration/index) to set limiter options. The following code updates the preceding code using [`MyRateLimitOptions`](https://github.com/dotnet/AspNetCore.Docs.Samples/blob/main/fundamentals/middleware/rate-limit/WebRateLimitAuth/Models/MyRateLimitOptions.cs) for configuration:
@@ -140,7 +140,7 @@ The <xref:System.Threading.RateLimiting.PartitionedRateLimiter.CreateChained%2A>
 
 The following code uses `CreateChained`:
 
-:::code language="csharp" source="~/../AspNetCore.Docs.Samples/fundamentals/middleware/rate-limit/WebRate2/Program.cs" id="snippet_3" highlight="21,51":::
+:::code language="csharp" source="~/../AspNetCore.Docs.Samples/fundamentals/middleware/rate-limit/WebRate2/Program.cs" id="snippet_3" highlight="19,20,33":::
 
 For more information, see the [CreateChained source code](https://github.com/dotnet/runtime/blob/79874806d246670ee5fe76e73ce566578fe675c0/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs#L52-L64)
 

--- a/aspnetcore/performance/rate-limit.md
+++ b/aspnetcore/performance/rate-limit.md
@@ -5,7 +5,7 @@ monikerRange: '>= aspnetcore-7.0'
 description: Learn how limit requests in ASP.NET Core apps
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 10/29/2022
+ms.date: 03/05/2025
 uid: performance/rate-limit
 ---
 


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #34442

I think a short mention of it can already help, otherwise the docs structure needs to be changed to incorporate this note imho.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/rate-limit.md](https://github.com/dotnet/AspNetCore.Docs/blob/38f3cd19b179dfc29c91795e6868f9d7c434d98d/aspnetcore/performance/rate-limit.md) | [Rate limiting middleware in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/rate-limit?branch=pr-en-us-34897) |


<!-- PREVIEW-TABLE-END -->