### PR TITLE
fix: ngnix -> nginx typo

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly.md
@@ -734,7 +734,7 @@ A standalone Blazor WebAssembly app is published as a set of static files for ho
 
 To host the app in Docker:
 
-* Choose a Docker container with web server support, such as Ngnix or Apache.
+* Choose a Docker container with web server support, such as Nginx or Apache.
 * Copy the `publish` folder assets to a location folder defined in the web server for serving static files.
 * Apply additional configuration as needed to serve the Blazor WebAssembly app.
 


### PR DESCRIPTION
Hey! 

Noticed a minor typo while reading the blazor wasm docs 😄 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/webassembly.md](https://github.com/dotnet/AspNetCore.Docs/blob/43bb5d0d73daba62e53dc50c63193e3f1ac0900f/aspnetcore/blazor/host-and-deploy/webassembly.md) | [Host and deploy ASP.NET Core Blazor WebAssembly](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/webassembly?branch=pr-en-us-34910) |

<!-- PREVIEW-TABLE-END -->