### PR TITLE
Add monthly cron job

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -2,6 +2,7 @@ name: "bulk quest import"
 on:
   schedule:
     - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
+    - cron: '0 9 6 * *'  # This is the morning of the 6th.
   workflow_dispatch:
     inputs:
       reason:
@@ -49,5 +50,5 @@ jobs:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
           issue: '-1'
-          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || 5 }}
+          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '0 9 6 * *' && -1 || 5 }}
           


### PR DESCRIPTION
Run Sequester monthly to catch all open issues that are still open. This will move them to the latest planned sprint, or the "backlog" sprint.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/workflows/quest-bulk.yml](https://github.com/dotnet/AspNetCore.Docs/blob/646d4e31136a9d2ef557b5255028654c77ca7966/.github/workflows/quest-bulk.yml) | [.github/workflows/quest-bulk](https://review.learn.microsoft.com/en-us/aspnet/core/.github/workflows/quest-bulk?branch=pr-en-us-34911) |

<!-- PREVIEW-TABLE-END -->