### PR TITLE
Documentation Provides Incorrect Values For Default Stack Size

### DIFF
--- a/aspnetcore/host-and-deploy/iis/advanced.md
+++ b/aspnetcore/host-and-deploy/iis/advanced.md
@@ -18,7 +18,7 @@ This article covers advanced configuration options and scenarios for the ASP.NET
 
 *Only applies when using the in-process hosting model.*
 
-Configure the managed stack size using the `stackSize` setting in bytes in the `web.config` file. The default size is 1,048,576 bytes (1 MB). The following example changes the stack size to 2 MB (2,097,152 bytes):
+Configure the managed stack size using the `stackSize` setting in bytes in hexadecimal in the `web.config` file. The default size is 1,048,576 bytes (1 MB) expressed in hexadecimal. The following example changes the stack size to 2 MB (2,097,152 bytes) in hexadecimal 0x200000:
 
 ```xml
 <aspNetCore processPath="dotnet"
@@ -27,7 +27,7 @@ Configure the managed stack size using the `stackSize` setting in bytes in the `
     stdoutLogFile="\\?\%home%\LogFiles\stdout"
     hostingModel="inprocess">
   <handlerSettings>
-    <handlerSetting name="stackSize" value="2097152" />
+    <handlerSetting name="stackSize" value="200000" />
   </handlerSettings>
 </aspNetCore>
 ```


### PR DESCRIPTION
Updating docs to indicate correct values and format.

This is doc bug in relationship to this issue in aspnetcore
https://github.com/dotnet/aspnetcore/issues/60762#issuecomment-2702460280

Contributes to #34922

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/host-and-deploy/iis/advanced.md](https://github.com/dotnet/AspNetCore.Docs/blob/2134975fc6bf8f536908237e5d282e5187fa5440/aspnetcore/host-and-deploy/iis/advanced.md) | [Advanced configuration of the ASP.NET Core Module and IIS](https://review.learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/advanced?branch=pr-en-us-34920) |

<!-- PREVIEW-TABLE-END -->