### PR TITLE
Update issueManagement-notTriaged.yml

### DIFF
--- a/.github/policies/issueManagement-notTriaged.yml
+++ b/.github/policies/issueManagement-notTriaged.yml
@@ -16,7 +16,7 @@ configuration:
         if:
           - payloadType: Issues
           - not:
-            - isAssignedToUser:
+              isAssignedToUser:
                 user: guardrex
           - or:
           

--- a/.github/policies/issueManagement-notTriaged.yml
+++ b/.github/policies/issueManagement-notTriaged.yml
@@ -16,7 +16,8 @@ configuration:
         if:
           - payloadType: Issues
           - not:
-            - isAssignedTo: guardrex
+            - isAssignedToUser:
+                user: guardrex
           - or:
           
             - or:

--- a/.github/policies/issueManagement-notTriaged.yml
+++ b/.github/policies/issueManagement-notTriaged.yml
@@ -15,6 +15,9 @@ configuration:
           * 'needs-more-info' label removed
         if:
           - payloadType: Issues
+          - not:
+            - isAssignedTo:
+                user: guardrex
           - or:
           
             - or:

--- a/.github/policies/issueManagement-notTriaged.yml
+++ b/.github/policies/issueManagement-notTriaged.yml
@@ -16,8 +16,7 @@ configuration:
         if:
           - payloadType: Issues
           - not:
-            - isAssignedTo:
-                user: guardrex
+            - isAssignedTo: guardrex
           - or:
           
             - or:


### PR DESCRIPTION
Skip handing not-triaged when the issue is assigned to guardrex

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/issueManagement-notTriaged.yml](https://github.com/dotnet/AspNetCore.Docs/blob/9a62a5bca8f93c5265d33a717fb55c95502ac55a/.github/policies/issueManagement-notTriaged.yml) | [.github/policies/issueManagement-notTriaged](https://review.learn.microsoft.com/en-us/aspnet/core/.github/policies/issueManagement-notTriaged?branch=pr-en-us-34933) |


<!-- PREVIEW-TABLE-END -->