### PR TITLE
Patch broken links

### DIFF
--- a/aspnetcore/blazor/security/includes/troubleshoot-server.md
+++ b/aspnetcore/blazor/security/includes/troubleshoot-server.md
@@ -91,7 +91,7 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 1. Delete all of the files in the deployment folder on the server prior to redeploying the app.
 
 > [!NOTE]
-> Use of package versions incompatible with the app's target framework isn't supported. For information on a package, use the [NuGet Gallery](https://www.nuget.org) or [FuGet Package Explorer](https://www.fuget.org).
+> Use of package versions incompatible with the app's target framework isn't supported. For information on a package, use the [NuGet Gallery](https://www.nuget.org).
 
 ### Run the server app
 

--- a/aspnetcore/blazor/security/includes/troubleshoot-wasm.md
+++ b/aspnetcore/blazor/security/includes/troubleshoot-wasm.md
@@ -91,7 +91,7 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 1. Delete all of the files in the deployment folder on the server prior to redeploying the app.
 
 > [!NOTE]
-> Use of package versions incompatible with the app's target framework isn't supported. For information on a package, use the [NuGet Gallery](https://www.nuget.org) or [FuGet Package Explorer](https://www.fuget.org).
+> Use of package versions incompatible with the app's target framework isn't supported. For information on a package, use the [NuGet Gallery](https://www.nuget.org).
 
 :::moniker range="< aspnetcore-8.0"
 

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity/index.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity/index.md
@@ -361,7 +361,7 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 1. Delete all of the files in the deployment folder on the server prior to redeploying the app.
 
 > [!NOTE]
-> Use of package versions incompatible with the app's target framework isn't supported. For information on a package, use the [NuGet Gallery](https://www.nuget.org) or [FuGet Package Explorer](https://www.fuget.org).
+> Use of package versions incompatible with the app's target framework isn't supported. For information on a package, use the [NuGet Gallery](https://www.nuget.org).
 
 ### Inspect the user's claims
 

--- a/aspnetcore/introduction-to-aspnet-core.md
+++ b/aspnetcore/introduction-to-aspnet-core.md
@@ -19,7 +19,7 @@ ASP.NET Core is a cross-platform, high-performance, [open-source](https://github
 
 With ASP.NET Core, you can:
 
-* Build web apps and services, [Internet of Things (IoT)](https://www.microsoft.com/internet-of-things/) apps, and mobile backends.
+* Build web apps and services, [Azure IoT (Internet of Things)](https://azure.microsoft.com/solutions/iot) apps, and mobile backends.
 * Use your favorite development tools on Windows, macOS, and Linux.
 * Deploy to the cloud or on-premises.
 * Run on [.NET](/dotnet/core/introduction).
@@ -98,7 +98,7 @@ For a reference guide to migrating ASP.NET 4.x apps to ASP.NET Core, see <xref:m
 
 ASP.NET Core is a cross-platform, high-performance, [open-source](https://github.com/dotnet/aspnetcore) framework for building modern, cloud-enabled, Internet-connected apps. With ASP.NET Core, you can:
 
-* Build web apps and services, [Internet of Things (IoT)](https://www.microsoft.com/internet-of-things/) apps, and mobile backends.
+* Build web apps and services, [Azure IoT (Internet of Things)](https://azure.microsoft.com/solutions/iot) apps, and mobile backends.
 * Use your favorite development tools on Windows, macOS, and Linux.
 * Deploy to the cloud or on-premises.
 * Run on [.NET Core or .NET Framework](/dotnet/articles/standard/choosing-core-framework-server).

--- a/aspnetcore/security/authentication/2fa.md
+++ b/aspnetcore/security/authentication/2fa.md
@@ -15,7 +15,7 @@ By [Rick Anderson](https://twitter.com/RickAndMSFT) and [Swiss-Devs](https://git
 >[!WARNING]
 > Two factor authentication (2FA) authenticator apps, using a Time-based One-time Password Algorithm (TOTP), are the industry recommended approach for 2FA. 2FA using TOTP is preferred to SMS 2FA. For more information, see [Enable QR Code generation for TOTP authenticator apps in ASP.NET Core](xref:security/authentication/identity-enable-qrcodes) for ASP.NET Core 2.0 and later.
 
-This tutorial shows how to set up two-factor authentication (2FA) using SMS. Instructions are given for [twilio](https://www.twilio.com/) and [ASPSMS](https://www.aspsms.com/asp.net/identity/core/testcredits/), but you can use any other SMS provider. We recommend you complete [Account Confirmation and Password Recovery](xref:security/authentication/accconfirm) before starting this tutorial.
+This tutorial shows how to set up two-factor authentication (2FA) using SMS. Instructions are given for [twilio](https://www.twilio.com/) and ASPSMS (`https://www.aspsms.com/asp.net/identity/core/testcredits/`), but you can use any other SMS provider. We recommend you complete [Account Confirmation and Password Recovery](xref:security/authentication/accconfirm) before starting this tutorial.
 
 [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/security/authentication/2fa/sample/Web2FA). [How to download](xref:index#how-to-download-a-sample).
 
@@ -25,7 +25,7 @@ Create a new ASP.NET Core web app named `Web2FA` with individual user accounts. 
 
 ### Create an SMS account
 
-Create an SMS account, for example, from [twilio](https://www.twilio.com/) or [ASPSMS](https://www.aspsms.com/asp.net/identity/core/testcredits/). Record the authentication credentials (for twilio: accountSid and authToken, for ASPSMS: Userkey and Password).
+Create an SMS account, for example, from [twilio](https://www.twilio.com/) or ASPSMS (`https://www.aspsms.com/asp.net/identity/core/testcredits/`). Record the authentication credentials (for twilio: accountSid and authToken, for ASPSMS: Userkey and Password).
 
 #### Figuring out SMS Provider credentials
 


### PR DESCRIPTION
Fixes #34945

In spite of the link loading their page, this will patch the ASPSMS link to get it out of our build reports ...

```diff
- [ASPSMS](https://www.aspsms.com/asp.net/identity/core/testcredits/)
+ ASPSMS (`https://www.aspsms.com/asp.net/identity/core/testcredits/`)
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/webassembly/standalone-with-identity/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/fdbf9cb8e963ff1cf6c8e9a372207bda1f714088/aspnetcore/blazor/security/webassembly/standalone-with-identity/index.md) | [aspnetcore/blazor/security/webassembly/standalone-with-identity/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-identity/index?branch=pr-en-us-34946) |
| [aspnetcore/introduction-to-aspnet-core.md](https://github.com/dotnet/AspNetCore.Docs/blob/fdbf9cb8e963ff1cf6c8e9a372207bda1f714088/aspnetcore/introduction-to-aspnet-core.md) | [aspnetcore/introduction-to-aspnet-core](https://review.learn.microsoft.com/en-us/aspnet/core/introduction-to-aspnet-core?branch=pr-en-us-34946) |
| [aspnetcore/security/authentication/2fa.md](https://github.com/dotnet/AspNetCore.Docs/blob/fdbf9cb8e963ff1cf6c8e9a372207bda1f714088/aspnetcore/security/authentication/2fa.md) | [aspnetcore/security/authentication/2fa](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/2fa?branch=pr-en-us-34946) |

<!-- PREVIEW-TABLE-END -->