### PR TITLE
Drop Blazor Hybrid from the PR mgmt policy

### DIFF
--- a/.github/policies/pullRequestManagement-labelFiles.yml
+++ b/.github/policies/pullRequestManagement-labelFiles.yml
@@ -22,15 +22,6 @@ configuration:
                 branch: live
         then:
           - if:
-            - filesMatchPattern:
-                matchAny: true
-                pattern: '(?i).*/blazor/hybrid/.*'
-            then:
-            - requestReview:
-                reviewer: guardrex
-            - addLabel:
-                label: 'blazor-hybrid/subsvc'
-          - if:
             - or:
               - filesMatchPattern:
                   matchAny: true

--- a/.github/policies/pullRequestManagement-labelFiles.yml
+++ b/.github/policies/pullRequestManagement-labelFiles.yml
@@ -19,7 +19,7 @@ configuration:
                 action: Synchronize
           - not:
               targetsBranch:
-                branch: live
+                branch: main
         then:
           - if:
             - or:

--- a/.github/policies/pullRequestManagement-labelFiles.yml
+++ b/.github/policies/pullRequestManagement-labelFiles.yml
@@ -19,7 +19,7 @@ configuration:
                 action: Synchronize
           - not:
               targetsBranch:
-                branch: main
+                branch: live
         then:
           - if:
             - or:


### PR DESCRIPTION
The Blazor Hybrid label was added to a PR at #34944. I don't need it, so I'm striking that section. The following section with its `'(?i).*/blazor/.*'` filter should also capture the Blazor Hybrid node (`*/blazor/hybrid/*`) and just apply my reviewer assignment.

Curious about something, too ...

Why doesn't ...

```yml
- not:
    targetsBranch:
      branch: live
```

... target the specific branch `main`? ...

```yml
- and:
    targetsBranch:
      branch: main
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/policies/pullRequestManagement-labelFiles.yml](https://github.com/dotnet/AspNetCore.Docs/blob/5b63d6510cf3a89ff1169a0b112386946ec820bb/.github/policies/pullRequestManagement-labelFiles.yml) | [.github/policies/pullRequestManagement-labelFiles](https://review.learn.microsoft.com/en-us/aspnet/core/.github/policies/pullRequestManagement-labelFiles?branch=pr-en-us-34950) |


<!-- PREVIEW-TABLE-END -->