### PR TITLE
Blazor Pre2 release note additions

### DIFF
--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -219,6 +219,40 @@ In the following example:
 
 :::moniker-end
 
+
+:::moniker range=">= aspnetcore-10.0"
+
+<!-- UPDATE 10.0 - API cross-link -->
+
+:::moniker-end
+
+### Close `QuickGrid` column options
+
+Close the `QuickGrid` column options UI with the `CloseColumnOptionsAsync` method.
+
+The following example closes the column options UI as soon as the title filter is applied:
+
+```razor
+<QuickGrid @ref="movieGrid" Items="movies">
+    <PropertyColumn Property="@(m => m.Title)" Title="Title">
+        <ColumnOptions>
+            <input type="search" @bind="titleFilter" placeholder="Filter by title" 
+                @bind:after="@(() => movieGrid.CloseColumnOptionsAsync())" />
+        </ColumnOptions>
+    </PropertyColumn>
+    <PropertyColumn Property="@(m => m.Genre)" Title="Genre" />
+    <PropertyColumn Property="@(m => m.ReleaseYear)" Title="Release Year" />
+</QuickGrid>
+
+@code {
+    private QuickGrid<Movie>? movieGrid;
+    private string titleFilter = string.Empty;
+    private IQueryable<Movie> movies = new List<Movie> { ... }.AsQueryable();
+    private IQueryable<Movie> filteredMovies => 
+        movies.Where(m => m.Title!.Contains(titleFilter));
+}
+```
+
 ## Entity Framework Core (EF Core) data source
 
 Use the factory pattern to resolve an EF Core database context that provides data to a `QuickGrid` component. For more information on why the factory pattern is recommended, see <xref:blazor/blazor-ef-core>.

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1624,7 +1624,7 @@ Use a <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component in place 
 
 There are two <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch> options that you can assign to the `Match` attribute of the `<NavLink>` element:
 
-* <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All?displayProperty=nameWithType>: The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches the current URL, ignoring the query string and fragment, if either or both are present. To include matching on the query string/fragment, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [AppContext](/dotnet/fundamentals/runtime-libraries/system-appcontext) switch.
+* <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All?displayProperty=nameWithType>: The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches the current URL, ignoring the query string and fragment. To include matching on the query string/fragment, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [`AppContext` switch](/dotnet/fundamentals/runtime-libraries/system-appcontext).
 * <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.Prefix?displayProperty=nameWithType> (*default*): The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches any prefix of the current URL.
 
 :::moniker-end
@@ -1633,7 +1633,7 @@ There are two <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch> option
 
 There are two <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch> options that you can assign to the `Match` attribute of the `<NavLink>` element:
 
-* <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All?displayProperty=nameWithType>: The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches the entire current URL, including the query string and fragment, if either or both are present.
+* <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All?displayProperty=nameWithType>: The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches the entire current URL, including the query string and fragment.
 * <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.Prefix?displayProperty=nameWithType> (*default*): The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches any prefix of the current URL.
 
 :::moniker-end
@@ -1644,14 +1644,14 @@ In the preceding example, the Home <xref:Microsoft.AspNetCore.Components.Routing
 
 <!-- UPDATE 10.0 - API cross-link -->
 
-To adopt custom matching logic, create a custom <xref:Microsoft.AspNetCore.Components.Routing.NavLink> and override the `NavLink.ShouldMatch` method. Return `true` from the method when you want to apply the `active` CSS class:
+To adopt custom matching logic, subclass <xref:Microsoft.AspNetCore.Components.Routing.NavLink> and override its `ShouldMatch` method. Return `true` from the method when you want to apply the `active` CSS class:
 
 ```csharp
 public class CustomNavLink : NavLink
 {
     protected override bool ShouldMatch(string currentUriAbsolute)
     {
-        // Custom matching logic.
+        // Custom matching logic
     }
 }
 ```

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1620,12 +1620,43 @@ For additional example code, see the [`ConfigurableNavigationLock` component in 
 
 Use a <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component in place of HTML hyperlink elements (`<a>`) when creating navigation links. A <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component behaves like an `<a>` element, except it toggles an `active` CSS class based on whether its `href` matches the current URL. The `active` class helps a user understand which page is the active page among the navigation links displayed. Optionally, assign a CSS class name to <xref:Microsoft.AspNetCore.Components.Routing.NavLink.ActiveClass?displayProperty=nameWithType> to apply a custom CSS class to the rendered link when the current route matches the `href`.
 
+:::moniker range=">= aspnetcore-10.0"
+
 There are two <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch> options that you can assign to the `Match` attribute of the `<NavLink>` element:
 
-* <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All?displayProperty=nameWithType>: The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches the entire current URL.
+* <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All?displayProperty=nameWithType>: The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches the current URL, ignoring the query string and fragment, if either or both are present. To include matching on the query string/fragment, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [AppContext](/dotnet/fundamentals/runtime-libraries/system-appcontext) switch.
 * <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.Prefix?displayProperty=nameWithType> (*default*): The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches any prefix of the current URL.
 
+:::moniker-end
+
+:::moniker range="< aspnetcore-10.0"
+
+There are two <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch> options that you can assign to the `Match` attribute of the `<NavLink>` element:
+
+* <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All?displayProperty=nameWithType>: The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches the entire current URL, including the query string and fragment, if either or both are present.
+* <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.Prefix?displayProperty=nameWithType> (*default*): The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches any prefix of the current URL.
+
+:::moniker-end
+
 In the preceding example, the Home <xref:Microsoft.AspNetCore.Components.Routing.NavLink> `href=""` matches the home URL and only receives the `active` CSS class at the app's default base path (`/`). The second <xref:Microsoft.AspNetCore.Components.Routing.NavLink> receives the `active` class when the user visits any URL with a `component` prefix (for example, `/component` and `/component/another-segment`).
+
+:::moniker range=">= aspnetcore-10.0"
+
+<!-- UPDATE 10.0 - API cross-link -->
+
+To adopt custom matching logic, create a custom <xref:Microsoft.AspNetCore.Components.Routing.NavLink> and override the `NavLink.ShouldMatch` method. Return `true` from the method when you want to apply the `active` CSS class:
+
+```csharp
+public class CustomNavLink : NavLink
+{
+    protected override bool ShouldMatch(string currentUriAbsolute)
+    {
+        // Custom matching logic.
+    }
+}
+```
+
+:::moniker-end
 
 Additional <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component attributes are passed through to the rendered anchor tag. In the following example, the <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component includes the `target` attribute:
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -49,7 +49,21 @@ For more information, see <xref:blazor/fundamentals/signalr?view=aspnetcore-10.0
 
 ### Ignore query string and fragment when using `NavLinkMatch.All`
 
-The `NavLink` component now ignores the query string and fragment when using the `NavLinkMatch.All` value for the `Match` parameter. This means that the link retains the `active` class if the URL path matches but the query string or fragment change. To revert to the original behavior, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [AppContext](/dotnet/fundamentals/runtime-libraries/system-appcontext) switch. You can also now override the `ShouldMatch` method on `NavLink` to customize the matching behavior.
+The `NavLink` component now ignores the query string and fragment when using the `NavLinkMatch.All` value for the `Match` parameter. This means that the link retains the `active` class if the URL path matches but the query string or fragment change. To revert to the original behavior, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [AppContext](/dotnet/fundamentals/runtime-libraries/system-appcontext) switch.
+
+You can also override the `ShouldMatch` method on `NavLink` to customize the matching behavior:
+
+```csharp
+public class CustomNavLink : NavLink
+{
+    protected override bool ShouldMatch(string currentUriAbsolute)
+    {
+        // Custom matching logic.
+    }
+}
+```
+
+For more information, see <xref:blazor/fundamentals/routing#navlink-component>.
 
 ### Close `QuickGrid` column options
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -47,9 +47,9 @@ New reconnection UI features:
 
 For more information, see <xref:blazor/fundamentals/signalr?view=aspnetcore-10.0#reflect-the-server-side-connection-state-in-the-ui>.
 
-### Ignore query string and fragment when using `NavLinkMatch.All`
+### Ignore the query string and fragment when using `NavLinkMatch.All`
 
-The `NavLink` component now ignores the query string and fragment when using the `NavLinkMatch.All` value for the `Match` parameter. This means that the link retains the `active` class if the URL path matches but the query string or fragment change. To revert to the original behavior, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [AppContext](/dotnet/fundamentals/runtime-libraries/system-appcontext) switch.
+The `NavLink` component now ignores the query string and fragment when using the `NavLinkMatch.All` value for the `Match` parameter. This means that the link retains the `active` class if the URL path matches but the query string or fragment change. To revert to the original behavior, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [`AppContext` switch](/dotnet/fundamentals/runtime-libraries/system-appcontext).
 
 You can also override the `ShouldMatch` method on `NavLink` to customize the matching behavior:
 
@@ -58,7 +58,7 @@ public class CustomNavLink : NavLink
 {
     protected override bool ShouldMatch(string currentUriAbsolute)
     {
-        // Custom matching logic.
+        // Custom matching logic
     }
 }
 ```

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -61,9 +61,8 @@ The following example uses the `CloseColumnOptionsAsync` method to close the col
 <QuickGrid @ref="movieGrid" Items="movies">
     <PropertyColumn Property="@(m => m.Title)" Title="Title">
         <ColumnOptions>
-            <input type="search" @bind="titleFilter" 
-                @bind:after="@(() => movieGrid.CloseColumnOptionsAsync())" 
-                placeholder="Filter by title" />
+            <input type="search" @bind="titleFilter" placeholder="Filter by title" 
+                @bind:after="@(() => movieGrid.CloseColumnOptionsAsync())" />
         </ColumnOptions>
     </PropertyColumn>
     <PropertyColumn Property="@(m => m.Genre)" Title="Genre" />

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -47,4 +47,36 @@ New reconnection UI features:
 
 For more information, see <xref:blazor/fundamentals/signalr?view=aspnetcore-10.0#reflect-the-server-side-connection-state-in-the-ui>.
 
+### Ignore query string and fragment when using `NavLinkMatch.All`
+
+The `NavLink` component now ignores the query string and fragment when using the `NavLinkMatch.All` value for the `Match` parameter. This means that the link retains the `active` class if the URL path matches but the query string or fragment change. To revert to the original behavior, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [AppContext](/dotnet/fundamentals/runtime-libraries/system-appcontext) switch. You can also now override the `ShouldMatch` method on `NavLink` to customize the matching behavior.
+
+### Close `QuickGrid` column options
+
+You can now close the `QuickGrid` column options UI using the new `CloseColumnOptionsAsync` method.
+
+The following example uses the `CloseColumnOptionsAsync` method to close the column options UI as soon as the title filter is applied:
+
+```razor
+<QuickGrid @ref="movieGrid" Items="movies">
+    <PropertyColumn Property="@(m => m.Title)" Title="Title">
+        <ColumnOptions>
+            <input type="search" @bind="titleFilter" 
+                @bind:after="@(() => movieGrid.CloseColumnOptionsAsync())" 
+                placeholder="Filter by title" />
+        </ColumnOptions>
+    </PropertyColumn>
+    <PropertyColumn Property="@(m => m.Genre)" Title="Genre" />
+    <PropertyColumn Property="@(m => m.ReleaseYear)" Title="Release Year" />
+</QuickGrid>
+
+@code {
+    private QuickGrid<Movie>? movieGrid;
+    private string titleFilter = string.Empty;
+    private IQueryable<Movie> movies = new List<Movie> { ... }.AsQueryable();
+    private IQueryable<Movie> filteredMovies => 
+        movies.Where(m => m.Title!.Contains(titleFilter));
+}
+```
+
 -->

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -38,7 +38,7 @@ Previously, <xref:Microsoft.AspNetCore.Components.NavigationManager.NavigateTo%2
 
 ### Reconnection UI component added to the Blazor Web App project template
 
-The Blazor Web App project template now includes a `ReconnectModal` component, including collocated stylesheet and JavaScript files, for improved developer control over the reconnection UI when the client loses the WebSocket connection to the server. The component doesn't insert styles programmatically, so it doesn't violate stricter Content Security Policy (CSP) settings for the `style-src` policy. In prior releases, the default reconnection UI was created by the framework in a way that could cause CSP violations. Note that the default reconnection UI is still used as fallback when the app doesn't define the reconnection UI, such as by using the project template's `ReconnectModal` component or a similar custom component.
+The Blazor Web App project template now includes a `ReconnectModal` component, including collocated stylesheet and JavaScript files, for improved developer control over the reconnection UI when the client loses the WebSocket connection to the server. The component doesn't insert styles programmatically, ensuring compliance with stricter Content Security Policy (CSP) settings for the `style-src` policy. In prior releases, the default reconnection UI was created by the framework in a way that could cause CSP violations. Note that the default reconnection UI is still used as fallback when the app doesn't define the reconnection UI, such as by using the project template's `ReconnectModal` component or a similar custom component.
 
 New reconnection UI features:
 


### PR DESCRIPTION
Addresses #34729
Fixes #34965
Fixes #34963

There's no reason to cross-link the feature coverage in the QuickGrid article because the reader wouldn't find more information there unless we add additional content.

WRT opt-out on the qs/framework matching behavior. Specifically, I assume that ...

```xml
AppContext.SetSwitch(
    "Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart", true);
```

... goes into the `Program` file for app devs. Lib devs will follow the AppContext article. Do you want to show that exact line, or should we leave the text as it reads now?

***RESOLVED!*** ... ~Also, isn't the new behavior to ignore the ***right part*** of the URI (qs/fragment), and I also wonder why it isn't referring to the qs/fragment specifically?~

```xml
AppContext.SetSwitch(
    "Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresQueryStringAndFragment", true);
```

***RESOLVED!*** ... ~... even simpler to avoid confusing "disable"-"ignores" language in the switch name ...~

```xml
AppContext.SetSwitch(
    "Microsoft.AspNetCore.Components.Routing.NavLink.EnableMatchAllForQueryStringAndFragment", true);
```

One more❓... Do we need to also mention anything about disabling this in the runtime config for WASM?


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/quickgrid.md](https://github.com/dotnet/AspNetCore.Docs/blob/35fcd470b1f2f591eaa064bb9079126da3e26468/aspnetcore/blazor/components/quickgrid.md) | [aspnetcore/blazor/components/quickgrid](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/quickgrid?branch=pr-en-us-34966) |
| [aspnetcore/blazor/fundamentals/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/35fcd470b1f2f591eaa064bb9079126da3e26468/aspnetcore/blazor/fundamentals/routing.md) | [aspnetcore/blazor/fundamentals/routing](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?branch=pr-en-us-34966) |

<!-- PREVIEW-TABLE-END -->