### PR TITLE
Prep: WN 10 Prev 2 OpenAPI.NET include

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiNetV2Prev7.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiNetV2Prev7.md
@@ -1,0 +1,6 @@
+### Upgrade to OpenAPI.NET v2.0.0-preview7
+
+The OpenAPI.NET library used in ASP.NET Core OpenAPI document generation has been upgraded to v2.0.0-preview7. This version includes a number of bug fixes and improvements and also introduces some breaking changes. The breaking changes should only impact users that use document, operation, or schema transformers. Breaking changes in this iteration include the following:
+
+- Entities within the OpenAPI document, like operations and parameters, are typed as interfaces. Concrete implementations exist for the inlined and referenced variants of an entity. For example, an `IOpenApiSchema` can be an inlined `OpenApiSchema` or an `OpenApiSchemaReference` that points to a schema defined elsewhere in the document.
+- The `Nullable` property has been removed from the `OpenApiSchema` type. To determine if a type is nullable, evaluate if the `OpenApiSchema.Type` property sets `JsonSchemaType.Null`.


### PR DESCRIPTION
Prep for moving the following What's new section from the issue to an include:
_Upgrade to OpenAPI.NET v2.0.0-preview7_

Leaving it as was provided in the issue comments, so that the PR on it that follows will allow reviewers to see any changes made.
Include is not added to the What's New doc in this prep step.
