### PR TITLE
Prep: WN .NET 10 Prev2: Move Min API empty string section to include

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10/includes/MinApiEmptyStringInFormPost.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/MinApiEmptyStringInFormPost.md
@@ -1,0 +1,25 @@
+### Treating empty string in form post as null for nullable value types
+
+When using the `[FromForm]` attribute with a complex object in minimal APIs, empty string values in a form post are now converted to null rather than causing a parse failure. This behavior matches the processing logic for form posts not associated with complex object's in minimal APIs.
+
+```csharp
+using Microsoft.AspNetCore.Http;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var app = builder.Build();
+
+app.MapPost("/todo", ([FromForm] Todo todo) => TypedResults.Ok(todo));
+
+app.Run();
+
+public class Todo
+{
+  public int Id { get; set; }
+  public DateOnly? DueDate { get; set; } // Empty strings map to `null`
+  public string Title { get; set; }
+  public bool IsCompleted { get; set; }
+}
+```
+
+Thanks to @nvmkpk for contributing this change!


### PR DESCRIPTION
Prep only: Moving the Min API empty string in form POST section draft that was in issue 34729 to an include.  Then I will create a new PR with an edit pass so changes can be viewed.