### PR TITLE
WN update with include: Min Api empty string in form post

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -35,6 +35,8 @@ This section describes new features for SignalR.
 
 This section describes new features for minimal APIs.
 
+[!INCLUDE[](~/release-notes/aspnetcore-10/includes/MinApiEmptyStringInFormPost.md)]
+
 ## OpenAPI
 
 This section describes new features for OpenAPI.

--- a/aspnetcore/release-notes/aspnetcore-10/includes/MinApiEmptyStringInFormPost.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/MinApiEmptyStringInFormPost.md
@@ -1,6 +1,6 @@
 ### Treating empty string in form post as null for nullable value types
 
-When using the `[FromForm]` attribute with a complex object in minimal APIs, empty string values in a form post are now converted to null rather than causing a parse failure. This behavior matches the processing logic for form posts not associated with complex object's in minimal APIs.
+When using the `[FromForm]` attribute with a complex object in minimal APIs, empty string values in a form post are now converted to `null` rather than causing a parse failure. This behavior matches the processing logic for form posts not associated with complex objects in minimal APIs.
 
 ```csharp
 using Microsoft.AspNetCore.Http;
@@ -22,4 +22,4 @@ public class Todo
 }
 ```
 
-Thanks to @nvmkpk for contributing this change!
+Thanks to [@nvmkpk](https://github.com/nvmkpk) for contributing this change!


### PR DESCRIPTION
Contributes to #34729
Moved section for Min API empty string in form post from issue to WN include and did an edit pass.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/456c67829d945935b0e5ed9bca510344d695f3f8/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-34990) |

<!-- PREVIEW-TABLE-END -->