### PR TITLE
WN .NET 10 Prev 2: link to include for Open API

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -45,6 +45,8 @@ This section describes new features for OpenAPI.
 
 [!INCLUDE[](~/release-notes/aspnetcore-10/includes/responseDescProducesResponseType.md)]
 
+[!INCLUDE[](~/release-notes/aspnetcore-10/includes/OpenApiPopulateXMLDocComments.md)]
+
 [!INCLUDE[](~/release-notes/aspnetcore-10/includes/OpenApiNetV2Prev7.md)]
 
 ## Authentication and authorization

--- a/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiPopulateXMLDocComments.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiPopulateXMLDocComments.md
@@ -45,7 +45,7 @@ static partial class Program
 In the previous example the `Hello` method is added to the `Program` class, but you can add it to any class in your project.
 
 The previous example illustrates the `<summary>`, `<remarks>`, and `<param>` XML doc comments.
-For more information about XML doc comments, including all the supported tags, see the [C# documentation](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags).
+For more information about XML doc comments, including all the supported tags, see the [C# documentation](/dotnet/csharp/language-reference/xmldoc/recommended-tags).
 
 Since the core functionality is provided via a source generator, it can be disabled by adding the following MSBuild to your project file.
 


### PR DESCRIPTION
Contributes to #34729 

Added remaining Open API link to include for PopulateXMLDocComments.md

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/e3a423d0e3b43094d495c525adf6981b5fa96f5b/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-34991) |


<!-- PREVIEW-TABLE-END -->