### PR TITLE
Correct typo

### DIFF
--- a/aspnetcore/mvc/models/model-binding.md
+++ b/aspnetcore/mvc/models/model-binding.md
@@ -162,7 +162,7 @@ By default, a model state error isn't created if no value is found for a model p
 
 If model state should be invalidated when nothing is found in form fields for a model property, use the [`[BindRequired]`](#bindrequired-attribute) attribute.
 
-Note that this `[BindRequired]` behavior applies to model binding from posted form data, not to JSON or XML data in a request body. Request body data is handled by [input formatters](#input-formatters).
+Note that this `[BindRequired]` behavior applies to model binding from posted form data, not from JSON or XML data in a request body. Request body data is handled by [input formatters](#input-formatters).
 
 ## Type conversion errors
 


### PR DESCRIPTION
Correct a word that I think the author meant differently.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/models/model-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/1a25c560480a1d032b73be22c90fbc643bf7eee3/aspnetcore/mvc/models/model-binding.md) | [Model Binding in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/models/model-binding?branch=pr-en-us-35031) |

<!-- PREVIEW-TABLE-END -->