### PR TITLE
[Blazor] static-files.md - ImportMap also applies for global WASM render-mode

### DIFF
--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -73,9 +73,6 @@ The Import Map component (<xref:Microsoft.AspNetCore.Components.ImportMap>) repr
 <ImportMap />
 ```
 
-> [!NOTE]
-> In Blazor Web Apps that adopt [global Interactive WebAssembly rendering](xref:blazor/components/render-modes#render-modes), the `ImportMap` component serves no purpose and can be removed from the `App` component. For more information, see the introductory remarks of this article. 
-
 If a custom <xref:Microsoft.AspNetCore.Components.ImportMapDefinition> isn't assigned to an Import Map component, the import map is generated based on the app's assets.
 
 The following examples demonstrate custom import map definitions and the import maps that they create.


### PR DESCRIPTION
I'm not sure why `<ImportMap />` wouldn't apply to applications using global Interactive WebAssembly rendering. JS modules can still benefit from mapping `import`s to fingerprinted URLs.

Maybe you meant Blazor WebAssembly standalone apps, where there's no ASP.NET Core hosting with the MapStaticAssets middleware?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/static-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/9efd0700ece6d185329ca268e570057dc78eaaa3/aspnetcore/blazor/fundamentals/static-files.md) | [ASP.NET Core Blazor static files](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?branch=pr-en-us-35034) |

<!-- PREVIEW-TABLE-END -->