### PR TITLE
Removed misplaced hashes in the title for two analyzers

### DIFF
--- a/aspnetcore/diagnostics/asp0026.md
+++ b/aspnetcore/diagnostics/asp0026.md
@@ -1,5 +1,5 @@
 ---
-title: "ASP0026: ## Analyzer to warn when [Authorize] is overridden by [AllowAnonymous] from 'farther away'" 
+title: "ASP0026: Analyzer to warn when [Authorize] is overridden by [AllowAnonymous] from 'farther away'" 
 ms.date: 07/08/2024
 description: "Learn about analysis rule ASP0026: [Authorize] is overridden by [AllowAnonymous] from 'farther away'"
 author: tdykstra

--- a/aspnetcore/diagnostics/asp0028.md
+++ b/aspnetcore/diagnostics/asp0028.md
@@ -1,5 +1,5 @@
 ---
-title: "ASP0028: ## Analyzer to suggest using IPAddress.IPv6Any instead of IPAddress.Any if applicable" 
+title: "ASP0028: Analyzer to suggest using IPAddress.IPv6Any instead of IPAddress.Any if applicable" 
 ms.date: 11/11/2024
 description: "Consider using IPAddress.IPv6Any instead of IPAddress.Any"
 author: deaglegross


### PR DESCRIPTION
I am working on creating the docs for the analyzer ASP0027.

Whilst starting this I spotted the title contains two hashes in both ASP0026 and ASP0028 but none of the other analyzers.

This causes the tab in the web browser to display with these hashes, which looks a little weird when the other analyzers don't have this.

If this is intended for some reason we can close this off.

https://learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0026
https://learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0028

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/diagnostics/asp0026.md](https://github.com/dotnet/AspNetCore.Docs/blob/ec1e2cea81f8fbb7e3f4f00c9dac34da9410f9db/aspnetcore/diagnostics/asp0026.md) | [ASP0026: `[Authorize]` is overridden by `[AllowAnonymous]` from "farther away"](https://review.learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0026?branch=pr-en-us-35041) |
| [aspnetcore/diagnostics/asp0028.md](https://github.com/dotnet/AspNetCore.Docs/blob/ec1e2cea81f8fbb7e3f4f00c9dac34da9410f9db/aspnetcore/diagnostics/asp0028.md) | ["ASP0028: Analyzer to suggest using IPAddress.IPv6Any instead of IPAddress.Any if applicable" ](https://review.learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0028?branch=pr-en-us-35041) |

<!-- PREVIEW-TABLE-END -->