### PR TITLE
[Pre3] Rename DisableMatchAllIgnoresLeftUriPart

### DIFF
--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -1624,6 +1624,12 @@ Use a <xref:Microsoft.AspNetCore.Components.Routing.NavLink> component in place 
 
 There are two <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch> options that you can assign to the `Match` attribute of the `<NavLink>` element:
 
+<!-- UPDATE 10.0 PREVIEW3 
+          Change `DisableMatchAllIgnoresLeftUriPart` to 
+          `EnableMatchAllForQueryStringAndFragmentSwitchKey` 
+          set to `true`.
+-->
+
 * <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.All?displayProperty=nameWithType>: The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches the current URL, ignoring the query string and fragment. To include matching on the query string/fragment, use the `Microsoft.AspNetCore.Components.Routing.NavLink.DisableMatchAllIgnoresLeftUriPart` [`AppContext` switch](/dotnet/fundamentals/runtime-libraries/system-appcontext).
 * <xref:Microsoft.AspNetCore.Components.Routing.NavLinkMatch.Prefix?displayProperty=nameWithType> (*default*): The <xref:Microsoft.AspNetCore.Components.Routing.NavLink> is active when it matches any prefix of the current URL.
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -122,4 +122,14 @@ requestMessage.SetBrowserResponseStreamingEnabled(false);
 
 For more information, see [`HttpClient` and `HttpRequestMessage` with Fetch API request options (*Call web API* article)](xref:blazor/call-web-api?view=aspnetcore-10.0#httpclient-and-httprequestmessage-with-fetch-api-request-options).
 
+XXXXXXXXXXXXXXXXXXXX CHANGE EARLIER COVERAGE XXXXXXXXXXXXXXXXXXXX
+
+In the "Ignore the query string and fragment when using `NavLinkMatch.All`" section, change 
+`DisableMatchAllIgnoresLeftUriPart` to `EnableMatchAllForQueryStringAndFragmentSwitchKey` 
+set to `true`.
+
+Also make this change in the *Routing* article at Line 1633.
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
 -->


### PR DESCRIPTION
Fixes #34978
Addresses #34948

Not necessary to inform the .NET Core docs team on this because they didn't make specific reference to it. They only cross-linked our *Release Notes* article for it. 

Cross-ref: https://learn.microsoft.com/dotnet/core/whats-new/dotnet-10/overview#aspnet-core

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/1d49775a5d02774b8bc7eeb5ecae8f2b72ca00ec/aspnetcore/blazor/fundamentals/routing.md) | [aspnetcore/blazor/fundamentals/routing](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?branch=pr-en-us-35056) |

<!-- PREVIEW-TABLE-END -->