### PR TITLE
[Pre3] Blazor WASM fingerprinting and environment property

### DIFF
--- a/aspnetcore/blazor/components/built-in-components.md
+++ b/aspnetcore/blazor/components/built-in-components.md
@@ -27,7 +27,7 @@ The following built-in Razor components are provided by the Blazor framework. Fo
 * [`FocusOnNavigate`](xref:blazor/fundamentals/routing#focus-an-element-on-navigation)
 * [`HeadContent`](xref:blazor/components/control-head-content)
 * [`HeadOutlet`](xref:blazor/components/control-head-content)
-* [`ImportMap`](xref:blazor/fundamentals/static-files#import-maps)
+* [`ImportMap`](xref:blazor/fundamentals/static-files#importmap-component)
 * [`InputCheckbox`](xref:blazor/forms/input-components)
 * [`InputDate`](xref:blazor/forms/input-components)
 * [`InputFile`](xref:blazor/file-uploads)

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -45,14 +45,27 @@ On the client for a Blazor Web App, the environment is determined from the serve
 
 The environment is set using any of the following approaches:
 
+:::moniker-end
+
+:::moniker range=">= aspnetcore-10.0"
+
+* Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
+* Blazor Server or Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration).
+* Blazor WebAssembly: `<WasmApplicationEnvironmentName>` property.
+* Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service).
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
+
 * Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
 * Blazor Server or Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
 * Blazor WebAssembly: [`Blazor-Environment` header](#set-the-client-side-environment-via-header)
 * Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service)
 
-On the client for a Blazor Web App or the client of a hosted Blazor WebAssembly app, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
-
 :::moniker-end
+
+On the client for a Blazor Web App or the client of a hosted Blazor WebAssembly app, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
 
 :::moniker range=">= aspnetcore-10.0"
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -28,24 +28,7 @@ We recommend the following conventions:
 
 ## Set the environment
 
-:::moniker range=">= aspnetcore-8.0"
-
 The environment is set using any of the following approaches:
-
-* Blazor Web App: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
-* Blazor Web App or standalone Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
-* Standalone Blazor WebAssembly: [`Blazor-Environment` header](#set-the-client-side-environment-via-header)
-* Blazor Web App or standalone Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service)
-
-On the client for a Blazor Web App, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-8.0"
-
-The environment is set using any of the following approaches:
-
-:::moniker-end
 
 :::moniker range=">= aspnetcore-10.0"
 
@@ -54,20 +37,7 @@ The environment is set using any of the following approaches:
 * Blazor WebAssembly: `<WasmApplicationEnvironmentName>` property.
 * Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service).
 
-:::moniker-end
-
-:::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
-
-* Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
-* Blazor Server or Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
-* Blazor WebAssembly: [`Blazor-Environment` header](#set-the-client-side-environment-via-header)
-* Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service)
-
-:::moniker-end
-
-On the client for a Blazor Web App or the client of a hosted Blazor WebAssembly app, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
-
-:::moniker range=">= aspnetcore-10.0"
+On the client for a Blazor Web App, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
 
 For a standalone Blazor WebAssembly app, set the environment with the `<WasmApplicationEnvironmentName>` property in the app's project file (`.csproj`). The following example sets the `Staging` environment:
 
@@ -79,7 +49,27 @@ The default environment is `Development` when running the app locally and `Produ
 
 :::moniker-end
 
-:::moniker range="< aspnetcore-10.0"
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
+
+* Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
+* Blazor Server or Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
+* Blazor WebAssembly: [`Blazor-Environment` header](#set-the-client-side-environment-via-header)
+* Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service)
+
+On the client for a Blazor Web App, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
+
+For a standalone Blazor WebAssembly app running locally, the development server adds the `Blazor-Environment` header with the environment name obtained from the hosting environment. The hosting environment sets the environment from the `ASPNETCORE_ENVIRONMENT` environment variable established by the project's `Properties/launchSettings.json` file. The default value of the environment variable in a project created from the Blazor WebAssembly project template is `Development`. For more information, see the [Set the client-side environment via header](#set-the-client-side-environment-via-header) section.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-8.0"
+
+* Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
+* Blazor Server or Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
+* Blazor WebAssembly: [`Blazor-Environment` header](#set-the-client-side-environment-via-header)
+* Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service)
+
+On the client of a hosted Blazor WebAssembly app, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
 
 For a standalone Blazor WebAssembly app running locally, the development server adds the `Blazor-Environment` header with the environment name obtained from the hosting environment. The hosting environment sets the environment from the `ASPNETCORE_ENVIRONMENT` environment variable established by the project's `Properties/launchSettings.json` file. The default value of the environment variable in a project created from the Blazor WebAssembly project template is `Development`. For more information, see the [Set the client-side environment via header](#set-the-client-side-environment-via-header) section.
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -54,7 +54,23 @@ On the client for a Blazor Web App or the client of a hosted Blazor WebAssembly 
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-10.0"
+
+For a standalone Blazor WebAssembly app, set the environment with the `<WasmApplicationEnvironmentName>` property in the app's project file (`.csproj`). The following example sets the `Staging` environment:
+
+```xml
+<WasmApplicationEnvironmentName>Staging</WasmApplicationEnvironmentName>
+```
+
+The default environment is `Development` when running the app locally and `Production` when the app is published.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-10.0"
+
 For a standalone Blazor WebAssembly app running locally, the development server adds the `Blazor-Environment` header with the environment name obtained from the hosting environment. The hosting environment sets the environment from the `ASPNETCORE_ENVIRONMENT` environment variable established by the project's `Properties/launchSettings.json` file. The default value of the environment variable in a project created from the Blazor WebAssembly project template is `Development`. For more information, see the [Set the client-side environment via header](#set-the-client-side-environment-via-header) section.
+
+:::moniker-end
 
 For app's running locally in development, the app defaults to the `Development` environment. Publishing the app defaults the environment to `Production`.
 
@@ -124,6 +140,8 @@ Console.WriteLine(
 
 For more information on Blazor startup, see <xref:blazor/fundamentals/startup>.
 
+:::moniker range="< aspnetcore-10.0"
+
 ## Set the client-side environment via header
 
 Blazor WebAssembly apps can set the environment with the `Blazor-Environment` header. Specifically, the response header must be set on the `_framework/blazor.boot.json` file, but there's no harm setting the header on file server responses for other Blazor file requests or the entire Blazor deployment.
@@ -131,6 +149,8 @@ Blazor WebAssembly apps can set the environment with the `Blazor-Environment` he
 Although the Blazor framework issues the header name in kebab case with mixed letter case (`Blazor-Environment`), you're welcome to use all-lower or all-upper kebab case (`blazor-environment`, `BLAZOR-ENVIRONMENT`).
 
 For local development runs with Blazor's built-in development server, you can control the value of the `Blazor-Environment` header by setting the value of the `ASPNETCORE_ENVIRONMENT` environment variable in the project's `Properties/launchSettings.json` file. When running locally with the development server, the order of precedence for determining the app's environment is [`Blazor.start` configuration (`environment` key)](#set-the-client-side-environment-via-blazor-startup-configuration) > `Blazor-Environment` response header (`blazor.boot.json` file) > `ASPNETCORE_ENVIRONMENT` environment variable (`launchSettings.json`). You can't use the `ASPNETCORE_ENVIRONMENT` environment variable (`launchSettings.json`) approach for a deployed Blazor WebAssembly app. The technique only works with the development server on local runs of the app.
+
+:::moniker-end
 
 ### IIS
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -32,10 +32,12 @@ The environment is set using any of the following approaches:
 
 :::moniker range=">= aspnetcore-10.0"
 
-* Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
-* Blazor Server or Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration).
-* Blazor WebAssembly: `<WasmApplicationEnvironmentName>` property.
-* Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service).
+* Blazor Web App or Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
+* Any Blazor app:
+  * [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
+  * [Azure App Service](#set-the-environment-for-azure-app-service)
+* Standalone Blazor WebAssembly: `<WasmApplicationEnvironmentName>` property
+* Any Blazor app: [Azure App Service](#set-the-environment-for-azure-app-service)
 
 On the client for a Blazor Web App, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
 
@@ -51,10 +53,11 @@ The default environment is `Development` when running the app locally and `Produ
 
 :::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
 
-* Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
-* Blazor Server or Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
+* Blazor Web App or Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
+* Any Blazor app:
+  * [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
+  * [Azure App Service](#set-the-environment-for-azure-app-service)
 * Blazor WebAssembly: [`Blazor-Environment` header](#set-the-client-side-environment-via-header)
-* Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service)
 
 On the client for a Blazor Web App, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -48,7 +48,7 @@ For a standalone Blazor WebAssembly app, set the environment with the `<WasmAppl
 <WasmApplicationEnvironmentName>Staging</WasmApplicationEnvironmentName>
 ```
 
-The default environment is `Development` when running the app locally and `Production` when the app is published.
+The default environments are `Development` for build and `Production` for publish.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -33,12 +33,14 @@ The environment is set using any of the following approaches:
 :::moniker range=">= aspnetcore-10.0"
 
 * Blazor Web App or Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
-* Any Blazor app:
-  * [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
-  * [Azure App Service](#set-the-environment-for-azure-app-service)
+* Any Blazor app: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
 * Standalone Blazor WebAssembly: `<WasmApplicationEnvironmentName>` property
 
-On the client for a Blazor Web App, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
+On the client for a Blazor Web App, the environment is determined from the server via an HTML comment:
+
+```html
+<!--Blazor-WebAssembly:{"environmentName":"Development", ...}-->
+```
 
 For a standalone Blazor WebAssembly app, set the environment with the `<WasmApplicationEnvironmentName>` property in the app's project file (`.csproj`). The following example sets the `Staging` environment:
 
@@ -133,9 +135,13 @@ Standalone Blazor WebAssembly:
 
 **In the preceding example, the `{BLAZOR SCRIPT}` placeholder is the Blazor script path and file name.** For the location of the script, see <xref:blazor/project-structure#location-of-the-blazor-script>.
 
+:::moniker range="< aspnetcore-10.0"
+
 Using the `environment` property overrides the environment set by the [`Blazor-Environment` header](#set-the-client-side-environment-via-header).
 
 The preceding approach sets the client's environment without changing the `Blazor-Environment` header's value, nor does it change the server project's console logging of the startup environment for a Blazor Web App that has adopted global Interactive WebAssembly rendering.
+
+:::moniker-end
 
 To log the environment to the console in either a standalone Blazor WebAssembly app or the `.Client` project of a Blazor Web App, place the following C# code in the `Program` file after the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created with <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType> and before the line that builds and runs the project (`await builder.Build().RunAsync();`):
 
@@ -155,8 +161,6 @@ Blazor WebAssembly apps can set the environment with the `Blazor-Environment` he
 Although the Blazor framework issues the header name in kebab case with mixed letter case (`Blazor-Environment`), you're welcome to use all-lower or all-upper kebab case (`blazor-environment`, `BLAZOR-ENVIRONMENT`).
 
 For local development runs with Blazor's built-in development server, you can control the value of the `Blazor-Environment` header by setting the value of the `ASPNETCORE_ENVIRONMENT` environment variable in the project's `Properties/launchSettings.json` file. When running locally with the development server, the order of precedence for determining the app's environment is [`Blazor.start` configuration (`environment` key)](#set-the-client-side-environment-via-blazor-startup-configuration) > `Blazor-Environment` response header (`blazor.boot.json` file) > `ASPNETCORE_ENVIRONMENT` environment variable (`launchSettings.json`). You can't use the `ASPNETCORE_ENVIRONMENT` environment variable (`launchSettings.json`) approach for a deployed Blazor WebAssembly app. The technique only works with the development server on local runs of the app.
-
-:::moniker-end
 
 ### IIS
 
@@ -217,7 +221,7 @@ For more information:
 * [Apache documentation (search the latest release for "`mod_headers`")](https://httpd.apache.org/docs/)
 * [Blazor WebAssembly Apache hosting guidance](xref:blazor/host-and-deploy/webassembly#apache)
 
-## Set the environment for Azure App Service
+### Set the environment for Azure App Service
 
 <!-- UPDATE 10.0 The underlying problem with app settings filename 
                  case sensitivity is tracked for 10.0 by ...
@@ -238,6 +242,8 @@ When requested in a browser, the `BlazorAzureAppSample/Staging` app loads in the
 When the app is loaded in the browser, the response header collection for `blazor.boot.json` indicates that the `Blazor-Environment` header value is `Staging`.
 
 App settings from the `appsettings.{ENVIRONMENT}.json` file are loaded by the app, where the `{ENVIRONMENT}` placeholder is the app's environment. In the preceding example, settings from the `appsettings.Staging.json` file are loaded.
+
+:::moniker-end
 
 ## Read the environment in a Blazor WebAssembly app
 

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -36,7 +36,7 @@ The environment is set using any of the following approaches:
 * Any Blazor app: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
 * Standalone Blazor WebAssembly: `<WasmApplicationEnvironmentName>` property
 
-On the client for a Blazor Web App, the environment is determined from the server via an HTML comment:
+On the client for a Blazor Web App, the environment is determined from the server via an HTML comment that developers don't interact with:
 
 ```html
 <!--Blazor-WebAssembly:{"environmentName":"Development", ...}-->

--- a/aspnetcore/blazor/fundamentals/environments.md
+++ b/aspnetcore/blazor/fundamentals/environments.md
@@ -37,7 +37,6 @@ The environment is set using any of the following approaches:
   * [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
   * [Azure App Service](#set-the-environment-for-azure-app-service)
 * Standalone Blazor WebAssembly: `<WasmApplicationEnvironmentName>` property
-* Any Blazor app: [Azure App Service](#set-the-environment-for-azure-app-service)
 
 On the client for a Blazor Web App, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
 
@@ -68,9 +67,10 @@ For a standalone Blazor WebAssembly app running locally, the development server 
 :::moniker range="< aspnetcore-8.0"
 
 * Blazor Server: Use any of the approaches described in <xref:fundamentals/environments> for general ASP.NET Core apps.
-* Blazor Server or Blazor WebAssembly: [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
+* Blazor Server or Blazor WebAssembly:
+  * [Blazor start configuration](#set-the-client-side-environment-via-blazor-startup-configuration)
+  * [Azure App Service](#set-the-environment-for-azure-app-service)
 * Blazor WebAssembly: [`Blazor-Environment` header](#set-the-client-side-environment-via-header)
-* Blazor Server or Blazor WebAssembly: [Azure App Service](#set-the-environment-for-azure-app-service)
 
 On the client of a hosted Blazor WebAssembly app, the environment is determined from the server via a middleware that communicates the environment to the browser via a header named `Blazor-Environment`. The header sets the environment when the <xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHost> is created in the client-side `Program` file (<xref:Microsoft.AspNetCore.Components.WebAssembly.Hosting.WebAssemblyHostBuilder.CreateDefault%2A?displayProperty=nameWithType>).
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -232,6 +232,17 @@ In the project file (`.csproj`), the `<WriteImportMapToHtml>` property is set to
 </Project>
 ```
 
+To fingerprint additional JS modules in standalone Blazor WebAssembly apps, use the `<StaticWebAssetFingerprintPattern>` property in the app's project file (`.csproj`).
+
+In the following example, a fingerprint is added for all developer-supplied `.mjs` files in the app:
+
+```xml
+<StaticWebAssetFingerprintPattern Include="JSModule" Pattern="*.mjs" 
+    Expression="#[.{fingerprint}]!" />
+```
+
+The files are placed into the import map, automatically for Blazor Web App CSR or when opting-into module fingerprinting in standalone Blazor WebAssembly apps per the preceding instructions. When resolving the import for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
+
 :::moniker-end
 
 :::moniker range="< aspnetcore-9.0"

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -64,17 +64,20 @@ Assets are delivered via the <xref:Microsoft.AspNetCore.Components.ComponentBase
 <link rel="stylesheet" href="@Assets["BlazorSample.styles.css"]" />
 ```
 
-## Import maps
+## `ImportMap` component
 
 *This section applies to server-side Blazor apps.*
 
-The Import Map component (<xref:Microsoft.AspNetCore.Components.ImportMap>) represents an import map element (`<script type="importmap"></script>`) that defines the import map for module scripts. The Import Map component is placed in `<head>` content of the root component, typically the `App` component (`Components/App.razor`).
+The `ImportMap` component (<xref:Microsoft.AspNetCore.Components.ImportMap>) represents an import map element (`<script type="importmap"></script>`) that defines the import map for module scripts. The Import Map component is placed in `<head>` content of the root component, typically the `App` component (`Components/App.razor`).
 
 ```razor
 <ImportMap />
 ```
 
 If a custom <xref:Microsoft.AspNetCore.Components.ImportMapDefinition> isn't assigned to an Import Map component, the import map is generated based on the app's assets.
+
+> [!NOTE]
+> <xref:Microsoft.AspNetCore.Components.ImportMapDefinition> instances are expensive to create, so it is recommended to cache them if you are creating an additional instance.
 
 The following examples demonstrate custom import map definitions and the import maps that they create.
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -198,11 +198,11 @@ For examples of how to address the policy violation with Subresource Integrity (
 
 :::moniker range=">= aspnetcore-10.0"
 
-### Fingerprint static assets in standalone Blazor WebAssembly apps
+### Fingerprint client-side static assets
 
-In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets. A fingerprint is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
+In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets for client-side rendering (CSR). A fingerprint is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
 
-The following configuration must be present in the `wwwwoot/index.html` file to adopt the fingerprinting feature:
+The following configuration must be present in the `wwwwoot/index.html` file of a standalone Blazor WebAssembly app to adopt the fingerprinting feature:
 
 ```html
 <head>
@@ -232,7 +232,9 @@ In the project file (`.csproj`), the `<WriteImportMapToHtml>` property is set to
 </Project>
 ```
 
-To fingerprint additional JS modules in standalone Blazor WebAssembly apps, use the `<StaticWebAssetFingerprintPattern>` property in the app's project file (`.csproj`).
+For CSR in Blazor Web Apps (Interactive Auto or Interactive WebAssembly render modes), [server-side fingerprinting](https://en.wikipedia.org/wiki/Fingerprint_(computing)) of static assets was introduced in .NET 9 or later with [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files) and the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component).
+
+To fingerprint additional JS modules for CSR, use the `<StaticWebAssetFingerprintPattern>` property in the app's project file (`.csproj`).
 
 In the following example, a fingerprint is added for all developer-supplied `.mjs` files in the app:
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -196,11 +196,19 @@ For examples of how to address the policy violation with Subresource Integrity (
 
 :::moniker-end
 
+:::moniker range="< aspnetcore-9.0"
+
+Configure Static File Middleware to serve static assets to clients by calling <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> in the app's request processing pipeline. For more information, see <xref:fundamentals/static-files>.
+
+In releases prior to .NET 8, Blazor framework static files, such as the Blazor script, are served via Static File Middleware. In .NET 8 or later, Blazor framework static files are mapped using endpoint routing, and Static File Middleware is no longer used.
+
+:::moniker-end
+
 :::moniker range=">= aspnetcore-10.0"
 
-### Fingerprint client-side static assets
+## Fingerprint client-side static assets in standalone Blazor WebAssembly apps
 
-In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets for client-side rendering (CSR). A [fingerprint](https://en.wikipedia.org/wiki/Fingerprint_(computing)) is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
+In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets for client-side rendering. A [fingerprint](https://wikipedia.org/wiki/Fingerprint_(computing)) is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
 
 The following configuration must be present in the `wwwwoot/index.html` file of a standalone Blazor WebAssembly app to adopt fingerprinting:
 
@@ -223,42 +231,29 @@ The following configuration must be present in the `wwwwoot/index.html` file of 
 In the project file (`.csproj`), the `<OverrideHtmlAssetPlaceholders>` property is set to `true`:
 
 ```xml
-<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
-  <PropertyGroup>
-    ...
-    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    ...
-  </PropertyGroup>
-</Project>
+<PropertyGroup>
+  <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+</PropertyGroup>
 ```
 
-For CSR in Blazor Web Apps (Interactive Auto or Interactive WebAssembly render modes), static asset server-side fingerprinting is enabled by adopting [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files) and the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component).
+When resolving imports for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
 
-To fingerprint additional JavaScript modules for CSR, use the `<StaticWebAssetFingerprintPattern>` property in the app's project file (`.csproj`).
+## Fingerprint client-side static assets in Blazor Web Apps
 
-In the following example, a fingerprint is added for all developer-supplied `.mjs` files in the app:
+For client-side rendering (CSR) in Blazor Web Apps (Interactive Auto or Interactive WebAssembly render modes), static asset server-side [fingerprinting](https://wikipedia.org/wiki/Fingerprint_(computing)) is enabled by adopting [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files), [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component), and the <xref:Microsoft.AspNetCore.Components.ComponentBase.Assets?displayProperty=nameWithType> property (`@Assets["..."]`).
+
+To fingerprint additional JavaScript modules for CSR, use the `<StaticWebAssetFingerprintPattern>` item in the app's project file (`.csproj`). In the following example, a fingerprint is added for all developer-supplied `.mjs` files in the app:
 
 ```xml
-<StaticWebAssetFingerprintPattern Include="JSModule" Pattern="*.mjs" 
-  Expression="#[.{fingerprint}]!" />
+<ItemGroup>
+  <StaticWebAssetFingerprintPattern Include="JSModule" Pattern="*.mjs" 
+    Expression="#[.{fingerprint}]!" />
+</ItemGroup>
 ```
 
-The files are automatically placed into the import map:
-
-* Automatically for Blazor Web App CSR.
-* When opting-into module fingerprinting in standalone Blazor WebAssembly apps per the preceding instructions.
-
-When resolving the import for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
+When resolving imports for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
 
 :::moniker-end
-
-:::moniker range="< aspnetcore-9.0"
-
-Configure Static File Middleware to serve static assets to clients by calling <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> in the app's request processing pipeline. For more information, see <xref:fundamentals/static-files>.
-
-:::moniker-end
-
-In releases prior to .NET 8, Blazor framework static files, such as the Blazor script, are served via Static File Middleware. In .NET 8 or later, Blazor framework static files are mapped using endpoint routing, and Static File Middleware is no longer used.
 
 ## Summary of static file `<link>` `href` formats
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -193,6 +193,44 @@ For examples of how to address the policy violation with Subresource Integrity (
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-10.0"
+
+### Fingerprint static assets in standalone Blazor WebAssembly apps
+
+In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets. A fingerprint is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
+
+The following configuration must be present in the `wwwwoot/index.html` file to adopt the fingerprinting feature:
+
+```html
+<head>
+    ...
+    <script type="importmap"></script>
+    ...
+</head>
+
+<body>
+    ...
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+    ...
+</body>
+
+</html>
+```
+
+In the project file (`.csproj`), the `<WriteImportMapToHtml>` property is set to `true`:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+  <PropertyGroup>
+    ...
+    <WriteImportMapToHtml>true</WriteImportMapToHtml>
+    ...
+  </PropertyGroup>
+</Project>
+```
+
+:::moniker-end
+
 :::moniker range="< aspnetcore-9.0"
 
 Configure Static File Middleware to serve static assets to clients by calling <xref:Microsoft.AspNetCore.Builder.StaticFileExtensions.UseStaticFiles%2A> in the app's request processing pipeline. For more information, see <xref:fundamentals/static-files>.

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -228,11 +228,11 @@ The following configuration must be present in the `wwwwoot/index.html` file of 
 </html>
 ```
 
-In the project file (`.csproj`), the `<OverrideHtmlAssetPlaceholders>` property is set to `true`:
+In the project file (`.csproj`), the `<WriteImportMapToHtml>` property is set to `true`:
 
 ```xml
 <PropertyGroup>
-  <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+  <WriteImportMapToHtml>true</WriteImportMapToHtml>
 </PropertyGroup>
 ```
 

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -220,13 +220,13 @@ The following configuration must be present in the `wwwwoot/index.html` file of 
 </html>
 ```
 
-In the project file (`.csproj`), the `<WriteImportMapToHtml>` property is set to `true`:
+In the project file (`.csproj`), the `<OverrideHtmlAssetPlaceholders>` property is set to `true`:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
   <PropertyGroup>
     ...
-    <WriteImportMapToHtml>true</WriteImportMapToHtml>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
     ...
   </PropertyGroup>
 </Project>

--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -77,7 +77,7 @@ The `ImportMap` component (<xref:Microsoft.AspNetCore.Components.ImportMap>) rep
 If a custom <xref:Microsoft.AspNetCore.Components.ImportMapDefinition> isn't assigned to an Import Map component, the import map is generated based on the app's assets.
 
 > [!NOTE]
-> <xref:Microsoft.AspNetCore.Components.ImportMapDefinition> instances are expensive to create, so it is recommended to cache them if you are creating an additional instance.
+> <xref:Microsoft.AspNetCore.Components.ImportMapDefinition> instances are expensive to create, so we recommended caching them when creating an additional instance.
 
 The following examples demonstrate custom import map definitions and the import maps that they create.
 
@@ -200,9 +200,9 @@ For examples of how to address the policy violation with Subresource Integrity (
 
 ### Fingerprint client-side static assets
 
-In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets for client-side rendering (CSR). A fingerprint is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
+In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets for client-side rendering (CSR). A [fingerprint](https://en.wikipedia.org/wiki/Fingerprint_(computing)) is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
 
-The following configuration must be present in the `wwwwoot/index.html` file of a standalone Blazor WebAssembly app to adopt the fingerprinting feature:
+The following configuration must be present in the `wwwwoot/index.html` file of a standalone Blazor WebAssembly app to adopt fingerprinting:
 
 ```html
 <head>
@@ -232,18 +232,23 @@ In the project file (`.csproj`), the `<WriteImportMapToHtml>` property is set to
 </Project>
 ```
 
-For CSR in Blazor Web Apps (Interactive Auto or Interactive WebAssembly render modes), [server-side fingerprinting](https://en.wikipedia.org/wiki/Fingerprint_(computing)) of static assets was introduced in .NET 9 or later with [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files) and the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component).
+For CSR in Blazor Web Apps (Interactive Auto or Interactive WebAssembly render modes), static asset server-side fingerprinting is enabled by adopting [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files) and the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component).
 
-To fingerprint additional JS modules for CSR, use the `<StaticWebAssetFingerprintPattern>` property in the app's project file (`.csproj`).
+To fingerprint additional JavaScript modules for CSR, use the `<StaticWebAssetFingerprintPattern>` property in the app's project file (`.csproj`).
 
 In the following example, a fingerprint is added for all developer-supplied `.mjs` files in the app:
 
 ```xml
 <StaticWebAssetFingerprintPattern Include="JSModule" Pattern="*.mjs" 
-    Expression="#[.{fingerprint}]!" />
+  Expression="#[.{fingerprint}]!" />
 ```
 
-The files are placed into the import map, automatically for Blazor Web App CSR or when opting-into module fingerprinting in standalone Blazor WebAssembly apps per the preceding instructions. When resolving the import for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
+The files are automatically placed into the import map:
+
+* Automatically for Blazor Web App CSR.
+* When opting-into module fingerprinting in standalone Blazor WebAssembly apps per the preceding instructions.
+
+When resolving the import for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
 
 :::moniker-end
 

--- a/aspnetcore/fundamentals/map-static-files.md
+++ b/aspnetcore/fundamentals/map-static-files.md
@@ -45,7 +45,7 @@ Creating performant web apps requires optimizing asset delivery to the browser. 
 * Use [Caching Middleware](xref:performance/caching/middleware).
 * Serve [compressed](/aspnet/core/performance/response-compression) versions of the assets when possible. This optimization doesn't include minification.
 * Use a [CDN](/microsoft-365/enterprise/content-delivery-networks?view=o365-worldwide&preserve-view=true) to serve the assets closer to the user.
-* [Fingerprinting assets](https://developer.mozilla.org/docs/Glossary/Fingerprinting) to prevent reusing old versions of files.
+* [Fingerprinting assets](https://en.wikipedia.org/wiki/Fingerprint_(computing)) to prevent reusing old versions of files.
 
 `MapStaticAssets`:
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -155,7 +155,7 @@ The following changes must be made in the `wwwwoot/index.html` file to adopt the
 </html>
 ```
 
-In the project file (`.csproj`), add the `<OverrideHtmlAssetPlaceholders>` property set to `true`:
+In the project file (`.csproj`), add the `<WriteImportMapToHtml>` property set to `true`:
 
 ```diff
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
@@ -164,7 +164,7 @@ In the project file (`.csproj`), add the `<OverrideHtmlAssetPlaceholders>` prope
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-+   <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
++   <WriteImportMapToHtml>true</WriteImportMapToHtml>
   </PropertyGroup>
 </Project>
 ```

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -134,7 +134,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ### Client-side fingerprinting
 
-Last year, the release of .NET 9 introduced [server-side fingerprinting](https://en.wikipedia.org/wiki/Fingerprint_(computing)) of static assets in Blazor Web Apps with the introduction of [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files) and the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component) to resolve fingerprinted JavaScript modules. For .NET 10, you can opt-into client-side fingerprinting of JavaScript modules for standalone Blazor WebAssembly apps.
+Last year, the release of .NET 9 introduced [server-side fingerprinting](https://en.wikipedia.org/wiki/Fingerprint_(computing)) of static assets in Blazor Web Apps with the introduction of [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files), the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component), and the <xref:Microsoft.AspNetCore.Components.ComponentBase.Assets?displayProperty=nameWithType> property (`@Assets["..."]`) to resolve fingerprinted JavaScript modules. For .NET 10, you can opt-into client-side fingerprinting of JavaScript modules for standalone Blazor WebAssembly apps.
 
 In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets. A fingerprint is placed into the `blazor.webassembly.js` script file name.
 
@@ -199,7 +199,7 @@ The following example sets the app's environment to `Staging`:
 
 As usual, the default environments are:
 
-* `Development` when running the app locally.
-* `Production` when the app is published.
+* `Development` for build.
+* `Production` for publish.
 
 -->

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -175,10 +175,15 @@ In the following example, a fingerprint is added for all developer-supplied `.mj
 
 ```xml
 <StaticWebAssetFingerprintPattern Include="JSModule" Pattern="*.mjs" 
-    Expression="#[.{fingerprint}]!" />
+  Expression="#[.{fingerprint}]!" />
 ```
 
-The files are placed into the import map, automatically for Blazor Web App CSR or when opting-into module fingerprinting in standalone Blazor WebAssembly apps per the preceding instructions. When resolving the import for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
+The files are automatically placed into the import map:
+
+* Automatically for Blazor Web App CSR.
+* When opting-into module fingerprinting in standalone Blazor WebAssembly apps per the preceding instructions.
+
+When resolving the import for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
 
 ### Set the environment in standalone Blazor WebAssembly apps
 
@@ -192,6 +197,9 @@ The following example sets the app's environment to `Staging`:
 <WasmApplicationEnvironmentName>Staging</WasmApplicationEnvironmentName>
 ```
 
-As usual, the default environment is `Development` when running the app locally and `Production` when the app is published.
+As usual, the default environments are:
+
+* `Development` when running the app locally.
+* `Production` when the app is published.
 
 -->

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -134,13 +134,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 ### Client-side fingerprinting
 
-Last year, the release of .NET 9 introduced [server-side fingerprinting](https://en.wikipedia.org/wiki/Fingerprint_(computing)) of static assets in Blazor Web Apps with the introduction of [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files) and the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component) to resolve fingerprinted JavaScript modules. For .NET 10, you can opt-into client-side fingerprinting of JavaScript modules for standalone Blazor WebAssembly apps and client-side rendering (CSR) of Blazor Web Apps (`.Client` project).
+Last year, the release of .NET 9 introduced [server-side fingerprinting](https://en.wikipedia.org/wiki/Fingerprint_(computing)) of static assets in Blazor Web Apps with the introduction of [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files) and the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component) to resolve fingerprinted JavaScript modules. For .NET 10, you can opt-into client-side fingerprinting of JavaScript modules for standalone Blazor WebAssembly apps.
 
 In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets. A fingerprint is placed into the `blazor.webassembly.js` script file name.
-
-WIP .................
-For client-side rendering in a Blazor Web App, In hosted mode all JS modules are soft fingerprinted, meaning that the file on disk don't have fingerprint and only aspnetcore server knows about URLs with fingerprint. We hard fingerprint .NET assets, meaning file on disk has a fingerprint. In standalone mode, there is no aspnetcore server and so only hard fingerprinted assets have fingerprint. And so if users want to fingerprint their JS modules and put them to importmap, they need to opt-in (as described in the linked comment).
-.....................
 
 The following changes must be made in the `wwwwoot/index.html` file to adopt the fingerprinting feature. The standalone Blazor WebAssembly project template will be updated to include these changes in an upcoming preview release:
 
@@ -173,7 +169,6 @@ In the project file (`.csproj`), add the `<WriteImportMapToHtml>` property set t
 </Project>
 ```
 
-WIP .................
 To fingerprint additional JS modules in standalone Blazor WebAssembly apps, use the `<StaticWebAssetFingerprintPattern>` property in the app's project file (`.csproj`).
 
 In the following example, a fingerprint is added for all developer-supplied `.mjs` files in the app:
@@ -184,7 +179,6 @@ In the following example, a fingerprint is added for all developer-supplied `.mj
 ```
 
 The files are placed into the import map, automatically for Blazor Web App CSR or when opting-into module fingerprinting in standalone Blazor WebAssembly apps per the preceding instructions. When resolving the import for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
-.....................
 
 ### Set the environment in standalone Blazor WebAssembly apps
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -197,7 +197,7 @@ The following example sets the app's environment to `Staging`:
 <WasmApplicationEnvironmentName>Staging</WasmApplicationEnvironmentName>
 ```
 
-As usual, the default environments are:
+The default environments are:
 
 * `Development` for build.
 * `Production` for publish.

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -132,9 +132,15 @@ Also make this change in the *Routing* article at Line 1633.
 
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
-### End-to-end fingerprinting of assets in standalone Blazor WebAssembly apps
+### Client-side fingerprinting
 
-In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets. A fingerprint is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
+Last year, the release of .NET 9 introduced [server-side fingerprinting](https://en.wikipedia.org/wiki/Fingerprint_(computing)) of static assets in Blazor Web Apps with the introduction of [Map Static Assets routing endpoint conventions (`MapStaticAssets`)](xref:fundamentals/map-static-files) and the [`ImportMap` component](xref:blazor/fundamentals/static-files#importmap-component) to resolve fingerprinted JavaScript modules. For .NET 10, you can opt-into client-side fingerprinting of JavaScript modules for standalone Blazor WebAssembly apps and client-side rendering (CSR) of Blazor Web Apps (`.Client` project).
+
+In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets. A fingerprint is placed into the `blazor.webassembly.js` script file name.
+
+WIP .................
+For client-side rendering in a Blazor Web App, In hosted mode all JS modules are soft fingerprinted, meaning that the file on disk don't have fingerprint and only aspnetcore server knows about URLs with fingerprint. We hard fingerprint .NET assets, meaning file on disk has a fingerprint. In standalone mode, there is no aspnetcore server and so only hard fingerprinted assets have fingerprint. And so if users want to fingerprint their JS modules and put them to importmap, they need to opt-in (as described in the linked comment).
+.....................
 
 The following changes must be made in the `wwwwoot/index.html` file to adopt the fingerprinting feature. The standalone Blazor WebAssembly project template will be updated to include these changes in an upcoming preview release:
 
@@ -166,6 +172,19 @@ In the project file (`.csproj`), add the `<WriteImportMapToHtml>` property set t
   </PropertyGroup>
 </Project>
 ```
+
+WIP .................
+To fingerprint additional JS modules in standalone Blazor WebAssembly apps, use the `<StaticWebAssetFingerprintPattern>` property in the app's project file (`.csproj`).
+
+In the following example, a fingerprint is added for all developer-supplied `.mjs` files in the app:
+
+```xml
+<StaticWebAssetFingerprintPattern Include="JSModule" Pattern="*.mjs" 
+    Expression="#[.{fingerprint}]!" />
+```
+
+The files are placed into the import map, automatically for Blazor Web App CSR or when opting-into module fingerprinting in standalone Blazor WebAssembly apps per the preceding instructions. When resolving the import for JavaScript interop, the import map is used by the browser resolve fingerprinted files.
+.....................
 
 ### Set the environment in standalone Blazor WebAssembly apps
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -167,4 +167,18 @@ In the project file (`.csproj`), add the `<WriteImportMapToHtml>` property set t
 </Project>
 ```
 
+### Set the environment in standalone Blazor WebAssembly apps
+
+The `Properties/launchSettings.json` file is no longer used to control the environment in standalone Blazor WebAssembly apps.
+
+Starting in .NET 10, set the environment with the `<WasmApplicationEnvironmentName>` property in the app's project file (`.csproj`).
+
+The following example sets the app's environment to `Staging`:
+
+```xml
+<WasmApplicationEnvironmentName>Staging</WasmApplicationEnvironmentName>
+```
+
+As usual, the default environment is `Development` when running the app locally and `Production` when the app is published.
+
 -->

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -155,7 +155,7 @@ The following changes must be made in the `wwwwoot/index.html` file to adopt the
 </html>
 ```
 
-In the project file (`.csproj`), add the `<WriteImportMapToHtml>` property set to `true`:
+In the project file (`.csproj`), add the `<OverrideHtmlAssetPlaceholders>` property set to `true`:
 
 ```diff
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
@@ -164,7 +164,7 @@ In the project file (`.csproj`), add the `<WriteImportMapToHtml>` property set t
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-+   <WriteImportMapToHtml>true</WriteImportMapToHtml>
++   <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
   </PropertyGroup>
 </Project>
 ```

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -132,4 +132,39 @@ Also make this change in the *Routing* article at Line 1633.
 
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
+### End-to-end fingerprinting of assets in standalone Blazor WebAssembly apps
+
+In standalone Blazor WebAssembly apps during build/publish, the framework overrides placeholders in `index.html` with values computed during build to fingerprint static assets. A fingerprint is placed into the `blazor.webassembly.js` script file name, and an import map is generated for other .NET assets.
+
+The following changes must be made in the `wwwwoot/index.html` file to adopt the fingerprinting feature. The standalone Blazor WebAssembly project template will be updated to include these changes in an upcoming preview release:
+
+```diff
+<head>
+    ...
++   <script type="importmap"></script>
+</head>
+
+<body>
+    ...
+-   <script src="_framework/blazor.webassembly.js"></script>
++   <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+</body>
+
+</html>
+```
+
+In the project file (`.csproj`), add the `<WriteImportMapToHtml>` property set to `true`:
+
+```diff
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
++   <WriteImportMapToHtml>true</WriteImportMapToHtml>
+  </PropertyGroup>
+</Project>
+```
+
 -->


### PR DESCRIPTION
Fixes #35023
Addresses #34948
Addresses #34437
Fixes #35075

Covering two Blazor WASM features now on this PR ...

* Fingerprinting
* `<WasmApplicationEnvironmentName>` to set the environment

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/built-in-components.md](https://github.com/dotnet/AspNetCore.Docs/blob/517a64adb10bc8bc2435bbc8f0347fea10c7cbc2/aspnetcore/blazor/components/built-in-components.md) | [aspnetcore/blazor/components/built-in-components](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/built-in-components?branch=pr-en-us-35057) |
| [aspnetcore/blazor/fundamentals/environments.md](https://github.com/dotnet/AspNetCore.Docs/blob/517a64adb10bc8bc2435bbc8f0347fea10c7cbc2/aspnetcore/blazor/fundamentals/environments.md) | [aspnetcore/blazor/fundamentals/environments](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/environments?branch=pr-en-us-35057) |
| [aspnetcore/blazor/fundamentals/static-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/517a64adb10bc8bc2435bbc8f0347fea10c7cbc2/aspnetcore/blazor/fundamentals/static-files.md) | [aspnetcore/blazor/fundamentals/static-files](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/static-files?branch=pr-en-us-35057) |
| [aspnetcore/fundamentals/map-static-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/517a64adb10bc8bc2435bbc8f0347fea10c7cbc2/aspnetcore/fundamentals/map-static-files.md) | [aspnetcore/fundamentals/map-static-files](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/map-static-files?branch=pr-en-us-35057) |


<!-- PREVIEW-TABLE-END -->