### PR TITLE
Remove misplaced quotation in ASP0027

### DIFF
--- a/aspnetcore/diagnostics/asp0027.md
+++ b/aspnetcore/diagnostics/asp0027.md
@@ -7,7 +7,7 @@ monikerRange: '>= aspnetcore-10.0'
 ms.author: riande
 uid: diagnostics/asp0027
 ---
-# ASP0027: Unnecessary `public Program` class declaration"
+# ASP0027: Unnecessary `public Program` class declaration
 
 |                                     | Value        |
 | -                                   | -            |


### PR DESCRIPTION
I have recently written the ASP0027 documentation.

After reviewing the [documentation](https://learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0027?view=aspnetcore-10.0) I spotted there was a misplaced quotation mark.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/diagnostics/asp0027.md](https://github.com/dotnet/AspNetCore.Docs/blob/6c1a5b4b7fdfbba1abc24862c87237cb127fb376/aspnetcore/diagnostics/asp0027.md) | [ASP0027: Unnecessary `public Program` class declaration](https://review.learn.microsoft.com/en-us/aspnet/core/diagnostics/asp0027?branch=pr-en-us-35066) |

<!-- PREVIEW-TABLE-END -->