### PR TITLE
Added missing ASP links in code analysis page

### DIFF
--- a/aspnetcore/diagnostics/code-analysis.md
+++ b/aspnetcore/diagnostics/code-analysis.md
@@ -41,6 +41,8 @@ Diagnostic ID:
 * [ASP0024](xref:diagnostics/asp0024)
 * [ASP0025](xref:diagnostics/asp0025)
 * [ASP0026](xref:diagnostics/asp0026)
+* [ASP0027](xref:diagnostics/asp0027)
+* [ASP0028](xref:diagnostics/asp0028)
 * [BL0001](xref:diagnostics/bl0001)
 * [BL0002](xref:diagnostics/bl0002)
 * [BL0003](xref:diagnostics/bl0003)


### PR DESCRIPTION
I spotted we were missing the links in the [code analysis page](https://learn.microsoft.com/en-us/aspnet/core/diagnostics/code-analysis?view=aspnetcore-10.0) for ASP0027 & ASP0028.

This change includes these links.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/diagnostics/code-analysis.md](https://github.com/dotnet/AspNetCore.Docs/blob/bbac5357f02841e086c3bc0ef0c2428c43b406b8/aspnetcore/diagnostics/code-analysis.md) | [Code analysis in ASP.NET Core apps](https://review.learn.microsoft.com/en-us/aspnet/core/diagnostics/code-analysis?branch=pr-en-us-35087) |

<!-- PREVIEW-TABLE-END -->