### PR TITLE
Fix typo in OIDC documentation

### DIFF
--- a/aspnetcore/security/authentication/configure-oidc-web-authentication.md
+++ b/aspnetcore/security/authentication/configure-oidc-web-authentication.md
@@ -101,7 +101,7 @@ For the different claims mapping possibilities, see <xref:security/authenticatio
 
 ### Setup the configuration properties
 
-Add the OpenID Connect client settings to the application configuration properties. The settings must match the client configuration in the OpenID Connect server. No secrets should be persisted in application settings where they might get accidentally checked in. Secrets should be stored in a secure location like Azure Key Vault in production environments or in user secrets in a development environment. For more informaiton, see <xref:security/app-secrets>.
+Add the OpenID Connect client settings to the application configuration properties. The settings must match the client configuration in the OpenID Connect server. No secrets should be persisted in application settings where they might get accidentally checked in. Secrets should be stored in a secure location like Azure Key Vault in production environments or in user secrets in a development environment. For more information, see <xref:security/app-secrets>.
 
 ```json
 "OpenIDConnectSettings": {


### PR DESCRIPTION
Simple typo fix of "informaiton".

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/configure-oidc-web-authentication.md](https://github.com/dotnet/AspNetCore.Docs/blob/e584a7c5006997c0bc497734191f02e8125e86ae/aspnetcore/security/authentication/configure-oidc-web-authentication.md) | [Configure OpenID Connect Web (UI) authentication in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication?branch=pr-en-us-35124) |

<!-- PREVIEW-TABLE-END -->