### PR TITLE
SSE return types /2

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/HeartRateRecord.cs
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/HeartRateRecord.cs
@@ -1,0 +1,4 @@
+public record HeartRateRecord(DateTime Timestamp, int HeartRate)
+{
+    public static HeartRateRecord Create(int heartRate) => new(DateTime.UtcNow, heartRate);
+}

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/MinimalServerSentEvents.http
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/MinimalServerSentEvents.http
@@ -1,4 +1,4 @@
-@baseUrl = http://localhost:5293
+@baseUrl = http://localhost:58489
 
 ### Connect to SSE stream
 # This request will open an SSE connection that stays open

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs
@@ -18,7 +18,8 @@ app.MapGet("/string-item", (CancellationToken cancellationToken) =>
         }
     }
 
-    return TypedResults.ServerSentEvents(GetHeartRate(cancellationToken), eventType: "heartRate");
+    return TypedResults.ServerSentEvents(GetHeartRate(cancellationToken),
+                                                  eventType: "heartRate");
 });
 // </snippet_string>
 
@@ -36,7 +37,8 @@ app.MapGet("/json-item", (CancellationToken cancellationToken) =>
         }
     }
 
-    return TypedResults.ServerSentEvents(GetHeartRate(cancellationToken), eventType: "heartRate");
+    return TypedResults.ServerSentEvents(GetHeartRate(cancellationToken),
+                                                  eventType: "heartRate");
 });
 // </snippet_json>
 

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs
@@ -25,13 +25,13 @@ app.MapGet("/string-item", (CancellationToken cancellationToken) =>
 // <snippet_json>
 app.MapGet("/json-item", (CancellationToken cancellationToken) =>
 {
-    async IAsyncEnumerable<HearRate> GetHeartRate(
+    async IAsyncEnumerable<HeartRateRecord> GetHeartRate(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         while (!cancellationToken.IsCancellationRequested)
         {
             var heartRate = Random.Shared.Next(60, 100);
-            yield return HearRate.Create(heartRate);
+            yield return HeartRateRecord.Create(heartRate);
             await Task.Delay(2000, cancellationToken);
         }
     }
@@ -64,7 +64,3 @@ app.MapGet("sse-item", (CancellationToken cancellationToken) =>
 
 app.Run();
 
-public record HearRate(DateTime Timestamp, int HeartRate)
-{
-    public static HearRate Create(int heartRate) => new(DateTime.UtcNow, heartRate);
-}

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs
@@ -13,7 +13,7 @@ app.MapGet("/string-item", (CancellationToken cancellationToken) =>
         while (!cancellationToken.IsCancellationRequested)
         {
             var heartRate = Random.Shared.Next(60, 100);
-            yield return $"Hear Rate: {heartRate} bpm";
+            yield return $"Heart Rate: {heartRate} bpm";
             await Task.Delay(2000, cancellationToken);
         }
     }

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -128,20 +128,6 @@ In order to document this endpoint correctly the extension method `Produces` is 
 
 The following sections demonstrate the usage of the common result helpers.
 
-#### Server-Sent Events (SSE)
-
-The [TypedResults.ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,051e6796e1492f84) API supports returning a [ServerSentEvents](xref:System.Net.ServerSentEvents) result.
-
-[Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) is a server push technology that allows a server to send a stream of event messages to a client over a single HTTP connection. In .NET, the event messages are represented as [`SseItem<T>`](/dotnet/api/system.net.serversentevents.sseitem-1) objects, which may contain an event type, an ID, and a data payload of type `T`.
-
-The [TypedResults](xref:Microsoft.AspNetCore.Http.TypedResults) class has a static method called [ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,ceb980606eb9e295) that can be used to return a `ServerSentEvents` result. The first parameter to this method is an `IAsyncEnumerable<SseItem<T>>` that represents the stream of event messages to be sent to the client.
-
-The following example illustrates how to use the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as JSON objects to the client:
-
-:::code language="csharp" source="~/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs" id="snippet_item" :::
-
-For more information, see the [Minimal API sample app](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs) using the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as string, `ServerSentEvents`, and JSON objects to the client.
-
 #### JSON
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_05":::
@@ -187,6 +173,20 @@ The following example streams an image from [Azure Blob storage](/azure/storage/
 The following example streams a video from an Azure Blob:
 
 [!code-csharp[](~/fundamentals/minimal-apis/resultsStream/7.0-samples/ResultsStreamSample/Program.cs?name=snippet_video)]
+
+#### Server-Sent Events (SSE)
+
+The [TypedResults.ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,051e6796e1492f84) API supports returning a [ServerSentEvents](xref:System.Net.ServerSentEvents) result.
+
+[Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) is a server push technology that allows a server to send a stream of event messages to a client over a single HTTP connection. In .NET, the event messages are represented as [`SseItem<T>`](/dotnet/api/system.net.serversentevents.sseitem-1) objects, which may contain an event type, an ID, and a data payload of type `T`.
+
+The [TypedResults](xref:Microsoft.AspNetCore.Http.TypedResults) class has a static method called [ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,ceb980606eb9e295) that can be used to return a `ServerSentEvents` result. The first parameter to this method is an `IAsyncEnumerable<SseItem<T>>` that represents the stream of event messages to be sent to the client.
+
+The following example illustrates how to use the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as JSON objects to the client:
+
+:::code language="csharp" source="~/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs" id="snippet_item" :::
+
+For more information, see the [Minimal API sample app](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs) using the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as string, `ServerSentEvents`, and JSON objects to the client.
 
 #### Redirect
 

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -150,8 +150,6 @@ The preceding example returns a 500 status code.
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_12":::
 
-#### Problem
-
 #### Text
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_08":::

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -138,7 +138,7 @@ The [TypedResults](xref:Microsoft.AspNetCore.Http.TypedResults) class has a stat
 
 The following example illustrates how to use the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as JSON objects to the client:
 
-:::code language="csharp" source="~/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs" id="snippet_json" :::
+:::code language="csharp" source="~/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs" id="snippet_item" :::
 
 For more information, see the [Minimal API sample app](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs) using the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as string, `ServerSentEvents`, and JSON objects to the client.
 

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -132,7 +132,7 @@ The following sections demonstrate the usage of the common result helpers.
 
 The [TypedResults.ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,051e6796e1492f84) API supports returning a [ServerSentEvents](xref:System.Net.ServerSentEvents) result.
 
-[Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) is a server push technology that allows a server to send a stream of event messages to a client over a single HTTP connection. In .NET, the event messages are represented as [`SseItem<T`>`](/dotnet/api/system.net.serversentevents.sseitem-1) objects, which may contain an event type, an ID, and a data payload of type `T`.
+[Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) is a server push technology that allows a server to send a stream of event messages to a client over a single HTTP connection. In .NET, the event messages are represented as [`SseItem<T>`](/dotnet/api/system.net.serversentevents.sseitem-1) objects, which may contain an event type, an ID, and a data payload of type `T`.
 
 The [TypedResults](xref:Microsoft.AspNetCore.Http.TypedResults) class has a static method called [ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,ceb980606eb9e295) that can be used to return a `ServerSentEvents` result. The first parameter to this method is an `IAsyncEnumerable<SseItem<T>>` that represents the stream of event messages to be sent to the client.
 

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -120,13 +120,27 @@ In order to document this endpoint correctly the extension method `Produces` is 
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_04":::
 
-<a name="binr7"></a>
+<a name="binr10"></a>
 
 ### Built-in results
 
 [!INCLUDE [results-helpers](~/fundamentals/minimal-apis/includes/results-helpers.md)]
 
 The following sections demonstrate the usage of the common result helpers.
+
+#### Server-Sent Events (SSE)
+
+The [TypedResults.ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,051e6796e1492f84) API supports returning a [ServerSentEvents](xref:System.Net.ServerSentEvents) result.
+
+[Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) is a server push technology that allows a server to send a stream of event messages to a client over a single HTTP connection. In .NET, the event messages are represented as [`SseItem<T`>`](/dotnet/api/system.net.serversentevents.sseitem-1) objects, which may contain an event type, an ID, and a data payload of type `T`.
+
+The [TypedResults](xref:Microsoft.AspNetCore.Http.TypedResults) class has a static method called [ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,ceb980606eb9e295) that can be used to return a `ServerSentEvents` result. The first parameter to this method is an `IAsyncEnumerable<SseItem<T>>` that represents the stream of event messages to be sent to the client.
+
+The following example illustrates how to use the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as JSON objects to the client:
+
+:::code language="csharp" source="~/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs" id="snippet_json" :::
+
+For more information, see the [Minimal API sample app](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs) using the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as string, `ServerSentEvents`, and JSON objects to the client.
 
 #### JSON
 
@@ -149,6 +163,8 @@ The preceding example returns a 500 status code.
 #### Problem and ValidationProblem
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_12":::
+
+#### Problem
 
 #### Text
 

--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -39,7 +39,6 @@ This section describes new features for minimal APIs.
 
 [!INCLUDE[](~/release-notes/aspnetcore-10/includes/sse.md)]
 
-
 ## OpenAPI
 
 This section describes new features for OpenAPI.

--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -37,6 +37,9 @@ This section describes new features for minimal APIs.
 
 [!INCLUDE[](~/release-notes/aspnetcore-10/includes/MinApiEmptyStringInFormPost.md)]
 
+[!INCLUDE[](~/release-notes/aspnetcore-10/includes/sse.md)]
+
+
 ## OpenAPI
 
 This section describes new features for OpenAPI.

--- a/aspnetcore/release-notes/aspnetcore-10/includes/sse.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/sse.md
@@ -2,7 +2,7 @@
 
 ASP.NET Core now supports returning a [ServerSentEvents](xref:System.Net.ServerSentEvents) result using the [TypedResults.ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,051e6796e1492f84) API. This feature is supported in both Minimal APIs and controller-based apps.
 
-Server-Sent Events is a server push technology that allows a server to send a stream of event messages to a client over a single HTTP connection. In .NET the event messages are represented as [`SseItem<T`>`](/dotnet/api/system.net.serversentevents.sseitem-1) objects, which may contain an event type, an ID, and a data payload of type `T`.
+Server-Sent Events is a server push technology that allows a server to send a stream of event messages to a client over a single HTTP connection. In .NET the event messages are represented as [`SseItem<T>`](/dotnet/api/system.net.serversentevents.sseitem-1) objects, which may contain an event type, an ID, and a data payload of type `T`.
 
 The [TypedResults](xref:Microsoft.AspNetCore.Http.TypedResults) class has a new static method called [ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,ceb980606eb9e295) that can be used to return a `ServerSentEvents` result. The first parameter to this method is an `IAsyncEnumerable<SseItem<T>>` that represents the stream of event messages to be sent to the client.
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/sse.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/sse.md
@@ -14,3 +14,4 @@ For more information, see:
 
 - 
 -  [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) on MDN.
+- 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/sse.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/sse.md
@@ -1,0 +1,16 @@
+### Support for Server-Sent Events (SSE)
+
+ASP.NET Core now supports returning a [ServerSentEvents](xref:System.Net.ServerSentEvents) result using the [TypedResults.ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,051e6796e1492f84) API. This feature is supported in both Minimal APIs and controller-based apps.
+
+Server-Sent Events is a server push technology that allows a server to send a stream of event messages to a client over a single HTTP connection. In .NET the event messages are represented as [`SseItem<T`>`](/dotnet/api/system.net.serversentevents.sseitem-1) objects, which may contain an event type, an ID, and a data payload of type `T`.
+
+The [TypedResults](xref:Microsoft.AspNetCore.Http.TypedResults) class has a new static method called [ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,ceb980606eb9e295) that can be used to return a `ServerSentEvents` result. The first parameter to this method is an `IAsyncEnumerable<SseItem<T>>` that represents the stream of event messages to be sent to the client.
+
+The following example illustrates how to use the  `TypedResults.ServerSentEvents` API to return a stream of heart rate events as JSON objects to the client:
+
+:::code language="csharp" source="~/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs" id="snippet_json" :::
+
+For more information, see:
+
+- 
+-  [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) on MDN.

--- a/aspnetcore/release-notes/aspnetcore-10/includes/sse.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/sse.md
@@ -6,12 +6,12 @@ Server-Sent Events is a server push technology that allows a server to send a st
 
 The [TypedResults](xref:Microsoft.AspNetCore.Http.TypedResults) class has a new static method called [ServerSentEvents](https://source.dot.net/#Microsoft.AspNetCore.Http.Results/TypedResults.cs,ceb980606eb9e295) that can be used to return a `ServerSentEvents` result. The first parameter to this method is an `IAsyncEnumerable<SseItem<T>>` that represents the stream of event messages to be sent to the client.
 
-The following example illustrates how to use the  `TypedResults.ServerSentEvents` API to return a stream of heart rate events as JSON objects to the client:
+The following example illustrates how to use the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as JSON objects to the client:
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs" id="snippet_json" :::
 
 For more information, see:
 
-- 
--  [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) on MDN.
-- 
+- [Server-Sent Events](https://developer.mozilla.org/docs/Web/API/Server-sent_events) on MDN.
+- [Minimal API sample app](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/fundamentals/minimal-apis/10.0-samples/MinimalServerSentEvents/Program.cs) using the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as string, `ServerSentEvents`, and JSON objects to the client.
+- [Controller API sample app](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE) using the `TypedResults.ServerSentEvents` API to return a stream of heart rate events as string, `ServerSentEvents`, and JSON objects to the client.

--- a/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/ControllerSSE.csproj
+++ b/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/ControllerSSE.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-*" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/ControllerSSE.http
+++ b/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/ControllerSSE.http
@@ -1,0 +1,15 @@
+@baseUrl = http://localhost:5201/HeartRate
+
+### Connect to SSE stream
+# This request will open an SSE connection that stays open
+GET {{baseUrl}}/string-item
+Accept: text/event-stream
+
+###
+GET {{baseUrl}}/json-item
+Accept: text/event-stream
+
+###
+
+GET {{baseUrl}}/sse-item
+Accept: text/event-stream

--- a/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/Controllers/HeartRateController.cs
+++ b/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/Controllers/HeartRateController.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Runtime.CompilerServices;
+using System.Net.ServerSentEvents;
+
+[ApiController]
+[Route("[controller]")]
+
+public class HeartRateController : ControllerBase
+{
+    // /HeartRate/json-item
+    [HttpGet("json-item")]
+    public IResult GetHeartRateJson(CancellationToken cancellationToken)
+    {
+        async IAsyncEnumerable<HearRate> StreamHeartRates(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var heartRate = Random.Shared.Next(60, 100);
+                yield return HearRate.Create(heartRate);
+                await Task.Delay(2000, cancellationToken);
+            }
+        }
+
+        return TypedResults.ServerSentEvents(StreamHeartRates(cancellationToken), eventType: "heartRate");
+    }
+
+    // /HeartRate/string-item
+    [HttpGet("string-item")]
+
+    public IResult GetHeartRateString(CancellationToken cancellationToken)
+    {
+        async IAsyncEnumerable<string> GetHeartRate(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var heartRate = Random.Shared.Next(60, 100);
+                yield return $"Hear Rate: {heartRate} bpm";
+                await Task.Delay(2000, cancellationToken);
+            }
+        }
+
+        return TypedResults.ServerSentEvents(GetHeartRate(cancellationToken), eventType: "heartRate");
+    }
+
+    // /HeartRate/sse-item
+    [HttpGet("sse-item")]
+
+    public IResult GetHeartRateSSE(CancellationToken cancellationToken)
+    {
+        async IAsyncEnumerable<SseItem<int>> GetHeartRate(
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var heartRate = Random.Shared.Next(60, 100);
+                yield return new SseItem<int>(heartRate, eventType: "heartRate")
+                {
+                    ReconnectionInterval = TimeSpan.FromMinutes(1)
+                };
+                await Task.Delay(2000, cancellationToken);
+            }
+        }
+
+        return TypedResults.ServerSentEvents(GetHeartRate(cancellationToken));
+    }
+}

--- a/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/HearRate.cs
+++ b/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/HearRate.cs
@@ -1,0 +1,4 @@
+public record HearRate(DateTime Timestamp, int HeartRate)
+{
+    public static HearRate Create(int heartRate) => new(DateTime.UtcNow, heartRate);
+}

--- a/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/HearRate.cs
+++ b/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/HearRate.cs
@@ -1,4 +1,4 @@
-public record HearRate(DateTime Timestamp, int HeartRate)
+public record HeartRate(DateTime Timestamp, int HeartRate)
 {
-    public static HearRate Create(int heartRate) => new(DateTime.UtcNow, heartRate);
+    public static HeartRate Create(int heartRate) => new(DateTime.UtcNow, heartRate);
 }

--- a/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/Program.cs
+++ b/aspnetcore/web-api/action-return-types/samples/10/ControllerSSE/Program.cs
@@ -1,0 +1,28 @@
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+
+app.MapControllers();
+
+app.MapGet("/", () => Results.Redirect("/HeartRate/json-item"));
+
+
+app.Run();


### PR DESCRIPTION
Fixes #35089

[Support for Server-Sent Events (SSE)](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?view=aspnetcore-9.0&branch=pr-en-us-35152#support-for-server-sent-events-sse)

[Responses: Server-Sent Events (SSE)](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/responses?view=aspnetcore-10.0&branch=pr-en-us-35152#server-sent-events-sse)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/minimal-apis/responses.md](https://github.com/dotnet/AspNetCore.Docs/blob/1da8e86cb555f6c32c9acb615d958544c499688b/aspnetcore/fundamentals/minimal-apis/responses.md) | [aspnetcore/fundamentals/minimal-apis/responses](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/responses?branch=pr-en-us-35152) |
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/1da8e86cb555f6c32c9acb615d958544c499688b/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-35152) |


<!-- PREVIEW-TABLE-END -->