### PR TITLE
Correct `dotnet new` command for creating an aot grpc app

### DIFF
--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -33,7 +33,7 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
     Native AOT can also be enabled by specifying the `-aot` option with the ASP.NET Core gRPC template:
 
     ```dotnetcli
-    dotnet new grpc -aot
+    dotnet new grpc --aot
     ```
 
 2. Publish the app for a specific [runtime identifier (RID)](/dotnet/core/rid-catalog) using `dotnet publish -r <RID>`.

--- a/aspnetcore/grpc/native-aot.md
+++ b/aspnetcore/grpc/native-aot.md
@@ -30,7 +30,7 @@ AOT compilation happens when the app is published. Native AOT is enabled with th
 
     [!code-xml[](~/grpc/native-aot/Server.csproj?highlight=5)]
 
-    Native AOT can also be enabled by specifying the `-aot` option with the ASP.NET Core gRPC template:
+    Native AOT can also be enabled by specifying the `--aot` option with the ASP.NET Core gRPC template:
 
     ```dotnetcli
     dotnet new grpc --aot


### PR DESCRIPTION
Correct `dotnet new` command for creating an aot grpc app

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/native-aot.md](https://github.com/dotnet/AspNetCore.Docs/blob/eef5255abc9cc1e410f3705b496f652ed4f7750a/aspnetcore/grpc/native-aot.md) | [aspnetcore/grpc/native-aot](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/native-aot?branch=pr-en-us-35153) |


<!-- PREVIEW-TABLE-END -->