### PR TITLE
Add MIA command set to CLI pivot

### DIFF
--- a/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-2.md
@@ -193,6 +193,18 @@ Paste all of the following commands  at the prompt (`>`) of the command shell. W
 
 When you paste multiple commands, all of the commands execute except the last one. The last command doesn't execute until you press <kbd>Enter</kbd> on the keyboard.
 
+```dotnetcli
+dotnet tool install --global dotnet-aspnet-codegenerator
+dotnet tool install --global dotnet-ef
+dotnet add package Microsoft.EntityFrameworkCore.SQLite
+dotnet add package Microsoft.VisualStudio.Web.CodeGeneration.Design
+dotnet add package Microsoft.EntityFrameworkCore.SqlServer
+dotnet add package Microsoft.EntityFrameworkCore.Tools
+dotnet add package Microsoft.AspNetCore.Components.QuickGrid
+dotnet add package Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter
+dotnet add package Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore
+```
+
 :::moniker range=">= aspnetcore-9.0"
 
 <!-- UPDATE 10.0 - Remove this when the 9.0.300 SDK lands. -->


### PR DESCRIPTION
Fixes #35169

Thanks @jcotton42! 🚀 ... Sorry about that! I've walked the article to check on the CLI expereince and didn't know the command block had gone MIA. I suppose that I was working on the article and perhaps removed them without replacing them, or maybe I was working on them and just inadvertently deleted them when they were selected offscreen and hit the Del button on the keyboard. Such things have been known to happen 😈. I'll merge this to main immediately, then I'll update the live article immediately after that. The update should hit the article in about ten minutes or so.