### PR TITLE
Adds .NET 9 sample to mongo app

### DIFF
--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -5,7 +5,7 @@ author: wadepickett
 description: This tutorial demonstrates how to create an ASP.NET Core web API using a MongoDB NoSQL database.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.custom: mvc, engagement-fy23
+ms.custom: mvc
 ms.date: 04/09/2025
 uid: tutorials/first-mongo-app
 ---

--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -6,7 +6,7 @@ description: This tutorial demonstrates how to create an ASP.NET Core web API us
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
 ms.custom: mvc, engagement-fy23
-ms.date: 04/17/2024
+ms.date: 04/09/2025
 uid: tutorials/first-mongo-app
 ---
 # Create a web API with ASP.NET Core and MongoDB

--- a/aspnetcore/tutorials/first-mongo-app.md
+++ b/aspnetcore/tutorials/first-mongo-app.md
@@ -182,7 +182,7 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 1. Add a *Models* directory to the project root.
 1. Add a `Book` class to the *Models* directory with the following code:
 
-   :::code language="csharp" source="first-mongo-app/samples_snapshot/6.x/Book.cs":::
+   :::code language="csharp" source="first-mongo-app/samples_snapshot/9.x/Book.cs":::
 
    In the preceding class, the `Id` property is:
 
@@ -196,48 +196,48 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 
 1. Add the following database configuration values to `appsettings.json`:
 
-   :::code language="json" source="first-mongo-app/samples/6.x/BookStoreApi/appsettings.json" highlight="2-6":::
+   :::code language="json" source="first-mongo-app/samples/9.x/BookStoreApi/appsettings.json" highlight="2-6":::
 
 1. Add a `BookStoreDatabaseSettings` class to the *Models* directory with the following code:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Models/BookStoreDatabaseSettings.cs":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Models/BookStoreDatabaseSettings.cs":::
 
    The preceding `BookStoreDatabaseSettings` class is used to store the `appsettings.json` file's `BookStoreDatabase` property values. The JSON and C# property names are named identically to ease the mapping process.
 
 1. Add the following highlighted code to `Program.cs`:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_BookStoreDatabaseSettings" highlight="4-5":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Program.cs" id="snippet_BookStoreDatabaseSettings" highlight="4-5":::
 
    In the preceding code, the configuration instance to which the `appsettings.json` file's `BookStoreDatabase` section binds is registered in the Dependency Injection (DI) container. For example, the `BookStoreDatabaseSettings` object's `ConnectionString` property is populated with the `BookStoreDatabase:ConnectionString` property in `appsettings.json`.
 
 1. Add the following code to the top of `Program.cs` to resolve the `BookStoreDatabaseSettings` reference:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_UsingModels":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Program.cs" id="snippet_UsingModels":::
 
 ## Add a CRUD operations service
 
 1. Add a *Services* directory to the project root.
 1. Add a `BooksService` class to the *Services* directory with the following code:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_File":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Services/BooksService.cs" id="snippet_File":::
 
    In the preceding code, a `BookStoreDatabaseSettings` instance is retrieved from DI via constructor injection. This technique provides access to the `appsettings.json` configuration values that were added in the [Add a configuration model](#add-a-configuration-model) section.
 
 1. Add the following highlighted code to `Program.cs`:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_BooksService" highlight="7":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Program.cs" id="snippet_BooksService" highlight="7":::
 
    In the preceding code, the `BooksService` class is registered with DI to support constructor injection in consuming classes. The singleton service lifetime is most appropriate because `BooksService` takes a direct dependency on `MongoClient`. Per the official [Mongo Client reuse guidelines](https://mongodb.github.io/mongo-csharp-driver/2.14/reference/driver/connecting/#re-use), `MongoClient` should be registered in DI with a singleton service lifetime.
 
 1. Add the following code to the top of `Program.cs` to resolve the `BooksService` reference:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_UsingServices":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Program.cs" id="snippet_UsingServices":::
 
 The `BooksService` class uses the following `MongoDB.Driver` members to run CRUD operations against the database:
 
 * [MongoClient](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/T_MongoDB_Driver_MongoClient.htm): Reads the server instance for running database operations. The constructor of this class is provided in the MongoDB connection string:
 
-  :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_ctor" highlight="4-5":::
+  :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Services/BooksService.cs" id="snippet_ctor" highlight="4-5":::
 
 * [IMongoDatabase](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/T_MongoDB_Driver_IMongoDatabase.htm): Represents the Mongo database for running operations. This tutorial uses the generic [GetCollection\<TDocument>(collection)](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/M_MongoDB_Driver_IMongoDatabase_GetCollection__1.htm) method on the interface to gain access to data in a specific collection. Run CRUD operations against the collection after this method is called. In the `GetCollection<TDocument>(collection)` method call:
 
@@ -255,7 +255,7 @@ The `BooksService` class uses the following `MongoDB.Driver` members to run CRUD
 
 Add a `BooksController` class to the *Controllers* directory with the following code:
 
-:::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Controllers/BooksController.cs":::
+:::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Controllers/BooksController.cs":::
 
 The preceding web API controller:
 
@@ -311,19 +311,19 @@ To satisfy the preceding requirements, make the following changes:
 
 1. In `Program.cs`, chain the following highlighted code on to the `AddControllers` method call:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_AddControllers" highlight="10-11":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Program.cs" id="snippet_AddControllers" highlight="10-11":::
 
    With the preceding change, property names in the web API's serialized JSON response match their corresponding property names in the CLR object type. For example, the `Book` class's `Author` property serializes as `Author` instead of `author`.
 
 1. In `Models/Book.cs`, annotate the `BookName` property with the [`[JsonPropertyName]`](xref:System.Text.Json.Serialization.JsonPropertyNameAttribute) attribute:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Models/Book.cs" id="snippet_BookName" highlight="2":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Models/Book.cs" id="snippet_BookName" highlight="2":::
 
    The `[JsonPropertyName]` attribute's value of `Name` represents the property name in the web API's serialized JSON response.
 
 1. Add the following code to the top of `Models/Book.cs` to resolve the `[JsonProperty]` attribute reference:
 
-   :::code language="csharp" source="first-mongo-app/samples/6.x/BookStoreApi/Models/Book.cs" id="snippet_UsingSystemTextJsonSerialization":::
+   :::code language="csharp" source="first-mongo-app/samples/9.x/BookStoreApi/Models/Book.cs" id="snippet_UsingSystemTextJsonSerialization":::
 
 1. Repeat the steps defined in the [Test the web API](#test-the-web-api) section. Notice the difference in JSON property names.
 
@@ -333,7 +333,7 @@ To satisfy the preceding requirements, make the following changes:
 
 ## Additional resources
 
-* [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/first-mongo-app/samples/8.x/BookStoreApi) ([how to download](xref:index#how-to-download-a-sample))
+* [View or download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi) ([how to download](xref:index#how-to-download-a-sample))
 * <xref:web-api/index>
 * <xref:web-api/action-return-types>
 * [Create a web API with ASP.NET Core](/training/modules/build-web-api-aspnet-core/)

--- a/aspnetcore/tutorials/first-mongo-app/includes/first-mongo-app8.md
+++ b/aspnetcore/tutorials/first-mongo-app/includes/first-mongo-app8.md
@@ -175,7 +175,7 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 1. Add a *Models* directory to the project root.
 1. Add a `Book` class to the *Models* directory with the following code:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples_snapshot/6.x/Book.cs":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples_snapshot/8.x/Book.cs":::
 
    In the preceding class, the `Id` property is:
 
@@ -189,48 +189,48 @@ Use the previously installed MongoDB Shell in the following steps to create a da
 
 1. Add the following database configuration values to `appsettings.json`:
 
-   :::code language="json" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/appsettings.json" highlight="2-6":::
+   :::code language="json" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/appsettings.json" highlight="2-6":::
 
 1. Add a `BookStoreDatabaseSettings` class to the *Models* directory with the following code:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Models/BookStoreDatabaseSettings.cs":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Models/BookStoreDatabaseSettings.cs":::
 
    The preceding `BookStoreDatabaseSettings` class is used to store the `appsettings.json` file's `BookStoreDatabase` property values. The JSON and C# property names are named identically to ease the mapping process.
 
 1. Add the following highlighted code to `Program.cs`:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_BookStoreDatabaseSettings" highlight="4-5":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Program.cs" id="snippet_BookStoreDatabaseSettings" highlight="4-5":::
 
    In the preceding code, the configuration instance to which the `appsettings.json` file's `BookStoreDatabase` section binds is registered in the Dependency Injection (DI) container. For example, the `BookStoreDatabaseSettings` object's `ConnectionString` property is populated with the `BookStoreDatabase:ConnectionString` property in `appsettings.json`.
 
 1. Add the following code to the top of `Program.cs` to resolve the `BookStoreDatabaseSettings` reference:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_UsingModels":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Program.cs" id="snippet_UsingModels":::
 
 ## Add a CRUD operations service
 
 1. Add a *Services* directory to the project root.
 1. Add a `BooksService` class to the *Services* directory with the following code:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_File":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Services/BooksService.cs" id="snippet_File":::
 
    In the preceding code, a `BookStoreDatabaseSettings` instance is retrieved from DI via constructor injection. This technique provides access to the `appsettings.json` configuration values that were added in the [Add a configuration model](#add-a-configuration-model) section.
 
 1. Add the following highlighted code to `Program.cs`:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_BooksService" highlight="7":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Program.cs" id="snippet_BooksService" highlight="7":::
 
    In the preceding code, the `BooksService` class is registered with DI to support constructor injection in consuming classes. The singleton service lifetime is most appropriate because `BooksService` takes a direct dependency on `MongoClient`. Per the official [Mongo Client reuse guidelines](https://mongodb.github.io/mongo-csharp-driver/2.14/reference/driver/connecting/#re-use), `MongoClient` should be registered in DI with a singleton service lifetime.
 
 1. Add the following code to the top of `Program.cs` to resolve the `BooksService` reference:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_UsingServices":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Program.cs" id="snippet_UsingServices":::
 
 The `BooksService` class uses the following `MongoDB.Driver` members to run CRUD operations against the database:
 
 * [MongoClient](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/T_MongoDB_Driver_MongoClient.htm): Reads the server instance for running database operations. The constructor of this class is provided in the MongoDB connection string:
 
-  :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Services/BooksService.cs" id="snippet_ctor" highlight="4-5":::
+  :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Services/BooksService.cs" id="snippet_ctor" highlight="4-5":::
 
 * [IMongoDatabase](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/T_MongoDB_Driver_IMongoDatabase.htm): Represents the Mongo database for running operations. This tutorial uses the generic [GetCollection\<TDocument>(collection)](https://mongodb.github.io/mongo-csharp-driver/2.14/apidocs/html/M_MongoDB_Driver_IMongoDatabase_GetCollection__1.htm) method on the interface to gain access to data in a specific collection. Run CRUD operations against the collection after this method is called. In the `GetCollection<TDocument>(collection)` method call:
 
@@ -248,7 +248,7 @@ The `BooksService` class uses the following `MongoDB.Driver` members to run CRUD
 
 Add a `BooksController` class to the *Controllers* directory with the following code:
 
-:::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Controllers/BooksController.cs":::
+:::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Controllers/BooksController.cs":::
 
 The preceding web API controller:
 
@@ -304,19 +304,19 @@ To satisfy the preceding requirements, make the following changes:
 
 1. In `Program.cs`, chain the following highlighted code on to the `AddControllers` method call:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Program.cs" id="snippet_AddControllers" highlight="10-11":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Program.cs" id="snippet_AddControllers" highlight="10-11":::
 
    With the preceding change, property names in the web API's serialized JSON response match their corresponding property names in the CLR object type. For example, the `Book` class's `Author` property serializes as `Author` instead of `author`.
 
 1. In `Models/Book.cs`, annotate the `BookName` property with the [`[JsonPropertyName]`](xref:System.Text.Json.Serialization.JsonPropertyNameAttribute) attribute:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Models/Book.cs" id="snippet_BookName" highlight="2":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Models/Book.cs" id="snippet_BookName" highlight="2":::
 
    The `[JsonPropertyName]` attribute's value of `Name` represents the property name in the web API's serialized JSON response.
 
 1. Add the following code to the top of `Models/Book.cs` to resolve the `[JsonProperty]` attribute reference:
 
-   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/6.x/BookStoreApi/Models/Book.cs" id="snippet_UsingSystemTextJsonSerialization":::
+   :::code language="csharp" source="~/tutorials/first-mongo-app/samples/8.x/BookStoreApi/Models/Book.cs" id="snippet_UsingSystemTextJsonSerialization":::
 
 1. Repeat the steps defined in the [Test the web API](#test-the-web-api) section. Notice the difference in JSON property names.
 

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/BookStoreApi.csproj
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/BookStoreApi.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/BookStoreApi.csproj
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/BookStoreApi.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
-    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
+    <PackageReference Include="MongoDB.Driver" Version="3.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
   </ItemGroup>
 
 </Project>

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Controllers/BooksController.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Controllers/BooksController.cs
@@ -1,0 +1,72 @@
+﻿using BookStoreApi.Models;
+using BookStoreApi.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BookStoreApi.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class BooksController : ControllerBase
+{
+    private readonly BooksService _booksService;
+
+    public BooksController(BooksService booksService) =>
+        _booksService = booksService;
+
+    [HttpGet]
+    public async Task<List<Book>> Get() =>
+        await _booksService.GetAsync();
+
+    [HttpGet("{id:length(24)}")]
+    public async Task<ActionResult<Book>> Get(string id)
+    {
+        var book = await _booksService.GetAsync(id);
+
+        if (book is null)
+        {
+            return NotFound();
+        }
+
+        return book;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Post(Book newBook)
+    {
+        await _booksService.CreateAsync(newBook);
+
+        return CreatedAtAction(nameof(Get), new { id = newBook.Id }, newBook);
+    }
+
+    [HttpPut("{id:length(24)}")]
+    public async Task<IActionResult> Update(string id, Book updatedBook)
+    {
+        var book = await _booksService.GetAsync(id);
+
+        if (book is null)
+        {
+            return NotFound();
+        }
+
+        updatedBook.Id = book.Id;
+
+        await _booksService.UpdateAsync(id, updatedBook);
+
+        return NoContent();
+    }
+
+    [HttpDelete("{id:length(24)}")]
+    public async Task<IActionResult> Delete(string id)
+    {
+        var book = await _booksService.GetAsync(id);
+
+        if (book is null)
+        {
+            return NotFound();
+        }
+
+        await _booksService.RemoveAsync(id);
+
+        return NoContent();
+    }
+}

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Controllers/WeatherForecastController.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Controllers/WeatherForecastController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace BookStoreApi.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class WeatherForecastController : ControllerBase
+    {
+        private static readonly string[] Summaries = new[]
+        {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+    };
+
+        private readonly ILogger<WeatherForecastController> _logger;
+
+        public WeatherForecastController(ILogger<WeatherForecastController> logger)
+        {
+            _logger = logger;
+        }
+
+        [HttpGet(Name = "GetWeatherForecast")]
+        public IEnumerable<WeatherForecast> Get()
+        {
+            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+            })
+            .ToArray();
+        }
+    }
+}

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Controllers/WeatherForecastController.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Controllers/WeatherForecastController.cs
@@ -1,33 +1,32 @@
 using Microsoft.AspNetCore.Mvc;
 
-namespace BookStoreApi.Controllers
+namespace BookStoreApi.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class WeatherForecastController : ControllerBase
 {
-    [ApiController]
-    [Route("[controller]")]
-    public class WeatherForecastController : ControllerBase
+    private static readonly string[] Summaries = new[]
     {
-        private static readonly string[] Summaries = new[]
-        {
         "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
     };
 
-        private readonly ILogger<WeatherForecastController> _logger;
+    private readonly ILogger<WeatherForecastController> _logger;
 
-        public WeatherForecastController(ILogger<WeatherForecastController> logger)
-        {
-            _logger = logger;
-        }
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        _logger = logger;
+    }
 
-        [HttpGet(Name = "GetWeatherForecast")]
-        public IEnumerable<WeatherForecast> Get()
+    [HttpGet(Name = "GetWeatherForecast")]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
         {
-            return Enumerable.Range(1, 5).Select(index => new WeatherForecast
-            {
-                Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-                TemperatureC = Random.Shared.Next(-20, 55),
-                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
-            })
-            .ToArray();
-        }
+            Date = DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            TemperatureC = Random.Shared.Next(-20, 55),
+            Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+        })
+        .ToArray();
     }
 }

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Models/Book.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Models/Book.cs
@@ -1,0 +1,26 @@
+﻿// <snippet_UsingSystemTextJsonSerialization>
+using System.Text.Json.Serialization;
+// </snippet_UsingSystemTextJsonSerialization>
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace BookStoreApi.Models;
+
+public class Book
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string? Id { get; set; }
+
+    // <snippet_BookName>
+    [BsonElement("Name")]
+    [JsonPropertyName("Name")]
+    public string BookName { get; set; } = null!;
+    // </snippet_BookName>
+
+    public decimal Price { get; set; }
+
+    public string Category { get; set; } = null!;
+
+    public string Author { get; set; } = null!;
+}

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Models/BookStoreDatabaseSettings.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Models/BookStoreDatabaseSettings.cs
@@ -1,0 +1,10 @@
+﻿namespace BookStoreApi.Models;
+
+public class BookStoreDatabaseSettings
+{
+    public string ConnectionString { get; set; } = null!;
+
+    public string DatabaseName { get; set; } = null!;
+
+    public string BooksCollectionName { get; set; } = null!;
+}

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Program.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Program.cs
@@ -1,0 +1,44 @@
+// <snippet_UsingModels>
+using BookStoreApi.Models;
+// </snippet_UsingModels>
+// <snippet_UsingServices>
+using BookStoreApi.Services;
+// </snippet_UsingServices>
+
+// <snippet_AddControllers>
+// <snippet_BooksService>
+// <snippet_BookStoreDatabaseSettings>
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.Configure<BookStoreDatabaseSettings>(
+    builder.Configuration.GetSection("BookStoreDatabase"));
+// </snippet_BookStoreDatabaseSettings>
+
+builder.Services.AddSingleton<BooksService>();
+// </snippet_BooksService>
+
+builder.Services.AddControllers()
+    .AddJsonOptions(
+        options => options.JsonSerializerOptions.PropertyNamingPolicy = null);
+// </snippet_AddControllers>
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Program.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Program.cs
@@ -23,16 +23,18 @@ builder.Services.AddControllers()
         options => options.JsonSerializerOptions.PropertyNamingPolicy = null);
 // </snippet_AddControllers>
 
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
+    app.MapOpenApi();
+    app.UseSwaggerUI(options =>
+    {
+        options.SwaggerEndpoint("/openapi/v1.json", "v1");
+    });
 }
 
 app.UseHttpsRedirection();

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Services/BooksService.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/Services/BooksService.cs
@@ -1,0 +1,42 @@
+﻿// <snippet_File>
+using BookStoreApi.Models;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace BookStoreApi.Services;
+
+public class BooksService
+{
+    private readonly IMongoCollection<Book> _booksCollection;
+
+    // <snippet_ctor>
+    public BooksService(
+        IOptions<BookStoreDatabaseSettings> bookStoreDatabaseSettings)
+    {
+        var mongoClient = new MongoClient(
+            bookStoreDatabaseSettings.Value.ConnectionString);
+
+        var mongoDatabase = mongoClient.GetDatabase(
+            bookStoreDatabaseSettings.Value.DatabaseName);
+
+        _booksCollection = mongoDatabase.GetCollection<Book>(
+            bookStoreDatabaseSettings.Value.BooksCollectionName);
+    }
+    // </snippet_ctor>
+
+    public async Task<List<Book>> GetAsync() =>
+        await _booksCollection.Find(_ => true).ToListAsync();
+
+    public async Task<Book?> GetAsync(string id) =>
+        await _booksCollection.Find(x => x.Id == id).FirstOrDefaultAsync();
+
+    public async Task CreateAsync(Book newBook) =>
+        await _booksCollection.InsertOneAsync(newBook);
+
+    public async Task UpdateAsync(string id, Book updatedBook) =>
+        await _booksCollection.ReplaceOneAsync(x => x.Id == id, updatedBook);
+
+    public async Task RemoveAsync(string id) =>
+        await _booksCollection.DeleteOneAsync(x => x.Id == id);
+}
+// </snippet_File>

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/WeatherForecast.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/WeatherForecast.cs
@@ -1,0 +1,13 @@
+namespace BookStoreApi
+{
+    public class WeatherForecast
+    {
+        public DateOnly Date { get; set; }
+
+        public int TemperatureC { get; set; }
+
+        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+
+        public string? Summary { get; set; }
+    }
+}

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/WeatherForecast.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/WeatherForecast.cs
@@ -1,13 +1,12 @@
-namespace BookStoreApi
+namespace BookStoreApi;
+
+public class WeatherForecast
 {
-    public class WeatherForecast
-    {
-        public DateOnly Date { get; set; }
+    public DateOnly Date { get; set; }
 
-        public int TemperatureC { get; set; }
+    public int TemperatureC { get; set; }
 
-        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
-        public string? Summary { get; set; }
-    }
+    public string? Summary { get; set; }
 }

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/appsettings.Development.json
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/appsettings.json
+++ b/aspnetcore/tutorials/first-mongo-app/samples/9.x/BookStoreApi/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "BookStoreDatabase": {
+    "ConnectionString": "mongodb://localhost:27017",
+    "DatabaseName": "BookStore",
+    "BooksCollectionName": "Books"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/aspnetcore/tutorials/first-mongo-app/samples_snapshot/9.x/Book.cs
+++ b/aspnetcore/tutorials/first-mongo-app/samples_snapshot/9.x/Book.cs
@@ -1,0 +1,20 @@
+﻿using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace BookStoreApi.Models;
+
+public class Book
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string? Id { get; set; }
+
+    [BsonElement("Name")]
+    public string BookName { get; set; } = null!;
+
+    public decimal Price { get; set; }
+
+    public string Category { get; set; } = null!;
+
+    public string Author { get; set; } = null!;
+}


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #35179

After the upgrade, the application can still be rendered via swagger and retrieve data:

![image](https://github.com/user-attachments/assets/7f38a97d-9250-47d6-b840-116db180a589)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mongo-app.md](https://github.com/dotnet/AspNetCore.Docs/blob/b282bb896a96d2cfa7d9a09a227785af4cfa36dc/aspnetcore/tutorials/first-mongo-app.md) | [aspnetcore/tutorials/first-mongo-app](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mongo-app?branch=pr-en-us-35189) |


<!-- PREVIEW-TABLE-END -->