### PR TITLE
Prep only: WN .NET10 Prev 3: webapiaot template adds OpenAPI

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10/includes/webapiaotTemplateAddedOpenAPI.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/webapiaotTemplateAddedOpenAPI.md
@@ -1,0 +1,5 @@
+### Add Microsoft.AspNetCore.OpenApi to the webapiaot template
+
+Support for OpenAPI document generation with the Microsoft.AspNetCore.OpenApi packagte is now included by default in the webapiaot project template. This support can be disabled if desired by using the `--no-openapi` flag when creating a new project.
+
+This was a community contribution by @sander1095. Thanks for this contribution!


### PR DESCRIPTION
Contributes to #34948 

Prep only.  Moving draft of _Add Microsoft.AspNetCore.OpenApi to the webapiaot template_ in issue discussion of #34948 to an include as is so it can be compared in the next PR that has its edit pass.