### PR TITLE
fixes links to grpc repo docs

### DIFF
--- a/aspnetcore/fundamentals/servers/yarp/grpc.md
+++ b/aspnetcore/fundamentals/servers/yarp/grpc.md
@@ -60,7 +60,7 @@ The following shows how to configure the outgoing proxy request to use HTTP/2:
 
 [gRPC-Web](https://grpc.io/docs/platforms/web/basics/) is an alternative wire-format for gRPC that's compatible with HTTP/1.1.
 
-* [`application/grpc`](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2) - gRPC over HTTP/2 is how gRPC is typically used.
-* [`application/grpc-web`](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB) - gRPC-Web modifies the gRPC protocol to be compatible with HTTP/1.1. gRPC-Web can be used in more places. gRPC-Web can be used by browser apps and in networks without complete support for HTTP/2. Two advanced gRPC features are not supported: client streaming and bidirectional streaming.
+* [`application/grpc`](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md) - gRPC over HTTP/2 is how gRPC is typically used.
+* [`application/grpc-web`](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md) - gRPC-Web modifies the gRPC protocol to be compatible with HTTP/1.1. gRPC-Web can be used in more places. gRPC-Web can be used by browser apps and in networks without complete support for HTTP/2. Two advanced gRPC features are not supported: client streaming and bidirectional streaming.
 
 gRPC-Web can be proxied by YARP's default configuration without any special considerations.


### PR DESCRIPTION
fixes links to grpc docs, was missing .md extension

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/yarp/grpc.md](https://github.com/dotnet/AspNetCore.Docs/blob/d204c821ff2a2e9baa6efaefab41d309afee121b/aspnetcore/fundamentals/servers/yarp/grpc.md) | [YARP Proxying gRPC](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/yarp/grpc?branch=pr-en-us-35211) |

<!-- PREVIEW-TABLE-END -->