### PR TITLE
move `TrimMode` configuration to `PropertyGroup`

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -33,9 +33,9 @@ To configure the IL Trimmer, see the [Trimming options](/dotnet/core/deploying/t
 The default trimmer granularity for Blazor apps is `partial`. To trim all assemblies, change the granularity to `full` in the app's project file:
 
 ```xml
-<ItemGroup>
+<PropertyGroup>
   <TrimMode>full</TrimMode>
-</ItemGroup>
+</PropertyGroup>
 ```
 
 For more information, see [Trimming options (.NET documentation)](/dotnet/core/deploying/trimming/trimming-options#trimming-granularity).


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

It seems that the `TrimMode` property was mistakenly placed under `ItemGroup` which doesn't work correctly.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/configure-trimmer.md](https://github.com/dotnet/AspNetCore.Docs/blob/e6a2e830a6335b370a35da6ee37b360b8255535c/aspnetcore/blazor/host-and-deploy/configure-trimmer.md) | [Configure the Trimmer for ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/configure-trimmer?branch=pr-en-us-35216) |

<!-- PREVIEW-TABLE-END -->