### PR TITLE
Include TryGetValue in activities that can trigger background scan

### DIFF
--- a/aspnetcore/performance/caching/memory.md
+++ b/aspnetcore/performance/caching/memory.md
@@ -160,7 +160,7 @@ Using a <xref:System.Threading.CancellationTokenSource> allows multiple cache en
 
 ## Additional notes
 
-* Expiration doesn't happen in the background. There's no timer that actively scans the cache for expired items. Any activity on the cache (`Get`, `Set`, `Remove`) can trigger a background scan for expired items. A timer on the `CancellationTokenSource` (<xref:System.Threading.CancellationTokenSource.CancelAfter%2A>) also removes the entry and triggers a scan for expired items. The following example uses <xref:System.Threading.CancellationTokenSource.%23ctor(System.TimeSpan)> for the registered token. When this token fires, it removes the entry immediately and fires the eviction callbacks:
+* Expiration doesn't happen in the background. There's no timer that actively scans the cache for expired items. Any activity on the cache (`Get`, `TryGetValue`, `Set`, `Remove`) can trigger a background scan for expired items. A timer on the `CancellationTokenSource` (<xref:System.Threading.CancellationTokenSource.CancelAfter%2A>) also removes the entry and triggers a scan for expired items. The following example uses <xref:System.Threading.CancellationTokenSource.%23ctor(System.TimeSpan)> for the registered token. When this token fires, it removes the entry immediately and fires the eviction callbacks:
 
   :::code language="csharp" source="memory/samples/6.x/CachingMemorySample/Snippets/Pages/Index.cshtml.cs" id="snippet_OnGeCacheExpirationToken":::
 


### PR DESCRIPTION
`MemoryCache.TryGetValue` can trigger a background scan for expired items.

https://github.com/dotnet/runtime/blob/d0e28e1c83d24ea41f7965d13dc01842ba1cf05a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs#L284

Fixes #35250
<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/caching/memory.md](https://github.com/dotnet/AspNetCore.Docs/blob/3d748900e26c58e64491fa11d136ae199a6764c6/aspnetcore/performance/caching/memory.md) | [Cache in-memory in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/caching/memory?branch=pr-en-us-35245) |

<!-- PREVIEW-TABLE-END -->