### PR TITLE
ASP.NET Core does not collect metadata from XML doc comments.

### DIFF
--- a/aspnetcore/fundamentals/openapi/include-metadata.md
+++ b/aspnetcore/fundamentals/openapi/include-metadata.md
@@ -33,6 +33,7 @@ The following table provides an overview of the metadata collected and the strat
 | responses | [`[Produces]`](xref:Microsoft.AspNetCore.Mvc.ProducesAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.Produces%2A>, <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ProducesProblem%2A> | <xref:Microsoft.AspNetCore.Http.TypedResults> |
 | Excluding endpoints | [`[ExcludeFromDescription]`](xref:Microsoft.AspNetCore.Routing.ExcludeFromDescriptionAttribute), [`[ApiExplorerSettings]`](xref:Microsoft.AspNetCore.Mvc.ApiExplorerSettingsAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ExcludeFromDescription%2A> | |
 
+ASP.NET Core can also collect metadata from XML doc comments. See <xref:fundamentals/openapi//aspnet-openapi-xml> for more details.
 The following sections demonstrate how to include metadata in an app to customize the generated OpenAPI document.
 
 ### Summary and description

--- a/aspnetcore/fundamentals/openapi/include-metadata.md
+++ b/aspnetcore/fundamentals/openapi/include-metadata.md
@@ -33,7 +33,7 @@ The following table provides an overview of the metadata collected and the strat
 | responses | [`[Produces]`](xref:Microsoft.AspNetCore.Mvc.ProducesAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.Produces%2A>, <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ProducesProblem%2A> | <xref:Microsoft.AspNetCore.Http.TypedResults> |
 | Excluding endpoints | [`[ExcludeFromDescription]`](xref:Microsoft.AspNetCore.Routing.ExcludeFromDescriptionAttribute), [`[ApiExplorerSettings]`](xref:Microsoft.AspNetCore.Mvc.ApiExplorerSettingsAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ExcludeFromDescription%2A> | |
 
-ASP.NET Core can also collect metadata from XML doc comments. See <xref:fundamentals/openapi/aspnet-openapi-xml> for more details.
+ASP.NET Core can also collect metadata from XML doc comments. For more information, see <xref:fundamentals/openapi/aspnet-openapi-xml> for more details.
 The following sections demonstrate how to include metadata in an app to customize the generated OpenAPI document.
 
 ### Summary and description

--- a/aspnetcore/fundamentals/openapi/include-metadata.md
+++ b/aspnetcore/fundamentals/openapi/include-metadata.md
@@ -33,8 +33,6 @@ The following table provides an overview of the metadata collected and the strat
 | responses | [`[Produces]`](xref:Microsoft.AspNetCore.Mvc.ProducesAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.Produces%2A>, <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ProducesProblem%2A> | <xref:Microsoft.AspNetCore.Http.TypedResults> |
 | Excluding endpoints | [`[ExcludeFromDescription]`](xref:Microsoft.AspNetCore.Routing.ExcludeFromDescriptionAttribute), [`[ApiExplorerSettings]`](xref:Microsoft.AspNetCore.Mvc.ApiExplorerSettingsAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ExcludeFromDescription%2A> | |
 
-ASP.NET Core does not collect metadata from XML doc comments.
-
 The following sections demonstrate how to include metadata in an app to customize the generated OpenAPI document.
 
 ### Summary and description

--- a/aspnetcore/fundamentals/openapi/include-metadata.md
+++ b/aspnetcore/fundamentals/openapi/include-metadata.md
@@ -34,6 +34,7 @@ The following table provides an overview of the metadata collected and the strat
 | Excluding endpoints | [`[ExcludeFromDescription]`](xref:Microsoft.AspNetCore.Routing.ExcludeFromDescriptionAttribute), [`[ApiExplorerSettings]`](xref:Microsoft.AspNetCore.Mvc.ApiExplorerSettingsAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ExcludeFromDescription%2A> | |
 
 ASP.NET Core can also collect metadata from XML doc comments. For more information, see <xref:fundamentals/openapi/aspnet-openapi-xml> for more details.
+
 The following sections demonstrate how to include metadata in an app to customize the generated OpenAPI document.
 
 ### Summary and description

--- a/aspnetcore/fundamentals/openapi/include-metadata.md
+++ b/aspnetcore/fundamentals/openapi/include-metadata.md
@@ -33,7 +33,7 @@ The following table provides an overview of the metadata collected and the strat
 | responses | [`[Produces]`](xref:Microsoft.AspNetCore.Mvc.ProducesAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.Produces%2A>, <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ProducesProblem%2A> | <xref:Microsoft.AspNetCore.Http.TypedResults> |
 | Excluding endpoints | [`[ExcludeFromDescription]`](xref:Microsoft.AspNetCore.Routing.ExcludeFromDescriptionAttribute), [`[ApiExplorerSettings]`](xref:Microsoft.AspNetCore.Mvc.ApiExplorerSettingsAttribute) | <xref:Microsoft.AspNetCore.Http.OpenApiRouteHandlerBuilderExtensions.ExcludeFromDescription%2A> | |
 
-ASP.NET Core can also collect metadata from XML doc comments. See <xref:fundamentals/openapi//aspnet-openapi-xml> for more details.
+ASP.NET Core can also collect metadata from XML doc comments. See <xref:fundamentals/openapi/aspnet-openapi-xml> for more details.
 The following sections demonstrate how to include metadata in an app to customize the generated OpenAPI document.
 
 ### Summary and description


### PR DESCRIPTION
Fixes #35081

@sander1095 please review

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/include-metadata.md](https://github.com/dotnet/AspNetCore.Docs/blob/8f619bd6a7d2825db2f1f95663c3b1820b0c4103/aspnetcore/fundamentals/openapi/include-metadata.md) | [aspnetcore/fundamentals/openapi/include-metadata](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/include-metadata?branch=pr-en-us-35257) |


<!-- PREVIEW-TABLE-END -->