### PR TITLE
[Pre4] Preloaded Blazor framework assets

### DIFF
--- a/aspnetcore/blazor/fundamentals/static-files.md
+++ b/aspnetcore/blazor/fundamentals/static-files.md
@@ -20,6 +20,30 @@ For general information on serving static files with Map Static Assets routing e
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-10.0"
+
+## Preloaded Blazor framework static assets
+
+In Blazor Web Apps, framework static assets are automatically preloaded using [`Link` headers](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Link), which allows the browser to preload resources before the initial page is fetched and rendered.
+
+In standalone Blazor WebAssembly apps, framework assets are scheduled for high priority downloading and caching early in browser `index.html` page processing when:
+
+* The `OverrideHtmlAssetPlaceholders` MSBuild property in the app's project file (`.csproj`) is set to `true`:
+
+  ```xml
+  <PropertyGroup>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+  </PropertyGroup>
+  ```
+
+* The following `<link>` element containing [`rel="preload"`](https://developer.mozilla.org/docs/Web/HTML/Reference/Attributes/rel/preload) is present in the `<head>` content of `wwwroot/index.html`:
+
+  ```html
+  <link rel="preload" id="webassembly" />
+  ```
+
+:::moniker-end
+
 ## Static asset delivery in server-side Blazor apps
 
 :::moniker range=">= aspnetcore-9.0"

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -351,14 +351,20 @@ The following synchronous methods are available on <xref:Microsoft.JSInterop.IJS
 
 For more information, see the following sections of the *Call JavaScript functions from .NET methods* article:
 
-* [Create an instance of a JS object using a constructor function](xref:blazor/js-interop/call-javascript-from-dotnet#create-an-instance-of-a-js-object-using-a-constructor-function)
-* [Read or modify the value of a JS object property](xref:blazor/js-interop/call-javascript-from-dotnet#read-or-modify-the-value-of-a-js-object-property)
+* [Create an instance of a JS object using a constructor function](xref:blazor/js-interop/call-javascript-from-dotnet?view=aspnetcore-10.0#create-an-instance-of-a-js-object-using-a-constructor-function)
+* [Read or modify the value of a JS object property](xref:blazor/js-interop/call-javascript-from-dotnet?view=aspnetcore-10.0#read-or-modify-the-value-of-a-js-object-property)
 
 ### Blazor WebAssembly performance profiling and diagnostic counters
 
 New performance profiling and diagnostic counters are available for Blazor WebAssembly apps. For more information, see the following articles:
 
-* <xref:blazor/performance/webassembly-browser-developer-tools>
-* <xref:blazor/performance/webassembly-event-pipe>
+* <xref:blazor/performance/webassembly-browser-developer-tools?view=aspnetcore-10.0>
+* <xref:blazor/performance/webassembly-event-pipe?view=aspnetcore-10.0>
+
+## Preloaded Blazor framework static assets
+
+In Blazor Web Apps, framework static assets are automatically preloaded using [`Link` headers](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Link), which allows the browser to preload resources before the initial page is fetched and rendered. In standalone Blazor WebAssembly apps, framework assets are scheduled for high priority downloading and caching early in browser `index.html` page processing.
+
+For more information, see <xref:blazor/fundamentals/static-files?view=aspnetcore-10.0#preloaded-blazor-framework-static-assets>.
 
 -->


### PR DESCRIPTION
Fixes #35273

The *Migration* article will explain adding the markup to standalone WASM apps, and that guidance is typically created much later in the release cycle (RC time frame).