### PR TITLE
WN: Prep Only: OpenApiSchemas in transformers moved to include

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -53,8 +53,6 @@ This section describes new features for OpenAPI.
 
 [!INCLUDE[](~/release-notes/aspnetcore-10/includes/webapiaotTemplateAddedOpenAPI.md)]
 
-[!INCLUDE[](~/release-notes/aspnetcore-10/includes/OpenApiSchemasInTransformers.md)]
-
 ## Authentication and authorization
 
 This section describes new features for authentication and authorization.

--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -53,6 +53,8 @@ This section describes new features for OpenAPI.
 
 [!INCLUDE[](~/release-notes/aspnetcore-10/includes/webapiaotTemplateAddedOpenAPI.md)]
 
+[!INCLUDE[](~/release-notes/aspnetcore-10/includes/OpenApiSchemasInTransformers.md)]
+
 ## Authentication and authorization
 
 This section describes new features for authentication and authorization.

--- a/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiSchemasInTransformers.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiSchemasInTransformers.md
@@ -1,0 +1,42 @@
+### Support for generating OpenApiSchemas in transformers
+<!-- https://github.com/dotnet/aspnetcore/pull/61050 -->
+
+Developers can now generate a schema for a C# type, using the same logic as ASP.NET Core OpenAPI document generation,
+and add it to the OpenAPI document. The schema can then be referenced from elsewhere in the OpenAPI document.
+
+The context passed to document, operation, and schema transformers now has a `GetOrCreateSchemaAsync` method that can be used to generate a schema for a type.
+This method also has an optional `ApiParameterDescription` parameter to specify additional metadata for the generated schema.
+
+To support adding the schema to the OpenAPI document, a `Document` property has been added to the Operation and Schema transformer contexts. This allows any transformer to add a schema to the OpenAPI document using the document's `AddComponent` method.
+
+#### Example
+
+To use this feature in an document, operation, or schema transformer, create the schema using the `GetOrCreateSchemaAsync` method provided in the context
+and add it to the OpenAPI document using the document's `AddComponent` method.
+
+<!-- In the docs, highlight the lines with the call to "GetOrCreateSchemaAsync" and "AddComponent" -->
+```csharp
+builder.Services.AddOpenApi(options =>
+{
+    options.AddOperationTransformer(async (operation, context, cancellationToken) =>
+    {
+        // Generate schema for error responses
+        var errorSchema = await context.GetOrCreateSchemaAsync(typeof(ProblemDetails), null, cancellationToken);
+        context.Document?.AddComponent("Error", errorSchema);
+
+        operation.Responses ??= new OpenApiResponses();
+        // Add a "4XX" response to the operation with the newly created schema
+        operation.Responses["4XX"] = new OpenApiResponse
+        {
+            Description = "Bad Request",
+            Content = new Dictionary<string, OpenApiMediaType>
+            {
+                ["application/problem+json"] = new OpenApiMediaType
+                {
+                    Schema = new OpenApiSchemaReference("Error", context.Document)
+                }
+            }
+        };
+    });
+});
+```


### PR DESCRIPTION
Contributes to #35393

**Prep only**: Moving initial draft from comments in WN to an include so a diff in edits can be seen after it is worked on in a new PR.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/8adb9b37a44cb4d48070afc9ff857cadf90629d6/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-35413) |

<!-- PREVIEW-TABLE-END -->