### PR TITLE
Clarify when the `InnerHandler` must be assigned

### DIFF
--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -387,7 +387,10 @@ builder.Services.AddScoped(sp => new HttpClient(
 });
 ```
 
-In the preceding code, the scopes `example.read` and `example.write` are generic examples not meant to reflect valid scopes for any particular provider.
+In the preceding code:
+
+* The scopes `example.read` and `example.write` are generic examples not meant to reflect valid scopes for any particular provider.
+* <xref:System.Net.Http.IHttpClientFactory> isn't used to create <xref:System.Net.Http.HttpClient> instances, so an <xref:System.Net.Http.HttpClientHandler> instance is manually created and assigned to the <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler>'s <xref:System.Net.Http.DelegatingHandler.InnerHandler%2A?displayProperty=nameWithType>.
 
 :::moniker range="< aspnetcore-8.0"
 

--- a/aspnetcore/blazor/security/webassembly/additional-scenarios.md
+++ b/aspnetcore/blazor/security/webassembly/additional-scenarios.md
@@ -300,6 +300,15 @@ public class CustomAuthorizationMessageHandler : AuthorizationMessageHandler
 }
 ```
 
+> [!NOTE]
+> In this section, the preceding message handler is used when a configured <xref:System.Net.Http.HttpClient> is created from an injected <xref:System.Net.Http.IHttpClientFactory>. If you don't use an <xref:System.Net.Http.IHttpClientFactory>, you must create an <xref:System.Net.Http.HttpClientHandler> instance and assign it to the <xref:Microsoft.AspNetCore.Components.WebAssembly.Authentication.AuthorizationMessageHandler>'s <xref:System.Net.Http.DelegatingHandler.InnerHandler%2A?displayProperty=nameWithType>:
+>
+> ```csharp
+> InnerHandler = new HttpClientHandler();
+> ```
+>
+> You don't need to make the preceding <xref:System.Net.Http.DelegatingHandler.InnerHandler> assignment if you use <xref:System.Net.Http.IHttpClientFactory>, as the `ExampleAPIMethod` call later in this section demonstrates.
+
 In the preceding code, the scopes `example.read` and `example.write` are generic examples not meant to reflect valid scopes for any particular provider.
 
 In the `Program` file, `CustomAuthorizationMessageHandler` is registered as a transient service and is configured as the <xref:System.Net.Http.DelegatingHandler> for outgoing <xref:System.Net.Http.HttpResponseMessage> instances made by a named <xref:System.Net.Http.HttpClient>.


### PR DESCRIPTION
Fixes #35416

Thanks @snew3687! 🚀 ... Let's see if this clarification will work for folks. It seems clear now that the reason I haven't been pinged by the community on this before now is that this specific example shouldn't require it. It's when devs don't use `IHttpClientFactory` that they'll hit the 💥. Since this section's example uses `IHttpClientFactory`, it has been mostly ok without mentioning it. Where it was required in the next section, it was called out several years ago ...

https://learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/additional-scenarios?view=aspnetcore-9.0#configure-authorizationmessagehandler

... and I'm adding a remark to that, too, on why it's done there.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/webassembly/additional-scenarios.md](https://github.com/dotnet/AspNetCore.Docs/blob/86eacf0b9b429a9bf73aa7aa072a46f343b37ad4/aspnetcore/blazor/security/webassembly/additional-scenarios.md) | [aspnetcore/blazor/security/webassembly/additional-scenarios](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/additional-scenarios?branch=pr-en-us-35417) |


<!-- PREVIEW-TABLE-END -->