### PR TITLE
WN10P4 Support OpenApiDocumentProvider in DI - prep only, move original content from WN issue to include file 

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10/includes/doc-provider-in-di.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/doc-provider-in-di.md
@@ -1,0 +1,6 @@
+## Support for IOpenApiDocumentProvider in the DI container.
+<!-- https://github.com/dotnet/aspnetcore/pull/61463 -->
+ASP.NET has added support for `IOpenApiDocumentProvider` in the DI container.
+This allows you to inject the `IOpenApiDocumentProvider` into your application and use it to access the OpenAPI document.
+This is useful for scenarios where you need to access the OpenAPI document outside of the context of an HTTP request,
+such as in a background service or a custom middleware.


### PR DESCRIPTION
WN10.P4 Support for OpenApiDocumentProvider in DI - prep only PR, moves original content from the WN issue to include file. 