### PR TITLE
Use sync variants of interop methods in IJSInProcessObjectReference example

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -498,8 +498,8 @@ Use `InvokeNew(string identifier, object?[]? args)` on <xref:Microsoft.JSInterop
 ```csharp
 var inProcRuntime = ((IJSInProcessRuntime)JSRuntime);
 var classRef = inProcRuntime.InvokeNew("TestClass", "Blazor!");
-var text = await classRef.GetValueAsync<string>("text");
-var textLength = await classRef.InvokeAsync<int>("getTextLength");
+var text = classRef.GetValue<string>("text");
+var textLength = classRef.Invoke<int>("getTextLength");
 ```
 
 An overload is available that takes a <xref:System.Threading.CancellationToken> argument or <xref:System.TimeSpan> timeout argument.


### PR DESCRIPTION
It seems more fitting to show sync variants of interop methods in the code example that creates `IJSInProcessObjectReference` using the sync `InvokeNew`.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md](https://github.com/dotnet/AspNetCore.Docs/blob/334cbe4234bcdd13563b5659c6b4620c629f2fd8/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md) | [Call JavaScript functions from .NET methods in ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?branch=pr-en-us-35452) |

<!-- PREVIEW-TABLE-END -->