### PR TITLE
Correct casing of ASP.NET Core in release notes

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -11,7 +11,7 @@ uid: aspnetcore-10
 
 This article highlights the most significant changes in ASP.NET Core 10.0 with links to relevant documentation.
 
-This article will be updated as new preview releases are made available. See the [ASP.NET Core announcement page](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0.0-rc2) until this page is updated.
+This article will be updated as new preview releases are made available. For breaking changes, see [Breaking changes in .NET](/dotnet/core/compatibility/breaking-changes).
 
 <!-- New content should be added to ~/aspnetcore-9/includes/newFeatureName.md files. This will help prevent merge conflicts in this file. -->
 

--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -11,7 +11,7 @@ uid: aspnetcore-10
 
 This article highlights the most significant changes in ASP.NET Core 10.0 with links to relevant documentation.
 
-This article will be updated as new preview releases are made available. See the [Asp.Net Core announcement page](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0.0-rc2) until this page is updated.
+This article will be updated as new preview releases are made available. See the [ASP.NET Core announcement page](https://github.com/aspnet/announcements/issues?q=is%3Aopen+is%3Aissue+milestone%3A1.0.0-rc2) until this page is updated.
 
 <!-- New content should be added to ~/aspnetcore-9/includes/newFeatureName.md files. This will help prevent merge conflicts in this file. -->
 


### PR DESCRIPTION
Just a quick product name nit fix

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/053e281ee28413deb3a449c1b1e1248a62ed5005/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-35472) |


<!-- PREVIEW-TABLE-END -->