### PR TITLE
Add warning about keepalives

### DIFF
--- a/aspnetcore/grpc/performance.md
+++ b/aspnetcore/grpc/performance.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: Learn the best practices for building high-performance gRPC services.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: wpickett
-ms.date: 04/11/2023
+ms.date: 05/16/2025
 uid: grpc/performance
 ---
 # Performance best practices with gRPC

--- a/aspnetcore/grpc/performance.md
+++ b/aspnetcore/grpc/performance.md
@@ -158,7 +158,7 @@ Consider using a transport like Unix domain sockets or named pipes for gRPC call
 ## Keep alive pings
 
 > [!IMPORTANT]
-> Keep alive pings require the cooperation of the server. Do not enable keep alive pings in the client without verifying that the server supports them. A server which does not support keep alive pings will usually ignore the first few pings, and will then send a GOAWAY message, closing the active HTTP/2 connection.
+> Keep alive pings require the cooperation of the server. Do not enable keep alive pings in the client without verifying that the server supports them. A server which does not support keep alive pings will usually ignore the first few pings, and will then send a `GOAWAY` message, closing the active HTTP/2 connection.
 
 Keep alive pings can be used to keep HTTP/2 connections alive during periods of inactivity. Having an existing HTTP/2 connection ready when an app resumes activity allows for the initial gRPC calls to be made quickly, without a delay caused by the connection being reestablished.
 

--- a/aspnetcore/grpc/performance.md
+++ b/aspnetcore/grpc/performance.md
@@ -157,6 +157,9 @@ Consider using a transport like Unix domain sockets or named pipes for gRPC call
 
 ## Keep alive pings
 
+> [!IMPORTANT]
+> Keep alive pings require the cooperation of the server. Do not enable keep alive pings in the client without verifying that the server supports them. A server which does not support keep alive pings will usually ignore the first few pings, and will then send a GOAWAY message, closing the active HTTP/2 connection.
+
 Keep alive pings can be used to keep HTTP/2 connections alive during periods of inactivity. Having an existing HTTP/2 connection ready when an app resumes activity allows for the initial gRPC calls to be made quickly, without a delay caused by the connection being reestablished.
 
 Keep alive pings are configured on <xref:System.Net.Http.SocketsHttpHandler>:


### PR DESCRIPTION
I'm going to be as clear as I can in this PR description about the symptoms we observed, in case it helps people Googling in the future.

Here's what happens when you copy-paste the client configuration from the keepalive docs:

* The default KeepAlive policy [is set at the HTTP level](https://github.com/dotnet/runtime/blob/b8752af999a212847b43034e7ef44cf6292b98c3/src/libraries/System.Net.Http/src/System/Net/Http/HttpHandlerDefaults.cs#L17) to "Always", which means that if you don't set a `KeepAlivePingPolicy` in the gRPC client settings but you *do* override `KeepAlivePingDelay` from its default of infinity ("don't send pings"), then the client will inherit the default "Always" and will send keepalives for the duration of the connection.
* `PooledConnectionIdleTimeout` in the docs snippet in this section is overridden from [the default "1 minute"](https://github.com/dotnet/runtime/blob/b8752af999a212847b43034e7ef44cf6292b98c3/src/libraries/Common/src/System/Net/Http/HttpHandlerDefaults.cs#L29) to "infinity".
* Keepalives [require cooperation with the server](https://github.com/grpc/grpc.io/blob/4896f5ed74f505637bea8c7618f6c6c2d0cee22c/content/en/docs/guides/keepalive.md#L24), as I describe in the patch.

This means that any given connection is open forever, pinging the server periodically (whether or not there is an active stream on the connection); and the server is completely free to close such a connection.

We experienced a hang condition where we speculate that this is what happened:

* Client performs a unary gRPC call to server, causing an HTTP/2 connection to be created.
* Call completes; connection is returned to client's pool.
* Client transparently starts sending pings once per minute after a minute of inactivity.
* Server ignores the first couple of pings, and then sends GOAWAY, in compliance with gRPC docs.
* Client performs a unary gRPC call, and is handed the connection from the pool to do so.
* The connection closes due to the GOAWAY.
* Client hangs because its unary gRPC call never completes.

The fix is simply not to attempt keepalives, because the server doesn't support them.

In this PR I essentially add a warning that there are other docs that the user must understand before enabling the feature, and a one-line summary of the failure mode they should expect if they get this wrong.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/performance.md](https://github.com/dotnet/AspNetCore.Docs/blob/23d8dca834d6980a788307fc6f3e3190cfc7cd83/aspnetcore/grpc/performance.md) | [aspnetcore/grpc/performance](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/performance?branch=pr-en-us-35481) |


<!-- PREVIEW-TABLE-END -->