### PR TITLE
[Blazor] Rendering - Rerender logic adjustments

### DIFF
--- a/aspnetcore/blazor/performance/rendering.md
+++ b/aspnetcore/blazor/performance/rendering.md
@@ -22,7 +22,7 @@ At runtime, components exist in a hierarchy. A root component (the first compone
 
 1. The event is dispatched to the component that rendered the event's handler. After executing the event handler, the component is rerendered.
 1. When a component is rerendered, it supplies a new copy of parameter values to each of its child components.
-1. After a new set of parameter values is received, each component decides whether to rerender. Components rerender if the parameter values may have changed, for example, if they're mutable objects.
+1. After a new set of parameter values is received, Blazor decides whether to rerender the component. Components rerender if the `ShouldRender()` method returns `true` (which is the default behavior unless overridden) and the parameter values may have changed, for example, if they're mutable objects.
 
 The last two steps of the preceding sequence continue recursively down the component hierarchy. In many cases, the entire subtree is rerendered. Events targeting high-level components can cause expensive rerendering because every component below the high-level component must rerender.
 

--- a/aspnetcore/blazor/performance/rendering.md
+++ b/aspnetcore/blazor/performance/rendering.md
@@ -22,7 +22,7 @@ At runtime, components exist in a hierarchy. A root component (the first compone
 
 1. The event is dispatched to the component that rendered the event's handler. After executing the event handler, the component is rerendered.
 1. When a component is rerendered, it supplies a new copy of parameter values to each of its child components.
-1. After a new set of parameter values is received, Blazor decides whether to rerender the component. Components rerender if the `ShouldRender()` method returns `true` (which is the default behavior unless overridden) and the parameter values may have changed, for example, if they're mutable objects.
+1. After a new set of parameter values is received, Blazor decides whether to rerender the component. Components rerender if [`ShouldRender`](xref:blazor/components/rendering#suppress-ui-refreshing-shouldrender) returns `true`, which is the default behavior unless overridden, and the parameter values may have changed, for example, if they're mutable objects.
 
 The last two steps of the preceding sequence continue recursively down the component hierarchy. In many cases, the entire subtree is rerendered. Events targeting high-level components can cause expensive rerendering because every component below the high-level component must rerender.
 


### PR DESCRIPTION
The component itself doesn't decide whether to rerender - this logic is handled by Blazor. A rerender happens if the received parameter values might have changed (e.g. they're mutable objects) **and** the component's `ShouldRender()` method returns `true` (which it does by default unless overridden).


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/performance/rendering.md](https://github.com/dotnet/AspNetCore.Docs/blob/246ad0ee29f01af43621c02e1ebc6150ecca6017/aspnetcore/blazor/performance/rendering.md) | [aspnetcore/blazor/performance/rendering](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/performance/rendering?branch=pr-en-us-35492) |


<!-- PREVIEW-TABLE-END -->