### PR TITLE
[Blazor] rendering perf - ShouldRender nits

### DIFF
--- a/aspnetcore/blazor/performance/rendering.md
+++ b/aspnetcore/blazor/performance/rendering.md
@@ -29,8 +29,8 @@ The last two steps of the preceding sequence continue recursively down the compo
 To prevent rendering recursion into a particular subtree, use either of the following approaches:
 
 * Ensure that child component parameters are of specific immutable types&dagger;, such as `string`, `int`, `bool`, and `DateTime`. The built-in logic for detecting changes automatically skips rerendering if the immutable parameter values haven't changed. If you render a child component with `<Customer CustomerId="item.CustomerId" />`, where `CustomerId` is an `int` type, then the `Customer` component isn't rerendered unless `item.CustomerId` changes.
-* Override [`ShouldRender`](xref:blazor/components/rendering#suppress-ui-refreshing-shouldrender), setting it to `false`:
-  * When parameters are nonprimitive types or unsupported immutable types&dagger;, such as complex custom model types or <xref:Microsoft.AspNetCore.Components.RenderFragment> values.
+* Override [`ShouldRender`](xref:blazor/components/rendering#suppress-ui-refreshing-shouldrender), returning `false`:
+  * When parameters are nonprimitive types or unsupported immutable types&dagger;, such as complex custom model types or <xref:Microsoft.AspNetCore.Components.RenderFragment> values, and the parameter values haven't changed,
   * If authoring a UI-only component that doesn't change after the initial render, regardless of parameter value changes.
 
 &dagger;For more information, see [the change detection logic in Blazor's reference source (`ChangeDetection.cs`)](https://github.com/dotnet/aspnetcore/blob/main/src/Components/Components/src/ChangeDetection.cs).


### PR DESCRIPTION
`ShouldRender` is a method, it is not being set, it returns a value.

I also added a part to clarify that you shouldn't always return false - only when the parameter values haven't changed. (Though feel free to cut that if it's too much detail.)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/performance/rendering.md](https://github.com/dotnet/AspNetCore.Docs/blob/11816147f56c233c6c9a6058d2b884b6c2e2b6a3/aspnetcore/blazor/performance/rendering.md) | [ASP.NET Core Blazor rendering performance best practices](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/performance/rendering?branch=pr-en-us-35495) |

<!-- PREVIEW-TABLE-END -->