### PR TITLE
Version out example for 8.0

### DIFF
--- a/aspnetcore/blazor/fundamentals/startup.md
+++ b/aspnetcore/blazor/fundamentals/startup.md
@@ -676,6 +676,10 @@ In a component that adopts Interactive WebAssembly rendering, wrap the component
 }
 ```
 
+:::moniker-end
+
+:::moniker range=">= aspnetcore-9.0"
+
 #### Global Interactive WebAssembly rendering with prerendering
 
 *This scenario applies to global Interactive WebAssembly rendering with prerendering (`@rendermode="InteractiveWebAssembly"` on the `HeadOutlet` and `Routes` components in the `App` component).*
@@ -721,6 +725,10 @@ In `Layout/MainLayout.razor`:
     @Body
 + </ContentLoading>
 ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
 
 #### Global Interactive WebAssembly rendering without prerendering
 


### PR DESCRIPTION
Fixes #35513

Thanks @frank-hoffman! 🚀 ... I'll open a follow-up issue in a minute to replace the approach for that example. This will at least get it out of the 8.0 version of the article for now.

**UPDATE**: ***Done!*** 👍 ... I opened #35515 to replace that example with something good for the 8.0 era. I'll get to that as soon as I can, and I might have some time next week to address it. Thanks again for the issue!

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/startup.md](https://github.com/dotnet/AspNetCore.Docs/blob/e8783e11dcc301edcdcbde2fe2e6a636588080bf/aspnetcore/blazor/fundamentals/startup.md) | [aspnetcore/blazor/fundamentals/startup](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/startup?branch=pr-en-us-35514) |

<!-- PREVIEW-TABLE-END -->