### PR TITLE
Fix wrong Culture reference in globalization-localization.md

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -54,7 +54,7 @@ The [`@bind`](xref:mvc/views/razor#bind) attribute directive applies formats and
 
 The current culture can be accessed from the <xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=fullName> property.
 
-<xref:System.Globalization.CultureInfo.InvariantCulture?displayProperty=nameWithType> is used for the following field types (`<input type="{TYPE}" />`, where the `{TYPE}` placeholder is the type):
+<xref:System.Globalization.CultureInfo.CurrentCulture?displayProperty=nameWithType> is used for the following field types (`<input type="{TYPE}" />`, where the `{TYPE}` placeholder is the type):
 
 * `date`
 * `number`


### PR DESCRIPTION
The globalization section explains how to `CurrentCulture` can be accessed. Then it goes on to wrongly say that `InvariantCulture` is used for setting the `CultureInfo` of displaying inputs of type `date` or `number`.

