### PR TITLE
Fix links to old 2FA SMS auth page

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -253,7 +253,7 @@ To prevent publishing static Identity assets (stylesheets and JavaScript files f
 * <xref:security/authentication/identity-enable-qrcodes>
 * <xref:migration/identity>
 * <xref:security/authentication/accconfirm>
-* <xref:security/authentication/2fa>
+* <xref:security/authentication/mfa>
 * <xref:host-and-deploy/web-farm>
 
 :::moniker-end

--- a/aspnetcore/security/how-to-choose-identity-solution.md
+++ b/aspnetcore/security/how-to-choose-identity-solution.md
@@ -17,7 +17,7 @@ Most web apps support authentication to ensure that users are who they claim to 
 ASP.NET Core ships with a built-in authentication provider: [ASP.NET Core Identity](xref:security/authentication/identity). The provider includes the APIs, UI, and backend database configuration to support managing user identities, storing user credentials, and granting or revoking permissions. Other features it supports include:
 
 * [External logins](xref:security/authentication/social/index)
-* [Two-factor authentication (2FA)](xref:security/authentication/2fa)
+* [Multi-factor authentication (MFA)](xref:security/authentication/mfa)
 * [Password management](xref:security/authentication/accconfirm)
 * Account lockout and reactivation
 * Authenticator apps


### PR DESCRIPTION
A user reported this, we should probably be linking to the MFA page.

/cc @guardrex 

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->