### PR TITLE
Clarify Razor's handling of data- attributes

### DIFF
--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -261,9 +261,9 @@ Extra `@` characters in a Razor file can cause compiler errors at statements lat
 
 ### Conditional attribute rendering
 
-Razor automatically omits attributes that aren't needed. If the value passed in is `null` or `false`, the attribute isn't rendered.
+Razor automatically omits attributes that aren't required. If the value passed in is `null` or `false`, the attribute isn't rendered.
 
-For example,  consider the following razor:
+For example, consider the following Razor markup:
 
 ```cshtml
 <div class="@false">False</div>
@@ -289,20 +289,19 @@ The preceding Razor markup generates the following HTML:
 <input type="checkbox" name="null">
 ```
 
-> [!NOTE]
-> Razor does not omit `data-` attributes if their values are `null` or `false`.
->
-> For example, the following razor:
->
-> ```razor
-> <div data-foo="@null" data-bar="@false"></div>
-> ```
->
-> generates the following HTML:
->
-> ```razor
-> <div data-foo="" data-bar="False"></div>
-> ```
+Razor retains `data-` attributes if their values are `null` or `false`.
+
+Consider the following Razor markup:
+
+```cshtml
+<div data-id="@null" data-active="@false"></div>
+```
+
+The preceding Razor markup generates the following HTML:
+
+```html
+<div data-id="" data-active="False"></div>
+```
 
 ## Control structures
 

--- a/aspnetcore/mvc/views/razor.md
+++ b/aspnetcore/mvc/views/razor.md
@@ -289,6 +289,21 @@ The preceding Razor markup generates the following HTML:
 <input type="checkbox" name="null">
 ```
 
+> [!NOTE]
+> Razor does not omit `data-` attributes if their values are `null` or `false`.
+>
+> For example, the following razor:
+>
+> ```razor
+> <div data-foo="@null" data-bar="@false"></div>
+> ```
+>
+> generates the following HTML:
+>
+> ```razor
+> <div data-foo="" data-bar="False"></div>
+> ```
+
 ## Control structures
 
 Control structures are an extension of code blocks. All aspects of code blocks (transitioning to markup, inline C#) also apply to the following structures:


### PR DESCRIPTION
Fixes #32916

Added a note explaining that Razor doesn't omit `data-` attributes with null or false values.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/views/razor.md](https://github.com/dotnet/AspNetCore.Docs/blob/42704f831520a9a13ea92e021d037faa6c6a6858/aspnetcore/mvc/views/razor.md) | [aspnetcore/mvc/views/razor](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/views/razor?branch=pr-en-us-35583) |


<!-- PREVIEW-TABLE-END -->