### PR TITLE
WN update prev 5: Validaton Min API and OpenAPI

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -61,7 +61,7 @@ This section describes new features for OpenAPI.
 
 [!INCLUDE[](~/release-notes/aspnetcore-10/includes/OpenApiSchemasInTransformers.md)]
 
-[!INCLUDE[](~/release-notes/aspnetcore-10/includes/OpenApiNetUpdatePrev17.md)]
+[!INCLUDE[](~/release-notes/aspnetcore-10/includes/OpenApiNetUpdatePrev.md)]
 
 ### Authentication and authorization
 

--- a/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiNetUpdatePrev.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiNetUpdatePrev.md
@@ -1,0 +1,8 @@
+### OpenAPI.NET updated to Preview.18
+
+The OpenAPI.NET library used in ASP.NET Core OpenAPI document generation was upgraded to [v2.0.0-preview18](https://www.nuget.org/packages/Microsoft.OpenApi/2.0.0-preview.18). The v2.0.0-preview18 version improves compatibility with the updated library version.
+
+The previous v2.0.0-preview17 version included a number of bug fixes and improvements and also introduced some breaking changes. The breaking changes should only affect users that use document, operation, or schema transformers. Breaking changes in this iteration that may affect developers include the following:
+
+* [Ephemeral object properties are now in Metadata](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-2.md#ephemeral-object-properties-are-now-in-metadata)
+* [Use HTTP Method Object Instead of Enum](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-2.md#use-http-method-object-instead-of-enum)

--- a/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiNetUpdatePrev17.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiNetUpdatePrev17.md
@@ -1,6 +1,0 @@
-### OpenAPI.NET updated to Preview.17
-
-The OpenAPI.NET library used in ASP.NET Core OpenAPI document generation was upgraded to [v2.0.0-preview17](https://www.nuget.org/packages/Microsoft.OpenApi/2.0.0-preview.17). This version includes a number of bug fixes and improvements and also introduces some breaking changes. The breaking changes should only affect users that use document, operation, or schema transformers. Breaking changes in this iteration that may affect developers include the following:
-
-* [Ephemeral object properties are now in Metadata](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-2.md#ephemeral-object-properties-are-now-in-metadata)
-* [Use HTTP Method Object Instead of Enum](https://github.com/microsoft/OpenAPI.NET/blob/main/docs/upgrade-guide-2.md#use-http-method-object-instead-of-enum)

--- a/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiPopulateXMLDocComments.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/OpenApiPopulateXMLDocComments.md
@@ -10,6 +10,8 @@ ASP.NET Core OpenAPI document generation will now include metadata from XML doc 
 
 At build-time, the OpenAPI package will leverage a source generator to discover XML comments in the current application assembly and any project references and emit source code to insert them into the document via an OpenAPI document transformer.
 
+Support for generating OpenAPI metadata from XML documentation comments has been extended with ASP.NET Core in .NET 10 to extract metadata for operation responses from `<returns>` and `<response>` XML tags.
+
 Note that the C# build process does not capture XML doc comments placed on lambda expresions, so to use XML doc comments to add metadata to a minimal API endpoint, you must define the endpoint handler as a method, put the XML doc comments on the method, and then reference that method from the `MapXXX` method. For example, to use XML doc comments to add metadata to a minimal API endpoint originally defined as a lambda expression:
 
 ```csharp

--- a/aspnetcore/release-notes/aspnetcore-10/includes/ValidationSupportMinAPI.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/ValidationSupportMinAPI.md
@@ -31,3 +31,6 @@ app.MapPost("/products",
         => TypedResults.Ok(productId))
     .DisableValidation();
 ```
+
+> [!NOTE]
+> Several small improvements and fixes have been made to the Minimal APIs validation generator introduced in ASP.NET Core 10. To support future enhancements, the underlying validation resolver APIs are now marked as experimental. The top-level `AddValidation` APIs and the built-in validation filter remain stable and non-experimental.


### PR DESCRIPTION
Fixes #35580, #35581, #35582

Move Minimal API and OpenAPI changes for .NET 10 Prev 5 into the What's New and edit.