### PR TITLE
[Pre5] Blazor What's New updates

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -1289,8 +1289,6 @@ Calling <xref:System.Net.Http.HttpContent.ReadAsStreamAsync%2A?displayProperty=n
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-<!-- UPDATE 10.0 - Tracking on https://github.com/dotnet/runtime/issues/97449
-
 To opt-out of response streaming globally, use either of the following approaches:
 
 * Add the `<WasmEnableStreamingResponse>` property to the project file with a value of `false`:
@@ -1300,12 +1298,6 @@ To opt-out of response streaming globally, use either of the following approache
   ```
 
 * Set the `DOTNET_WASM_ENABLE_STREAMING_RESPONSE` environment variable to `false` or `0`.
-
-............. AND REMOVE THE NEXT LINE .............
-
--->
-
-To opt-out of response streaming globally, set the `DOTNET_WASM_ENABLE_STREAMING_RESPONSE` environment variable to `false` or `0`.
 
 To opt-out of response streaming for an individual request, set <xref:Microsoft.AspNetCore.Components.WebAssembly.Http.WebAssemblyHttpRequestMessageExtensions.SetBrowserResponseStreamingEnabled%2A> to `false` on the <xref:System.Net.Http.HttpRequestMessage> (`request` in the following example):
 

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -732,6 +732,9 @@ When a component is rendered statically (static SSR) and `NavigationManager.NotF
 
 To provide Not Found content for global interactive rendering, use a Not Found page (Razor component).
 
+> [!NOTE]
+> The Blazor project template includes a `NotFound.razor` page by default. This page automatically renders whenever `NavigationManager.NotFound` is called, making it easier to handle missing routes with a consistent user experience.
+
 `NotFound.razor`:
 
 ```razor

--- a/aspnetcore/blazor/fundamentals/routing.md
+++ b/aspnetcore/blazor/fundamentals/routing.md
@@ -730,14 +730,9 @@ When a component is rendered statically (static SSR) and `NavigationManager.NotF
 }
 ```
 
-Two approaches for providing Not Found content for global interactive rendering:
+To provide Not Found content for global interactive rendering, use a Not Found page (Razor component).
 
-* Use a Not Found page (Razor component).
-* Specify Not Found content in the [`Router` component's](xref:blazor/fundamentals/routing#route-templates) <xref:Microsoft.AspNetCore.Components.Routing.Router.NotFound%2A> property (`<NotFound>...</NotFound>` markup or by setting the `NotFound` parameter to a render fragment in C# code).
-
-The following example uses a Not Found page (`NotFoundPage` component) to render Not Found content.
-
-`NotFoundPage.razor`:
+`NotFound.razor`:
 
 ```razor
 <h1>Not Found</h1>
@@ -745,20 +740,20 @@ The following example uses a Not Found page (`NotFoundPage` component) to render
 <p>Sorry! Nothing to show.</p>
 ```
 
-Specify the `NotFoundPage` component to the `Router` component in `Routes.razor`. You might need to specify the component's namespace with an [`@using`](xref:mvc/views/razor#using) directive either at the top of the `Routes.razor` file or in an [`_Imports.razor` file](xref:blazor/components/index#component-name-class-name-and-namespace).
+Assign the `NotFound` component to the router's `NotFoundPage` parameter. `NotFoundPage` supports routing that can be used across re-execution middleware, including non-Blazor middleware. If the `NotFound` render fragment is defined together with `NotFoundPage`, the page has higher priority.
+
+In the following example, the preceding `NotFound` component is present in the app's `Pages` folder and passed to the `NotFoundPage` parameter:
 
 ```razor
-<Router ...>
-    <Found ...>
-        ...
+<Router AppAssembly="@typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
     </Found>
-    <NotFound>
-        <NotFoundPage />
-    </NotFound>
 </Router>
 ```
 
-When a component is rendered with a global interactive render mode, calling `NotFound` signals the Blazor router to render Not Found content, which is the `NotFoundPage` component:
+When a component is rendered with a global interactive render mode, calling `NotFound` signals the Blazor router to render the `NotFound` component:
 
 ```razor
 @page "/render-not-found-interactive"

--- a/aspnetcore/blazor/performance/index.md
+++ b/aspnetcore/blazor/performance/index.md
@@ -51,6 +51,8 @@ builder.Services.ConfigureOpenTelemetryTracerProvider(tracerProvider =>
 
 ### Performance meters
 
+For more information on the following performance meters, see <xref:log-mon/metrics/built-in>.
+
 `Microsoft.AspNetCore.Components` meter:
 
 * `aspnetcore.components.navigation`: Tracks the total number of route changes in the app.
@@ -70,6 +72,8 @@ In server-side Blazor apps, additional circuit-specific metrics include:
 * `aspnetcore.components.circuit.duration`: Measures circuit lifetime duration and provides total circuit count.
 
 ### Blazor tracing
+
+For more information on the following tracing activities, see <xref:log-mon/metrics/built-in>.
 
 The new activity tracing capabilities use the `Microsoft.AspNetCore.Components` activity source and provide three main types of tracing activities: circuit lifecycle, navigation, and event handling.
 

--- a/aspnetcore/blazor/performance/index.md
+++ b/aspnetcore/blazor/performance/index.md
@@ -1,11 +1,11 @@
 ---
 title: ASP.NET Core Blazor performance best practices
 author: guardrex
-description: Tips for increasing the performance of ASP.NET Core Blazor apps and avoiding common performance problems.
+description: Guidance on ASP.NET Core Blazor metrics and tracing, improving app performance, and avoiding common performance problems.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 04/16/2025
+ms.date: 06/08/2025
 uid: blazor/performance/index
 ---
 # ASP.NET Core Blazor performance best practices
@@ -22,5 +22,89 @@ Blazor is optimized for high performance in most realistic application UI scenar
 ## Ahead-of-time (AOT) compilation
 
 Ahead-of-time (AOT) compilation compiles a Blazor app's .NET code directly into native WebAssembly for direct execution by the browser. AOT-compiled apps result in larger apps that take longer to download, but AOT-compiled apps usually provide better runtime performance, especially for apps that execute CPU-intensive tasks. For more information, see <xref:blazor/tooling/webassembly#ahead-of-time-aot-compilation>.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-10.0"
+
+## Metrics and tracing
+
+Metrics and tracing capabilities help you monitor and diagnose app performance, track user interactions, and understand component behavior in production environments.
+
+### Configuration
+
+To enable Blazor metrics and tracing in your app, configure [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-dotnet) with the following meters and activity sources in the app's `Program` file where services are registered:
+
+```csharp
+builder.Services.ConfigureOpenTelemetryMeterProvider(meterProvider =>
+{
+    meterProvider.AddMeter("Microsoft.AspNetCore.Components");
+    meterProvider.AddMeter("Microsoft.AspNetCore.Components.Lifecycle");
+    meterProvider.AddMeter("Microsoft.AspNetCore.Components.Server.Circuits");
+});
+
+builder.Services.ConfigureOpenTelemetryTracerProvider(tracerProvider =>
+{
+    tracerProvider.AddSource("Microsoft.AspNetCore.Components");
+});
+```
+
+### Performance meters
+
+`Microsoft.AspNetCore.Components` meter:
+
+* `aspnetcore.components.navigation`: Tracks the total number of route changes in the app.
+* `aspnetcore.components.event_handler`: Measures the duration of processing browser events, including business logic.
+
+`Microsoft.AspNetCore.Components.Lifecycle` meter:
+
+* `aspnetcore.components.update_parameters`: Measures the duration of processing component parameters, including business logic.
+* `aspnetcore.components.render_diff`: Tracks the duration of rendering batches.
+
+`Microsoft.AspNetCore.Components.Server.Circuits` meter:
+
+In server-side Blazor apps, additional circuit-specific metrics include:
+
+* `aspnetcore.components.circuit.active`: Shows the number of active circuits currently in memory.
+* `aspnetcore.components.circuit.connected`: Tracks the number of circuits connected to clients.
+* `aspnetcore.components.circuit.duration`: Measures circuit lifetime duration and provides total circuit count.
+
+### Blazor tracing
+
+The new activity tracing capabilities use the `Microsoft.AspNetCore.Components` activity source and provide three main types of tracing activities: circuit lifecycle, navigation, and event handling.
+
+Circuit lifecycle tracing:
+
+`Microsoft.AspNetCore.Components.CircuitStart`: Traces circuit initialization with the format `Circuit {circuitId}`.
+
+* Tag: `aspnetcore.components.circuit.id`
+* Link: HTTP activity
+
+Navigation tracing:
+
+`Microsoft.AspNetCore.Components.RouteChange`: Tracks route changes with the format `Route {route} -> {componentType}`.
+
+* Tags
+  * `aspnetcore.components.circuit.id`
+  * `aspnetcore.components.route`
+  * `aspnetcore.components.type`
+* Links
+  * HTTP trace
+  * Circuit trace
+
+Event handling tracing:
+
+`Microsoft.AspNetCore.Components.HandleEvent`: Traces event handling with the format `Event {attributeName} -> {componentType}.{methodName}`.
+
+* Tags
+  * `aspnetcore.components.attribute.name`
+  * `aspnetcore.components.circuit.id`
+  * `aspnetcore.components.method`
+  * `aspnetcore.components.type`
+  * `error.type`
+* Links
+  * HTTP trace
+  * Circuit trace
+  * Router trace
 
 :::moniker-end

--- a/aspnetcore/log-mon/metrics/built-in/includes/built-in10.md
+++ b/aspnetcore/log-mon/metrics/built-in/includes/built-in10.md
@@ -3,7 +3,113 @@
 This article describes the metrics built-in for ASP.NET Core produced using the
 <xref:System.Diagnostics.Metrics?displayProperty=nameWithType> API. For a listing of metrics based on the older [EventCounters](/dotnet/core/diagnostics/event-counters) API, see [Available counters](/dotnet/core/diagnostics/available-counters).
 
-See [Using ASP.NET Core metrics](xref:log-mon/metrics/metrics) for information about how to collect, report, enrich, and test ASP.NET Core metrics
+For information about how to collect, report, enrich, and test ASP.NET Core metrics, see <xref:log-mon/metrics/metrics>.
+
+## `Microsoft.AspNetCore.Components`
+
+The `Microsoft.AspNetCore.Components` metrics report information on Razor component route changes and browser events:
+
+* [`aspnetcore.components.navigation`](#metric-aspnetcorecomponentsnavigation)
+* [`aspnetcore.components.event_handler`](#metric-aspnetcorecomponentsevent_handler)
+
+#### Metric: `aspnetcore.components.navigation`
+
+Name | Instrument Type | Unit (UCUM) | Description
+--- | --- | --- | ---
+`aspnetcore.components.navigation`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentsnavigation)--> | Histogram | `s` | Tracks the total number of route changes in the app.
+
+Attribute | Type | Description | Examples | Presence
+--- | --- | --- | --- | ---
+xxx | xxx | xxx | xxx | xxx
+
+.
+
+#### Metric: `aspnetcore.components.event_handler`
+
+Name | Instrument Type | Unit (UCUM) | Description
+--- | --- | --- | ---
+`aspnetcore.components.event_handler`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentsevent_handler)--> | Histogram | `s` | Measures the duration of processing browser events, including business logic.
+
+Attribute | Type | Description | Examples | Presence
+--- | --- | --- | --- | ---
+xxx | xxx | xxx | xxx | xxx
+
+.
+
+## `Microsoft.AspNetCore.Components.Lifecycle`
+
+The `Microsoft.AspNetCore.Components.Lifecycle` metrics report information on Razor component lifecycle events:
+
+* [`aspnetcore.components.update_parameters`](#metric-aspnetcorecomponentsupdate_parameters)
+* [`aspnetcore.components.render_diff`](#metric-aspnetcorecomponentsrender_diff)
+
+#### Metric: `aspnetcore.components.update_parameters`
+
+Name | Instrument Type | Unit (UCUM) | Description
+--- | --- | --- | ---
+`aspnetcore.components.update_parameters`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentsupdate_parameters)--> | Histogram | `s` | Measures the duration of processing component parameters, including business logic.
+
+Attribute | Type | Description | Examples | Presence
+--- | --- | --- | --- | ---
+xxx | xxx | xxx | xxx | xxx
+
+.
+
+#### Metric: `aspnetcore.components.render_diff`
+
+Name | Instrument Type | Unit (UCUM) | Description
+--- | --- | --- | ---
+`aspnetcore.components.render_diff`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentsrender_diff) | Histogram | `s` | Tracks the duration of rendering batches.
+
+Attribute | Type | Description | Examples | Presence
+--- | --- | --- | --- | ---
+xxx | xxx | xxx | xxx | xxx
+
+.
+
+## `Microsoft.AspNetCore.Components.Server.Circuits`
+
+The `Microsoft.AspNetCore.Components.Server.Circuits` metrics report information on server-side Blazor circuits in Blazor Server and Blazor Web Apps:
+
+* [`aspnetcore.components.circuit.active`](#metric-aspnetcorecomponentscircuitactive)
+* [`aspnetcore.components.circuit.connected`](#metric-aspnetcorecomponentscircuitconnected)
+* [`aspnetcore.components.circuit.duration`](#metric-aspnetcorecomponentscircuitduration)
+
+#### Metric: `aspnetcore.components.circuit.active`
+
+Name | Instrument Type | Unit (UCUM) | Description
+--- | --- | --- | ---
+`aspnetcore.components.circuit.active`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitactive)--> | Histogram | `s` | Shows the number of active circuits currently in memory.
+
+Attribute | Type | Description | Examples | Presence
+--- | --- | --- | --- | ---
+xxx | xxx | xxx | xxx | xxx
+
+.
+
+#### Metric: `aspnetcore.components.circuit.connected`
+
+Name | Instrument Type | Unit (UCUM) | Description
+--- | --- | --- | ---
+`aspnetcore.components.circuit.connected`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitconnected)--> | Histogram | `s` | Tracks the number of circuits connected to clients.
+
+Attribute | Type | Description | Examples | Presence
+--- | --- | --- | --- | ---
+xxx | xxx | xxx | xxx | xxx
+
+.
+
+#### Metric: `aspnetcore.components.circuit.duration`
+
+Name | Instrument Type | Unit (UCUM) | Description
+--- | --- | --- | ---
+`aspnetcore.components.circuit.duration`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitduration)--> | Histogram | `s` | Measures circuit lifetime duration and provides total circuit count.
+
+Attribute | Type | Description | Examples | Presence
+--- | --- | --- | --- | ---
+xxx | xxx | xxx | xxx | xxx
+
+.
 
 ## `Microsoft.AspNetCore.Hosting`
 

--- a/aspnetcore/log-mon/metrics/built-in/includes/built-in10.md
+++ b/aspnetcore/log-mon/metrics/built-in/includes/built-in10.md
@@ -20,9 +20,8 @@ Name | Instrument Type | Unit (UCUM) | Description
 
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
-xxx | xxx | xxx | xxx | xxx
-
-.
+`aspnetcore.components.type` | string | Component navigated to. | `TestComponent` | Always
+`aspnetcore.components.route` | string | The component's route | `/test-route` | Always
 
 #### Metric: `aspnetcore.components.event_handler`
 
@@ -32,9 +31,10 @@ Name | Instrument Type | Unit (UCUM) | Description
 
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
-xxx | xxx | xxx | xxx | xxx
-
-.
+`aspnetcore.components.type` | string | Component type handling the event. | `TestComponent` | Always
+`aspnetcore.components.method` | string | C# method handling the event. | `OnClick` | Always
+`aspnetcore.components.attribute.name` | string | Component attribute name. | `onclick` | Always
+`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception was thrown.
 
 ## `Microsoft.AspNetCore.Components.Lifecycle`
 
@@ -51,21 +51,20 @@ Name | Instrument Type | Unit (UCUM) | Description
 
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
-xxx | xxx | xxx | xxx | xxx
-
-.
+`aspnetcore.components.type` | string | Component type handling the event. | `TestComponent` | Always
+`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception was thrown.
 
 #### Metric: `aspnetcore.components.render_diff`
 
 Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
-`aspnetcore.components.render_diff`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentsrender_diff) | Histogram | `s` | Tracks the duration of rendering batches.
+`aspnetcore.components.render_diff`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentsrender_diff)--> | Histogram | `s` | Tracks the duration of rendering batches.
 
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
-xxx | xxx | xxx | xxx | xxx
+`aspnetcore.components.diff.length` | int | The length of the render diff. | 50 | Always
+`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception was thrown.
 
-.
 
 ## `Microsoft.AspNetCore.Components.Server.Circuits`
 
@@ -85,8 +84,6 @@ Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
 xxx | xxx | xxx | xxx | xxx
 
-.
-
 #### Metric: `aspnetcore.components.circuit.connected`
 
 Name | Instrument Type | Unit (UCUM) | Description
@@ -97,8 +94,6 @@ Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
 xxx | xxx | xxx | xxx | xxx
 
-.
-
 #### Metric: `aspnetcore.components.circuit.duration`
 
 Name | Instrument Type | Unit (UCUM) | Description
@@ -108,8 +103,6 @@ Name | Instrument Type | Unit (UCUM) | Description
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
 xxx | xxx | xxx | xxx | xxx
-
-.
 
 ## `Microsoft.AspNetCore.Hosting`
 

--- a/aspnetcore/log-mon/metrics/built-in/includes/built-in10.md
+++ b/aspnetcore/log-mon/metrics/built-in/includes/built-in10.md
@@ -16,7 +16,7 @@ The `Microsoft.AspNetCore.Components` metrics report information on Razor compon
 
 Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
-`aspnetcore.components.navigation`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentsnavigation)--> | Histogram | `s` | Tracks the total number of route changes in the app.
+`aspnetcore.components.navigation`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentsnavigation)--> | Counter | `{route}` | Tracks the total number of route changes in the app.
 
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
@@ -79,7 +79,7 @@ The `Microsoft.AspNetCore.Components.Server.Circuits` metrics report information
 
 Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
-`aspnetcore.components.circuit.active`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitactive)--> | Histogram | `s` | Shows the number of active circuits currently in memory.
+`aspnetcore.components.circuit.active`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitactive)--> | UpDownCounter | `{circuit}` | Shows the number of active circuits currently in memory.
 
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
@@ -91,7 +91,7 @@ xxx | xxx | xxx | xxx | xxx
 
 Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
-`aspnetcore.components.circuit.connected`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitconnected)--> | Histogram | `s` | Tracks the number of circuits connected to clients.
+`aspnetcore.components.circuit.connected`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitconnected)--> | UpDownCounter | `{circuit}` | Tracks the number of circuits connected to clients.
 
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---

--- a/aspnetcore/log-mon/metrics/built-in/includes/built-in10.md
+++ b/aspnetcore/log-mon/metrics/built-in/includes/built-in10.md
@@ -21,7 +21,7 @@ Name | Instrument Type | Unit (UCUM) | Description
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
 `aspnetcore.components.type` | string | Component navigated to. | `TestComponent` | Always
-`aspnetcore.components.route` | string | The component's route | `/test-route` | Always
+`aspnetcore.components.route` | string | The component's route. | `/test-route` | Always
 
 #### Metric: `aspnetcore.components.event_handler`
 
@@ -33,8 +33,8 @@ Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
 `aspnetcore.components.type` | string | Component type handling the event. | `TestComponent` | Always
 `aspnetcore.components.method` | string | C# method handling the event. | `OnClick` | Always
-`aspnetcore.components.attribute.name` | string | Component attribute name. | `onclick` | Always
-`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception was thrown.
+`aspnetcore.components.attribute.name` | string | Component attribute name handling the event. | `onclick` | Always
+`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception is thrown.
 
 ## `Microsoft.AspNetCore.Components.Lifecycle`
 
@@ -52,7 +52,7 @@ Name | Instrument Type | Unit (UCUM) | Description
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
 `aspnetcore.components.type` | string | Component type handling the event. | `TestComponent` | Always
-`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception was thrown.
+`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception is thrown.
 
 #### Metric: `aspnetcore.components.render_diff`
 
@@ -63,8 +63,7 @@ Name | Instrument Type | Unit (UCUM) | Description
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---
 `aspnetcore.components.diff.length` | int | The length of the render diff. | 50 | Always
-`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception was thrown.
-
+`error.type` | string | The full name of exception type. | `System.InvalidOperationException`; `Contoso.MyException` | If an exception is thrown.
 
 ## `Microsoft.AspNetCore.Components.Server.Circuits`
 
@@ -80,29 +79,17 @@ Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
 `aspnetcore.components.circuit.active`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitactive)--> | UpDownCounter | `{circuit}` | Shows the number of active circuits currently in memory.
 
-Attribute | Type | Description | Examples | Presence
---- | --- | --- | --- | ---
-xxx | xxx | xxx | xxx | xxx
-
 #### Metric: `aspnetcore.components.circuit.connected`
 
 Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
 `aspnetcore.components.circuit.connected`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitconnected)--> | UpDownCounter | `{circuit}` | Tracks the number of circuits connected to clients.
 
-Attribute | Type | Description | Examples | Presence
---- | --- | --- | --- | ---
-xxx | xxx | xxx | xxx | xxx
-
 #### Metric: `aspnetcore.components.circuit.duration`
 
 Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
 `aspnetcore.components.circuit.duration`<!--](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-aspnetcorecomponentscircuitduration)--> | Histogram | `s` | Measures circuit lifetime duration and provides total circuit count.
-
-Attribute | Type | Description | Examples | Presence
---- | --- | --- | --- | ---
-xxx | xxx | xxx | xxx | xxx
 
 ## `Microsoft.AspNetCore.Hosting`
 

--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn about the new features in ASP.NET Core in .NET 10.
 ms.author: riande
 ms.custom: mvc
-ms.date: 4/12/2025
+ms.date: 6/9/2025
 uid: aspnetcore-10
 ---
 # What's new in ASP.NET Core in .NET 10

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -401,9 +401,7 @@ For more information and examples, see <xref:blazor/fundamentals/routing?view=as
 
 ### Blazor router has a `NotFoundPage` parameter
 
-Rendering content after triggering the `NavigationManager.NotFound` method can be now handled by passing a parameter with a component type to the router. This is now recommended over using the `NotFound` render fragment because `NotFoundPage` supports routing that can be used across re-execution middleware, including non-Blazor middleware. If the `NotFound` render fragment is defined together with `NotFoundPage`, the page has higher priority.
-
-In the following example, a `NotFound` component is present in the app's `Pages` folder and passed to the `NotFoundPage` parameter. The `NotFound` page takes priority over the content in the `NotFound` fragment.
+Blazor now provides an improved way to display a "Not Found" page when navigating to a non-existent page. You can specify a page to render when `NavigationManager.NotFound` by passing a page type to the `Router` component using the `NotFoundPage` parameter. This approach is recommended over the previous `NotFound` fragment, as it supports routing, works across code re-execution middleware, and is compatible even with non-Blazor scenarios. If both a `NotFound` fragment and `NotFoundPage` are defined, the page specified by `NotFoundPage` takes priority.
 
 ```razor
 <Router AppAssembly="@typeof(Program).Assembly" NotFoundPage="typeof(Pages.NotFound)">
@@ -411,8 +409,10 @@ In the following example, a `NotFound` component is present in the app's `Pages`
         <RouteView RouteData="@routeData" />
         <FocusOnNavigate RouteData="@routeData" Selector="h1" />
     </Found>
-    <NotFound>This content is ignored because 'NotFoundPage' is defined.</NotFound>
+    <NotFound>This content is ignored because NotFoundPage is defined.</NotFound>
 </Router>
 ```
+
+The Blazor project template now includes a `NotFound.razor` page by default. This page automatically renders whenever `NavigationManager.NotFound` is called in your app, making it easier to handle missing routes with a consistent user experience.
 
 For more information, see <xref:blazor/fundamentals/routing#not-found-responses>.

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -1,6 +1,6 @@
 ### New and updated Blazor Web App security samples
 
-We've added and updated Blazor Web App security samples cross-linked in the following articles:
+We've added and updated the Blazor Web App security samples linked in the following articles:
 
 * <xref:blazor/security/blazor-web-app-oidc>
 * <xref:blazor/security/blazor-web-app-entra>

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -416,3 +416,9 @@ Blazor now provides an improved way to display a "Not Found" page when navigatin
 The Blazor project template now includes a `NotFound.razor` page by default. This page automatically renders whenever `NavigationManager.NotFound` is called in your app, making it easier to handle missing routes with a consistent user experience.
 
 For more information, see <xref:blazor/fundamentals/routing#not-found-responses>.
+
+### Metrics and tracing
+
+This release introduces comprehensive metrics and tracing capabilities for Blazor apps, providing detailed observability of the component lifecycle, navigation, event handling, and circuit management.
+
+For more information, see <xref:blazor/performance/index#metrics-and-tracing>.


### PR DESCRIPTION
Addresses #35473
Fixes #35361
Addresses #34870
Fixes #34893 
Fixes #35278

## Ilona

You only need to see the Not Found parts.

## Pavel

*Note to self (PU PRs):* https://github.com/dotnet/aspnetcore/pull/61516 and https://github.com/dotnet/aspnetcore/pull/61609

The metrics part of this is still incomplete ...

Check the DIFF to see my progress.

1. In terms of Blazor node coverage, is it OK to place the metrics coverage into the [Blazor Perf Overview article](https://learn.microsoft.com/en-us/aspnet/core/blazor/performance/?view=aspnetcore-9.0) (that's where I placed it thus far), or do you want a dedicated article for metrics and tracing?

The rest of these questions refer to the coverage going into the main doc set's built-in metrics article at ...

https://learn.microsoft.com/en-us/aspnet/core/log-mon/metrics/built-in?view=aspnetcore-9.0

2. Because the metrics are new, none of them are available to cross-link in [OpenTelemetry documentation: Semantic conventions for ASP.NET Core metrics](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-aspnetcore-metrics/). Currently, I'm placing commented-out cross-links into our content because it seems like after GA their content will be updated to include them. It will easy to activate the links later if I go ahead and place them now. Is that the right thing to do, or should I remove the commented-out cross-links to the OT doc?

3. *Resolved but needs review* &mdash; I think I have the "Instrument Type" and "Unit (UCUM)" entries correct. 👀 

4. *Resolved but needs review* &mdash; I also worked with the rubber 🦆 to create the "Attribute" tables. 👀 

5. The pattern of the built-in metrics article matches the content that was placed in the "Blazor metrics" section for What's New content. However, the "Blazor tracing" content doesn't match and doesn't seem like it should go into the built-in metrics article. Do the tracing activities go into the article or not? If they do, then I'll need a little help organizing them for the article given that the coverage pattern doesn't match. For example, are the "Tags" in the What's New content for "Attributes" tables (the second tables)? If so, what's the first table? Is there a first table at all for each activity? You get the picture: I need to understand how to lay out the content.

WRT to the AppContext key for streaming responses, I only show .......

```csharp
request.SetBrowserResponseStreamingEnabled(false);
```

... do I also need to show the following? ...

```csharp
request.Options.Set(new HttpRequestOptionsKey<bool>("WebAssemblyEnableStreamingResponse"), false);
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/call-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/2132180df1187dbc1f4062866c103bfbf1062499/aspnetcore/blazor/call-web-api.md) | [aspnetcore/blazor/call-web-api](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/call-web-api?branch=pr-en-us-35590) |
| [aspnetcore/blazor/fundamentals/routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/2132180df1187dbc1f4062866c103bfbf1062499/aspnetcore/blazor/fundamentals/routing.md) | [aspnetcore/blazor/fundamentals/routing](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/routing?branch=pr-en-us-35590) |
| [aspnetcore/blazor/performance/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/2132180df1187dbc1f4062866c103bfbf1062499/aspnetcore/blazor/performance/index.md) | [aspnetcore/blazor/performance/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/performance/index?branch=pr-en-us-35590) |
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/2132180df1187dbc1f4062866c103bfbf1062499/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-35590) |


<!-- PREVIEW-TABLE-END -->