### PR TITLE
Fixed comparison table HTTP/2 <-> HTTP/3

### DIFF
--- a/aspnetcore/fundamentals/servers/kestrel/http3.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http3.md
@@ -27,18 +27,15 @@ uid: fundamentals/servers/kestrel/http3
 * Is the latest version of the Hypertext Transfer Protocol.
 * Builds on the strengths of `HTTP/2` while addressing some of its limitations, particularly in terms of performance, latency, reliability, and security.
 
-+---------------+-------------------------+-------------------------+
-| Feature | `HTTP/2` | `HTTP/3` |
-+---------------+-------------------------+-------------------------+
-| Transport | Uses [TCP](https://developer.mozilla.org/docs/Glossary/TCP) | Uses [QUIC](https://www.rfc-editor.org/rfc/rfc9000.html)  |
-| Layer | | |
-| Connection | Slower due to TCP + TLS | Faster with 0-RTT QUIC |
-| Setup | handshake | handshakes |
-| Head-of-Line | Affected by TCP-level | Eliminated with QUIC |
-| Blocking | blocking | stream multiplexing |
-| Encryption | TLS over TCP | TLS is built into QUIC |
-+---------------+-------------------------+-------------------------+
-
+| Feature      | `HTTP/2`                                                    | `HTTP/3`                                                 |
+|--------------|-------------------------------------------------------------|----------------------------------------------------------|
+| Transport    | Uses [TCP](https://developer.mozilla.org/docs/Glossary/TCP) | Uses [QUIC](https://www.rfc-editor.org/rfc/rfc9000.html) |
+| Layer        |                                                             |                                                          |
+| Connection   | Slower due to TCP + TLS                                     | Faster with 0-RTT QUIC                                   |
+| Setup        | handshake                                                   | handshakes                                               |
+| Head-of-Line | Affected by TCP-level                                       | Eliminated with QUIC                                     |
+| Blocking     | blocking                                                    | stream multiplexing                                      |
+| Encryption   | TLS over TCP                                                | TLS is built into QUIC                                   |
 
 The key differences from `HTTP/2` to `HTTP/3` are:
 

--- a/aspnetcore/fundamentals/servers/kestrel/http3.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http3.md
@@ -30,7 +30,6 @@ uid: fundamentals/servers/kestrel/http3
 | Feature      | `HTTP/2`                                                    | `HTTP/3`                                                 |
 |--------------|-------------------------------------------------------------|----------------------------------------------------------|
 | Transport    | Uses [TCP](https://developer.mozilla.org/docs/Glossary/TCP) | Uses [QUIC](https://www.rfc-editor.org/rfc/rfc9000.html) |
-| Layer        |                                                             |                                                          |
 | Connection   | Slower due to TCP + TLS                                     | Faster with 0-RTT QUIC                                   |
 | Setup        | handshake                                                   | handshakes                                               |
 | Head-of-Line | Affected by TCP-level                                       | Eliminated with QUIC                                     |


### PR DESCRIPTION
The layout was broken.

![grafik](https://github.com/user-attachments/assets/da246c50-5282-4f27-a403-2664ff73fb1c)


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/kestrel/http3.md](https://github.com/dotnet/AspNetCore.Docs/blob/c3cfc20cda2b7ff57e943d1b938759d64616b175/aspnetcore/fundamentals/servers/kestrel/http3.md) | [aspnetcore/fundamentals/servers/kestrel/http3](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/http3?branch=pr-en-us-35591) |


<!-- PREVIEW-TABLE-END -->