### PR TITLE
Enhance instructions to Test CORS

### DIFF
--- a/aspnetcore/security/cors.md
+++ b/aspnetcore/security/cors.md
@@ -547,7 +547,7 @@ The [sample download](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnet
   > `WithOrigins("https://localhost:<port>");` should only be used for testing a sample app similar to the [download sample code](https://github.com/dotnet/AspNetCore.Docs/tree/live/aspnetcore/security/cors/8.0sample/Cors).
 
 > [!NOTE]
-> If you're using launchSettings.json in Visual Studio or [configuring C# debug settings in VS Code](https://code.visualstudio.com/docs/csharp/debugger-settings), and using IIS Express to debug locally, ensure that you've configured the IISExpress for `"anonymousAuthentication": true`. When `"anonymousAuthentication"` is `false`, the ASP.NET Core web environment host will not see any preflight requests. In particular, if you're using NTLM authentication (`"windowsAuthentication": true`), the first step of the NTLM challenge-response is to send the web browser a 401 challenge, which can make it challenging to verify your preflight route is configured correctly.
+> If you're using `launchSettings.json` in Visual Studio or [configuring C# debug settings in VS Code](https://code.visualstudio.com/docs/csharp/debugger-settings), and using IIS Express to debug locally, ensure that you've configured IIS Express for `"anonymousAuthentication": true`. When `"anonymousAuthentication"` is `false`, the ASP.NET Core web environment host will not see any preflight requests. In particular, if you're using NTLM authentication (`"windowsAuthentication": true`), the first step of the NTLM challenge-response is to send the web browser a 401 challenge, which can make it challenging to verify your preflight route is configured correctly.
 
 The following `ValuesController` provides the endpoints for testing:
 


### PR DESCRIPTION
I spent about two days banging my head against the wall wondering why I could not get a jQuery AJAX CORS request to work. Turns out the answer was not in this document.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/cors.md](https://github.com/dotnet/AspNetCore.Docs/blob/3e27a2d9e02b17213ba6abb283278f4184e32766/aspnetcore/security/cors.md) | [Enable Cross-Origin Requests (CORS) in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/cors?branch=pr-en-us-35593) |


<!-- PREVIEW-TABLE-END -->