### PR TITLE
Update Program.cs

### DIFF
--- a/aspnetcore/grpc/grpcweb/sample/8.x/GrpcGreeter/Program.cs
+++ b/aspnetcore/grpc/grpcweb/sample/8.x/GrpcGreeter/Program.cs
@@ -33,7 +33,7 @@ var app = builder.Build();
 
 app.UseGrpcWeb(new GrpcWebOptions { DefaultEnabled = true });
 
-app.MapGrpcService<GreeterService>().EnableGrpcWeb();
+app.MapGrpcService<GreeterService>();
 app.MapGet("/", () => "All gRPC service are supported by default in this example, and are callable from browser apps using the gRPC-Web protocol");
 
 app.Run();


### PR DESCRIPTION
GrpcWeb is enabled by default (line 34), therefore EnableGrpcWeb() call is redundant. This is for web enable all services snippet.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->