### PR TITLE
Version the Let's Encrypt article

### DIFF
--- a/aspnetcore/fundamentals/servers/yarp/lets-encrypt.md
+++ b/aspnetcore/fundamentals/servers/yarp/lets-encrypt.md
@@ -3,6 +3,7 @@ uid: fundamentals/servers/yarp/lets-encrypt
 title: YARP Lets Encrypt
 description: YARP Lets Encrypt
 author: samsp-msft
+monikerRange: '<= aspnetcore-8.0'
 ms.author: samsp
 ms.date: 2/6/2025
 ms.topic: article

--- a/aspnetcore/fundamentals/servers/yarp/lets-encrypt.md
+++ b/aspnetcore/fundamentals/servers/yarp/lets-encrypt.md
@@ -3,28 +3,33 @@ uid: fundamentals/servers/yarp/lets-encrypt
 title: YARP Lets Encrypt
 description: YARP Lets Encrypt
 author: samsp-msft
-monikerRange: '<= aspnetcore-8.0'
+monikerRange: '<= aspnetcore-7.0'
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 6/13/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted
 ---
-
 # YARP Lets Encrypt
 
+> [!NOTE]
+> The [`LettuceEncrypt` NuGet package](https://github.com/natemcmaster/LettuceEncrypt) described in this article is archived and no longer supported, so the package isn't recommended for use.
+
 ## Introduction
-YARP can support the certificate authority [Lets Encrypt](https://letsencrypt.org/) by using the API of another ASP.NET Core project [LettuceEncrypt](https://github.com/natemcmaster/LettuceEncrypt). It allows you to set up TLS between the client and YARP with minimal configuration.
+
+YARP can support the certificate authority [Lets Encrypt](https://letsencrypt.org/) by using the API of another ASP.NET Core project, [`LettuceEncrypt`](https://github.com/natemcmaster/LettuceEncrypt). It allows you to set up TLS between the client and YARP with minimal configuration.
 
 ## Requirements
 
-Add the LettuceEncrypt package dependency:
+Add the `LettuceEncrypt` package dependency:
+
 ```csproj
 <PackageReference Include="LettuceEncrypt" Version="1.1.2" />
 ```
 
 ## Configuration
-There are required options for LettuceEncrypt that should be set, see the example of `appsettings.json`:
+
+There are required options for `LettuceEncrypt` that should be set. See the example of `appsettings.json`:
 
 ```json
 {
@@ -38,8 +43,10 @@ There are required options for LettuceEncrypt that should be set, see the exampl
   },
 
   "LettuceEncrypt": {
-    // Set this to automatically accept the terms of service of your certificate authority.
-    // If you don't set this in config, you will need to press "y" whenever the application starts
+    // Set this to automatically accept the terms of service of your certificate 
+    // authority.
+    // If you don't set this in config, you will need to press "y" whenever the 
+    // application starts
     "AcceptTermsOfService": true,
 
     // You must specify at least one domain name
@@ -57,16 +64,17 @@ There are required options for LettuceEncrypt that should be set, see the exampl
 services.AddLettuceEncrypt();
 ```
 
-For more options (i.e. saving certificates) see examples in [LettuceEncrypt doc](https://github.com/natemcmaster/LettuceEncrypt).
+For more options (for example, saving certificates) see the examples in the [`LettuceEncrypt` project README](https://github.com/natemcmaster/LettuceEncrypt).
 
 ## Kestrel Endpoints
 
-If your project is explicitly using kestrel options to configure IP addresses, ports, or HTTPS settings, you will also need to call `UseLettuceEncrypt`.
+If your project is explicitly using Kestrel options to configure IP addresses, ports, or HTTPS settings, call `UseLettuceEncrypt`:
 
 Example:
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
+
 builder.WebHost.ConfigureKestrel(kestrel =>
 {
     kestrel.ListenAnyIP(443, portOptions =>
@@ -78,4 +86,3 @@ builder.WebHost.ConfigureKestrel(kestrel =>
     });
 });
 ```
-


### PR DESCRIPTION
Fixes #35611

Thanks @danielwertheim! 🚀 

Here's the article ...

https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/yarp/lets-encrypt?view=aspnetcore-9.0

@natemcmaster, Dan ... Archived mid-.NET 9, so I marked the article for up to 8.0. Is that what you'd like to do here?

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/yarp/lets-encrypt.md](https://github.com/dotnet/AspNetCore.Docs/blob/8dad23e862b41f45eec6dfc4ca115d678b97ebf6/aspnetcore/fundamentals/servers/yarp/lets-encrypt.md) | [aspnetcore/fundamentals/servers/yarp/lets-encrypt](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/yarp/lets-encrypt?branch=pr-en-us-35615) |


<!-- PREVIEW-TABLE-END -->