### PR TITLE
Focus Identity on BWAs

### DIFF
--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -69,13 +69,13 @@ dotnet new blazor -au Individual -uld -o BlazorApp1
 
 ---
 
-The generated project includes Identity Razor components. The components are found in the `Components/Account` folder of the project. For example:
+The generated project includes Identity Razor components. The components are found in the `Components/Account` folder. For example:
 
 * `/Components/Account/Pages/Register`
 * `/Components/Account/Pages/Login`
 * `/Components/Account/Pages/ChangePassword`
 
-Blazor Identity components can be viewed in the [Blazor project template ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository)](https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account).
+Blazor Identity components can be viewed in the [Blazor project template in the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository)](https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account).
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -45,10 +45,12 @@ Create an ASP.NET Core Blazor Web App project with Individual Accounts.
 
 > [!NOTE]
 > For a Razor Pages experience, see the [Create a Razor Pages app with authentication](#create-a-razor-pages-app-with-authentication) section.
+>
+> For an MVC experience, see the [Create an MVC app with authentication](#create-an-mvc-app-with-authentication) section.
 
 # [Visual Studio](#tab/visual-studio)
 
-* Select the **Blazor Web App** template and select **Next**. Name the project **BlazorApp1**. Select **Next**.
+* Select the **Blazor Web App** template and select **Next**. Select **Next**.
 * Make the following selections:
   * **Authentication type**: **Individual Accounts**
   * **Interactive render mode**: **Server**
@@ -61,7 +63,9 @@ Create an ASP.NET Core Blazor Web App project with Individual Accounts.
 dotnet new blazor -au Individual -o BlazorApp1
 ```
 
-The preceding command creates a Blazor Web App using SQLite. To create the web app with LocalDB, run the following command:
+The `-o|--output` option creates a folder for the app with a folder name matching the default app name/namespace.
+
+The preceding command creates a Blazor Web App using SQLite. To create the app with LocalDB, run the following command:
 
 ```dotnetcli
 dotnet new blazor -au Individual -uld -o BlazorApp1
@@ -73,9 +77,9 @@ The generated project includes Identity Razor components. The components are fou
 
 * `/Components/Account/Pages/Register`
 * `/Components/Account/Pages/Login`
-* `/Components/Account/Pages/ChangePassword`
+* `/Components/Account/Pages/Manage/ChangePassword`
 
-Blazor Identity components can be viewed in the [Blazor project template in the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository)](https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account).
+Identity Razor components are described individually in the documentation for specific use cases and are subject to change each release. To view all of the components in the framework, see the [Blazor project template in the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository)](https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account).
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
@@ -83,32 +87,69 @@ For more information, see <xref:blazor/security/index> and the articles that fol
 
 ## Create a Razor Pages app with authentication
 
-Create an ASP.NET Core Web Application project with Individual Accounts.
+Create an ASP.NET Core Web Application (Razor Pages) project with Individual Accounts.
 
 # [Visual Studio](#tab/visual-studio)
 
-* Select the **ASP.NET Core Web App** template. Name the project **WebApp1**. Click **OK**.
-* In the **Authentication type** input, select **Individual Accounts**.
+* Select the **ASP.NET Core Web App (Razor Pages)** template. Select **Next**.
+* For the **Authentication type** input, select **Individual Accounts**.
+* Select **Create**.
 
 # [.NET CLI](#tab/net-cli)
 
 ```dotnetcli
-dotnet new webapp --auth Individual -o WebApp1
+dotnet new webapp -au Individual -o WebApp1
 ```
 
-The preceding command creates a Razor web app using SQLite. To create the web app with LocalDB, run the following command:
+The `-o|--output` option creates a folder for the app with a folder name matching the default app name/namespace.
+
+The preceding command creates a Razor Pages app using SQLite. To create the app with LocalDB, run the following command:
 
 ```dotnetcli
-dotnet new webapp --auth Individual -uld -o WebApp1
+dotnet new webapp -au Individual -uld -o WebApp1
 ```
 
 ---
 
 The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library](xref:razor-pages/ui-class). The Identity Razor class library exposes endpoints with the `Identity` area. For example:
 
-* `/Identity/Account/Login`
-* `/Identity/Account/Logout`
-* `/Identity/Account/Manage`
+* `Areas/Identity/Pages/Account/Register`
+* `Areas/Identity/Pages/Account/Logoin`
+* `Areas/Identity/Pages/Account/Manage/ChangePassword`
+
+Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages in the framework, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages).
+
+## Create an MVC app with authentication
+
+Create an ASP.NET Core MVC project with Individual Accounts.
+
+# [Visual Studio](#tab/visual-studio)
+
+* Select the **ASP.NET Core Web App (Model-View-Controller)** template. Select **Next**.
+* For the **Authentication type** input, select **Individual Accounts**.
+* Select **Create**.
+
+# [.NET CLI](#tab/net-cli)
+
+```dotnetcli
+dotnet new mvc -au Individual -o WebApplication1
+```
+
+The `-o|--output` option creates a folder for the app with a folder name matching the default app name/namespace.
+
+The preceding command creates an MVC app using SQLite. To create the web app with LocalDB, run the following command:
+
+```dotnetcli
+dotnet new mvc -au Individual -uld -o WebApplication1
+```
+
+---
+
+The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library](xref:razor-pages/ui-class). The Identity Razor class library is based on Razor Pages and exposes endpoints with the `Identity` area. For example:
+
+* `Areas/Identity/Pages/Account/Register`
+* `Areas/Identity/Pages/Account/Logoin`
+* `Areas/Identity/Pages/Account/Manage/ChangePassword`
 
 Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages).
 

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -48,7 +48,7 @@ Create an ASP.NET Core Blazor Web App project with Individual Accounts.
 
 # [Visual Studio](#tab/visual-studio)
 
-* Select the **Blazor Web App** template and select **Next**. Name the project **BlazorApp1** to have the same namespace as the project download. Select **Next**.
+* Select the **Blazor Web App** template and select **Next**. Name the project **BlazorApp1**. Select **Next**.
 * Make the following selections:
   * **Authentication type**: **Individual Accounts**
   * **Interactive render mode**: **Server**
@@ -87,7 +87,7 @@ Create an ASP.NET Core Web Application project with Individual Accounts.
 
 # [Visual Studio](#tab/visual-studio)
 
-* Select the **ASP.NET Core Web App** template. Name the project **WebApp1** to have the same namespace as the project download. Click **OK**.
+* Select the **ASP.NET Core Web App** template. Name the project **WebApp1**. Click **OK**.
 * In the **Authentication type** input, select **Individual Accounts**.
 
 # [.NET CLI](#tab/net-cli)

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -11,8 +11,6 @@ uid: security/authentication/identity
 
 :::moniker range=">= aspnetcore-8.0"
 
-By [Rick Anderson](https://twitter.com/RickAndMSFT)
-
 ASP.NET Core Identity:
 
 * Is an API that supports user interface (UI) login functionality.
@@ -28,6 +26,8 @@ Identity is typically configured using a SQL Server database to store user names
 
 In this topic, you learn how to use Identity to register, log in, and log out a user. Note: the templates treat username and email as the same for users. For more detailed instructions about creating apps that use Identity, see [Next Steps](#next).
 
+For more information on Identity in Blazor apps, see <xref:blazor/security/index> and the articles that follow it in the Blazor documentation.
+
 ASP.NET Core Identity isn't related to the [Microsoft identity platform](/azure/active-directory/develop/). Microsoft identity platform is:
 
 * An evolution of the Azure Active Directory (Azure AD) developer platform.
@@ -39,7 +39,49 @@ ASP.NET Core Identity isn't related to the [Microsoft identity platform](/azure/
 
 <a name="adi"></a>
 
-## Create a Web app with authentication
+## Create a Blazor Web App with authentication
+
+Create an ASP.NET Core Blazor Web App project with Individual Accounts.
+
+> [!NOTE]
+> For a Razor Pages experience, see the [Create a Razor Pages app with authentication](#create-a-razor-pages-app-with-authentication) section.
+
+# [Visual Studio](#tab/visual-studio)
+
+* Select the **Blazor Web App** template and select **Next**. Name the project **BlazorApp1** to have the same namespace as the project download. Select **Next**.
+* Make the following selections:
+  * **Authentication type**: **Individual Accounts**
+  * **Interactive render mode**: **Server**
+  * **Interactivity Location**: **Global**
+* Select **Create**.
+
+# [.NET CLI](#tab/net-cli)
+
+```dotnetcli
+dotnet new blazor -au Individual -o BlazorApp1
+```
+
+The preceding command creates a Blazor Web App using SQLite. To create the web app with LocalDB, run the following command:
+
+```dotnetcli
+dotnet new blazor -au Individual -uld -o BlazorApp1
+```
+
+---
+
+The generated project includes Identity Razor components. The components are found in the `Components/Account` folder of the project. For example:
+
+* `/Components/Account/Pages/Register`
+* `/Components/Account/Pages/Login`
+* `/Components/Account/Pages/ChangePassword`
+
+Blazor Identity components can be viewed in the [Blazor project template ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository)](https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account).
+
+[!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
+
+For more information, see <xref:blazor/security/index> and the articles that follow it in the Blazor documentation. Most of the articles in the *Security and Identity* area of the main ASP.NET Core documentation set apply to Blazor apps. However, the Blazor documentation set contains articles and guidance that supercedes or adds information. We recommend studying the general ASP.NET Core documentation set first, followed by accessing the articles in the Blazor *Security and Identity* documentation.
+
+## Create a Razor Pages app with authentication
 
 Create an ASP.NET Core Web Application project with Individual Accounts.
 
@@ -64,9 +106,11 @@ dotnet new webapp --auth Individual -uld -o WebApp1
 
 The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library](xref:razor-pages/ui-class). The Identity Razor class library exposes endpoints with the `Identity` area. For example:
 
-* /Identity/Account/Login
-* /Identity/Account/Logout
-* /Identity/Account/Manage
+* `/Identity/Account/Login`
+* `/Identity/Account/Logout`
+* `/Identity/Account/Manage`
+
+Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages).
 
 ### Apply migrations
 
@@ -243,10 +287,11 @@ To prevent publishing static Identity assets (stylesheets and JavaScript files f
 
 ## Next Steps
 
+* <xref:blazor/security/index>
 * [ASP.NET Core Identity source code](https://github.com/dotnet/aspnetcore/tree/main/src/Identity)
 * [How to work with Roles in ASP.NET Core Identity](https://www.yogihosting.com/aspnet-core-identity-roles/)
 <!-- https://github.com/dotnet/AspNetCore.Docs/issues/7114 -->
-* See [this GitHub issue](https://github.com/dotnet/AspNetCore.Docs/issues/5131) for information on configuring Identity using SQLite.
+* For information on configuring Identity using SQLite, see [How to config Identity for SQLite (`dotnet/AspNetCore.Docs` #5131)](https://github.com/dotnet/AspNetCore.Docs/issues/5131).
 * [Configure Identity](xref:security/authentication/identity-configuration)
 * <xref:security/authorization/secure-data>
 * <xref:security/authentication/add-user-data>

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -83,7 +83,7 @@ Identity Razor components are described individually in the documentation for sp
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
-For more information, see <xref:blazor/security/index> and the articles that follow it in the Blazor documentation. Most of the articles in the *Security and Identity* area of the main ASP.NET Core documentation set apply to Blazor apps. However, the Blazor documentation set contains articles and guidance that supercedes or adds information. We recommend studying the general ASP.NET Core documentation set first, followed by accessing the articles in the Blazor *Security and Identity* documentation.
+For more information, see <xref:blazor/security/index> and the articles that follow it in the Blazor documentation. Most of the articles in the *Security and Identity* area of the main ASP.NET Core documentation set apply to Blazor apps. However, the Blazor documentation set contains articles and guidance that supersedes or adds information. We recommend studying the general ASP.NET Core documentation set first, followed by accessing the articles in the Blazor *Security and Identity* documentation.
 
 ## Create a Razor Pages app with authentication
 
@@ -114,7 +114,7 @@ dotnet new webapp -au Individual -uld -o WebApp1
 The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library (RCL)](xref:razor-pages/ui-class). The Identity Razor class library exposes endpoints with the `Identity` area. For example:
 
 * `Areas/Identity/Pages/Account/Register`
-* `Areas/Identity/Pages/Account/Logoin`
+* `Areas/Identity/Pages/Account/Login`
 * `Areas/Identity/Pages/Account/Manage/ChangePassword`
 
 Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages in the RCL, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages). You can *scaffold* individual pages or all of the pages into the app. For more information, see <xref:security/authentication/scaffold-identity>.
@@ -148,7 +148,7 @@ dotnet new mvc -au Individual -uld -o WebApplication1
 The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library (RCL)](xref:razor-pages/ui-class). The Identity Razor class library is based on Razor Pages and exposes endpoints with the `Identity` area. For example:
 
 * `Areas/Identity/Pages/Account/Register`
-* `Areas/Identity/Pages/Account/Logoin`
+* `Areas/Identity/Pages/Account/Login`
 * `Areas/Identity/Pages/Account/Manage/ChangePassword`
 
 Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages in the RCL, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages). You can *scaffold* individual pages or all of the pages into the app. For more information, see <xref:security/authentication/scaffold-identity>.

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -50,7 +50,7 @@ Create an ASP.NET Core Blazor Web App project with Individual Accounts.
 
 # [Visual Studio](#tab/visual-studio)
 
-* Select the **Blazor Web App** template and select **Next**. Select **Next**.
+* Select the **Blazor Web App** template. Select **Next**.
 * Make the following selections:
   * **Authentication type**: **Individual Accounts**
   * **Interactive render mode**: **Server**

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -92,7 +92,7 @@ Create an ASP.NET Core Web Application (Razor Pages) project with Individual Acc
 # [Visual Studio](#tab/visual-studio)
 
 * Select the **ASP.NET Core Web App (Razor Pages)** template. Select **Next**.
-* For the **Authentication type** input, select **Individual Accounts**.
+* For **Authentication type**, select **Individual Accounts**.
 * Select **Create**.
 
 # [.NET CLI](#tab/net-cli)
@@ -126,7 +126,7 @@ Create an ASP.NET Core MVC project with Individual Accounts.
 # [Visual Studio](#tab/visual-studio)
 
 * Select the **ASP.NET Core Web App (Model-View-Controller)** template. Select **Next**.
-* For the **Authentication type** input, select **Individual Accounts**.
+* For **Authentication type**, select **Individual Accounts**.
 * Select **Create**.
 
 # [.NET CLI](#tab/net-cli)

--- a/aspnetcore/security/authentication/identity.md
+++ b/aspnetcore/security/authentication/identity.md
@@ -63,7 +63,7 @@ Create an ASP.NET Core Blazor Web App project with Individual Accounts.
 dotnet new blazor -au Individual -o BlazorApp1
 ```
 
-The `-o|--output` option creates a folder for the app with a folder name matching the default app name/namespace.
+The `-o|--output` option creates a folder for the app and sets the app name/namespace.
 
 The preceding command creates a Blazor Web App using SQLite. To create the app with LocalDB, run the following command:
 
@@ -79,7 +79,7 @@ The generated project includes Identity Razor components. The components are fou
 * `/Components/Account/Pages/Login`
 * `/Components/Account/Pages/Manage/ChangePassword`
 
-Identity Razor components are described individually in the documentation for specific use cases and are subject to change each release. To view all of the components in the framework, see the [Blazor project template in the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository)](https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account).
+Identity Razor components are described individually in the documentation for specific use cases and are subject to change each release. When you generate a Blazor Web App with Individual Accounts, Identity Razor components are included in the generated project. The Identity Razor components can also be inspected in the [Blazor project template in the ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository)](https://github.com/dotnet/aspnetcore/tree/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWeb-CSharp/Components/Account). 
 
 [!INCLUDE[](~/includes/aspnetcore-repo-ref-source-links.md)]
 
@@ -101,7 +101,7 @@ Create an ASP.NET Core Web Application (Razor Pages) project with Individual Acc
 dotnet new webapp -au Individual -o WebApp1
 ```
 
-The `-o|--output` option creates a folder for the app with a folder name matching the default app name/namespace.
+The `-o|--output` option creates a folder for the app and sets the app name/namespace.
 
 The preceding command creates a Razor Pages app using SQLite. To create the app with LocalDB, run the following command:
 
@@ -111,13 +111,13 @@ dotnet new webapp -au Individual -uld -o WebApp1
 
 ---
 
-The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library](xref:razor-pages/ui-class). The Identity Razor class library exposes endpoints with the `Identity` area. For example:
+The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library (RCL)](xref:razor-pages/ui-class). The Identity Razor class library exposes endpoints with the `Identity` area. For example:
 
 * `Areas/Identity/Pages/Account/Register`
 * `Areas/Identity/Pages/Account/Logoin`
 * `Areas/Identity/Pages/Account/Manage/ChangePassword`
 
-Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages in the framework, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages).
+Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages in the RCL, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages). You can *scaffold* individual pages or all of the pages into the app. For more information, see <xref:security/authentication/scaffold-identity>.
 
 ## Create an MVC app with authentication
 
@@ -135,7 +135,7 @@ Create an ASP.NET Core MVC project with Individual Accounts.
 dotnet new mvc -au Individual -o WebApplication1
 ```
 
-The `-o|--output` option creates a folder for the app with a folder name matching the default app name/namespace.
+The `-o|--output` option creates a folder for the app and sets the app name/namespace.
 
 The preceding command creates an MVC app using SQLite. To create the web app with LocalDB, run the following command:
 
@@ -145,13 +145,13 @@ dotnet new mvc -au Individual -uld -o WebApplication1
 
 ---
 
-The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library](xref:razor-pages/ui-class). The Identity Razor class library is based on Razor Pages and exposes endpoints with the `Identity` area. For example:
+The generated project provides [ASP.NET Core Identity](xref:security/authentication/identity) as a [Razor class library (RCL)](xref:razor-pages/ui-class). The Identity Razor class library is based on Razor Pages and exposes endpoints with the `Identity` area. For example:
 
 * `Areas/Identity/Pages/Account/Register`
 * `Areas/Identity/Pages/Account/Logoin`
 * `Areas/Identity/Pages/Account/Manage/ChangePassword`
 
-Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages).
+Pages are described individually in the documentation for specific use cases and are subject to change each release. To view all of the pages in the RCL, see the [ASP.NET Core reference source (`dotnet/aspnetcore` GitHub repository, `Identity/UI/src/Areas/Identity/Pages` folder)](https://github.com/dotnet/aspnetcore/tree/main/src/Identity/UI/src/Areas/Identity/Pages). You can *scaffold* individual pages or all of the pages into the app. For more information, see <xref:security/authentication/scaffold-identity>.
 
 ### Apply migrations
 


### PR DESCRIPTION
Fixes #35526

Thanks for the issue, @silajim! 🚀 ... We want the main doc set to focus more on Blazor. I retain the Razor Pages section here, but I inject a new section on Identity with Blazor Web Apps. For both sections, I include a cross-link to where you can see either the Identity pages (Razor Pages) or Identity components (Blazor Web Apps). I also make a remark about how the Blazor security docs supersede or add to Identity and security content here. I may as well toss in MVC in case the dev is looking for that experience.

Sorry for all of the churn (email pings!). I thought this one would be a quick fix, but there was a lot to do to bring it up to speed. We're good now. It's much better than before. Thanks again for your issue!

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/identity.md](https://github.com/dotnet/AspNetCore.Docs/blob/f5c0b8bf053066bf60c02ba3f5a4957628abb3de/aspnetcore/security/authentication/identity.md) | [aspnetcore/security/authentication/identity](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/identity?branch=pr-en-us-35618) |


<!-- PREVIEW-TABLE-END -->