### PR TITLE
Update BWA solution start guidance

### DIFF
--- a/aspnetcore/blazor/security/includes/troubleshoot-server.md
+++ b/aspnetcore/blazor/security/includes/troubleshoot-server.md
@@ -103,9 +103,12 @@ A functioning app may fail immediately after upgrading either the .NET Core SDK 
 > [!NOTE]
 > Use of package versions incompatible with the app's target framework isn't supported. For information on a package, use the [NuGet Gallery](https://www.nuget.org).
 
-### Run the server app
+### Start the solution
 
-When testing and troubleshooting Blazor Web App, make sure that you're running the app from the server project.
+When testing and troubleshooting Blazor Web App, make sure that:
+
+* For one of the Backend-for-Frontend (BFF) pattern sample apps that you start the solution from the ***`Aspire/Aspire.AppHost` project***.
+* For one of the non-BFF pattern sample apps that you start the solution from the ***server project***.
 
 ### Inspect the user
 


### PR DESCRIPTION
Addresses https://github.com/dotnet/blazor-samples/issues/555

Noticed in passing while chatting with a dev about running a BFF sample app. The guidance here predates our addition of the BFF sample apps, and they must be started from the correct project to run correctly.