### PR TITLE
Update dotnet-counters cli options to supply counter provider

### DIFF
--- a/aspnetcore/grpc/diagnostics.md
+++ b/aspnetcore/grpc/diagnostics.md
@@ -192,7 +192,7 @@ gRPC client metrics are reported on `Grpc.Net.Client` event source.
 [dotnet-counters](/dotnet/core/diagnostics/dotnet-counters) is a performance monitoring tool for ad-hoc health monitoring and first-level performance investigation. Monitor a .NET app with either `Grpc.AspNetCore.Server` or `Grpc.Net.Client` as the provider name.
 
 ```console
-> dotnet-counters monitor --process-id 1902 Grpc.AspNetCore.Server
+> dotnet-counters monitor --process-id 1902 --counters Grpc.AspNetCore.Server
 
 Press p to pause, r to resume, q to quit.
     Status: Running

--- a/aspnetcore/grpc/diagnostics.md
+++ b/aspnetcore/grpc/diagnostics.md
@@ -416,7 +416,7 @@ gRPC client metrics are reported on `Grpc.Net.Client` event source.
 [dotnet-counters](/dotnet/core/diagnostics/dotnet-counters) is a performance monitoring tool for ad-hoc health monitoring and first-level performance investigation. Monitor a .NET app with either `Grpc.AspNetCore.Server` or `Grpc.Net.Client` as the provider name.
 
 ```console
-> dotnet-counters monitor --process-id 1902 Grpc.AspNetCore.Server
+> dotnet-counters monitor --process-id 1902 --counters Grpc.AspNetCore.Server
 
 Press p to pause, r to resume, q to quit.
     Status: Running

--- a/aspnetcore/grpc/diagnostics.md
+++ b/aspnetcore/grpc/diagnostics.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: Learn how to gather diagnostics from your gRPC app on .NET.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: wpickett
-ms.date: 10/01/2021
+ms.date: 06/20/2025
 uid: grpc/diagnostics
 ---
 # Logging and diagnostics in gRPC on .NET

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -277,7 +277,7 @@ SignalR server metrics are reported on the <xref:Microsoft.AspNetCore.Http.Conne
 [dotnet-counters](/dotnet/core/diagnostics/dotnet-counters) is a performance monitoring tool for ad-hoc health monitoring and first-level performance investigation. Monitor a .NET app with `Microsoft.AspNetCore.Http.Connections` as the provider name. For example:
 
 ```console
-> dotnet-counters monitor --process-id 37016 Microsoft.AspNetCore.Http.Connections
+> dotnet-counters monitor --process-id 37016 --counters Microsoft.AspNetCore.Http.Connections
 
 Press p to pause, r to resume, q to quit.
     Status: Running

--- a/aspnetcore/signalr/diagnostics.md
+++ b/aspnetcore/signalr/diagnostics.md
@@ -5,7 +5,7 @@ description: Learn how to gather diagnostics from your ASP.NET Core SignalR app.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: wpickett
 ms.custom: devx-track-csharp, signalr, linux-related-content
-ms.date: 03/30/2025
+ms.date: 06/20/2025
 uid: signalr/diagnostics
 ---
 # Logging and diagnostics in ASP.NET Core SignalR


### PR DESCRIPTION
dotnet-counters released a breaking change in v9.0.621003.

"Previously dotnet-counters allowed specifying a list of space separated counters prior to the -- token in collect/monitor mode. Counters must now be supplied explicitly in the --counters option as a list of comma-separated values." - https://github.com/dotnet/diagnostics/releases/tag/v9.0.621003


Fixes #35664

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/diagnostics.md](https://github.com/dotnet/AspNetCore.Docs/blob/acc66b6e7690974deec0b16f453d5b7a4e1c498c/aspnetcore/grpc/diagnostics.md) | [aspnetcore/grpc/diagnostics](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/diagnostics?branch=pr-en-us-35647) |
| [aspnetcore/signalr/diagnostics.md](https://github.com/dotnet/AspNetCore.Docs/blob/acc66b6e7690974deec0b16f453d5b7a4e1c498c/aspnetcore/signalr/diagnostics.md) | [aspnetcore/signalr/diagnostics](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/diagnostics?branch=pr-en-us-35647) |


<!-- PREVIEW-TABLE-END -->