### PR TITLE
remove @page directive from sample component

### DIFF
--- a/aspnetcore/blazor/components/js-spa-frameworks.md
+++ b/aspnetcore/blazor/components/js-spa-frameworks.md
@@ -378,8 +378,6 @@ The following `Counter` component uses an `IncrementAmount` parameter to set the
 `Counter.razor`:
 
 ```razor
-@page "/counter"
-
 <h1>Counter</h1>
 
 <p role="status">Current count: @currentCount</p>


### PR DESCRIPTION
The `@page` directive isn't needed and is rather confusing in that context, where the component is clearly not used as page.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/js-spa-frameworks.md](https://github.com/dotnet/AspNetCore.Docs/blob/9b6aceb8386f7aabea73f98979d3c5c9ca8a1560/aspnetcore/blazor/components/js-spa-frameworks.md) | [Use Razor components in JavaScript apps and SPA frameworks](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/js-spa-frameworks?branch=pr-en-us-35651) |

<!-- PREVIEW-TABLE-END -->