### PR TITLE
Fix broken code snippets and links

### DIFF
--- a/aspnetcore/security/authentication/ws-federation.md
+++ b/aspnetcore/security/authentication/ws-federation.md
@@ -74,9 +74,13 @@ By default, the new middleware:
 
 ![Microsoft Entra ID: App registration properties](ws-federation/_static/AadAppIdUri.png)
 
+:::moniker range=">= aspnetcore-2.1
+
 ## Use WS-Federation without ASP.NET Core Identity
 
 The WS-Federation middleware can be used without Identity. For example:
+
+:::moniker-end
 
 :::moniker range=">= aspnetcore-3.0"
 
@@ -90,14 +94,21 @@ The WS-Federation middleware can be used without Identity. For example:
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-2.1
+
 ## Add WS-Federation as an external login provider for ASP.NET Core Identity
 
 * Add a dependency on [Microsoft.AspNetCore.Authentication.WsFederation](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.WsFederation) to the project.
+
 * Add WS-Federation to `Startup.ConfigureServices`:
+
+:::moniker-end
 
 :::moniker range=">= aspnetcore-3.0"
 
 :::code language="csharp" source="ws-federation/samples/Startup31.cs" id="snippet":::
+
+[!INCLUDE [default settings configuration](social/includes/default-settings.md)]
 
 :::moniker-end
 
@@ -105,9 +116,9 @@ The WS-Federation middleware can be used without Identity. For example:
 
 :::code language="csharp" source="ws-federation/samples/Startup21.cs" id="snippet":::
 
-:::moniker-end
-
 [!INCLUDE [default settings configuration](social/includes/default-settings.md)]
+
+:::moniker-end
 
 ### Log in with WS-Federation
 

--- a/aspnetcore/security/authentication/ws-federation.md
+++ b/aspnetcore/security/authentication/ws-federation.md
@@ -77,12 +77,17 @@ By default, the new middleware:
 ## Use WS-Federation without ASP.NET Core Identity
 
 The WS-Federation middleware can be used without Identity. For example:
+
 :::moniker range=">= aspnetcore-3.0"
-[!code-csharp[](ws-federation/samples/StartupNon31.cs?name=snippet)]
+
+:::code language="csharp" source="ws-federation/samples/StartupNon31.cs" id="snippet":::
+
 :::moniker-end
 
 :::moniker range=">= aspnetcore-2.1 < aspnetcore-3.0"
-[!code-csharp[](ws-federation/samples/StartupNon21.cs?name=snippet)]
+
+:::code language="csharp" source="ws-federation/samples/StartupNon21.cs" id="snippet":::
+
 :::moniker-end
 
 ## Add WS-Federation as an external login provider for ASP.NET Core Identity
@@ -91,11 +96,15 @@ The WS-Federation middleware can be used without Identity. For example:
 * Add WS-Federation to `Startup.ConfigureServices`:
 
 :::moniker range=">= aspnetcore-3.0"
-[!code-csharp[](ws-federation/samples/Startup31.cs?name=snippet)]
+
+:::code language="csharp" source="ws-federation/samples/Startup31.cs" id="snippet":::
+
 :::moniker-end
 
 :::moniker range=">= aspnetcore-2.1 < aspnetcore-3.0"
-[!code-csharp[](ws-federation/samples/Startup21.cs?name=snippet)]
+
+:::code language="csharp" source="ws-federation/samples/Startup21.cs" id="snippet":::
+
 :::moniker-end
 
 [!INCLUDE [default settings configuration](social/includes/default-settings.md)]
@@ -103,13 +112,17 @@ The WS-Federation middleware can be used without Identity. For example:
 ### Log in with WS-Federation
 
 Browse to the app and click the **Log in** link in the nav header. There's an option to log in with WsFederation:
+
 ![Log in page](ws-federation/_static/WsFederationButton.png)
 
 With ADFS as the provider, the button redirects to an ADFS sign-in page:
+
 ![ADFS sign-in page](ws-federation/_static/AdfsLoginPage.png)
 
 With Microsoft Entra ID as the provider, the button redirects to a Microsoft Entra ID sign-in page:
+
 ![Microsoft Entra ID sign-in page](ws-federation/_static/AadSignIn.png)
 
 A successful sign-in for a new user redirects to the app's user registration page:
+
 ![Register page](ws-federation/_static/Register.png)

--- a/aspnetcore/security/authentication/ws-federation.md
+++ b/aspnetcore/security/authentication/ws-federation.md
@@ -74,7 +74,7 @@ By default, the new middleware:
 
 ![Microsoft Entra ID: App registration properties](ws-federation/_static/AadAppIdUri.png)
 
-:::moniker range=">= aspnetcore-2.1
+:::moniker range=">= aspnetcore-2.1"
 
 ## Use WS-Federation without ASP.NET Core Identity
 
@@ -94,7 +94,7 @@ The WS-Federation middleware can be used without Identity. For example:
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-2.1
+:::moniker range=">= aspnetcore-2.1"
 
 ## Add WS-Federation as an external login provider for ASP.NET Core Identity
 

--- a/aspnetcore/security/authentication/ws-federation/samples/Startup21.cs
+++ b/aspnetcore/security/authentication/ws-federation/samples/Startup21.cs
@@ -25,7 +25,7 @@ namespace WebApp21
         public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        #region snippet
+        // <snippet>
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDbContext<ApplicationDbContext>(options =>
@@ -50,7 +50,7 @@ namespace WebApp21
 
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
-        #endregion
+        // </snippet>
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)

--- a/aspnetcore/security/authentication/ws-federation/samples/Startup31.cs
+++ b/aspnetcore/security/authentication/ws-federation/samples/Startup31.cs
@@ -18,7 +18,7 @@ namespace WebApplication88
 
         public IConfiguration Configuration { get; }
 
-        #region snippet
+        // <snippet>
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddDbContext<ApplicationDbContext>(options =>
@@ -45,7 +45,7 @@ namespace WebApplication88
             services.AddControllersWithViews();
             services.AddRazorPages();
         }
-        #endregion
+        // </snippet>
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)

--- a/aspnetcore/security/authentication/ws-federation/samples/StartupNon21.cs
+++ b/aspnetcore/security/authentication/ws-federation/samples/StartupNon21.cs
@@ -17,7 +17,7 @@ namespace WebApp21
 
         public IConfiguration Configuration { get; }
 
-        #region snippet
+        // <snippet>
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddAuthentication(sharedOptions =>
@@ -62,7 +62,7 @@ namespace WebApp21
                     template: "{controller=Home}/{action=Index}/{id?}");
             });
         }
-        #endregion
+        // </snippet>
 
     }
 }

--- a/aspnetcore/security/authentication/ws-federation/samples/StartupNon31.cs
+++ b/aspnetcore/security/authentication/ws-federation/samples/StartupNon31.cs
@@ -17,7 +17,7 @@ namespace WebApplication88
 
         public IConfiguration Configuration { get; }
 
-        #region snippet
+        // <snippet>
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddAuthentication(sharedOptions =>
@@ -64,6 +64,6 @@ namespace WebApplication88
                 endpoints.MapRazorPages();
             });
         }
-        #endregion
+        // </snippet>
     }
 }


### PR DESCRIPTION
Fixes #35650

Thanks @shectorwood! 🚀 ... The article was using an old approach for code cross-linking. I've updated it. I'll merge the updates into the live article in a few minutes, and they should be published in perhaps 15 minutes after that.

In the meantime, you can inspect the files manually in our source ...

https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/security/authentication/ws-federation/samples

* `StartupNon31.cs`
* `Startup31.cs`

This is some awfully old code (ASP.NET Core 3.1). The framework is out of support. Hopefully, the code examples are fine and will work well in the current release.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/ws-federation.md](https://github.com/dotnet/AspNetCore.Docs/blob/10d1666904915a185f9d3fda8f33d229e3d5ff29/aspnetcore/security/authentication/ws-federation.md) | [aspnetcore/security/authentication/ws-federation](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/ws-federation?branch=pr-en-us-35655) |


<!-- PREVIEW-TABLE-END -->