### PR TITLE
Update phrasing to fix loc problem

### DIFF
--- a/aspnetcore/blazor/tutorials/signalr-blazor.md
+++ b/aspnetcore/blazor/tutorials/signalr-blazor.md
@@ -217,7 +217,7 @@ Use Response Compression Middleware at the top of the processing pipeline's conf
 app.UseResponseCompression();
 ```
 
-Add an endpoint for the hub immediately before the line that runs the app (`app.Run();`):
+Add an endpoint for the hub:
 
 ```csharp
 app.MapHub<ChatHub>("/chathub");


### PR DESCRIPTION
Fixes #35623

Thanks @KM5075! 🚀 ... Most developers will know that they should add the line for the endpoint before the line that runs the app. I simplify the line ...

```diff
- Add an endpoint for the hub immediately before the line that runs the app (`app.Run();`):
+ Add an endpoint for the hub:
```

That will fix the localization problem. The question is on the timing. MT (machine translation) runs on a schedule. If the article is localized with MT, it might take a few weeks to update the Japanese version of the article. If the article is human translated (HT), it might take considerably longer to receive this update. Either way, this update will fix the problem.