### PR TITLE
Patch new coverage

### DIFF
--- a/aspnetcore/blazor/security/account-confirmation-and-password-recovery.md
+++ b/aspnetcore/blazor/security/account-confirmation-and-password-recovery.md
@@ -87,7 +87,7 @@ When establishing the key vault in the Entra or Azure portal:
 * Create an Azure Managed Identity (or add a role to the existing Managed Identity that you plan to use) with the **Key Vault Secrets User** role. Assign the Managed Identity to the Azure App Service that's hosting the deployment: **Settings** > **Identity** > **User assigned** > **Add**.
 
   > [!NOTE]
-  > If you also plan to run an app locally with an authorized user for blob access using the [Azure CLI](/cli/azure/) or Visual Studio's Azure Service Authentication, add your developer Azure user account in **Access Control (IAM)** with the **Key Vault Secrets User** role. If you want to use the Azure CLI through Visual Studio, execute the `az login` command from the Developer PowerShell panel and follow the prompts to authenticate with the tenant.
+  > If you also plan to run an app locally with an authorized user for key vault access using the [Azure CLI](/cli/azure/) or Visual Studio's Azure Service Authentication, add your developer Azure user account in **Access Control (IAM)** with the **Key Vault Secrets User** role. If you want to use the Azure CLI through Visual Studio, execute the `az login` command from the Developer PowerShell panel and follow the prompts to authenticate with the tenant.
 
 To implement the code in this section, record the key vault URI (example: "`https://contoso.vault.azure.net/`", trailing slash required) and the secret name (example: "`EmailAuthKey`") from Azure when you create the key vault and secret.
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -487,7 +487,7 @@ When establishing the key vault in the Entra or Azure portal:
 * Create an Azure Managed Identity (or add a role to the existing Managed Identity that you plan to use) with the **Key Vault Secrets User** role. Assign the Managed Identity to the Azure App Service that's hosting the deployment: **Settings** > **Identity** > **User assigned** > **Add**.
 
   > [!NOTE]
-  > If you also plan to run an app locally with an authorized user for blob access using the [Azure CLI](/cli/azure/) or Visual Studio's Azure Service Authentication, add your developer Azure user account in **Access Control (IAM)** with the **Key Vault Secrets User** role. If you want to use the Azure CLI through Visual Studio, execute the `az login` command from the Developer PowerShell panel and follow the prompts to authenticate with the tenant.
+  > If you also plan to run an app locally with an authorized user for key vault access using the [Azure CLI](/cli/azure/) or Visual Studio's Azure Service Authentication, add your developer Azure user account in **Access Control (IAM)** with the **Key Vault Secrets User** role. If you want to use the Azure CLI through Visual Studio, execute the `az login` command from the Developer PowerShell panel and follow the prompts to authenticate with the tenant.
 
 To implement the code in this section, record the key vault URI (example: "`https://contoso.vault.azure.net/`", trailing slash required) and the secret name (example: "`BlazorWebAppEntraClientSecret`") from Azure when you create the key vault and secret.
 


### PR DESCRIPTION
Addresses #35665

***Oooops!*** A 😈 got me on cut-'n-paste coverage. This should refer to the key vault, not blob storage, where the content was copied from.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/account-confirmation-and-password-recovery.md](https://github.com/dotnet/AspNetCore.Docs/blob/be4ccda0b1ac829d13bd571cc0cae6cafd62a495/aspnetcore/blazor/security/account-confirmation-and-password-recovery.md) | [aspnetcore/blazor/security/account-confirmation-and-password-recovery](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/account-confirmation-and-password-recovery?branch=pr-en-us-35671) |
| [aspnetcore/blazor/security/blazor-web-app-with-entra.md](https://github.com/dotnet/AspNetCore.Docs/blob/be4ccda0b1ac829d13bd571cc0cae6cafd62a495/aspnetcore/blazor/security/blazor-web-app-with-entra.md) | [aspnetcore/blazor/security/blazor-web-app-with-entra](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-entra?branch=pr-en-us-35671) |

<!-- PREVIEW-TABLE-END -->