### PR TITLE
Update ClockHub.cs - Clarify the method's purpose

### DIFF
--- a/aspnetcore/signalr/background-service/samples/6.0/Server/ClockHub.cs
+++ b/aspnetcore/signalr/background-service/samples/6.0/Server/ClockHub.cs
@@ -6,7 +6,7 @@ namespace Server;
 #region ClockHub
 public class ClockHub : Hub<IClock>
 {
-    public async Task SendTimeToClients(DateTime dateTime)
+    public async Task SendMyLocalTimeToOtherClients(DateTime dateTime)
     {
         await Clients.All.ShowTime(dateTime);
     }


### PR DESCRIPTION
This change is intended to make it clearer that the ClockHub's method is called (used) only by clients.

I was going through the ["Host ASP.NET Core SignalR in background services"](https://learn.microsoft.com/en-us/aspnet/core/signalr/background-services) tutorial, but then wondered why `SendTimeToClients()` [isn't called anywhere](https://github.com/search?q=repo%3Adotnet%2FAspNetCore.Docs%20SendTimeToClients&type=code).
I first thought that this method is used by the server to send the current time to clients, but that's actually done by `_clockHubContext.Clients.All.ShowTime(DateTime.Now);`

Furthermore, it makes no sense that a(ny) client sends a time to all clients.

The tutorial would even work without this method, so `ClockHub` could be empty and everything runs as intended.