### PR TITLE
Fix metrics links

### DIFF
--- a/aspnetcore/log-mon/metrics/built-in.md
+++ b/aspnetcore/log-mon/metrics/built-in.md
@@ -115,7 +115,7 @@ The `Microsoft.AspNetCore.Hosting` metrics report high-level information about H
 
 Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
-[`http.server.request.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpclientrequestduration) | Histogram | `s` | Measures the duration of inbound HTTP requests.
+[`http.server.request.duration`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpserverrequestduration) | Histogram | `s` | Measures the duration of inbound HTTP requests.
 
 Attribute | Type | Description | Examples | Presence
 --- |--- | --- | --- | ---
@@ -144,7 +144,7 @@ When using OpenTelemetry, the default buckets for this metric are set to [ 0.005
 
 Name | Instrument Type | Unit (UCUM) | Description
 --- | --- | --- | ---
-[`http.server.active_requests`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpclientactive_requests) | UpDownCounter | `{request}` | Measures the number of concurrent HTTP requests that are currently in-flight.
+[`http.server.active_requests`](https://opentelemetry.io/docs/specs/semconv/dotnet/dotnet-http-metrics/#metric-httpserveractive_requests) | UpDownCounter | `{request}` | Measures the number of concurrent HTTP requests that are currently in-flight.
 
 Attribute | Type | Description | Examples | Presence
 --- | --- | --- | --- | ---


### PR DESCRIPTION
Links incorrectly pointed to client instead of server HTTP metrics.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/log-mon/metrics/built-in.md](https://github.com/dotnet/AspNetCore.Docs/blob/0a0c5b9a78a2710cdbef25581f985b7f8e60f7e3/aspnetcore/log-mon/metrics/built-in.md) | [aspnetcore/log-mon/metrics/built-in](https://review.learn.microsoft.com/en-us/aspnet/core/log-mon/metrics/built-in?branch=pr-en-us-35725) |

<!-- PREVIEW-TABLE-END -->