### PR TITLE
Ms.date sync with last signficant commit

### DIFF
--- a/aspnetcore/client-side/bundling-and-minification.md
+++ b/aspnetcore/client-side/bundling-and-minification.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how to optimize static resources in an ASP.NET Core web application by applying bundling and minification techniques.
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 05/08/2025
+ms.date: 05/09/2025
 uid: client-side/bundling-and-minification
 ---
 # Bundle and minify static assets in ASP.NET Core

--- a/aspnetcore/client-side/spa/angular.md
+++ b/aspnetcore/client-side/spa/angular.md
@@ -5,7 +5,7 @@ description: Learn how to get started with the ASP.NET Core Single Page Applicat
 monikerRange: '>= aspnetcore-3.1'
 ms.author: stevesa
 ms.custom: mvc
-ms.date: 09/12/2023
+ms.date: 09/29/2023
 uid: spa/angular
 ---
 # Use the Angular project template with ASP.NET Core

--- a/aspnetcore/data/ef-mvc/concurrency.md
+++ b/aspnetcore/data/ef-mvc/concurrency.md
@@ -4,7 +4,7 @@ description: "This tutorial shows how to handle conflicts when multiple users up
 author: tdykstra
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 03/27/2019
+ms.date: 07/09/2024
 ms.topic: tutorial
 uid: data/ef-mvc/concurrency
 ---

--- a/aspnetcore/data/ef-mvc/intro.md
+++ b/aspnetcore/data/ef-mvc/intro.md
@@ -4,7 +4,7 @@ description: "This page is the first in a series of tutorials that explain how t
 author: tdykstra
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 11/06/2020
+ms.date: 05/28/2025
 ms.topic: tutorial
 uid: data/ef-mvc/intro
 ---

--- a/aspnetcore/data/ef-rp/complex-data-model.md
+++ b/aspnetcore/data/ef-rp/complex-data-model.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Part 5 of Razor Pages and Entity Framework tutorial series.
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 3/3/2021
+ms.date: 04/10/2025
 uid: data/ef-rp/complex-data-model
 ---
 

--- a/aspnetcore/data/ef-rp/concurrency.md
+++ b/aspnetcore/data/ef-rp/concurrency.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Part 8 of Razor Pages and Entity Framework tutorial series.
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 07/22/2019
+ms.date: 01/29/2025
 uid: data/ef-rp/concurrency
 ---
 # Part 8, Razor Pages with EF Core in ASP.NET Core - Concurrency

--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -5,7 +5,7 @@ description: Shows how to create a Razor Pages app using Entity Framework Core
 ms.author: tdykstra
 monikerRange: '>= aspnetcore-3.1'
 ms.custom: "mvc"
-ms.date: 11/11/2021
+ms.date: 04/23/2025
 uid: data/ef-rp/intro
 ---
 

--- a/aspnetcore/data/scaffold_RP.md
+++ b/aspnetcore/data/scaffold_RP.md
@@ -4,7 +4,7 @@ description: Scaffold a data model with dotnet scaffold in a Razor Pages project
 author: rick-anderson
 ms.author: riande
 monikerRange: '>= aspnetcore-9.0'
-ms.date: 3/15/2025
+ms.date: 04/24/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/diagnostics/asp0000.md
+++ b/aspnetcore/diagnostics/asp0000.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0000: Do not call 'IServiceCollection
 author: pranavkm
 monikerRange: '>= aspnetcore-5.0'
 ms.author: wpickett
-ms.date: 10/21/2021
+ms.date: 03/27/2025
 uid: diagnostics/asp0000
 ---
 # ASP0000: Do not call 'IServiceCollection.BuildServiceProvider' in 'ConfigureServices'

--- a/aspnetcore/diagnostics/asp0001.md
+++ b/aspnetcore/diagnostics/asp0001.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0001: Authorization middleware is inc
 author: pranavkm
 monikerRange: '>= aspnetcore-5.0'
 ms.author: wpickett
-ms.date: 10/21/2021
+ms.date: 03/27/2025
 uid: diagnostics/asp0001
 ---
 # ASP0001: Authorization middleware is incorrectly configured

--- a/aspnetcore/diagnostics/asp0003.md
+++ b/aspnetcore/diagnostics/asp0003.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0003: Do not use action results with 
 author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
-ms.date: 10/21/2021
+ms.date: 03/27/2025
 uid: diagnostics/asp0003
 ---
 # ASP0003: Do not use model binding attributes with route handlers

--- a/aspnetcore/diagnostics/asp0004.md
+++ b/aspnetcore/diagnostics/asp0004.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0004: Do not use action results with 
 author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
-ms.date: 10/21/2021
+ms.date: 03/27/2025
 uid: diagnostics/asp0004
 ---
 # ASP0004: Do not use action results with route handlers

--- a/aspnetcore/diagnostics/asp0005.md
+++ b/aspnetcore/diagnostics/asp0005.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0005: Do not place attribute on metho
 author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
-ms.date: 10/21/2021
+ms.date: 03/27/2025
 uid: diagnostics/asp0005
 ---
 # ASP0005: Do not place attribute on method called by route handler lambda

--- a/aspnetcore/diagnostics/asp0006.md
+++ b/aspnetcore/diagnostics/asp0006.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0006: Do not use non-literal sequence
 author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
-ms.date: 10/21/2021
+ms.date: 03/27/2025
 uid: diagnostics/asp0006
 ---
 # ASP0006: Do not use non-literal sequence numbers

--- a/aspnetcore/diagnostics/asp0007.md
+++ b/aspnetcore/diagnostics/asp0007.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0007: Route parameter and argument op
 author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.author: riande
-ms.date: 10/21/2021
+ms.date: 03/27/2025
 uid: diagnostics/asp0007
 ---
 # ASP0007: Route parameter and argument optionality is mismatched

--- a/aspnetcore/diagnostics/asp0008.md
+++ b/aspnetcore/diagnostics/asp0008.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0008: Do not use ConfigureWebHost wit
 author: safia
 monikerRange: '>= aspnetcore-7.0'
 ms.author: safia
-ms.date: 09/23/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0008
 ---
 # ASP0008: Do not use ConfigureWebHost with WebApplicationBuilder.Host

--- a/aspnetcore/diagnostics/asp0009.md
+++ b/aspnetcore/diagnostics/asp0009.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0009: Do not use Configure with WebAp
 author: safia
 monikerRange: '>= aspnetcore-7.0'
 ms.author: safia
-ms.date: 09/23/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0009
 ---
 # ASP0009: Do not use Configure with WebApplicationBuilder.WebHost

--- a/aspnetcore/diagnostics/asp0010.md
+++ b/aspnetcore/diagnostics/asp0010.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0010: Do not use UseStartup with WebA
 author: safia
 monikerRange: '>= aspnetcore-7.0'
 ms.author: wpickett
-ms.date: 09/23/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0010
 ---
 # ASP0010: Do not use UseStartup with WebApplicationBuilder.WebHost

--- a/aspnetcore/diagnostics/asp0011.md
+++ b/aspnetcore/diagnostics/asp0011.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0011: Suggest using builder.Logging o
 author: safia
 monikerRange: '>= aspnetcore-7.0'
 ms.author: safia
-ms.date: 09/27/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0011
 ---
 # ASP0011: Suggest using builder.Logging over Host.ConfigureLogging or WebHost.ConfigureLogging

--- a/aspnetcore/diagnostics/asp0012.md
+++ b/aspnetcore/diagnostics/asp0012.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0012: Suggest using builder.Services 
 author: safia
 monikerRange: '>= aspnetcore-7.0'
 ms.author: safia
-ms.date: 09/27/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0012
 ---
 # ASP0012: Suggest using builder.Services over Host.ConfigureServices or WebHost.ConfigureServices

--- a/aspnetcore/diagnostics/asp0013.md
+++ b/aspnetcore/diagnostics/asp0013.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0013: Suggest switching from using Co
 author: rick-anderson
 monikerRange: '>= aspnetcore-7.0'
 ms.author: riande
-ms.date: 09/27/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0013
 ---
 # ASP0013: Suggest switching from using Configure methods to WebApplicationBuilder.Configuration

--- a/aspnetcore/diagnostics/asp0014.md
+++ b/aspnetcore/diagnostics/asp0014.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0014: Suggest using top level route r
 author: captainsafia
 monikerRange: '>= aspnetcore-7.0'
 ms.author: safia
-ms.date: 09/27/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0014
 ---
 # ASP0014: Suggest using top level route registrations

--- a/aspnetcore/diagnostics/asp0015.md
+++ b/aspnetcore/diagnostics/asp0015.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0015: Suggest using IHeaderDictionary
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 11/23/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0015
 ---
 # ASP0015: Suggest using IHeaderDictionary properties

--- a/aspnetcore/diagnostics/asp0016.md
+++ b/aspnetcore/diagnostics/asp0016.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0016: Do not return a value from Requ
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 11/22/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0016
 ---
 # ASP0016: Do not return a value from RequestDelegate

--- a/aspnetcore/diagnostics/asp0017.md
+++ b/aspnetcore/diagnostics/asp0017.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0017: Invalid route pattern"
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 11/22/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0017
 ---
 # ASP0017: Invalid route pattern

--- a/aspnetcore/diagnostics/asp0018.md
+++ b/aspnetcore/diagnostics/asp0018.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0018: Unused route parameter"
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 4/1/2024
+ms.date: 03/27/2025
 uid: diagnostics/asp0018
 ---
 # ASP0018: Unused route parameter

--- a/aspnetcore/diagnostics/asp0019.md
+++ b/aspnetcore/diagnostics/asp0019.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0019: Suggest using IHeaderDictionary
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 11/22/2022
+ms.date: 03/27/2025
 uid: diagnostics/asp0019
 ---
 # ASP0019: Suggest using IHeaderDictionary.Append or the indexer

--- a/aspnetcore/diagnostics/asp0020.md
+++ b/aspnetcore/diagnostics/asp0020.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0020: Complex types referenced by rou
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 03/24/2023
+ms.date: 03/27/2025
 uid: diagnostics/asp0020
 ---
 # ASP0020: Complex types referenced by route parameters must be parsable

--- a/aspnetcore/diagnostics/asp0021.md
+++ b/aspnetcore/diagnostics/asp0021.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0021: When implementing the BindAsync
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 03/27/2023
+ms.date: 03/27/2025
 uid: diagnostics/asp0021
 ---
 # ASP0021: The return type of the BindAsync method must be `ValueTask<T>`.

--- a/aspnetcore/diagnostics/asp0022.md
+++ b/aspnetcore/diagnostics/asp0022.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0022: Route conflict detected between
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 11/08/2023
+ms.date: 03/27/2025
 uid: diagnostics/asp0022
 ---
 # ASP0022: Route conflict detected between route handlers

--- a/aspnetcore/diagnostics/asp0023.md
+++ b/aspnetcore/diagnostics/asp0023.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule ASP0023: Route conflict detected between
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 3/24/2023
+ms.date: 03/27/2025
 uid: diagnostics/asp0023
 ---
 # ASP0023: Route conflict detected between route handlers

--- a/aspnetcore/diagnostics/asp0024.md
+++ b/aspnetcore/diagnostics/asp0024.md
@@ -1,6 +1,6 @@
 ---
 title: "ASP0024: A route handler has multiple parameters with the [FromBody] attribute"
-ms.date: 03/28/2023
+ms.date: 03/27/2025
 description: "Learn about analysis rule ASP0024: A route handler has multiple parameters with the [FromBody] attribute"
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'

--- a/aspnetcore/diagnostics/asp0025.md
+++ b/aspnetcore/diagnostics/asp0025.md
@@ -1,6 +1,6 @@
 ---
 title: "ASP0025: Use AddAuthorizationBuilder to register authorization services and construct policies."
-ms.date: 05/11/2023
+ms.date: 04/30/2025
 description: "Learn about analysis rule ASP0025: Use AddAuthorizationBuilder to register authorization services and construct policies."
 author: tdykstra
 monikerRange: '>= aspnetcore-8.0'

--- a/aspnetcore/diagnostics/asp0026.md
+++ b/aspnetcore/diagnostics/asp0026.md
@@ -1,6 +1,6 @@
 ---
 title: "ASP0026: Analyzer to warn when [Authorize] is overridden by [AllowAnonymous] from 'farther away'" 
-ms.date: 07/08/2024
+ms.date: 03/27/2025
 description: "Learn about analysis rule ASP0026: [Authorize] is overridden by [AllowAnonymous] from 'farther away'"
 author: tdykstra
 monikerRange: '>= aspnetcore-9.0'

--- a/aspnetcore/diagnostics/mvc1001.md
+++ b/aspnetcore/diagnostics/mvc1001.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule MVC1001: Filters cannot be applied to pa
 author: pranavkm
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 10/21/2021
+ms.date: 03/27/2025
 uid: diagnostics/mvc1001
 ---
 # MVC1001: Filters cannot be applied to page handler methods

--- a/aspnetcore/diagnostics/mvc1002.md
+++ b/aspnetcore/diagnostics/mvc1002.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule MVC1002: Route attribute cannot be appli
 author: pranavkm
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 10/22/2021
+ms.date: 03/27/2025
 uid: diagnostics/mvc1002
 ---
 # MVC1002: Route attribute cannot be applied to page handler methods

--- a/aspnetcore/diagnostics/mvc1003.md
+++ b/aspnetcore/diagnostics/mvc1003.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule MVC1003: Route attributes cannot be appl
 author: pranavkm
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 10/22/2021
+ms.date: 03/27/2025
 uid: diagnostics/mvc1003
 ---
 # MVC1003: Route attributes cannot be applied to page models

--- a/aspnetcore/diagnostics/mvc1004.md
+++ b/aspnetcore/diagnostics/mvc1004.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule MVC1004: Rename model bound parameter"
 author: pranavkm
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
-ms.date: 10/22/2021
+ms.date: 03/27/2025
 uid: diagnostics/mvc1004
 ---
 # MVC1004: Rename model bound parameter

--- a/aspnetcore/diagnostics/mvc1005.md
+++ b/aspnetcore/diagnostics/mvc1005.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule MVC1005: Cannot use UseMvc with Endpoint
 author: pranavkm
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
-ms.date: 10/22/2021
+ms.date: 03/27/2025
 uid: diagnostics/mvc1005
 ---
 # MVC1005: Cannot use UseMvc with Endpoint Routing

--- a/aspnetcore/diagnostics/mvc1006.md
+++ b/aspnetcore/diagnostics/mvc1006.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule MVC1006: Methods containing TagHelpers m
 author: pranavkm
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 10/22/2021
+ms.date: 03/27/2025
 uid: diagnostics/mvc1006
 ---
 # MVC1006: Methods containing TagHelpers must be async and return Task

--- a/aspnetcore/fundamentals/aot/native-aot-tutorial.md
+++ b/aspnetcore/fundamentals/aot/native-aot-tutorial.md
@@ -7,7 +7,7 @@ ms.topic: tutorial
 content_well_notification: AI-contribution
 ms.author: midenn
 ms.custom: mvc
-ms.date: 5/10/2023
+ms.date: 05/13/2025
 uid: fundamentals/native-aot-tutorial
 ai-usage: ai-assisted
 ---

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg001.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg001.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG001: Unable to resolve route pattern"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 09/15/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg001
 ---
 # RDG001: Unable to resolve route pattern

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg002.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg002.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG002: Unable to resolve endpoint handl
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 09/15/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg002
 ---
 # RDG002: Unable to resolve endpoint handler

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg003.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg003.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG003: Unable to resolve parameter"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 09/15/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg003
 ---
 # RDG003: Unable to resolve parameter

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg004.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg004.md
@@ -5,7 +5,7 @@ author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 content_well_notification: AI-contribution
 ms.author: safia
-ms.date: 09/15/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg004
 ai-usage: ai-assisted
 ---

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg005.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg005.md
@@ -5,7 +5,7 @@ author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
 content_well_notification: AI-contribution
-ms.date: 9/27/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg005
 ai-usage: ai-assisted
 ---

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg006.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg006.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG006: Invalid constructor parameters"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 9/29/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg006
 ---
 # RDG006: Invalid constructor parameters

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg007.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg007.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG007: No valid constructor found"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 09/15/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg007
 ---
 # RDG007: No valid constructor found

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg008.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg008.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG008: Multiple public constructors"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 10/10/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg008
 ---
 # RDG008: Multiple public constructors

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg009.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg009.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG009: Invalid nested AsParameters"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 11/1/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg009
 ---
 # RDG009: Invalid nested AsParameters

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg010.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg010.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG010: InvalidAsParameters Nullable"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 09/15/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg010
 ---
 # RDG010: InvalidAsParameters Nullable

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg011.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg011.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG011: Type parameters not supported"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 09/15/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg011
 ---
 # RDG011: Type parameters not supported

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg012.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg012.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG012: Unable to resolve inaccessible t
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 09/15/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg012
 ---
 # RDG012: Unable to resolve inaccessible type

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg013.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/diagnostics/rdg013.md
@@ -4,7 +4,7 @@ description: "Learn about analysis rule RDG013: Invalid source attributes"
 author: captainsafia
 monikerRange: '>= aspnetcore-8.0'
 ms.author: safia
-ms.date: 10/5/2023
+ms.date: 03/29/2025
 uid: fundamentals/aot/request-delegate-generator/diagnostics/rdg013
 ---
 # RDG013: Invalid source attributes

--- a/aspnetcore/fundamentals/aot/request-delegate-generator/rdg.md
+++ b/aspnetcore/fundamentals/aot/request-delegate-generator/rdg.md
@@ -6,7 +6,7 @@ ms.author: riande
 content_well_notification: AI-contribution
 monikerRange: '>= aspnetcore-8.0'
 ms.topic: article
-ms.date: 9/21/2023
+ms.date: 03/01/2025
 uid: fundamentals/aot/rdg
 ai-usage: ai-assisted
 ---

--- a/aspnetcore/fundamentals/app-state.md
+++ b/aspnetcore/fundamentals/app-state.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Discover approaches to preserve session between requests.
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 05/29/2024
+ms.date: 04/24/2025
 uid: fundamentals/app-state
 ---
 # Session and state management in ASP.NET Core

--- a/aspnetcore/fundamentals/choose-aspnet-framework.md
+++ b/aspnetcore/fundamentals/choose-aspnet-framework.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Explains ASP.NET Core vs. ASP.NET 4.x and how to choose between them.
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 02/12/2020
+ms.date: 05/28/2025
 uid: fundamentals/choose-between-aspnet-and-aspnetcore
 ---
 # Choose between ASP.NET 4.x and ASP.NET Core

--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -5,7 +5,7 @@ description: Learn how to use the Configuration API to configure AppSettings in 
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 04/26/2024
+ms.date: 06/28/2025
 uid: fundamentals/configuration/index
 ---
 <!-- ms.sfi.ropc: t -->

--- a/aspnetcore/fundamentals/configuration/options.md
+++ b/aspnetcore/fundamentals/configuration/options.md
@@ -5,7 +5,7 @@ description: Discover how to use the options pattern to represent groups of rela
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 04/19/2025
+ms.date: 04/20/2025
 uid: fundamentals/configuration/options
 --- 
 # Options pattern in ASP.NET Core

--- a/aspnetcore/fundamentals/dependency-injection/includes/dependency-injection-5-7.md
+++ b/aspnetcore/fundamentals/dependency-injection/includes/dependency-injection-5-7.md
@@ -1,7 +1,7 @@
 ---
 author: rick-anderson
 ms.author: riande
-ms.date: 10/17/2023
+ms.date: 04/01/2025
 ---
 :::moniker range=">= aspnetcore-6.0 <= aspnetcore-7.0"
 

--- a/aspnetcore/fundamentals/dotnet-scaffold-telemetry.md
+++ b/aspnetcore/fundamentals/dotnet-scaffold-telemetry.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Learn about the telemetry collected by the dotnet-scaffold CLI tool.
 monikerRange: '>= aspnetcore-8.0'
 ms.author: tdykstra
-ms.date: 11/06/2024
+ms.date: 11/12/2024
 uid: fundamentals/dotnet-scaffold-telemetry
 ---
 # dotnet-scaffold telemetry

--- a/aspnetcore/fundamentals/environments.md
+++ b/aspnetcore/fundamentals/environments.md
@@ -5,7 +5,7 @@ description: Learn how to control app behavior across multiple environments in A
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 04/26/2024
+ms.date: 09/18/2024
 uid: fundamentals/environments
 ---
 # Use multiple environments in ASP.NET Core

--- a/aspnetcore/fundamentals/error-handling.md
+++ b/aspnetcore/fundamentals/error-handling.md
@@ -5,7 +5,7 @@ description: Discover how to handle errors in ASP.NET Core apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 08/25/2024
+ms.date: 01/15/2025
 uid: fundamentals/error-handling
 ---
 # Handle errors in ASP.NET Core

--- a/aspnetcore/fundamentals/host/hosted-services.md
+++ b/aspnetcore/fundamentals/host/hosted-services.md
@@ -5,7 +5,7 @@ description: Learn how to implement background tasks with hosted services in ASP
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 5/10/2024
+ms.date: 05/28/2025
 uid: fundamentals/host/hosted-services
 ---
 # Background tasks with hosted services in ASP.NET Core

--- a/aspnetcore/fundamentals/host/web-host.md
+++ b/aspnetcore/fundamentals/host/web-host.md
@@ -5,7 +5,7 @@ description: Learn about Web Host in ASP.NET Core, which is responsible for app 
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 08/29/2024
+ms.date: 09/06/2024
 uid: fundamentals/host/web-host
 ---
 # ASP.NET Core Web Host

--- a/aspnetcore/fundamentals/http-context.md
+++ b/aspnetcore/fundamentals/http-context.md
@@ -5,7 +5,7 @@ description: Learn about using HttpContext in ASP.NET Core apps. HttpContext isn
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 01/31/2022
+ms.date: 02/12/2025
 uid: fundamentals/httpcontext
 ---
 # Access `HttpContext` in ASP.NET Core

--- a/aspnetcore/fundamentals/http-logging/includes/index-6-7.md
+++ b/aspnetcore/fundamentals/http-logging/includes/index-6-7.md
@@ -1,7 +1,7 @@
 ---
 author: rick-anderson
 ms.author: riande
-ms.date: 10/19/2023
+ms.date: 09/25/2024
 ---
 
 :::moniker range=">= aspnetcore-6.0 <= aspnetcore-7.0"

--- a/aspnetcore/fundamentals/http-logging/index.md
+++ b/aspnetcore/fundamentals/http-logging/index.md
@@ -5,7 +5,7 @@ description: Learn how to log HTTP requests and responses.
 monikerRange: '>= aspnetcore-6.0'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 10/25/2023
+ms.date: 04/25/2025
 uid: fundamentals/http-logging/index
 ---
 # HTTP logging in ASP.NET Core

--- a/aspnetcore/fundamentals/localization.md
+++ b/aspnetcore/fundamentals/localization.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how ASP.NET Core provides services and middleware for localizing content into different languages and cultures.
 ms.author: riande
 monikerRange: '>= aspnetcore-3.1'
-ms.date: 02/23/2023
+ms.date: 06/20/2025
 uid: fundamentals/localization
 ---
 # Globalization and localization in ASP.NET Core

--- a/aspnetcore/fundamentals/localization/make-content-localizable.md
+++ b/aspnetcore/fundamentals/localization/make-content-localizable.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to make an ASP.NET Core app's content localizable to prepare the app for localizing content into different languages and cultures.
 ms.author: riande
 monikerRange: '>= aspnetcore-5.0'
-ms.date: 02/23/2023
+ms.date: 06/20/2025
 uid: fundamentals/localization/make-content-localizable
 ---
 # Make an ASP.NET Core app's content localizable

--- a/aspnetcore/fundamentals/localization/provide-resources.md
+++ b/aspnetcore/fundamentals/localization/provide-resources.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to provide localized resources for localizing content of an ASP.NET Core app into different languages and cultures.
 ms.author: riande
 monikerRange: '>= aspnetcore-5.0'
-ms.date: 02/23/2023
+ms.date: 06/20/2025
 uid: fundamentals/localization/provide-resources
 ---
 # Provide localized resources for languages and cultures in an ASP.NET Core app

--- a/aspnetcore/fundamentals/localization/select-language-culture.md
+++ b/aspnetcore/fundamentals/localization/select-language-culture.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn how to select a language and culture when localizing content into different languages and cultures in an ASP.NET Core app.
 ms.author: riande
 monikerRange: '>= aspnetcore-5.0'
-ms.date: 5/9/2023
+ms.date: 06/20/2025
 uid: fundamentals/localization/select-language-culture
 ---
 # Implement a strategy to select the language/culture for each request in a localized ASP.NET Core app

--- a/aspnetcore/fundamentals/logging/index.md
+++ b/aspnetcore/fundamentals/logging/index.md
@@ -5,7 +5,7 @@ description: Learn how to use the logging framework provided by the Microsoft.Ex
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 9/5/2023
+ms.date: 09/18/2024
 uid: fundamentals/logging/index
 ---
 

--- a/aspnetcore/fundamentals/map-static-files.md
+++ b/aspnetcore/fundamentals/map-static-files.md
@@ -5,7 +5,7 @@ description: Learn how to serve and secure mapped static files and configure sta
 monikerRange: '>= aspnetcore-9.0'
 ms.author: riande
 ms.custom: mvc
-ms.date: 3/18/2025
+ms.date: 06/09/2025
 uid: fundamentals/map-static-files
 ---
 # Map static files in ASP.NET Core

--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -5,7 +5,7 @@ description: Learn about ASP.NET Core middleware and the request pipeline.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 05/03/2023
+ms.date: 06/21/2025
 uid: fundamentals/middleware/index
 ms.ai: assisted
 ---

--- a/aspnetcore/fundamentals/middleware/request-response.md
+++ b/aspnetcore/fundamentals/middleware/request-response.md
@@ -5,7 +5,7 @@ description: Learn how to read the request body and write the response body in A
 monikerRange: '>= aspnetcore-3.0'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 4/22/2025
+ms.date: 04/24/2025
 uid: fundamentals/middleware/request-response
 ---
 # Request and response operations in ASP.NET Core

--- a/aspnetcore/fundamentals/middleware/write.md
+++ b/aspnetcore/fundamentals/middleware/write.md
@@ -5,7 +5,7 @@ description: Learn how to write custom ASP.NET Core middleware.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 12/18/2021
+ms.date: 06/21/2025
 uid: fundamentals/middleware/write
 ---
 # Write custom ASP.NET Core middleware

--- a/aspnetcore/fundamentals/minimal-apis.md
+++ b/aspnetcore/fundamentals/minimal-apis.md
@@ -5,7 +5,7 @@ description: Provides an overview of minimal APIs in ASP.NET Core
 ms.author: wpickett
 content_well_notification: AI-contribution
 monikerRange: '>= aspnetcore-6.0'
-ms.date: 05/19/2025
+ms.date: 05/20/2025
 uid: fundamentals/minimal-apis
 ai-usage: ai-assisted
 ---

--- a/aspnetcore/fundamentals/minimal-apis/includes/responses7-8.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/responses7-8.md
@@ -1,7 +1,7 @@
 ---
 author: tdykstra
 ms.author: tdykstra
-ms.date: 04/10/2024
+ms.date: 08/07/2024
 ---
 
 :::moniker range=">= aspnetcore-7.0 <= aspnetcore-8.0"

--- a/aspnetcore/fundamentals/minimal-apis/parameter-binding.md
+++ b/aspnetcore/fundamentals/minimal-apis/parameter-binding.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn how parameters are populated before invoking minimal route handlers.
 ms.author: wpickett
 monikerRange: '>= aspnetcore-7.0'
-ms.date: 05/17/2025
+ms.date: 05/18/2025
 uid: fundamentals/minimal-apis/parameter-binding
 ---
 

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -4,7 +4,7 @@ author: brunolins16
 description: Learn how to create responses for minimal APIs in ASP.NET Core.
 ms.author: brolivei
 monikerRange: '>= aspnetcore-7.0'
-ms.date: 02/07/2025
+ms.date: 05/09/2025
 uid: fundamentals/minimal-apis/responses
 ---
 

--- a/aspnetcore/fundamentals/minimal-apis/webapplication.md
+++ b/aspnetcore/fundamentals/minimal-apis/webapplication.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn about how to use WebApplication and WebApplicationBuilder.
 ms.author: wpickett
 monikerRange: '>= aspnetcore-7.0'
-ms.date: 10/31/2022
+ms.date: 05/18/2025
 uid: fundamentals/minimal-apis/webapplication
 ---
 

--- a/aspnetcore/fundamentals/native-aot.md
+++ b/aspnetcore/fundamentals/native-aot.md
@@ -5,7 +5,7 @@ ms.author: riande
 description: Learn about ASP.NET Core support for Native AOT
 content_well_notification: AI-contribution
 ms.custom: mvc, engagement-fy23
-ms.date: 8/11/2024
+ms.date: 03/27/2025
 uid: fundamentals/native-aot
 ai-usage: ai-assisted
 ---

--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -5,7 +5,7 @@ description: Learn how to generate and customize OpenAPI documents in an ASP.NET
 ms.author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.custom: mvc
-ms.date: 3/18/2025
+ms.date: 04/19/2025
 uid: fundamentals/openapi/aspnetcore-openapi
 ---
 # Generate OpenAPI documents

--- a/aspnetcore/fundamentals/openapi/customize-openapi.md
+++ b/aspnetcore/fundamentals/openapi/customize-openapi.md
@@ -5,7 +5,7 @@ description: Learn how to customize OpenAPI documents in an ASP.NET Core app
 ms.author: safia
 monikerRange: '>= aspnetcore-9.0'
 ms.custom: mvc
-ms.date: 05/15/2025
+ms.date: 05/17/2025
 uid: fundamentals/openapi/customize-openapi
 ---
 # Customize OpenAPI documents

--- a/aspnetcore/fundamentals/openapi/include-metadata.md
+++ b/aspnetcore/fundamentals/openapi/include-metadata.md
@@ -5,7 +5,7 @@ description: Learn how to add OpenAPI metadata in an ASP.NET Core app.
 ms.author: safia
 monikerRange: '>= aspnetcore-9.0'
 ms.custom: mvc
-ms.date: 4/22/2024
+ms.date: 06/12/2025
 uid: fundamentals/openapi/include-metadata
 ---
 # Include OpenAPI metadata in an ASP.NET Core app

--- a/aspnetcore/fundamentals/openapi/openapi-comments.md
+++ b/aspnetcore/fundamentals/openapi/openapi-comments.md
@@ -5,7 +5,7 @@ description: Learn how to integrate XML documentation comments on types by OpenA
 ms.author: safia
 monikerRange: '>= aspnetcore-10.0'
 ms.custom: mvc
-ms.date: 4/12/2025
+ms.date: 04/15/2025
 uid: fundamentals/openapi/aspnet-openapi-xml
 ---
 <!-- backup author: rick-anderson -->

--- a/aspnetcore/fundamentals/openapi/openapi-tools.md
+++ b/aspnetcore/fundamentals/openapi/openapi-tools.md
@@ -4,7 +4,7 @@ author: ryanbrandenburg
 description: Demonstrates how to use the 'Microsoft.dotnet-openapi' tool to add references to OpenAPI files.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 3/9/2022
+ms.date: 08/06/2024
 uid: fundamentals/openapi/openapi-tools
 ---
 # .NET OpenAPI tool command reference and installation

--- a/aspnetcore/fundamentals/openapi/overview.md
+++ b/aspnetcore/fundamentals/openapi/overview.md
@@ -4,7 +4,7 @@ author: rick-anderson
 description: Learn about OpenAPI features in ASP.NET Core.
 ms.author: riande
 monikerRange: '>= aspnetcore-6.0'
-ms.date: 8/02/2024
+ms.date: 05/14/2025
 uid: fundamentals/openapi/overview
 ---
 # OpenAPI support in ASP.NET Core API apps

--- a/aspnetcore/fundamentals/openapi/using-openapi-documents.md
+++ b/aspnetcore/fundamentals/openapi/using-openapi-documents.md
@@ -5,7 +5,7 @@ description: Learn how to use OpenAPI documents in an ASP.NET Core app.
 ms.author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.custom: mvc
-ms.date: 09/04/2024
+ms.date: 05/09/2025
 uid: fundamentals/openapi/using-openapi-documents
 ---
 # Use openAPI documents

--- a/aspnetcore/fundamentals/owin.md
+++ b/aspnetcore/fundamentals/owin.md
@@ -4,7 +4,7 @@ author: ardalis
 description: Discover how ASP.NET Core supports the Open Web Interface for .NET (OWIN), which allows web apps to be decoupled from web servers.
 ms.author: riande
 ms.custom: H1Hack27Feb2017
-ms.date: 2/8/2021
+ms.date: 04/24/2025
 uid: fundamentals/owin
 ---
 # Open Web Interface for .NET (OWIN) with ASP.NET Core

--- a/aspnetcore/fundamentals/portable-object-localization.md
+++ b/aspnetcore/fundamentals/portable-object-localization.md
@@ -3,7 +3,7 @@ title: Configure portable object localization in ASP.NET Core
 author: sebastienros
 description: This article introduces Portable Object files and outlines steps for using them in an ASP.NET Core application with the Orchard Core framework.
 ms.author: wpickett
-ms.date: 09/26/2017
+ms.date: 04/06/2025
 uid: fundamentals/portable-object-localization
 ---
 # Configure portable object localization in ASP.NET Core

--- a/aspnetcore/fundamentals/routing.md
+++ b/aspnetcore/fundamentals/routing.md
@@ -6,7 +6,7 @@ monikerRange: '>= aspnetcore-3.1'
 content_well_notification: AI-contribution
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 6/14/2023
+ms.date: 09/18/2024
 uid: fundamentals/routing
 ai-usage: ai-assisted
 ---

--- a/aspnetcore/fundamentals/servers/httpsys.md
+++ b/aspnetcore/fundamentals/servers/httpsys.md
@@ -5,7 +5,7 @@ description: Learn about HTTP.sys, a web server for ASP.NET Core on Windows. Bui
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 06/12/2025
+ms.date: 06/13/2025
 uid: fundamentals/servers/httpsys
 ---
 # HTTP.sys web server implementation in ASP.NET Core

--- a/aspnetcore/fundamentals/servers/index.md
+++ b/aspnetcore/fundamentals/servers/index.md
@@ -5,7 +5,7 @@ description: Discover the web servers Kestrel and HTTP.sys for ASP.NET Core. Lea
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 11/07/2019
+ms.date: 05/28/2025
 uid: fundamentals/servers/index
 ---
 # Web server implementations in ASP.NET Core

--- a/aspnetcore/fundamentals/servers/kestrel/endpoints.md
+++ b/aspnetcore/fundamentals/servers/kestrel/endpoints.md
@@ -5,7 +5,7 @@ description: Learn about configuring endpoints with Kestrel, the cross-platform 
 monikerRange: '>= aspnetcore-5.0'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 2/4/2025
+ms.date: 03/05/2025
 uid: fundamentals/servers/kestrel/endpoints
 ---
 

--- a/aspnetcore/fundamentals/servers/kestrel/http3.md
+++ b/aspnetcore/fundamentals/servers/kestrel/http3.md
@@ -5,7 +5,7 @@ description: Learn about using HTTP/3 with Kestrel, the cross-platform web serve
 monikerRange: '>= aspnetcore-6.0'
 ms.author: wigodbe
 ms.custom: mvc, linux-related-content
-ms.date: 08/24/2023
+ms.date: 06/08/2025
 uid: fundamentals/servers/kestrel/http3
 ---
 

--- a/aspnetcore/fundamentals/servers/kestrel/when-to-use-a-reverse-proxy.md
+++ b/aspnetcore/fundamentals/servers/kestrel/when-to-use-a-reverse-proxy.md
@@ -5,7 +5,7 @@ description: Learn about when to use a reverse proxy in front of Kestrel, the cr
 monikerRange: '>= aspnetcore-5.0'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 04/01/2022
+ms.date: 02/06/2025
 uid: fundamentals/servers/kestrel/when-to-use-a-reverse-proxy
 ---
 

--- a/aspnetcore/fundamentals/servers/yarp/dests-health-checks.md
+++ b/aspnetcore/fundamentals/servers/yarp/dests-health-checks.md
@@ -4,7 +4,7 @@ title: YARP Destination health checks
 description: YARP Destination health checks
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 04/06/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/distributed-tracing.md
+++ b/aspnetcore/fundamentals/servers/yarp/distributed-tracing.md
@@ -4,7 +4,7 @@ title: YARP Distributed tracing
 description: YARP Distributed tracing
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 04/24/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/extensibility.md
+++ b/aspnetcore/fundamentals/servers/yarp/extensibility.md
@@ -4,7 +4,7 @@ title: Overview of extensibility
 description: Overview of extensibility
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/12/2025
+ms.date: 04/03/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/grpc.md
+++ b/aspnetcore/fundamentals/servers/yarp/grpc.md
@@ -4,7 +4,7 @@ title: YARP Proxying gRPC
 description: YARP Proxying gRPC
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 04/12/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/header-guidelines.md
+++ b/aspnetcore/fundamentals/servers/yarp/header-guidelines.md
@@ -4,7 +4,7 @@ title: YARP HTTP header guidelines
 description: Learn about YARP HTTP header guidelines.
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 04/03/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/https-tls.md
+++ b/aspnetcore/fundamentals/servers/yarp/https-tls.md
@@ -4,7 +4,7 @@ title: YARP HTTPS & TLS
 description: YARP HTTPS & TLS
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 02/14/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/httpsys-delegation.md
+++ b/aspnetcore/fundamentals/servers/yarp/httpsys-delegation.md
@@ -4,7 +4,7 @@ title: YARP HTTP.sys Delegation
 description: YARP HTTP.sys Delegation
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 04/03/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/kubernetes-ingress.md
+++ b/aspnetcore/fundamentals/servers/yarp/kubernetes-ingress.md
@@ -4,7 +4,7 @@ title: YARP Kubernetes Ingress Controller
 description: YARP Kubernetes Ingress Controller
 author: samsp-msft
 ms.author: samsp
-ms.date: 3/6/2025
+ms.date: 04/03/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/lets-encrypt.md
+++ b/aspnetcore/fundamentals/servers/yarp/lets-encrypt.md
@@ -5,7 +5,7 @@ description: YARP Lets Encrypt
 author: samsp-msft
 monikerRange: '<= aspnetcore-7.0'
 ms.author: samsp
-ms.date: 6/13/2025
+ms.date: 06/14/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/middleware.md
+++ b/aspnetcore/fundamentals/servers/yarp/middleware.md
@@ -4,7 +4,7 @@ title: YARP Middleware
 description: YARP Middleware
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 04/04/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/service-fabric-int.md
+++ b/aspnetcore/fundamentals/servers/yarp/service-fabric-int.md
@@ -4,7 +4,7 @@ title: YARP Service Fabric Integration
 description: YARP Service Fabric Integration
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 04/03/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/transforms-response.md
+++ b/aspnetcore/fundamentals/servers/yarp/transforms-response.md
@@ -4,7 +4,7 @@ title: YARP Response and Response Trailer Transforms
 description: YARP Response and Response Trailer Transforms
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/6/2025
+ms.date: 04/04/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/servers/yarp/yarp-overview.md
+++ b/aspnetcore/fundamentals/servers/yarp/yarp-overview.md
@@ -4,7 +4,7 @@ title: Overview of YARP
 description: Overview of YARP
 author: samsp-msft
 ms.author: samsp
-ms.date: 2/18/2025
+ms.date: 04/03/2025
 ms.topic: article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted

--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -5,7 +5,7 @@ description: Learn how to serve and secure static files and configure static fil
 monikerRange: '>= aspnetcore-3.1'
 ms.author: riande
 ms.custom: mvc
-ms.date: 7/25/2024
+ms.date: 03/18/2025
 uid: fundamentals/static-files
 ---
 # Static files in ASP.NET Core

--- a/aspnetcore/fundamentals/tools/dotnet-aspnet-codegenerator.md
+++ b/aspnetcore/fundamentals/tools/dotnet-aspnet-codegenerator.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: The ASP.NET Core code generator tool scaffolds ASP.NET Core projects.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
-ms.date: 07/05/2024
+ms.date: 11/09/2024
 uid: fundamentals/tools/dotnet-aspnet-codegenerator
 ---
 # ASP.NET Core code generator tool (`aspnet-codegenerator`)

--- a/aspnetcore/fundamentals/troubleshoot-aspnet-core-localization.md
+++ b/aspnetcore/fundamentals/troubleshoot-aspnet-core-localization.md
@@ -3,7 +3,7 @@ title: Troubleshoot ASP.NET Core localization
 author: hishamco
 description: Learn how to diagnose problems with localization in ASP.NET Core apps.
 ms.author: riande
-ms.date: 01/24/2019
+ms.date: 05/03/2024
 uid: fundamentals/troubleshoot-aspnet-core-localization
 ---
 # Troubleshoot ASP.NET Core localization

--- a/aspnetcore/fundamentals/use-http-context.md
+++ b/aspnetcore/fundamentals/use-http-context.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: How to use HttpContext in ASP.NET Core.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 12/13/2024
+ms.date: 12/18/2024
 uid: fundamentals/use-httpcontext
 ---
 <!-- ms.sfi.ropc: t -->

--- a/aspnetcore/fundamentals/websockets.md
+++ b/aspnetcore/fundamentals/websockets.md
@@ -5,7 +5,7 @@ description: Learn how to get started with WebSockets in ASP.NET Core.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 04/23/2024
+ms.date: 05/08/2025
 uid: fundamentals/websockets
 ---
 # WebSockets support in ASP.NET Core

--- a/aspnetcore/introduction-to-aspnet-core.md
+++ b/aspnetcore/introduction-to-aspnet-core.md
@@ -4,7 +4,7 @@ author: tdykstra
 description: Get an overview of ASP.NET Core, a cross-platform, high-performance, open-source framework for building modern, cloud-enabled, Internet-connected apps.
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 04/21/2025
+ms.date: 06/21/2025
 uid: index
 ---
 # Overview of ASP.NET Core


### PR DESCRIPTION

Logic is:

Update .md file metadata ms.date value to match last commit with a change of over 50 characters.
If the ms.date is already newer, leave it alone since someone reviewed it and then updated the date.
Includes are skipped since includes do not have an ms.date in metadata.

For this run, only including the following paths:
aspnetcore/client-side/
aspnetcore/data/
aspnetcore/diagnostics/
aspnetcore/fundamentals/



