### PR TITLE
docs: Add `Grpc-Status-Details-Bin` to exposed headers in grpcweb docs

### DIFF
--- a/aspnetcore/grpc/grpcweb.md
+++ b/aspnetcore/grpc/grpcweb.md
@@ -4,7 +4,7 @@ author: jamesnk
 description: Learn how to configure gRPC services on ASP.NET Core to be callable from browser apps using gRPC-Web.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: wpickett
-ms.date: 04/29/2025
+ms.date: 07/10/2025
 uid: grpc/grpcweb
 ---
 # gRPC-Web in ASP.NET Core gRPC apps

--- a/aspnetcore/grpc/grpcweb/sample/8.x/GrpcGreeter/Program.cs
+++ b/aspnetcore/grpc/grpcweb/sample/8.x/GrpcGreeter/Program.cs
@@ -14,7 +14,8 @@ var app = builder.Build();
 app.UseGrpcWeb();
 
 app.MapGrpcService<GreeterService>().EnableGrpcWeb();
-app.MapGet("/", () => "This gRPC service is gRPC-Web enabled and is callable from browser apps using the gRPC-Web protocol");
+app.MapGet("/", () => "This gRPC service is gRPC-Web enabled and is " +
+    "callable from browser apps using the gRPC-Web protocol");
 
 app.Run();
 // </snippet_WebEnable>
@@ -34,7 +35,9 @@ var app = builder.Build();
 app.UseGrpcWeb(new GrpcWebOptions { DefaultEnabled = true });
 
 app.MapGrpcService<GreeterService>();
-app.MapGet("/", () => "All gRPC service are supported by default in this example, and are callable from browser apps using the gRPC-Web protocol");
+app.MapGet("/", () => "All gRPC service are supported by default in " +
+    "this example, and are callable from browser apps using the " +
+    "gRPC-Web protocol");
 
 app.Run();
 // </snippet_WebEnableAllServices>
@@ -53,7 +56,9 @@ builder.Services.AddCors(o => o.AddPolicy("AllowAll", builder =>
     builder.AllowAnyOrigin()
             .AllowAnyMethod()
             .AllowAnyHeader()
-            .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding", "Grpc-Status-Details-Bin");
+            .WithExposedHeaders("Grpc-Status", "Grpc-Message", 
+                "Grpc-Encoding", "Grpc-Accept-Encoding", 
+                "Grpc-Status-Details-Bin");
 }));
 
 var app = builder.Build();
@@ -64,7 +69,9 @@ app.UseCors();
 app.MapGrpcService<GreeterService>().EnableGrpcWeb()
                                     .RequireCors("AllowAll");
 
-app.MapGet("/", () => "This gRPC service is gRPC-Web enabled, CORS enabled, and is callable from browser apps using the gRPC-Web protocol");
+app.MapGet("/", () => "This gRPC service is gRPC-Web enabled, CORS " +
+    "enabled, and is callable from browser apps using the gRPC-Web " +
+    "protocol");
 
 app.Run();
 // </snippet_WebEnableCORS>

--- a/aspnetcore/grpc/grpcweb/sample/8.x/GrpcGreeter/Program.cs
+++ b/aspnetcore/grpc/grpcweb/sample/8.x/GrpcGreeter/Program.cs
@@ -53,7 +53,7 @@ builder.Services.AddCors(o => o.AddPolicy("AllowAll", builder =>
     builder.AllowAnyOrigin()
             .AllowAnyMethod()
             .AllowAnyHeader()
-            .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding");
+            .WithExposedHeaders("Grpc-Status", "Grpc-Message", "Grpc-Encoding", "Grpc-Accept-Encoding", "Grpc-Status-Details-Bin");
 }));
 
 var app = builder.Build();


### PR DESCRIPTION
Add `Grpc-Status-Details-Bin` to exposed headers in grpc web docs.
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/grpcweb.md](https://github.com/dotnet/AspNetCore.Docs/blob/378489b325cfc0982194659f63f66ecd1bbd8039/aspnetcore/grpc/grpcweb.md) | [aspnetcore/grpc/grpcweb](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/grpcweb?branch=pr-en-us-35733) |

<!-- PREVIEW-TABLE-END -->