### PR TITLE
JWT bearer authentication in ASP.NET Core layout improvement

### DIFF
--- a/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
+++ b/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
@@ -326,22 +326,13 @@ Refer to the following document:
 
 ## Standards
 
-[JSON Web Token (JWT)](https://datatracker.ietf.org/doc/html/rfc7519)
-
-[The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
-
-[OAuth 2.0 Demonstrating Proof of Possession DPoP](https://datatracker.ietf.org/doc/html/rfc9449)
-
-[OAuth 2.0 JWT-Secured Authorization Request (JAR) RFC 9101](https://datatracker.ietf.org/doc/rfc9101/)
-
-[OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens](https://datatracker.ietf.org/doc/html/rfc8705)
-
-[OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0-final.html)
-
-[Microsoft identity platform and OAuth 2.0 On-Behalf-Of flow](/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow)
-
-[OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693)
-
-[JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/html/rfc9068)
-
-[HTTP Semantics RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.2)
+* [JSON Web Token (JWT)](https://datatracker.ietf.org/doc/html/rfc7519)
+* [The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+* [OAuth 2.0 Demonstrating Proof of Possession DPoP](https://datatracker.ietf.org/doc/html/rfc9449)
+* [OAuth 2.0 JWT-Secured Authorization Request (JAR) RFC 9101](https://datatracker.ietf.org/doc/rfc9101/)
+* [OAuth 2.0 Mutual-TLS Client Authentication and Certificate-Bound Access Tokens](https://datatracker.ietf.org/doc/html/rfc8705)
+* [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0-final.html)
+* [Microsoft identity platform and OAuth 2.0 On-Behalf-Of flow](/azure/active-directory/develop/v2-oauth2-on-behalf-of-flow)
+* [OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693)
+* [JSON Web Token (JWT) Profile for OAuth 2.0 Access Tokens](https://datatracker.ietf.org/doc/html/rfc9068)
+* [HTTP Semantics RFC 9110](https://datatracker.ietf.org/doc/html/rfc9110#section-15.5.2)


### PR DESCRIPTION
Updated Configure JWT bearer authentication in ASP.NET Core, switched the standards to a list like the other docs