### PR TITLE
SQLite guidance for case insensitive filtering

### DIFF
--- a/aspnetcore/blazor/tutorials/movie-database-app/part-6.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-6.md
@@ -60,7 +60,7 @@ The `movie => movie.Title!.Contains(...)` code is a *lambda expression*. Lambdas
 
 The <xref:System.Data.Objects.DataClasses.EntityCollection%601.Contains%2A> method is run on the database, not in the C# code. The case sensitivity of the query depends on the database and the collation. For SQL Server, <xref:System.String.Contains%2A> maps to [SQL `LIKE`](/sql/t-sql/language-elements/like-transact-sql), which is case insensitive. SQLite with default collation provides a mixture of case-sensitive and case-insensitive filtering, depending on the query. The remainder of this tutorial assumes case-insensitive database collation.
 
-If you're following this tutorial using Visual Studio Code or the .NET CLI, you're using a SQLite database. To adopt case-insensitive collation, open the `Data/BlazorWebAppMoviesContext.cs` file. Inside the `BlazorWebAppMoviesContext` class, add the following code:
+To adopt case-insensitive collation when using SQLite (<xref:Microsoft.EntityFrameworkCore.SqliteDbContextOptionsBuilderExtensions.UseSqlite%2A> is called in `Program.cs`), open the `Data/BlazorWebAppMoviesContext.cs` file. Inside the `BlazorWebAppMoviesContext` class, add the following code:
 
 ```csharp
 protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
Fixes #35851

Thanks @rodbeck! 🚀 

Dan, we might ***not*** want to do this, or we might want to do something different. I started by trying to update the instructions to specifically tell SQLite folks to use case sensitive search terms (e.g., "Road Warrior" instead of "road warrior"). The problem with modifying all of the instructions that way is that it muddies up the text with distracting parenthetical information that still doesn't match the images. Therefore if we do anything, it might be best to show the workaround approach of using `ToLower` (on this PR), which is simpler and quicker than getting into the weeds with SQLite dB collation, which we do cross-link.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tutorials/movie-database-app/part-6.md](https://github.com/dotnet/AspNetCore.Docs/blob/69268a422701f8aedfeb95fdbb832a9ea9e17c49/aspnetcore/blazor/tutorials/movie-database-app/part-6.md) | [aspnetcore/blazor/tutorials/movie-database-app/part-6](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/movie-database-app/part-6?branch=pr-en-us-35853) |


<!-- PREVIEW-TABLE-END -->