### PR TITLE
Fix invalid ms.author: Update docfx.json

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -51,10 +51,10 @@
     },
     "fileMetadata": {
       "author": {
-        "whats-new/**/**.md": "tdykstra"
+        "whats-new/**/**.md": "wadepickett"
       },
       "ms.author": {
-        "whats-new/**/**.md": "tdykstra"
+        "whats-new/**/**.md": "wpickett"
       },
       "ms.subservice": {
         "introduction-to-aspnet-core.md": "index-page",

--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -51,10 +51,10 @@
     },
     "fileMetadata": {
       "author": {
-        "whats-new/**/**.md": "rick-anderson"
+        "whats-new/**/**.md": "tdykstra"
       },
       "ms.author": {
-        "whats-new/**/**.md": "riande"
+        "whats-new/**/**.md": "tdykstra"
       },
       "ms.subservice": {
         "introduction-to-aspnet-core.md": "index-page",


### PR DESCRIPTION
Update to fix invalid ms.author value in docfx.json for content in what's new in docs.

Contributes to https://github.com/dotnet/AspNetCore.Docs/issues/35827

