### PR TITLE
Fix legacy Azure SDK API links

### DIFF
--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -1594,7 +1594,7 @@ Common storage options for files include:
   * Services usually offer improved scalability and resiliency over on-premises solutions that are usually subject to single points of failure.
   * Services are potentially lower cost in large storage infrastructure scenarios.
 
-  For more information, see [Quickstart: Use .NET to create a blob in object storage](/azure/storage/blobs/storage-quickstart-blobs-dotnet). The topic demonstrates <xref:Microsoft.Azure.Storage.File.CloudFile.UploadFromFileAsync%2A>, but <xref:Microsoft.Azure.Storage.File.CloudFile.UploadFromStreamAsync%2A> can be used to save a <xref:System.IO.FileStream> to blob storage when working with a <xref:System.IO.Stream>.
+  For more information, see [Quickstart: Use .NET to create a blob in object storage](/azure/storage/blobs/storage-quickstart-blobs-dotnet). The topic demonstrates [`UploadFromFileAsync`](/dotnet/api/microsoft.azure.storage.file.cloudfile.uploadfromfileasync), but [`UploadFromStreamAsync`](/dotnet/api/microsoft.azure.storage.file.cloudfile.UploadFromStreamAsync) can be used to save a <xref:System.IO.FileStream> to blob storage when working with a <xref:System.IO.Stream>.
 
 ## File upload scenarios
 

--- a/aspnetcore/mvc/models/file-uploads.md
+++ b/aspnetcore/mvc/models/file-uploads.md
@@ -1594,7 +1594,7 @@ Common storage options for files include:
   * Services usually offer improved scalability and resiliency over on-premises solutions that are usually subject to single points of failure.
   * Services are potentially lower cost in large storage infrastructure scenarios.
 
-  For more information, see [Quickstart: Use .NET to create a blob in object storage](/azure/storage/blobs/storage-quickstart-blobs-dotnet). The topic demonstrates [`UploadFromFileAsync`](/dotnet/api/microsoft.azure.storage.file.cloudfile.uploadfromfileasync), but [`UploadFromStreamAsync`](/dotnet/api/microsoft.azure.storage.file.cloudfile.UploadFromStreamAsync) can be used to save a <xref:System.IO.FileStream> to blob storage when working with a <xref:System.IO.Stream>.
+  For more information, see [Quickstart: Use .NET to create a blob in object storage](/azure/storage/blobs/storage-quickstart-blobs-dotnet). The topic demonstrates [`UploadFromFileAsync`](/dotnet/api/microsoft.azure.storage.file.cloudfile.uploadfromfileasync), but [`UploadFromStreamAsync`](/dotnet/api/microsoft.azure.storage.file.cloudfile.uploadfromstreamasync) can be used to save a <xref:System.IO.FileStream> to blob storage when working with a <xref:System.IO.Stream>.
 
 ## File upload scenarios
 


### PR DESCRIPTION
Fixes #35874

### ***Disco Fever!*** 🕺💃🪩

Let's fix them this way. 🤔 I think the reason that they're failing is that they're marked "legacy." That's a wild guess tho.

I think these should be reported because API docs exist for them. Seems like the XREF links should still work for them.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/models/file-uploads.md](https://github.com/dotnet/AspNetCore.Docs/blob/8195034210a9d3fec40561bb83a1a824eedd4a3a/aspnetcore/mvc/models/file-uploads.md) | [aspnetcore/mvc/models/file-uploads](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/models/file-uploads?branch=pr-en-us-35875) |


<!-- PREVIEW-TABLE-END -->