### PR TITLE
Fix invalid ms.author value: YARP: config-providers.md

### DIFF
--- a/aspnetcore/fundamentals/servers/yarp/config-providers.md
+++ b/aspnetcore/fundamentals/servers/yarp/config-providers.md
@@ -2,8 +2,8 @@
 uid: fundamentals/servers/yarp/config-providers
 title: YARP Extensibility Configuration Providers
 description: YARP Extensibility Configuration Providers
-author: samsp-msft
-ms.author: samsp
+author: wadepickett
+ms.author: wpickett
 ms.date: 2/6/2025
 ms.topic: article
 content_well_notification: AI-contribution


### PR DESCRIPTION
Found a YARP file that still had an invalid ms.author and fixed it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/yarp/config-providers.md](https://github.com/dotnet/AspNetCore.Docs/blob/cb14f510f52f5ec31eb398216a026840a35d734f/aspnetcore/fundamentals/servers/yarp/config-providers.md) | [YARP Extensibility: Configuration Providers](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/yarp/config-providers?branch=pr-en-us-35886) |

<!-- PREVIEW-TABLE-END -->