### PR TITLE
Versioning  Prep Only: Using-openapi-documents.md

### DIFF
--- a/aspnetcore/fundamentals/openapi/includes/using-openapi-documents-9.md
+++ b/aspnetcore/fundamentals/openapi/includes/using-openapi-documents-9.md
@@ -1,16 +1,4 @@
----
-title: Use the generated OpenAPI documents
-author: captainsafia
-description: Learn how to use OpenAPI documents in an ASP.NET Core app.
-ms.author: safia
-monikerRange: '>= aspnetcore-6.0'
-ms.custom: mvc
-ms.date: 05/09/2025
-uid: fundamentals/openapi/using-openapi-documents
----
-# Use openAPI documents
-
-:::moniker range=">= aspnetcore-10.0"
+:::moniker range="= aspnetcore-9.0"
 
 ## Use Swagger UI for local ad-hoc testing
 
@@ -100,6 +88,3 @@ The output shows any issues with the OpenAPI document. For example:
 ✖ 5 problems (0 errors, 5 warnings, 0 infos, 0 hints)
 ```
 :::moniker-end
-
-[!INCLUDE[](~/fundamentals/openapi/includes/using-openapi-documents-6-8.md)]
-[!INCLUDE[](~/fundamentals/openapi/includes/using-openapi-documents-9.md)]


### PR DESCRIPTION
Versioning  Prep Only: Moving the .NET 9 version of the topic to includes, starting a new one with the .NET 10 moniker range in prep for updating in new PR afterwards so diffs are easily seen.

Contributes to #35408

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/using-openapi-documents.md](https://github.com/dotnet/AspNetCore.Docs/blob/ed79a3be0dba737bcf54bf8e5d9c3af0bbe187af/aspnetcore/fundamentals/openapi/using-openapi-documents.md) | [Use openAPI documents](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/using-openapi-documents?branch=pr-en-us-35887) |

<!-- PREVIEW-TABLE-END -->