### PR TITLE
Add cross-link to RCL article

### DIFF
--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -468,3 +468,4 @@ In the preceding example, the `{TARGET FRAMEWORK}` placeholder is the [target fr
   * [.NET WebAssembly runtime](https://github.com/dotnet/runtime/tree/main/src/mono/wasm)
   * [`dotnet.d.ts` file (.NET WebAssembly runtime configuration)](https://github.com/dotnet/runtime/blob/main/src/mono/browser/runtime/dotnet.d.ts)
 * [Use .NET from any JavaScript app in .NET 7](https://devblogs.microsoft.com/dotnet/use-net-7-from-any-javascript-app-in-net-7/)
+* <xref:blazor/components/class-libraries>

--- a/aspnetcore/client-side/dotnet-interop.md
+++ b/aspnetcore/client-side/dotnet-interop.md
@@ -468,4 +468,6 @@ In the preceding example, the `{TARGET FRAMEWORK}` placeholder is the [target fr
   * [.NET WebAssembly runtime](https://github.com/dotnet/runtime/tree/main/src/mono/wasm)
   * [`dotnet.d.ts` file (.NET WebAssembly runtime configuration)](https://github.com/dotnet/runtime/blob/main/src/mono/browser/runtime/dotnet.d.ts)
 * [Use .NET from any JavaScript app in .NET 7](https://devblogs.microsoft.com/dotnet/use-net-7-from-any-javascript-app-in-net-7/)
-* <xref:blazor/components/class-libraries>
+* Including static assets from a Razor class library
+  * <xref:blazor/components/class-libraries> (Blazor documentation)
+  * <xref:razor-pages/ui-class#create-an-rcl-with-static-assets> (Razor Pages documentation)


### PR DESCRIPTION
Fixes #35900

Per https://github.com/dotnet/AspNetCore.Docs/issues/35882.

Marek, do we need anything else outside of a cross-link?

**UPDATE**: Should we link the non-Blazor article instead for this? We can link directly to the section that pertains to static assets ...

https://learn.microsoft.com/aspnet/core/razor-pages/ui-class#create-an-rcl-with-static-assets

**UPDATE**: *Yes!* Let me see if I can link both.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/client-side/dotnet-interop.md](https://github.com/dotnet/AspNetCore.Docs/blob/74e661740853aeea37c8323cdedaf867bf85b976/aspnetcore/client-side/dotnet-interop.md) | [aspnetcore/client-side/dotnet-interop](https://review.learn.microsoft.com/en-us/aspnet/core/client-side/dotnet-interop?branch=pr-en-us-35901) |


<!-- PREVIEW-TABLE-END -->