### PR TITLE
Update WN date to grab updated Blazor include

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn about the new features in ASP.NET Core in .NET 10.
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 7/18/2025
+ms.date: 8/11/2025
 uid: aspnetcore-10
 ---
 # What's new in ASP.NET Core in .NET 10


### PR DESCRIPTION
I'll set the date to yesterday for now to draw the Blazor content into the WN article.

That way, any late PRs this evening for WN include content can still go in using today's date.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/3cd99a16e10ebbb826df9ee89d77470e40551e12/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-35932) |

<!-- PREVIEW-TABLE-END -->