### PR TITLE
Replace InvokeNew[Async] with InvokeConstructor[Async]

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -462,8 +462,8 @@ IJSRuntime JS { get; set; }
 
 Create an instance of a JS object using a constructor function and get the <xref:Microsoft.JSInterop.IJSObjectReference>/<xref:Microsoft.JSInterop.IJSInProcessObjectReference> .NET handle for referencing the instance with the following API:
 
-* `InvokeNewAsync` (asynchronous)
-* `InvokeNew` (synchronous)
+* `InvokeConstructorAsync` (asynchronous)
+* `InvokeConstructor` (synchronous)
 
 Examples in this section demonstrate the API calls with the following `TestClass` with a constructor function (`constructor(text)`):
 
@@ -479,25 +479,25 @@ window.TestClass = class {
 }
 ```
 
-### Asynchronous `InvokeNewAsync`
+### Asynchronous `InvokeConstructorAsync`
 
-Use `InvokeNewAsync(string identifier, object?[]? args)` on <xref:Microsoft.JSInterop.IJSRuntime> and <xref:Microsoft.JSInterop.IJSObjectReference> to invoke the specified JS constructor function asynchronously. The function is invoked with the `new` operator. In the following example, `TestClass` contains a constructor function, and `classRef` is an <xref:Microsoft.JSInterop.IJSObjectReference>.
+Use `InvokeConstructorAsync(string identifier, object?[]? args)` on <xref:Microsoft.JSInterop.IJSRuntime> and <xref:Microsoft.JSInterop.IJSObjectReference> to invoke the specified JS constructor function asynchronously. The function is invoked with the `new` operator. In the following example, `TestClass` contains a constructor function, and `classRef` is an <xref:Microsoft.JSInterop.IJSObjectReference>.
 
 ```csharp
-var classRef = await JSRuntime.InvokeNewAsync("TestClass", "Blazor!");
+var classRef = await JSRuntime.InvokeConstructorAsync("TestClass", "Blazor!");
 var text = await classRef.GetValueAsync<string>("text");
 var textLength = await classRef.InvokeAsync<int>("getTextLength");
 ```
 
 An overload is available that takes a <xref:System.Threading.CancellationToken> argument or <xref:System.TimeSpan> timeout argument.
 
-### Synchronous `InvokeNew`
+### Synchronous `InvokeConstructor`
 
-Use `InvokeNew(string identifier, object?[]? args)` on <xref:Microsoft.JSInterop.IJSInProcessRuntime> and <xref:Microsoft.JSInterop.IJSInProcessObjectReference> to invoke the specified JS constructor function synchronously. The function is invoked with the `new` operator. In the following example, `TestClass` contains a constructor function, and `classRef` is an <xref:Microsoft.JSInterop.IJSInProcessObjectReference>:
+Use `InvokeConstructor(string identifier, object?[]? args)` on <xref:Microsoft.JSInterop.IJSInProcessRuntime> and <xref:Microsoft.JSInterop.IJSInProcessObjectReference> to invoke the specified JS constructor function synchronously. The function is invoked with the `new` operator. In the following example, `TestClass` contains a constructor function, and `classRef` is an <xref:Microsoft.JSInterop.IJSInProcessObjectReference>:
 
 ```csharp
 var inProcRuntime = ((IJSInProcessRuntime)JSRuntime);
-var classRef = inProcRuntime.InvokeNew("TestClass", "Blazor!");
+var classRef = inProcRuntime.InvokeConstructor("TestClass", "Blazor!");
 var text = classRef.GetValue<string>("text");
 var textLength = classRef.Invoke<int>("getTextLength");
 ```
@@ -630,7 +630,7 @@ In server-side scenarios, JS interop calls can't be issued after Blazor's Signal
   * <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A?displayProperty=nameWithType>
   * <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeAsync%2A?displayProperty=nameWithType>
   * <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A?displayProperty=nameWithType>
-  * `InvokeNewAsync`
+  * `InvokeConstructorAsync`
   * `GetValueAsync`
   * `SetValueAsync`
 * `Dispose`/`DisposeAsync` calls on any <xref:Microsoft.JSInterop.IJSObjectReference>.

--- a/aspnetcore/blazor/javascript-interoperability/index.md
+++ b/aspnetcore/blazor/javascript-interoperability/index.md
@@ -337,7 +337,7 @@ JavaScript (JS) interop calls can't be issued after Blazor's SignalR circuit is 
   * <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A?displayProperty=nameWithType>
   * <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeAsync%2A?displayProperty=nameWithType>
   * <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeVoidAsync%2A?displayProperty=nameWithType>
-  * `InvokeNewAsync`
+  * `InvokeConstructorAsync`
   * `GetValueAsync`
   * `SetValueAsync`
 * `Dispose`/`DisposeAsync` calls on any <xref:Microsoft.JSInterop.IJSObjectReference>.

--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn about the new features in ASP.NET Core in .NET 10.
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 08/13/2025
+ms.date: 08/14/2025
 uid: aspnetcore-10
 ---
 # What's new in ASP.NET Core in .NET 10

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -305,10 +305,10 @@ Blazor adds support for the following JS interop features:
 
 The following asynchronous methods are available on <xref:Microsoft.JSInterop.IJSRuntime> and <xref:Microsoft.JSInterop.IJSObjectReference> with the same scoping behavior as the existing <xref:Microsoft.JSInterop.IJSRuntime.InvokeAsync%2A?displayProperty=nameWithType> method:
 
-* `InvokeNewAsync(string identifier, object?[]? args)`: Invokes the specified JS constructor function asynchronously. The function is invoked with the `new` operator. In the following example, `jsInterop.TestClass` is a class with a constructor function, and `classRef` is an <xref:Microsoft.JSInterop.IJSObjectReference>:
+* `InvokeConstructorAsync(string identifier, object?[]? args)`: Invokes the specified JS constructor function asynchronously. The function is invoked with the `new` operator. In the following example, `jsInterop.TestClass` is a class with a constructor function, and `classRef` is an <xref:Microsoft.JSInterop.IJSObjectReference>:
 
   ```csharp
-  var classRef = await JSRuntime.InvokeNewAsync("jsInterop.TestClass", "Blazor!");
+  var classRef = await JSRuntime.InvokeConstructorAsync("jsInterop.TestClass", "Blazor!");
   var text = await classRef.GetValueAsync<string>("text");
   var textLength = await classRef.InvokeAsync<int>("getTextLength");
   ```
@@ -330,11 +330,11 @@ Overloads are available for each of the preceding methods that take a <xref:Syst
 
 The following synchronous methods are available on <xref:Microsoft.JSInterop.IJSInProcessRuntime> and <xref:Microsoft.JSInterop.IJSInProcessObjectReference> with the same scoping behavior as the existing <xref:Microsoft.JSInterop.IJSInProcessObjectReference.Invoke%2A?displayProperty=nameWithType> method:
 
-* `InvokeNew(string identifier, object?[]? args)`: Invokes the specified JS constructor function synchronously. The function is invoked with the `new` operator. In the following example, `jsInterop.TestClass` is a class with a constructor function, and `classRef` is an <xref:Microsoft.JSInterop.IJSInProcessObjectReference>:
+* `InvokeConstructor(string identifier, object?[]? args)`: Invokes the specified JS constructor function synchronously. The function is invoked with the `new` operator. In the following example, `jsInterop.TestClass` is a class with a constructor function, and `classRef` is an <xref:Microsoft.JSInterop.IJSInProcessObjectReference>:
 
   ```csharp
   var inProcRuntime = ((IJSInProcessRuntime)JSRuntime);
-  var classRef = inProcRuntime.InvokeNew("jsInterop.TestClass", "Blazor!");
+  var classRef = inProcRuntime.InvokeConstructor("jsInterop.TestClass", "Blazor!");
   var text = classRef.GetValue<string>("text");
   var textLength = classRef.Invoke<int>("getTextLength");
   ```


### PR DESCRIPTION
Replace `InvokeNew`/`InvokeNewAsync` with `InvokeConstructor`/`InvokeConstructorAsync` due to changes in .NET 10 Preview 7.

Fixes #35948


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md](https://github.com/dotnet/AspNetCore.Docs/blob/2bce2d2b509b124c0ad8e804eb359a3da82c1ce3/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md) | [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?branch=pr-en-us-35949) |
| [aspnetcore/blazor/javascript-interoperability/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/2bce2d2b509b124c0ad8e804eb359a3da82c1ce3/aspnetcore/blazor/javascript-interoperability/index.md) | [aspnetcore/blazor/javascript-interoperability/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/index?branch=pr-en-us-35949) |
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/2bce2d2b509b124c0ad8e804eb359a3da82c1ce3/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-35949) |


<!-- PREVIEW-TABLE-END -->