### PR TITLE
Surface .dev.localhost TLD Visual Studio option

### DIFF
--- a/aspnetcore/blazor/tutorials/movie-database-app/part-1.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/part-1.md
@@ -59,35 +59,17 @@ In Visual Studio:
 
 * Confirm that the **Location** for the app is suitable. Set the **Place solution and project in the same directory** checkbox to match your preferred solution file location. Select the **Next** button.
 
-:::moniker range=">= aspnetcore-9.0"
-
 * In the **Additional information** dialog, use the following settings:
 
-  * **Framework**: Select **.NET 9.0 (Standard Term Support)**.
+  * **Framework**: Confirm that the [latest framework](https://dotnet.microsoft.com/download/dotnet) is selected. If Visual Studio's **Framework** dropdown list doesn't include the latest available .NET framework, [update Visual Studio](/visualstudio/install/update-visual-studio) and restart the tutorial.
   * **Authentication type**: **None**
   * **Configure for HTTPS**: Selected
   * **Interactive render mode**: **Server**
   * **Interactivity location**: **Per page/component**
   * **Include sample pages**: Selected
   * **Do not use top-level statements**: Not selected
+  * **Use the .dev.localhost TLD in the application URL**: Not selected
   * Select **Create**.
-
-:::moniker-end
-
-:::moniker range="< aspnetcore-9.0"
-
-* In the **Additional information** dialog, use the following settings:
-
-  * **Framework**: Select **.NET 8.0 (Long Term Support)**.
-  * **Authentication type**: **None**
-  * **Configure for HTTPS**: Selected
-  * **Interactive render mode**: **Server**
-  * **Interactivity location**: **Per page/component**
-  * **Include sample pages**: Selected
-  * **Do not use top-level statements**: Not selected
-  * Select **Create**.
-
-:::moniker-end
 
 The Visual Studio instructions in parts of this tutorial series use EF Core commands to add database migrations and update the database. EF Core commands are issued using [Visual Studio Connected Services](/visualstudio/azure/overview-connected-services). More information is provided later in this tutorial series.
 

--- a/aspnetcore/blazor/tutorials/signalr-blazor.md
+++ b/aspnetcore/blazor/tutorials/signalr-blazor.md
@@ -94,6 +94,7 @@ In Visual Studio:
   * **Interactivity location**: **Per page/component**
   * **Include sample pages**: Selected
   * **Do not use top-level statements**: Not selected
+  * **Use the .dev.localhost TLD in the application URL**: Not selected
   * Select **Create**.
 
 # [Visual Studio Code](#tab/visual-studio-code)
@@ -116,13 +117,14 @@ In VS Code:
 
   After the preceding changes are made, the **Command Palette** shows the following:
 
-  * **Framework**: Set to the latest public non-preview release of .NET.
+  * **Framework**: Confirm that the [latest framework](https://dotnet.microsoft.com/download/dotnet) is selected. If Visual Studio's **Framework** dropdown list doesn't include the latest available .NET framework, [update Visual Studio](/visualstudio/install/update-visual-studio) and restart the tutorial.
   * **Authentication type**: **None**
-  * **Configure for HTTPS**: **true**
+  * **Configure for HTTPS**: Selected
   * **Interactive render mode**: **WebAssembly**
   * **Interactivity location**: **Per page/component**
-  * **Include sample pages**: **true**
-  * **Do not use top-level statements**: **false**
+  * **Include sample pages**: Selected
+  * **Do not use top-level statements**: Not selected
+  * **Use the .dev.localhost TLD in the application URL**: Not selected
 
 * Select **Create project** from the **Command Palette**.
 

--- a/aspnetcore/release-notes/aspnetcore-7.0.md
+++ b/aspnetcore/release-notes/aspnetcore-7.0.md
@@ -669,6 +669,8 @@ With Visual Studio, select the new **Do not use top-level statements** checkbox 
 
 ![checkbox](https://user-images.githubusercontent.com/3605364/180587645-90f7cce5-d9f8-49d2-88cf-2258960394e1.png)
 
+Verify that **Use the .dev.localhost TLD in the application URL** is unchecked.
+
 ### Updated Angular and React templates
 
 The Angular project template has been updated to Angular 14. The React project template has been updated to React 18.2.

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc.md
@@ -59,6 +59,7 @@ See https://github.com/dotnet/AspNetCore.Docs/issues/21193
 * In the **Additional information** dialog:
   * Select **.NET 9.0 (Standard Term Support)**.
   * Verify that **Do not use top-level statements** is unchecked.
+  * Verify that **Use the .dev.localhost TLD in the application URL** is unchecked.
 * Select **Create**.
 
 ![Additional info dialog](~/tutorials/first-mvc-app/start-mvc/_static/9/additional-info-VS22-17.11.0.png)

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc7.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc7.md
@@ -48,6 +48,7 @@ See https://github.com/dotnet/AspNetCore.Docs/issues/21193
 * In the **Additional information** dialog:
   * Select **.NET 7.0**.
   * Verify that **Do not use top-level statements** is unchecked.
+  * Verify that **Use the .dev.localhost TLD in the application URL** is unchecked.
 * Select **Create**.
 
 ![Additional info dialog](~/tutorials/first-mvc-app/start-mvc/_static/net7-additional-info.png)
@@ -85,6 +86,7 @@ The tutorial assumes familiarity with VS Code. For more information, see [Gettin
 * In the **Configure your new Web Application (Model-View-Controller)** dialog:
   * Select **.NET 7.0** for the **Target Framework**.
   * Verify that **Do not use top-level statements** is unchecked.
+  * Verify that **Use the .dev.localhost TLD in the application URL** is unchecked.
 * Select **Continue**.
 * Enter `MvcMovie` for **Project name**. It's important to name the project *MvcMovie*. Capitalization needs to match each `namespace` when code is copied.
 * The **Location** for the project can be set to anywhere.

--- a/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc8.md
+++ b/aspnetcore/tutorials/first-mvc-app/start-mvc/includes/start-mvc8.md
@@ -44,6 +44,7 @@ See https://github.com/dotnet/AspNetCore.Docs/issues/21193
 * In the **Additional information** dialog:
   * Select **.NET 8.0 (Long Term Support)**.
   * Verify that **Do not use top-level statements** is unchecked.
+  * Verify that **Use the .dev.localhost TLD in the application URL** is unchecked.
 * Select **Create**.
 
 ![Additional info dialog](~/tutorials/first-mvc-app/start-mvc/_static/8/additional-info-VS22-17.9.0.png)

--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -62,6 +62,7 @@ This tutorial creates the following API:
 * In the **Additional information** dialog:
   * Select **.NET 9.0**
   * Uncheck **Do not use top-level statements**
+  * Uncheck **Use the .dev.localhost TLD in the application URL**
   * Select **Create**
 
   ![Additional information](~/tutorials/min-web-api/_static/9.x/add-info-vs17.11.0.png)

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api6-7.md
@@ -44,6 +44,7 @@ This tutorial creates the following API:
 * In the **Additional information** dialog:
   * Select **.NET 7.0**
   * Uncheck **Do not use top-level statements**
+  * Uncheck **Use the .dev.localhost TLD in the application URL**
   * Select **Create**
 
   ![Additional information](~/tutorials/min-web-api/_static/add-info7.png)
@@ -499,6 +500,7 @@ This tutorial creates the following API:
 * In the **Additional information** dialog:
   * Select **.NET 6.0**
   * Uncheck **Do not use top-level statements**
+  * Uncheck **Use the .dev.localhost TLD in the application URL**
   * Select **Create**
 
 # [Visual Studio Code](#tab/visual-studio-code)

--- a/aspnetcore/tutorials/min-web-api/includes/min-web-api8.md
+++ b/aspnetcore/tutorials/min-web-api/includes/min-web-api8.md
@@ -44,6 +44,7 @@ This tutorial creates the following API:
 * In the **Additional information** dialog:
   * Select **.NET 8.0 (Long Term Support)**
   * Uncheck **Do not use top-level statements**
+  * Uncheck **Use the .dev.localhost TLD in the application URL**
   * Select **Create**
 
   ![Additional information](~/tutorials/min-web-api/_static/8.x/add-info-vs17.9.0.png)

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start.md
@@ -49,6 +49,7 @@ At the end of this tutorial, you'll have a Razor Pages web app that manages a da
 * In the **Additional information** dialog:
   * Select **.NET 9.0**.
   * Verify: **Do not use top-level statements** is unchecked.
+  * Verify: **Use the .dev.localhost TLD in the application URL** is unchecked.
 * Select **Create**.
 
    ![Additional information](~/tutorials/razor-pages/razor-pages-start/_static/9/net9-additional-info.png)

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/includes/razor-pages-start7.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/includes/razor-pages-start7.md
@@ -37,6 +37,7 @@ At the end of this tutorial, you'll have a Razor Pages web app that manages a da
 * In the **Additional information** dialog:
   * Select **.NET 7.0 (Standard Term Support)**.
   * Verify: **Do not use top-level statements** is unchecked.
+  * Verify: **Use the .dev.localhost TLD in the application URL** is unchecked.
 * Select **Create**.
 
    ![Additional information](~/tutorials/razor-pages/razor-pages-start/_static/7/additional_info.png)
@@ -78,6 +79,7 @@ The tutorial assumes familiarity with VS Code. For more information, see [Gettin
   * Verify: **Target framework** is set to **.NET 7.0** (or later).
   * Verify: **Authentication** is set to **No Authentication**.
   * Verify: **Do not use top-level statements** is unchecked.
+  * Verify: **Use the .dev.localhost TLD in the application URL** is unchecked.
   * Select **Continue**.
 
 * In the **Configure your new Web Application** dialog:

--- a/aspnetcore/tutorials/razor-pages/razor-pages-start/includes/razor-pages-start8.md
+++ b/aspnetcore/tutorials/razor-pages/razor-pages-start/includes/razor-pages-start8.md
@@ -34,6 +34,7 @@ At the end of this tutorial, you'll have a Razor Pages web app that manages a da
 * In the **Additional information** dialog:
   * Select **.NET 8.0 (Long Term Support)**.
   * Verify: **Do not use top-level statements** is unchecked.
+  * Verify: **Use the .dev.localhost TLD in the application URL** is unchecked.
 * Select **Create**.
 
    ![Additional information](~/tutorials/razor-pages/razor-pages-start/_static/8/net8-additional-info.png)


### PR DESCRIPTION
Fixes #35936

We don't (usually) version VS tooling guidance. We assume that the dev is using the latest tooling. This updates our guidance to include coverage for the new "**Use the .dev.localhost TLD in the application URL**" option. I made the update across the repo, using whatever styling the doc author had in place.

This is in VS Preview. I'm not aware if it has made its way into VS GA. I run 100% of the time on VS Preview these days, so can either of you confirm if it's in VS GA yet? If it hasn't reached VS GA yet, we can sit on this PR or merge it now because VS GA should get it soon. Personally, I'd like to clear this through ... I don't like *merge conflicts* 😈 if they can be avoided.

<img width="714" height="276" alt="image" src="https://github.com/user-attachments/assets/09616b98-e446-401a-a524-0fb682ec3250" />