### PR TITLE
Update min-web-api.md

### DIFF
--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -94,7 +94,7 @@ The `Program.cs` file contains the following code:
 The preceding code:
 
 * Creates a <xref:Microsoft.AspNetCore.Builder.WebApplicationBuilder> and a <xref:Microsoft.AspNetCore.Builder.WebApplication> with preconfigured defaults.
-* Creates an HTTP GET endpoint `/` that returns `Hello World!`:
+* Creates an HTTP GET endpoint `/` that returns `Hello World!`.
 
 ### Run the app
 


### PR DESCRIPTION
replaced a colon with a period to fix a typo in the docs

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/min-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/fbfb62839f8b1612f1655bbf605f30163b980149/aspnetcore/tutorials/min-web-api.md) | [Tutorial: Create a minimal API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?branch=pr-en-us-35957) |

<!-- PREVIEW-TABLE-END -->