### PR TITLE
Patch update date format

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ When creating a PR for an issue:
   - For any new or updated .md file added to the repository, ensure the following frontmatter (metadata) is included:
     - Metadata `ai-usage: ai-assisted` if any AI assistance was used
     - Place the title metadata first, followed by the remaining metadata lines in alphabetical order. Example: `title`, `author`, `description`, `monikerRange`, `ms.author`, `ms.custom`, `ms.date`, `uid`, `zone_pivot_groups`
-    - Metadata `ms.date: <today's date>` with a format of MM-DD-YYYY.  If the file already has a `ms.date` metadata, update it to today's date if more than 50 characters are changed in the file.
+    - Metadata `ms.date: <today's date>` with a format of MM/DD/YYYY. If the file already has a `ms.date` metadata, update it to today's date if more than 50 characters are changed in the file.
     
 ### Version Targeting Common Range Patterns
 - Fixed Range: `>= aspnetcore-7.0 <= aspnetcore-9.0`


### PR DESCRIPTION
Quick patch update of the date format. It came up when Copilot suggested a change on my static files PR at https://github.com/dotnet/AspNetCore.Docs/pull/35967.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/copilot-instructions.md](https://github.com/dotnet/AspNetCore.Docs/blob/b2d5d8e0456b32b02257508304b0f13dcb930e48/.github/copilot-instructions.md) | [.github/copilot-instructions](https://review.learn.microsoft.com/en-us/aspnet/core/.github/copilot-instructions?branch=pr-en-us-35969) |

<!-- PREVIEW-TABLE-END -->