### PR TITLE
Correct comparison to @bind:set

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -228,7 +228,7 @@ Components support two-way data binding by defining a pair of `@bind` attributes
 
 The `:get` and `:set` modifiers are always used together.
 
-With `:get`/`:set` binding, you can react to a value change before it's applied to the DOM, and you can change the applied value, if necessary. Whereas with `@bind:event="{EVENT}"` attribute binding, where the `{EVENT}` placeholder is a DOM event, you receive the notification after the DOM is updated, and there's no capacity to modify the applied value while binding.
+With `:get`/`:set` binding, you can react to a value change before it's applied to the DOM, and you can change the applied value, if necessary. Whereas with `@on{DOM EVENT}="{DELEGATE}"`, where the `{DOM EVENT}` placeholder is a DOM event, you receive the notification after the DOM is updated, and there's no capacity to modify the applied value while binding.
 
 `BindGetSet.razor`:
 


### PR DESCRIPTION
Tweak to the comparison to @bind:set.

The current comparison doesn't make sense to me, I assume it's a copy-and-paste bug.

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->
