### PR TITLE
Revert "Correct comparison to @bind:set"

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -228,7 +228,7 @@ Components support two-way data binding by defining a pair of `@bind` attributes
 
 The `:get` and `:set` modifiers are always used together.
 
-With `:get`/`:set` binding, you can react to a value change before it's applied to the DOM, and you can change the applied value, if necessary. Whereas with `@on{DOM EVENT}="{DELEGATE}"`, where the `{DOM EVENT}` placeholder is a DOM event and the `{DELEGATE}` placeholder is the delegate, you receive the notification after the DOM is updated, and there's no way to modify the applied value while binding.
+With `:get`/`:set` binding, you can react to a value change before it's applied to the DOM, and you can change the applied value, if necessary. Whereas with `@bind:event="{EVENT}"` attribute binding, where the `{EVENT}` placeholder is a DOM event, you receive the notification after the DOM is updated, and there's no capacity to modify the applied value while binding.
 
 `BindGetSet.razor`:
 


### PR DESCRIPTION
Reverts dotnet/AspNetCore.Docs#35973

@georgehemmings ... I've opened #35978 to take a closer look. I don't think this was a mistake after all.

Wade ... Reverting one from this morning that I thought would be correct, but the text is probably right in its current form. I might just need to check the organization to where `bind:event` is covered. I'll work it on the new issue. For now, I just need to revert the change from this morning.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/data-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/b6004cd6938ce0d914c32dfdb985ca397ebc4cee/aspnetcore/blazor/components/data-binding.md) | [aspnetcore/blazor/components/data-binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?branch=pr-en-us-35977) |

<!-- PREVIEW-TABLE-END -->