### PR TITLE
Fix missing AspNetCore.Hosting provider built-in metrics doc

### DIFF
--- a/aspnetcore/log-mon/metrics/built-in.md
+++ b/aspnetcore/log-mon/metrics/built-in.md
@@ -129,14 +129,14 @@ Usage:
 * How many sessions processed?
 * How long do users keep the session/tab open?
 
+:::moniker-end
+
 ## `Microsoft.AspNetCore.Hosting`
 
 The `Microsoft.AspNetCore.Hosting` metrics report high-level information about HTTP requests received by ASP.NET Core:
 
 * [`http.server.request.duration`](#metric-httpserverrequestduration)
 * [`http.server.active_requests`](#metric-httpserveractive_requests)
-
-:::moniker-end
 
 ### Metric: `http.server.request.duration`
 


### PR DESCRIPTION
The hosting provider had the initial text missing. I assume the moniker was making that part conditional and it was misplaced in the text.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/log-mon/metrics/built-in.md](https://github.com/dotnet/AspNetCore.Docs/blob/9ef5886d36f53b0ee3e60426231a5f7a652551fc/aspnetcore/log-mon/metrics/built-in.md) | [ASP.NET Core built-in metrics](https://review.learn.microsoft.com/en-us/aspnet/core/log-mon/metrics/built-in?branch=pr-en-us-35998) |

<!-- PREVIEW-TABLE-END -->