### PR TITLE
Minimal API responces.md: add missing IBindableFromHttpContext section

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/CustomBindingExample.csproj
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/CustomBindingExample.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/CustomBoundParameters.cs
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/CustomBoundParameters.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace CustomBindingExample;
+
+public class CustomBoundParameter : IBindableFromHttpContext<CustomBoundParameter>
+{
+    public string Value { get; init; } = default!;
+
+    public static ValueTask<CustomBoundParameter?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        // Custom binding logic here
+        // This example reads from a custom header
+        var value = context.Request.Headers["X-Custom-Header"].ToString();
+        
+        // If no header was provided, you could fall back to a query parameter
+        if (string.IsNullOrEmpty(value))
+        {
+            value = context.Request.Query["customValue"].ToString();
+        }
+        
+        return ValueTask.FromResult<CustomBoundParameter?>(new CustomBoundParameter 
+        {
+            Value = value
+        });
+    }
+}

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/Program.cs
@@ -1,0 +1,37 @@
+
+// <snippet_IBindableFromHttpContext>
+using CustomBindingExample;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+// Basic endpoint to test the application
+app.MapGet("/", () => "Hello, IBindableFromHttpContext example!");
+
+// Endpoint using the CustomBoundParameter
+app.MapGet("/custom-binding", (CustomBoundParameter param) =>
+{
+    return $"Value from custom binding: {param.Value}";
+});
+
+// Endpoint showing how to combine with other parameters
+app.MapGet("/combined/{id}", (int id, CustomBoundParameter param) =>
+{
+    return $"ID: {id}, Custom Value: {param.Value}";
+});
+
+// Endpoint showing validation example
+app.MapGet("/validated", (ValidatedParameter param) =>
+{
+    if (string.IsNullOrEmpty(param.Value))
+    {
+        return Results.BadRequest("Value cannot be empty");
+    }
+    
+    return Results.Ok($"Validated value: {param.Value}");
+});
+// <//snippet_IBindableFromHttpContext>
+
+app.Run();

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/TestCustomBindingExample.http
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/TestCustomBindingExample.http
@@ -1,0 +1,24 @@
+@host = https://localhost:7176
+
+### Test the root endpoint
+GET {{host}}/
+Accept: text/plain
+
+### Test the custom binding endpoint
+GET {{host}}/custom-binding
+X-Custom-Header: TestHeaderValue
+Accept: text/plain
+
+### Test the combined parameter endpoint
+GET {{host}}/combined/42
+X-Custom-Header: TestHeaderValue
+Accept: text/plain
+
+### Test the validated parameter endpoint - valid case
+GET {{host}}/validated
+X-Custom-Header: ValidValue
+Accept: text/plain
+
+### Test the validated parameter endpoint - invalid case
+GET {{host}}/validated
+Accept: text/plain

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/ValidatedParameters.cs
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/ValidatedParameters.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+
+namespace CustomBindingExample;
+
+public class ValidatedParameter : IBindableFromHttpContext<ValidatedParameter>
+{
+    public string Value { get; init; } = default!;
+
+    public static ValueTask<ValidatedParameter?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        // Get the value from a query parameter
+        var value = context.Request.Query["value"].ToString();
+        
+        // Perform some basic validation here
+        if (string.IsNullOrEmpty(value))
+        {
+            // Return an empty instance - the controller action will handle the validation failure
+            return ValueTask.FromResult<ValidatedParameter?>(new ValidatedParameter
+            {
+                Value = string.Empty
+            });
+        }
+        
+        return ValueTask.FromResult<ValidatedParameter?>(new ValidatedParameter
+        {
+            Value = value
+        });
+    }
+}

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/appsettings.Development.json
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/appsettings.json
+++ b/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/CustomBindingExample.cs
+++ b/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/CustomBindingExample.cs
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/CustomBoundParameters.cs
+++ b/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/CustomBoundParameters.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace CustomBindingExample;
+
+public class CustomBoundParameter : IBindableFromHttpContext<CustomBoundParameter>
+{
+    public string Value { get; init; } = default!;
+
+    public static ValueTask<CustomBoundParameter?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        // Custom binding logic here
+        // This example reads from a custom header
+        var value = context.Request.Headers["X-Custom-Header"].ToString();
+        
+        // If no header was provided, you could fall back to a query parameter
+        if (string.IsNullOrEmpty(value))
+        {
+            value = context.Request.Query["customValue"].ToString();
+        }
+        
+        return ValueTask.FromResult<CustomBoundParameter?>(new CustomBoundParameter 
+        {
+            Value = value
+        });
+    }
+}

--- a/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/Program.cs
@@ -1,0 +1,37 @@
+
+// <snippet_IBindableFromHttpContext>
+using CustomBindingExample;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+// Basic endpoint to test the application
+app.MapGet("/", () => "Hello, IBindableFromHttpContext example!");
+
+// Endpoint using the CustomBoundParameter
+app.MapGet("/custom-binding", (CustomBoundParameter param) =>
+{
+    return $"Value from custom binding: {param.Value}";
+});
+
+// Endpoint showing how to combine with other parameters
+app.MapGet("/combined/{id}", (int id, CustomBoundParameter param) =>
+{
+    return $"ID: {id}, Custom Value: {param.Value}";
+});
+
+// Endpoint showing validation example
+app.MapGet("/validated", (ValidatedParameter param) =>
+{
+    if (string.IsNullOrEmpty(param.Value))
+    {
+        return Results.BadRequest("Value cannot be empty");
+    }
+    
+    return Results.Ok($"Validated value: {param.Value}");
+});
+// <//snippet_IBindableFromHttpContext>
+
+app.Run();

--- a/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/TestCustomBindingExample.http
+++ b/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/TestCustomBindingExample.http
@@ -1,0 +1,18 @@
+@HostAddress = https://localhost:7042
+
+### Basic endpoint with IBindableFromHttpContext
+GET {{HostAddress}}/bindable
+X-Custom-Header: TestHeaderValue
+Accept: text/plain
+
+### IBindableFromHttpContext with query parameter
+GET {{HostAddress}}/bindable?customValue=TestQueryValue
+Accept: text/plain
+
+### IBindableFromHttpContext with validation - valid
+GET {{HostAddress}}/validated?value=ValidValue
+Accept: application/json
+
+### IBindableFromHttpContext with validation - invalid
+GET {{HostAddress}}/validated
+Accept: application/json

--- a/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/ValidatedParameters.cs
+++ b/aspnetcore/fundamentals/minimal-apis/7.0-samples/CustomBindingExample/ValidatedParameters.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+
+namespace CustomBindingExample;
+
+public class ValidatedParameter : IBindableFromHttpContext<ValidatedParameter>
+{
+    public string Value { get; init; } = default!;
+
+    public static ValueTask<ValidatedParameter?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        // Get the value from a query parameter
+        var value = context.Request.Query["value"].ToString();
+        
+        // Perform some basic validation here
+        if (string.IsNullOrEmpty(value))
+        {
+            // Return an empty instance - the controller action will handle the validation failure
+            return ValueTask.FromResult<ValidatedParameter?>(new ValidatedParameter
+            {
+                Value = string.Empty
+            });
+        }
+        
+        return ValueTask.FromResult<ValidatedParameter?>(new ValidatedParameter
+        {
+            Value = value
+        });
+    }
+}

--- a/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/CustomBindingExample.csproj
+++ b/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/CustomBindingExample.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/CustomBoundParameters.cs
+++ b/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/CustomBoundParameters.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace CustomBindingExample;
+
+public class CustomBoundParameter : IBindableFromHttpContext<CustomBoundParameter>
+{
+    public string Value { get; init; } = default!;
+
+    public static ValueTask<CustomBoundParameter?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        // Custom binding logic here
+        // This example reads from a custom header
+        var value = context.Request.Headers["X-Custom-Header"].ToString();
+        
+        // If no header was provided, you could fall back to a query parameter
+        if (string.IsNullOrEmpty(value))
+        {
+            value = context.Request.Query["customValue"].ToString();
+        }
+        
+        return ValueTask.FromResult<CustomBoundParameter?>(new CustomBoundParameter 
+        {
+            Value = value
+        });
+    }
+}

--- a/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/Program.cs
@@ -1,0 +1,37 @@
+
+// <snippet_IBindableFromHttpContext>
+using CustomBindingExample;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+// Basic endpoint to test the application
+app.MapGet("/", () => "Hello, IBindableFromHttpContext example!");
+
+// Endpoint using the CustomBoundParameter
+app.MapGet("/custom-binding", (CustomBoundParameter param) =>
+{
+    return $"Value from custom binding: {param.Value}";
+});
+
+// Endpoint showing how to combine with other parameters
+app.MapGet("/combined/{id}", (int id, CustomBoundParameter param) =>
+{
+    return $"ID: {id}, Custom Value: {param.Value}";
+});
+
+// Endpoint showing validation example
+app.MapGet("/validated", (ValidatedParameter param) =>
+{
+    if (string.IsNullOrEmpty(param.Value))
+    {
+        return Results.BadRequest("Value cannot be empty");
+    }
+    
+    return Results.Ok($"Validated value: {param.Value}");
+});
+// <//snippet_IBindableFromHttpContext>
+
+app.Run();

--- a/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/TestCustomBindingExample.http
+++ b/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/TestCustomBindingExample.http
@@ -1,0 +1,24 @@
+@host = https://localhost:7176
+
+### Test the root endpoint
+GET {{host}}/
+Accept: text/plain
+
+### Test the custom binding endpoint
+GET {{host}}/custom-binding
+X-Custom-Header: TestHeaderValue
+Accept: text/plain
+
+### Test the combined parameter endpoint
+GET {{host}}/combined/42
+X-Custom-Header: TestHeaderValue
+Accept: text/plain
+
+### Test the validated parameter endpoint - valid case
+GET {{host}}/validated
+X-Custom-Header: ValidValue
+Accept: text/plain
+
+### Test the validated parameter endpoint - invalid case
+GET {{host}}/validated
+Accept: text/plain

--- a/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/ValidatedParameters.cs
+++ b/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/ValidatedParameters.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+
+namespace CustomBindingExample;
+
+public class ValidatedParameter : IBindableFromHttpContext<ValidatedParameter>
+{
+    public string Value { get; init; } = default!;
+
+    public static ValueTask<ValidatedParameter?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        // Get the value from a query parameter
+        var value = context.Request.Query["value"].ToString();
+        
+        // Perform some basic validation here
+        if (string.IsNullOrEmpty(value))
+        {
+            // Return an empty instance - the controller action will handle the validation failure
+            return ValueTask.FromResult<ValidatedParameter?>(new ValidatedParameter
+            {
+                Value = string.Empty
+            });
+        }
+        
+        return ValueTask.FromResult<ValidatedParameter?>(new ValidatedParameter
+        {
+            Value = value
+        });
+    }
+}

--- a/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/appsettings.Development.json
+++ b/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/appsettings.json
+++ b/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/CustomBindingExample.csproj
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/CustomBindingExample.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/CustomBoundParameters.cs
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/CustomBoundParameters.cs
@@ -1,0 +1,26 @@
+using System.Reflection;
+
+namespace CustomBindingExample;
+
+public class CustomBoundParameter : IBindableFromHttpContext<CustomBoundParameter>
+{
+    public string Value { get; init; } = default!;
+
+    public static ValueTask<CustomBoundParameter?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        // Custom binding logic here
+        // This example reads from a custom header
+        var value = context.Request.Headers["X-Custom-Header"].ToString();
+        
+        // If no header was provided, you could fall back to a query parameter
+        if (string.IsNullOrEmpty(value))
+        {
+            value = context.Request.Query["customValue"].ToString();
+        }
+        
+        return ValueTask.FromResult<CustomBoundParameter?>(new CustomBoundParameter 
+        {
+            Value = value
+        });
+    }
+}

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/Program.cs
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/Program.cs
@@ -1,0 +1,37 @@
+
+// <snippet_IBindableFromHttpContext>
+using CustomBindingExample;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.UseHttpsRedirection();
+
+// Basic endpoint to test the application
+app.MapGet("/", () => "Hello, IBindableFromHttpContext example!");
+
+// Endpoint using the CustomBoundParameter
+app.MapGet("/custom-binding", (CustomBoundParameter param) =>
+{
+    return $"Value from custom binding: {param.Value}";
+});
+
+// Endpoint showing how to combine with other parameters
+app.MapGet("/combined/{id}", (int id, CustomBoundParameter param) =>
+{
+    return $"ID: {id}, Custom Value: {param.Value}";
+});
+
+// Endpoint showing validation example
+app.MapGet("/validated", (ValidatedParameter param) =>
+{
+    if (string.IsNullOrEmpty(param.Value))
+    {
+        return Results.BadRequest("Value cannot be empty");
+    }
+    
+    return Results.Ok($"Validated value: {param.Value}");
+});
+// <//snippet_IBindableFromHttpContext>
+
+app.Run();

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/TestCustomBindingExample.http
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/TestCustomBindingExample.http
@@ -1,0 +1,24 @@
+@host = https://localhost:7176
+
+### Test the root endpoint
+GET {{host}}/
+Accept: text/plain
+
+### Test the custom binding endpoint
+GET {{host}}/custom-binding
+X-Custom-Header: TestHeaderValue
+Accept: text/plain
+
+### Test the combined parameter endpoint
+GET {{host}}/combined/42
+X-Custom-Header: TestHeaderValue
+Accept: text/plain
+
+### Test the validated parameter endpoint - valid case
+GET {{host}}/validated
+X-Custom-Header: ValidValue
+Accept: text/plain
+
+### Test the validated parameter endpoint - invalid case
+GET {{host}}/validated
+Accept: text/plain

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/ValidatedParameters.cs
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/ValidatedParameters.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+
+namespace CustomBindingExample;
+
+public class ValidatedParameter : IBindableFromHttpContext<ValidatedParameter>
+{
+    public string Value { get; init; } = default!;
+
+    public static ValueTask<ValidatedParameter?> BindAsync(HttpContext context, ParameterInfo parameter)
+    {
+        // Get the value from a query parameter
+        var value = context.Request.Query["value"].ToString();
+        
+        // Perform some basic validation here
+        if (string.IsNullOrEmpty(value))
+        {
+            // Return an empty instance - the controller action will handle the validation failure
+            return ValueTask.FromResult<ValidatedParameter?>(new ValidatedParameter
+            {
+                Value = string.Empty
+            });
+        }
+        
+        return ValueTask.FromResult<ValidatedParameter?>(new ValidatedParameter
+        {
+            Value = value
+        });
+    }
+}

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/appsettings.Development.json
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/appsettings.json
+++ b/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/aspnetcore/fundamentals/minimal-apis/includes/responses7-8.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/responses7-8.md
@@ -1,7 +1,7 @@
 ---
 author: tdykstra
 ms.author: tdykstra
-ms.date: 08/07/2024
+ms.date: 08/26/2025
 ---
 
 :::moniker range=">= aspnetcore-7.0 <= aspnetcore-8.0"
@@ -229,6 +229,23 @@ public static void PopulateMetadata(MethodInfo method, EndpointBuilder builder)
     builder.Metadata.Add(new ProducesAttribute(MediaTypeNames.Text.Html));
 }
 ```
+## Custom parameter binding with IBindableFromHttpContext
+
+ASP.NET Core provides support for custom parameter binding in Minimal APIs using the <xref:Microsoft.AspNetCore.Http.IBindableFromHttpContext%601> interface. This interface, introduced with C# 11's static abstract members, allows you to create types that can be bound from an HTTP context directly in route handler parameters.
+
+```csharp
+public interface IBindableFromHttpContext<TSelf>
+    where TSelf : class, IBindableFromHttpContext<TSelf>
+{
+    static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
+}
+```
+
+By implementing the <xref:Microsoft.AspNetCore.Http.IBindableFromHttpContext%601>, you can create custom types that handle their own binding logic from the HttpContext. When a route handler includes a parameter of this type, the framework automatically calls the static BindAsync method to create the instance:
+
+:::code language="csharp" source="~/fundamentals/minimal-apis/8.0-samples/CustomBindingExample/Program.cs" id="snippet_IBindableFromHttpContext":::
+
+[View or download the sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/fundamentals/minimal-apis/8.0-samples/CustomBindingExample) ([how to download](xref:index#how-to-download-a-sample))
 
 ## Configure JSON serialization options
 

--- a/aspnetcore/fundamentals/minimal-apis/includes/responses9.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/responses9.md
@@ -223,6 +223,24 @@ An alternative approach is using the <xref:Microsoft.AspNetCore.Mvc.ProducesAttr
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_11":::
 
+## Custom parameter binding with IBindableFromHttpContext
+
+ASP.NET Core provides support for custom parameter binding in Minimal APIs using the <xref:Microsoft.AspNetCore.Http.IBindableFromHttpContext%601> interface. This interface, introduced with C# 11's static abstract members, allows you to create types that can be bound from an HTTP context directly in route handler parameters.
+
+```csharp
+public interface IBindableFromHttpContext<TSelf>
+    where TSelf : class, IBindableFromHttpContext<TSelf>
+{
+    static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
+}
+```
+
+By implementing the <xref:Microsoft.AspNetCore.Http.IBindableFromHttpContext%601>, you can create custom types that handle their own binding logic from the HttpContext. When a route handler includes a parameter of this type, the framework automatically calls the static BindAsync method to create the instance:
+
+:::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/CustomBindingExample/Program.cs" id="snippet_IBindableFromHttpContext":::
+
+[View or download the sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/fundamentals/minimal-apis/9.0-samples/CustomBindingExample) ([how to download](xref:index#how-to-download-a-sample))
+
 ## Configure JSON serialization options
 
 By default, minimal API apps use [`Web defaults`](/dotnet/standard/serialization/system-text-json-configure-options#web-defaults-for-jsonserializeroptions) options during JSON serialization and deserialization.

--- a/aspnetcore/fundamentals/minimal-apis/responses.md
+++ b/aspnetcore/fundamentals/minimal-apis/responses.md
@@ -4,7 +4,7 @@ author: brunolins16
 description: Learn how to create responses for minimal APIs in ASP.NET Core.
 ms.author: brolivei
 monikerRange: '>= aspnetcore-7.0'
-ms.date: 08/22/2025
+ms.date: 08/26/2025
 uid: fundamentals/minimal-apis/responses
 ai-usage: ai-assisted
 ---
@@ -273,6 +273,24 @@ The `ProducesHtmlMetadata` is an implementation of <xref:Microsoft.AspNetCore.Ht
 An alternative approach is using the <xref:Microsoft.AspNetCore.Mvc.ProducesAttribute?displayProperty=fullName> to describe the produced response. The following code changes the `PopulateMetadata` method to use `ProducesAttribute`.
 
 :::code language="csharp" source="~/fundamentals/minimal-apis/9.0-samples/Snippets/Program.cs" id="snippet_11":::
+
+## Custom parameter binding with IBindableFromHttpContext
+
+ASP.NET Core provides support for custom parameter binding in Minimal APIs using the <xref:Microsoft.AspNetCore.Http.IBindableFromHttpContext%601> interface. This interface, introduced with C# 11's static abstract members, allows you to create types that can be bound from an HTTP context directly in route handler parameters.
+
+```csharp
+public interface IBindableFromHttpContext<TSelf>
+    where TSelf : class, IBindableFromHttpContext<TSelf>
+{
+    static abstract ValueTask<TSelf?> BindAsync(HttpContext context, ParameterInfo parameter);
+}
+```
+
+By implementing the <xref:Microsoft.AspNetCore.Http.IBindableFromHttpContext%601>, you can create custom types that handle their own binding logic from the HttpContext. When a route handler includes a parameter of this type, the framework automatically calls the static BindAsync method to create the instance:
+
+:::code language="csharp" source="~/fundamentals/minimal-apis/10.0-samples/CustomBindingExample/Program.cs" id="snippet_IBindableFromHttpContext":::
+
+[View or download the sample code](https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/fundamentals/minimal-apis/10.0-samples/CustomBindingExample) ([how to download](xref:index#how-to-download-a-sample))
 
 ## Configure JSON serialization options
 


### PR DESCRIPTION
Fixes #32903

For versions 7-10 of the responses.md topic:
- Added new section:
Custom parameter binding with IBindableFromHttpContext
- Added a new app sample.

