### PR TITLE
Add .NET 8 fix cross-link

### DIFF
--- a/aspnetcore/migration/fx-to-core/inc/blazor.md
+++ b/aspnetcore/migration/fx-to-core/inc/blazor.md
@@ -10,7 +10,7 @@ uid: migration/fx-to-core/inc/blazor
 ---
 # Enable ASP.NET Core Blazor Server support with Yarp in incremental migration
 
-When adding Yarp to a Blazor Server app, both attempt to act as fallback routes for the app's request routing. Either Blazor or Yarp handles routing arbitrarily, which means that scenarios such as deep linking in Blazor may fail. This is [fixed in .NET 8](xref:migration/70-80#drop-blazor-server-with-yarp-routing-workaround). For migration to ASP.NET Core in .NET 6 and .NET 7, map Blazor's endpoints to achieve correct request routing by following the guidance in this article.
+When adding Yarp to a Blazor Server app, both attempt to act as fallback routes for the app's request routing. Either Blazor or Yarp handles routing arbitrarily, which means that scenarios such as deep linking in Blazor may fail. This is [fixed in .NET 8](xref:migration/70-to-80#drop-blazor-server-with-yarp-routing-workaround). For migration to ASP.NET Core in .NET 6 and .NET 7, map Blazor's endpoints to achieve correct request routing by following the guidance in this article.
 
 Add the following route builder extensions class to the project.
 


### PR DESCRIPTION
Fixes #36049

This should do the trick to make it clear that it was indeed fixed in .NET 8. No further changes are required because we have both migration and release notes coverage that were added back when .NET 8 released.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/fx-to-core/inc/blazor.md](https://github.com/dotnet/AspNetCore.Docs/blob/34098ac5561ec4c66b2d83da21eaa4498ca59d74/aspnetcore/migration/fx-to-core/inc/blazor.md) | [aspnetcore/migration/fx-to-core/inc/blazor](https://review.learn.microsoft.com/en-us/aspnet/core/migration/fx-to-core/inc/blazor?branch=pr-en-us-36050) |


<!-- PREVIEW-TABLE-END -->