### PR TITLE
Cover `RenderFragment` caching behavior

### DIFF
--- a/aspnetcore/blazor/components/sections.md
+++ b/aspnetcore/blazor/components/sections.md
@@ -5,7 +5,7 @@ description: Learn how to control the content in a Razor component from a child 
 monikerRange: '>= aspnetcore-8.0'
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 11/12/2024
+ms.date: 09/10/2025
 uid: blazor/components/sections
 ---
 # ASP.NET Core Blazor sections
@@ -84,6 +84,10 @@ When the `Counter` component is accessed, the `MainLayout` component renders the
 
 > [!NOTE]
 > <xref:Microsoft.AspNetCore.Components.Sections.SectionOutlet> and <xref:Microsoft.AspNetCore.Components.Sections.SectionContent> components can only set either <xref:Microsoft.AspNetCore.Components.Sections.SectionOutlet.SectionId%2A> or <xref:Microsoft.AspNetCore.Components.Sections.SectionOutlet.SectionName%2A>, not both.
+
+## `RenderFragment` caching rules and section rendering behavior
+
+When a <xref:Microsoft.AspNetCore.Components.Sections.SectionContent>'s <xref:Microsoft.AspNetCore.Components.RenderFragment> content changes, which is a different instance than the component where it's rendered, Blazor completely destroys and recreates the section instead of attempting to update the section's content. Unlike normal rendering, the section's content could come from different instances, and it doesn't make sense to attempt processing content from two separate components, which might lead to unexpected results. For a detailed explanation on this behavior, see [Inconsistent component initialization with Blazor SectionOutlet/SectionContent and CascadingValue (`dotnet/aspnetcore` #58316)](https://github.com/dotnet/aspnetcore/issues/58316).
 
 ## Section interaction with other Blazor features
 


### PR DESCRIPTION
Fixes #36067

I thought it would be good to ...

* Put this a little out of the way after the basics are covered (separate section).
* Go ahead and cross-link your excellent analysis and explanation for advanced devs to see in full.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/sections.md](https://github.com/dotnet/AspNetCore.Docs/blob/1c98c0df7ab32f214f7ded0b9bd1e02c0f752833/aspnetcore/blazor/components/sections.md) | [aspnetcore/blazor/components/sections](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/sections?branch=pr-en-us-36087) |

<!-- PREVIEW-TABLE-END -->