### PR TITLE
[Blazor] Clarify trimming behavior for custom types

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -96,7 +96,7 @@ To address lost types, consider adopting one of the following approaches.
 
 ### Custom types
 
-Custom types aren't trimmed by Blazor when an app is published, so we recommend using custom types for JS interop, JSON serialization/deserialization, and other operations that rely on reflection.
+Custom types aren't trimmed by Blazor when an app is published (unless explicitly opted in), so we recommend using custom types for JS interop, JSON serialization/deserialization, and other operations that rely on reflection.
 
 The following modifications create a `StringTuple` type for use by the component.
 
@@ -123,7 +123,7 @@ The component is modified to use the `StringTuple` type:
 + items = JsonSerializer.Deserialize<List<StringTuple>>(data, options)!;
 ```
 
-Because custom types are never trimmed by Blazor when an app is published, the component works as designed after the app is published.
+Because custom types aren't trimmed by Blazor when an app is published (unless explicitly opted in), the component works as designed after the app is published.
 
 :::moniker range=">= aspnetcore-10.0"
 


### PR DESCRIPTION
I think saying "never trimmed" is a bit too strong, since you can still enable trimming for your own assemblies and types.
