### PR TITLE
Remove redundant command argument

### DIFF
--- a/aspnetcore/tutorials/first-web-api.md
+++ b/aspnetcore/tutorials/first-web-api.md
@@ -79,7 +79,7 @@ A NuGet package must be added to support the database used in this tutorial.
    dotnet new webapi --use-controllers -o TodoApi
    cd TodoApi
    dotnet add package Microsoft.EntityFrameworkCore.InMemory
-   code -r ../TodoApi
+   code -r .
    ```
 
   These commands:


### PR DESCRIPTION
this pr replaces the redundant specification of `../TodoApi` with `.` as the command 2 steps before it already results in you being within the `TodoApi` directory 
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #36099

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/806625d93b4768a141699cf8759a897ee153d82a/aspnetcore/tutorials/first-web-api.md) | [Tutorial: Create a controller-based web API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?branch=pr-en-us-36098) |

<!-- PREVIEW-TABLE-END -->