### PR TITLE
Fix typo in configure-jwt-bearer-authentication.md

### DIFF
--- a/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
+++ b/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
@@ -268,7 +268,7 @@ When using access tokens in a client application, the access tokens need to be r
 `SaveTokens` will not currently refresh access tokens automatically, but this functionality is planned for .NET 10. Follow https://github.com/dotnet/aspnetcore/issues/8175 for updates. In the meantime, you can manually refresh the access token as [demonstrated in the Blazor Web App with OIDC documentation](/aspnet/core/blazor/security/blazor-web-app-with-oidc?pivots=with-bff-pattern#token-refresh) or use a third-party NuGet package like [Duende.AccessTokenManagement.OpenIdConnect](https://www.nuget.org/packages/Duende.AccessTokenManagement.OpenIdConnect) for handling and managing access tokens in the client app.  For more information, see [Duende token management](https://docs.duendesoftware.com/identityserver/v7/quickstarts/3a_token_management/).
 
 > [!NOTE]
-> If deploying to production, the cache should work in a mutli-instance deployment. A persistent cache is normally required.
+> If deploying to production, the cache should work in a multi-instance deployment. A persistent cache is normally required.
 
 Some secure token servers encrypt the access tokens. Access tokens do not require any format. When using OAuth introspection, a reference token is used instead of an access token. A client (UI) application should never open an access token as the access token is not intended for this. Only an API for which the access token was created for should open the access token. 
 


### PR DESCRIPTION
Fixed a small typo: mutli -> multi

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/configure-jwt-bearer-authentication.md](https://github.com/dotnet/AspNetCore.Docs/blob/5af0aaf4b4496fa6799f5c8b0e63d638f6696d6e/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md) | [Configure JWT bearer authentication in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-jwt-bearer-authentication?branch=pr-en-us-36103) |

<!-- PREVIEW-TABLE-END -->