### PR TITLE
[RC1] Blazor WASM respects UI culture setting

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -514,7 +514,7 @@ await host.RunAsync();
 :::moniker range="< aspnetcore-10.0"
 
 > [!NOTE]
-> In .NET 9 or earlier, standalone Blazor WebAssembly load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
+> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -514,7 +514,7 @@ await host.RunAsync();
 :::moniker range="< aspnetcore-10.0"
 
 > [!NOTE]
-> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
+> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI globalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. If you want to additionally load globalization data for your localization culture defined by <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType>, [upgrade the app to .NET 10 or later](xref:migration/index).
 
 :::moniker-end
 
@@ -1017,7 +1017,7 @@ await host.RunAsync();
 :::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
 
 > [!NOTE]
-> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
+> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI globalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. If you want to additionally load globalization data for your localization culture defined by <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType>, [upgrade the app to .NET 10 or later](xref:migration/index).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -1012,12 +1012,16 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 await host.RunAsync();
 ```
 
-:::moniker range="< aspnetcore-10.0"
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
 
 > [!NOTE]
 > In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
 
 :::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
 
 Add the following `CultureSelector` component to the `.Client` project.
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -366,7 +366,7 @@ CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 :::moniker range="< aspnetcore-10.0"
 
 > [!NOTE]
-> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
+> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI globalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. If you want to additionally load globalization data for your localization culture defined by <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType>, [upgrade the app to .NET 10 or later](xref:migration/index).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -363,8 +363,12 @@ CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 ```
 
+:::moniker range="< aspnetcore-10.0"
+
 > [!NOTE]
-> Currently, Blazor WebAssembly apps only load resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture>. For more information, see [Blazor WASM only relies on the current culture (current UI culture isn't respected) (`dotnet/aspnetcore` #56824)](https://github.com/dotnet/aspnetcore/issues/56824).
+> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
+
+:::moniker-end
 
 Use the `CultureExample1` component shown in the [Demonstration component](#demonstration-component) section to study how globalization works. Issue a request with United States English (`en-US`). Switch to Costa Rican Spanish (`es-CR`) in the browser's language settings. Request the webpage again. When the requested language is Costa Rican Spanish, the app's culture remains United States English (`en-US`).
 
@@ -507,8 +511,12 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 await host.RunAsync();
 ```
 
+:::moniker range="< aspnetcore-10.0"
+
 > [!NOTE]
-> Currently, Blazor WebAssembly apps only load resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture>. For more information, see [Blazor WASM only relies on the current culture (current UI culture isn't respected) (`dotnet/aspnetcore` #56824)](https://github.com/dotnet/aspnetcore/issues/56824).
+> In .NET 9 or earlier, standalone Blazor WebAssembly load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
+
+:::moniker-end
 
 The following `CultureSelector` component shows how to perform the following actions:
 
@@ -1004,8 +1012,12 @@ CultureInfo.DefaultThreadCurrentUICulture = culture;
 await host.RunAsync();
 ```
 
+:::moniker range="< aspnetcore-10.0"
+
 > [!NOTE]
-> Currently, Blazor WebAssembly apps only load resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture>. For more information, see [Blazor WASM only relies on the current culture (current UI culture isn't respected) (`dotnet/aspnetcore` #56824)](https://github.com/dotnet/aspnetcore/issues/56824).
+> In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. To set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType> in a standalone Blazor WebAssembly app, [upgrade the app to .NET 10 or later](xref:migration/index).
+
+:::moniker-end
 
 Add the following `CultureSelector` component to the `.Client` project.
 

--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -4,7 +4,7 @@ author: wadepickett
 description: Learn about the new features in ASP.NET Core in .NET 10.
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 09/09/2025
+ms.date: 09/15/2025
 uid: aspnetcore-10
 ---
 # What's new in ASP.NET Core in .NET 10

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -759,3 +759,7 @@ public int CounterNotRestoredOnReconnect { get; set; }
 ```
 
 Call `PersistentComponentState.RegisterOnRestoring` to register a callback for imperatively controlling how state is restored, similar to how <xref:Microsoft.AspNetCore.Components.PersistentComponentState.RegisterOnPersisting%2A?displayProperty=nameWithType> provides full control of how state is persisted.
+
+### Blazor WebAssembly respects the current UI culture setting
+
+In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. With the release of .NET 10, you can set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType>. For general guidance, see <xref:blazor/globalization-localization>.

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -762,4 +762,4 @@ Call `PersistentComponentState.RegisterOnRestoring` to register a callback for i
 
 ### Blazor WebAssembly respects the current UI culture setting
 
-In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI internationalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. With the release of .NET 10, you can set the default UI culture using <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType>. For general guidance, see <xref:blazor/globalization-localization>.
+In .NET 9 or earlier, standalone Blazor WebAssembly apps load UI globalization resources based on <xref:System.Globalization.CultureInfo.DefaultThreadCurrentCulture?displayProperty=nameWithType>. If you want to additionally load globalization data for your localization culture defined by <xref:System.Globalization.CultureInfo.DefaultThreadCurrentUICulture?displayProperty=nameWithType>, [upgrade the app to .NET 10 or later](xref:migration/index).


### PR DESCRIPTION
Fixes #35872

This one is a little late ... I should've had this in last week. 🙈🏃‍♂️😄 We won't link to a specific section from the *What's New* section because there isn't one to link to. This was just a NOTE in the article, so we'll version that content for <10.0 and [float on](https://www.youtube.com/watch?v=CTAud5O7Qqk).

Since it's a little late .........................

<img width="634" alt="willis" src="https://user-images.githubusercontent.com/1622880/105532195-20d8a300-5cb0-11eb-86de-f8065db785f4.png">

*Welcome to the party pal!* - John McClane ([Bruce Willis](https://www.imdb.com/name/nm0000246/)), [Die Hard](https://www.20thcenturystudios.com/movies/die-hard), &copy;1988 [20th Century Fox](https://www.20thcenturystudios.com/)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/globalization-localization.md](https://github.com/dotnet/AspNetCore.Docs/blob/dd6b4b3150ed22d531eb0611393434f9d9862f4a/aspnetcore/blazor/globalization-localization.md) | [aspnetcore/blazor/globalization-localization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?branch=pr-en-us-36105) |
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/dd6b4b3150ed22d531eb0611393434f9d9862f4a/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-36105) |


<!-- PREVIEW-TABLE-END -->