### PR TITLE
Blazor bundle HTTP caching remarks

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/webassembly/http-caching-issues.md
+++ b/aspnetcore/blazor/host-and-deploy/webassembly/http-caching-issues.md
@@ -20,9 +20,21 @@ While future Blazor releases might provide better solutions for dealing with HTT
 
 Common problems that negatively impact the user upgrade experience include:
 
+:::moniker range=">= aspnetcore-10.0"
+
+* **Incorrect handling of project and package updates**: This happens if you don't update all of the app's deployed projects to use the same major framework version or if you use packages from a previous version when a newer version is available as part of the major upgrade.
+* **Incorrect configuration of caching headers**: HTTP caching headers control how, where, and for how long the app's responses are cached. If headers aren't configured correctly, users might receive stale content. This includes the caching of [Blazor bundle assets](xref:blazor/host-and-deploy/webassembly/bundle-caching-and-integrity-check-failures), where server caching headers must be properly set to avoid stale or mismatched Blazor assets on the client.
+* **Incorrect configuration of other layers**: Content Delivery Networks (CDNs) and other layers of the deployed app can cause issues if incorrectly configured. For example, CDNs are designed to cache and deliver content to improve performance and reduce latency. If a CDN is incorrectly serving cached versions of assets, it can lead to stale content delivery to the user.
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-10.0"
+
 * **Incorrect handling of project and package updates**: This happens if you don't update all of the app's deployed projects to use the same major framework version or if you use packages from a previous version when a newer version is available as part of the major upgrade.
 * **Incorrect configuration of caching headers**: HTTP caching headers control how, where, and for how long the app's responses are cached. If headers aren't configured correctly, users might receive stale content.
 * **Incorrect configuration of other layers**: Content Delivery Networks (CDNs) and other layers of the deployed app can cause issues if incorrectly configured. For example, CDNs are designed to cache and deliver content to improve performance and reduce latency. If a CDN is incorrectly serving cached versions of assets, it can lead to stale content delivery to the user.
+
+:::moniker-end
 
 ## Detect and diagnose upgrade issues
 


### PR DESCRIPTION
Fixes #35821

Marek ... A minor update based on your remark ...

> Now that resources are not cached in the custom cache, applications will be more sensitive to server caching properly set. I'm thinking if we should call that out somehow in docs, or if we have it covered somewhere. It might be different based on server application and hosting model

I'm also adding a remark in the *Host and Deploy* overview that bundle caching/integrity and general caching for Blazor WebAssembly apply to Blazor Web Apps that adopt Interactive WebAssembly/Auto render modes.