### PR TITLE
Further opt-in trimming guidance (class libs)

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -5,7 +5,7 @@ description: Learn how to control the Intermediate Language (IL) Trimmer when bu
 monikerRange: '>= aspnetcore-5.0'
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 09/08/2025
+ms.date: 09/19/2025
 uid: blazor/host-and-deploy/configure-trimmer
 ---
 # Configure the Trimmer for ASP.NET Core Blazor
@@ -15,6 +15,18 @@ uid: blazor/host-and-deploy/configure-trimmer
 This article explains how to control the Intermediate Language (IL) Trimmer when building a Blazor app.
 
 Blazor WebAssembly performs [Intermediate Language (IL)](/dotnet/standard/glossary#il) trimming to reduce the size of the published output. Trimming occurs when publishing an app.
+
+## Default trimmer granularity
+
+The default trimmer granularity for Blazor apps is `partial`. To trim all assemblies, change the granularity to `full` in the app's project file:
+
+```xml
+<PropertyGroup>
+  <TrimMode>full</TrimMode>
+</PropertyGroup>
+```
+
+For more information, see [Trimming options (.NET documentation)](/dotnet/core/deploying/trimming/trimming-options#trimming-granularity).
 
 ## Configuration
 
@@ -28,17 +40,13 @@ To configure the IL Trimmer, see the [Trimming options](/dotnet/core/deploying/t
 * Control symbol trimming and debugger support.
 * Set IL Trimmer features for trimming framework library features.
 
-## Default trimmer granularity
-
-The default trimmer granularity for Blazor apps is `partial`. To trim all assemblies, change the granularity to `full` in the app's project file:
+When the [trimmer granularity](#default-trimmer-granularity) is `partial`, which is the default value, the IL Trimmer trims the base class library and any other assemblies of the app. To opt into trimming in any of the app's class library projects, set the `<IsTrimmable>` MSBuild property to `true` in those projects:
 
 ```xml
 <PropertyGroup>
-  <TrimMode>full</TrimMode>
+  <IsTrimmable>true</IsTrimmable>
 </PropertyGroup>
 ```
-
-For more information, see [Trimming options (.NET documentation)](/dotnet/core/deploying/trimming/trimming-options#trimming-granularity).
 
 ## Failure to preserve types used by a published app
 
@@ -96,7 +104,7 @@ To address lost types, consider adopting one of the following approaches.
 
 ### Custom types
 
-Custom types aren't trimmed by Blazor when an app is published (unless explicitly opted in), so we recommend using custom types for JS interop, JSON serialization/deserialization, and other operations that rely on reflection.
+Custom types aren't trimmed by Blazor when an app is published (and unless [explicitly opted in](#configuration) for class libraries), so we recommend using custom types for JS interop, JSON serialization/deserialization, and other operations that rely on reflection.
 
 The following modifications create a `StringTuple` type for use by the component.
 
@@ -123,7 +131,7 @@ The component is modified to use the `StringTuple` type:
 + items = JsonSerializer.Deserialize<List<StringTuple>>(data, options)!;
 ```
 
-Because custom types aren't trimmed by Blazor when an app is published (unless explicitly opted in), the component works as designed after the app is published.
+Because custom types aren't trimmed by Blazor when an app is published (and unless [explicitly opted in](#configuration) for class libraries), the component works as designed after the app is published.
 
 :::moniker range=">= aspnetcore-10.0"
 

--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -47,7 +47,7 @@ To configure the IL Trimmer, see the [Trimming options](/dotnet/core/deploying/t
 * Control symbol trimming and debugger support.
 * Set IL Trimmer features for trimming framework library features.
 
-When the [trimmer granularity](#default-trimmer-granularity) is `partial`, which is the default value, the IL Trimmer trims the base class library and any other assemblies of the app. To opt into trimming in any of the app's class library projects, set the `<IsTrimmable>` MSBuild property to `true` in those projects:
+When the [trimmer granularity](#default-trimmer-granularity) is `partial`, which is the default value, the IL Trimmer trims the base class library and any other assemblies marked as trimmable. To opt into trimming in any of the app's class library projects, set the `<IsTrimmable>` MSBuild property to `true` in those projects:
 
 ```xml
 <PropertyGroup>

--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -55,6 +55,8 @@ When the [trimmer granularity](#default-trimmer-granularity) is `partial`, which
 </PropertyGroup>
 ```
 
+For guidance that pertains to .NET libraries, see [Prepare .NET libraries for trimming](/dotnet/core/deploying/trimming/prepare-libraries-for-trimming).
+
 ## Failure to preserve types used by a published app
 
 Trimming may have detrimental effects for a published app leading to runtime errors, even in spite of setting the [`<PublishTrimmed>` property](#configuration) to `false` in the project file. In apps that use [reflection](/dotnet/csharp/advanced-topics/reflection-and-attributes/), the IL Trimmer often can't determine the required types for runtime reflection and trims them away or trims away parameter names from methods. This can happen with complex framework types used for JS interop, JSON serialization/deserialization, and other operations.
@@ -220,4 +222,5 @@ As a workaround in .NET 8, you can add the `_ExtraTrimmerArgs` MSBuild property 
 ## Additional resources
 
 * [Trim self-contained deployments and executables](/dotnet/core/deploying/trimming/trim-self-contained)
+* [Prepare .NET libraries for trimming](/dotnet/core/deploying/trimming/prepare-libraries-for-trimming)
 * <xref:blazor/performance/app-download-size#intermediate-language-il-trimming>

--- a/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
+++ b/aspnetcore/blazor/host-and-deploy/configure-trimmer.md
@@ -18,6 +18,9 @@ Blazor WebAssembly performs [Intermediate Language (IL)](/dotnet/standard/glossa
 
 ## Default trimmer granularity
 
+<!-- UPDATE 10.0 - HOLD until https://github.com/dotnet/aspnetcore/issues/49409
+                   is addressed.
+
 The default trimmer granularity for Blazor apps is `partial`. To trim all assemblies, change the granularity to `full` in the app's project file:
 
 ```xml
@@ -25,6 +28,10 @@ The default trimmer granularity for Blazor apps is `partial`. To trim all assemb
   <TrimMode>full</TrimMode>
 </PropertyGroup>
 ```
+
+-->
+
+The default trimmer granularity for Blazor apps is `partial`, which means that only core framework libraries and libraries that have explicitly enabled trimming support are trimmed. Full trimming isn't supported.
 
 For more information, see [Trimming options (.NET documentation)](/dotnet/core/deploying/trimming/trimming-options#trimming-granularity).
 
@@ -104,7 +111,7 @@ To address lost types, consider adopting one of the following approaches.
 
 ### Custom types
 
-Custom types aren't trimmed by Blazor when an app is published (and unless [explicitly opted in](#configuration) for class libraries), so we recommend using custom types for JS interop, JSON serialization/deserialization, and other operations that rely on reflection.
+To avoid issues with .NET trimming in scenarios that rely on reflection, such as JS interop and JSON serialization, use custom types defined in non-trimmable libraries or preserve the types via linker configuration.
 
 The following modifications create a `StringTuple` type for use by the component.
 
@@ -131,7 +138,7 @@ The component is modified to use the `StringTuple` type:
 + items = JsonSerializer.Deserialize<List<StringTuple>>(data, options)!;
 ```
 
-Because custom types aren't trimmed by Blazor when an app is published (and unless [explicitly opted in](#configuration) for class libraries), the component works as designed after the app is published.
+Because custom types defined in non-trimmable assemblies aren't trimmed by Blazor when an app is published, the component works as designed after the app is published.
 
 :::moniker range=">= aspnetcore-10.0"
 


### PR DESCRIPTION
Fixes #36126

cc: @hakenr 

Let's see about filling in the additional detail following the work in #36094:

* Move the trimming granularity section up to facilitate the *Configuration* section cross-linking to it with more information.
* Explain the use of `<IsTrimmable>` in the *Configuration* section.
* Cross-link the "explicitly opted in" remark of the *Custom type* section to the *Configuration* section, and add "class libraries" to it to clarify what is being opted-in.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/configure-trimmer.md](https://github.com/dotnet/AspNetCore.Docs/blob/2ef7174f48bc353842359e2c668aeeea2930cce4/aspnetcore/blazor/host-and-deploy/configure-trimmer.md) | [aspnetcore/blazor/host-and-deploy/configure-trimmer](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/configure-trimmer?branch=pr-en-us-36127) |


<!-- PREVIEW-TABLE-END -->