### PR TITLE
Copilot-instructions: Add new sections per Copilot issue & review tests

### DIFF
--- a/.github/copilot-code-instructions.md
+++ b/.github/copilot-code-instructions.md
@@ -1,0 +1,108 @@
+---
+author: tdykstra
+ms.author: wpickett
+ms.date: 09-22-2025
+---
+
+# Copilot Code Instructions for `dotnet/AspNetCore.Docs`
+
+## Introduction
+This document contains code-specific instructions for GitHub Copilot when assisting with the `dotnet/AspNetCore.Docs` repository. For general instructions and documentation guidelines, please refer to the [copilot-instructions.md](./copilot-instructions.md) file.
+
+## Code-Related Guidelines
+
+### 1. Code Snippets
+- [ ] For code snippets longer than 6 lines:
+  - [ ] Create a subfolder named after the document the snippet supports.
+  - [ ] Create a `snippets` folder inside that subfolder.
+  - [ ] For the code file:
+     - [ ] If the snippet is not version-specific, place the code in a file with the appropriate extension (for example, `.cs` for C#) in the `snippets` folder.
+     - [ ] If the snippet is version-specific:
+        - [ ] Create a subfolder inside the `snippets` folder named for the version (for example, `9.0` for .NET 9 or ASP.NET Core 9).
+        - [ ] Place the code in a file with the correct extension inside the version subfolder.
+        - [ ] Add a project file (`.csproj`) to the version subfolder targeting the matching .NET version, if necessary to run or build the snippet.
+- [ ] Reference snippets using triple-colon syntax:
+  - [ ] **Use file-relative paths** for snippets located in the same file as the articles that refer to it.
+    ```
+    :::code language="csharp" source="../snippets/my-doc/Program.cs":::
+    ```
+  - [ ] **Use repository root-relative paths** for shared snippets:
+    ```
+    :::code language="csharp" source="~/tutorials/min-web-api/samples/9.x/todoGroup/TodoDb.cs":::
+    ```
+- [ ] For longer snippets, highlight specific lines:
+  ```
+  :::code language="csharp" source="~/path/to/file.cs" range="5-10" highlight="2-3":::
+  ```
+- [ ] Use the latest, non-preview C# coding patterns in non-preview code examples
+- [ ] Use the latest preview C# coding patterns in preview code examples
+- [ ] Use the following language code and indentation standards for markdown code blocks or the `language` attribute of code snippets:
+
+  Content of the snippet | Language code | Indentation in spaces
+  :--------------------: | :-----------: | :-------------------:
+  C#                     | csharp        | 4
+  HTML                   | html          | 4
+  CSS                    | css           | 4
+  JavaScript             | javascript    | 2 spaces (use 4 spaces for line continuation)
+  XML                    | xml           | 2
+  JSON                   | json          | 2
+  Console                | console       | 2
+  Text                   | -             | 2
+
+- [ ] Code Snippet Folder Structure Requirements:
+  - [ ] For code snippets longer than 6 lines, create proper folder structure: article-name/snippets/version/filename.cs (e.g., cookie/snippets/6.0/Program.cs)
+  - [ ] Create version-specific subfolders: 3.x, 6.0, 8.0, 9.0, etc.
+  - [ ] Use file-relative paths for snippets in same article folder
+  - [ ] Use repository root-relative paths (~/) for shared snippets
+- [ ] Code Snippet Markers in .cs Files - CRITICAL:
+  - [ ] NEVER use #region snippet_name and #endregion syntax in .cs files
+  - [ ] ALWAYS use // <snippet_name> and // </snippet_name> format (all lowercase)
+  - [ ] Examples of correct .cs file snippet markers:
+    ```csharp
+    // <snippet_policy>
+    var cookiePolicyOptions = new CookiePolicyOptions
+    {
+        MinimumSameSitePolicy = SameSiteMode.Strict,
+    };
+    app.UseCookiePolicy(cookiePolicyOptions);
+    // </snippet_policy>
+    ```
+  - [ ] INCORRECT format to avoid:
+    ```csharp
+    #region snippet_policy
+    // code here
+    #endregion
+    ```
+- [ ] Code Comments and Localization:
+  - [ ] NEVER add explanatory code comments like `// Configure cookie policy options` in .cs snippet files
+  - [ ] NEVER add comments like `// Add Cookie Policy Middleware` - these prevent proper localization
+  - [ ] Rely on markdown prose before/after code snippets for explanations instead of inline comments
+  - [ ] Only keep comments that are essential to the code's functionality
+- [ ] Common Syntax Errors to Avoid:
+  - [ ] Using `range="5-10"` instead of `id="snippet_name"`
+  - [ ] Using `name="snippet_name"` instead of `id="snippet_name"`
+  - [ ] Mixing old [!code-csharp[]] syntax with new triple-colon syntax.  Use triple-colon syntax.
+  - [ ] Using absolute line numbers in highlight="" instead of relative to snippet
+  - [ ] Using #region/#endregion in .cs files instead of // <snippet_name> format
+- [ ] Version-Specific Considerations:
+  - [ ] Create separate snippet files for different .NET versions (3.x, 6.0, 8.0, 9.0+)
+  - [ ] Ensure examples use appropriate syntax for the target version
+  - [ ] Reference the correct version-specific snippet file in markdown
+
+### 2. Code Build and Testing Requirements
+- [ ] Ensure all code samples build successfully against the targeted .NET version
+- [ ] Include necessary using statements in code samples
+- [ ] When you're assigned an issue involving code changes, after you've completed your work and the workflows (status checks) have run, ensure there are no build warnings under the OpenPublishing.Build status check
+- [ ] Use `#nullable enable` in C# code samples that use nullable reference types
+- [ ] For Minimal API examples, use the latest patterns including group-based routing where appropriate
+- [ ] For code samples targeting preview versions:
+  - [ ] Clearly indicate in comments or surrounding documentation that the code targets a preview version
+  - [ ] Provide fallback examples for current stable versions when possible
+
+### 3. ASP.NET Core Code-Specific Guidelines
+- [ ] Use the latest supported version for examples unless otherwise specified
+- [ ] Include differences between Minimal API and controller-based approaches when relevant
+- [ ] For middleware content and examples, use the middleware class approach
+- [ ] Code examples should be concise and focused on demonstrating a specific concept
+- [ ] Include error handling in code examples where appropriate
+- [ ] Ensure all code is accessible and follows best practices for ASP.NET Core applications

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,8 @@ ms.date: 09-21-2025
 ## Introduction
 This document contains general and repository-specific instructions for GitHub Copilot when assisting with the `dotnet/AspNetCore.Docs` repository. **Unless otherwise specified, all ".NET" references refer to modern .NET, not .NET Framework.**
 
+For code-specific guidelines, including code snippets, version targeting, and language standards, please refer to the [copilot-code-instructions.md](./copilot-code-instructions.md) file.
+
 ## General Guidelines
 
 ### 1. Issue Handling
@@ -124,96 +126,9 @@ When working on an issue:
      - [ ] Maintain alphabetical order of the `source_path` entries for better organization
      - [ ] Ensure proper JSON formatting with correct commas between entries
 - [ ] When selecting a redirect target, choose the most relevant existing content that would serve the user's original intent
-- [ ] If no direct replacement exists, redirect to a parent category page or related topic
-    
-### 4. Code Snippets
-- [ ] For code snippets longer than 6 lines:
-  - [ ] Create a subfolder named after the document the snippet supports.
-  - [ ] Create a `snippets` folder inside that subfolder.
-  - [ ] For the code file:
-     - [ ] If the snippet is not version-specific, place the code in a file with the appropriate extension (for example, `.cs` for C#) in the `snippets` folder.
-     - [ ] If the snippet is version-specific:
-        - [ ] Create a subfolder inside the `snippets` folder named for the version (for example, `9.0` for .NET 9 or ASP.NET Core 9).
-        - [ ] Place the code in a file with the correct extension inside the version subfolder.
-        - [ ] Add a project file (`.csproj`) to the version subfolder targeting the matching .NET version, if necessary to run or build the snippet.
-- [ ] Reference snippets using triple-colon syntax:
-  - [ ] **Use file-relative paths** for snippets located in the same file as the articles that refer to it.
-    ```
-    :::code language="csharp" source="../snippets/my-doc/Program.cs":::
-    ```
-  - [ ] **Use repository root-relative paths** for shared snippets:
-    ```
-    :::code language="csharp" source="~/tutorials/min-web-api/samples/9.x/todoGroup/TodoDb.cs":::
-    ```
-- [ ] For longer snippets, highlight specific lines:
-  ```
-  :::code language="csharp" source="~/path/to/file.cs" range="5-10" highlight="2-3":::
-  ```
-- [ ] Use the latest, non-preview C# coding patterns in non-preview code examples
-- [ ] Use the latest preview C# coding patterns in preview code examples
-- [ ] Use the following language code and indentation standards for markdown code blocks or the `language` attribute of code snippets:
+- [ ] If no direct replacement exists, redirect to a parent category page or related topic  
 
-  Content of the snippet | Language code | Indentation in spaces
-  :--------------------: | :-----------: | :-------------------:
-  C#                     | csharp        | 4
-  HTML                   | html          | 4
-  CSS                    | css           | 4
-  JavaScript             | javascript    | 2 spaces (use 4 spaces for line continuation)
-  XML                    | xml           | 2
-  JSON                   | json          | 2
-  Console                | console       | 2
-  Text                   | -             | 2
-- [ ] Triple-Colon Syntax Requirements:
-  - [ ] NEVER use [!code-csharp[]] syntax - this is incorrect and will cause build errors
-  - [ ] ALWAYS use triple-colon syntax: :::code language="csharp" source="path" id="snippet_name" highlight="lines":::
-  - [ ] NEVER use `name="snippet_name"` attribute - this is unsupported and causes build errors
-  - [ ] ALWAYS use `id="snippet_name"` to reference named snippets
-  - [ ] Use `highlight=` when needed and make sure the line numbers are relative to the snippet content, not absolute file line numbers.
-  - [ ] Example of correct  triple colon syntax with example highlight line number:
-    ```
-    :::code language="csharp" source="~/path/to/file.cs" id="snippet_policy" highlight="3-5,9":::
-    ```
-- [ ] Code Snippet Folder Structure Requirements:
-  - [ ] For code snippets longer than 6 lines, create proper folder structure: article-name/snippets/version/filename.cs (e.g., cookie/snippets/6.0/Program.cs)
-  - [ ] Create version-specific subfolders: 3.x, 6.0, 8.0, 9.0, etc.
-  - [ ] Use file-relative paths for snippets in same article folder
-  - [ ] Use repository root-relative paths (~/) for shared snippets
-- [ ] Code Snippet Markers in .cs Files - CRITICAL:
-  - [ ] NEVER use #region snippet_name and #endregion syntax in .cs files
-  - [ ] ALWAYS use // <snippet_name> and // </snippet_name> format (all lowercase)
-  - [ ] Examples of correct .cs file snippet markers:
-    ```csharp
-    // <snippet_policy>
-    var cookiePolicyOptions = new CookiePolicyOptions
-    {
-        MinimumSameSitePolicy = SameSiteMode.Strict,
-    };
-    app.UseCookiePolicy(cookiePolicyOptions);
-    // </snippet_policy>
-    ```
-  - [ ] INCORRECT format to avoid:
-    ```csharp
-    #region snippet_policy
-    // code here
-    #endregion
-    ```
-- [ ] Code Comments and Localization:
-  - [ ] NEVER add explanatory code comments like `// Configure cookie policy options` in .cs snippet files
-  - [ ] NEVER add comments like `// Add Cookie Policy Middleware` - these prevent proper localization
-  - [ ] Rely on markdown prose before/after code snippets for explanations instead of inline comments
-  - [ ] Only keep comments that are essential to the code's functionality
-- [ ] Common Syntax Errors to Avoid:
-  - [ ] Using `range="5-10"` instead of `id="snippet_name"`
-  - [ ] Using `name="snippet_name"` instead of `id="snippet_name"`
-  - [ ] Mixing old [!code-csharp[]] syntax with new triple-colon syntax
-  - [ ] Using absolute line numbers in highlight="" instead of relative to snippet
-  - [ ] Using #region/#endregion in .cs files instead of // <snippet_name> format
-- [ ] Version-Specific Considerations:
-  - [ ] Create separate snippet files for different .NET versions (3.x, 6.0, 8.0, 9.0+)
-  - [ ] Ensure examples use appropriate syntax for the target version
-  - [ ] Reference the correct version-specific snippet file in markdown
-
-### 5. ASP.NET Core Specific Guidelines
+### 4. ASP.NET Core Specific Guidelines
 - [ ] Use the latest supported version for examples unless otherwise specified
 - [ ] Title and section header casing is sentence case (capitalize the first word and any proper nouns)
 - [ ] For parts of a title or section header that normally use code style in article text (backticks around the content), also use code style in the title or section header (example H1 header: "# Modify the `Program.cs` file")
@@ -224,14 +139,14 @@ When working on an issue:
 - [ ] Include differences between Minimal API and controller-based approaches when relevant
 - [ ] For middleware content and examples, use the middleware class approach
 
-### 6. Content Writing Guidelines
+### 5. Content Writing Guidelines
 - [ ] Introductory paragraph:
   - [ ] When drafting the first paragraph of any new article, or when significantly updating an existing article:
   - [ ] Explain why and when the topic matters in practical ASP.NET Core development scenarios.
   - [ ] Give a concise summary of what the article covers or enables, so readers know what to expect.
   - [ ] When significantly updating, revise the introductory paragraph to match the new scope and content.
 
-### 7. PR Description Requirements
+### 6. PR Description Requirements
 - [ ] ALWAYS include "Fixes #[issue-number]" in the PR description, at the first line of the description to link back to the original issue
 - [ ] Include a clear summary of changes made
 - [ ] List all files that were modified with brief descriptions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -85,14 +85,20 @@ When working on an issue:
     - [ ] Metadata `ai-usage: ai-assisted` if any AI assistance was used
     - [ ] Place the title metadata first, followed by the remaining metadata lines in alphabetical order. Example: `title`, `author`, `description`, `monikerRange`, `ms.author`, `ms.custom`, `ms.date`, `uid`, `zone_pivot_groups`
     - [ ] Metadata `ms.date: <today's date>` with a format of MM/DD/YYYY. If the file already has a `ms.date` metadata, update it to today's date if more than 50 characters are changed in the file.
+
+### 1. Metadata and Date Requirements
+- [ ] CRITICAL: Set ms.date to the actual current date in MM/DD/YYYY format (GitHub Copilot often uses incorrect future dates)
+- [ ] Add ai-usage: ai-assisted metadata if any AI assistance was used
+- [ ] Place title metadata first, followed by remaining metadata in alphabetical order
+- [ ] Update ms.date if more than 50 characters are changed in existing files
     
-### 1. Version Targeting Common Range Patterns
+### 2. Version Targeting Common Range Patterns
 - [ ] Fixed Range: `>= aspnetcore-7.0 <= aspnetcore-9.0`
 - [ ] Open Upper Bound: `>= aspnetcore-7.0`
 - [ ] Open Lower Bound: `<= aspnetcore-9.0`
 - [ ] Specific Version: `== aspnetcore-9.0`
 
-### 2. Handling File Redirections
+### 3. Handling File Redirections
 - [ ] When a Markdown (.md) article file (this does not apply to includes) is deleted in a PR, create a redirection entry.
 - [ ] Redirections ensure users following existing links aren't left with broken links
 - [ ] To add a redirection:
@@ -115,7 +121,7 @@ When working on an issue:
 - [ ] When selecting a redirect target, choose the most relevant existing content that would serve the user's original intent
 - [ ] If no direct replacement exists, redirect to a parent category page or related topic
     
-### 3. Code Snippets
+### 4. Code Snippets
 - [ ] For code snippets longer than 6 lines:
   - [ ] Create a subfolder named after the document the snippet supports.
   - [ ] Create a `snippets` folder inside that subfolder.
@@ -153,7 +159,7 @@ When working on an issue:
   Console                | console       | 2
   Text                   | -             | 2
 
-### 4. ASP.NET Core Specific Guidelines
+### 5. ASP.NET Core Specific Guidelines
 - [ ] Use the latest supported version for examples unless otherwise specified
 - [ ] Title and section header casing is sentence case (capitalize the first word and any proper nouns)
 - [ ] For parts of a title or section header that normally use code style in article text (backticks around the content), also use code style in the title or section header (example H1 header: "# Modify the `Program.cs` file")
@@ -164,7 +170,7 @@ When working on an issue:
 - [ ] Include differences between Minimal API and controller-based approaches when relevant
 - [ ] For middleware content and examples, use the middleware class approach
 
-### 5. PR Description Requirements
+### 6. PR Description Requirements
 - [ ] ALWAYS include "Fixes #[issue-number]" in the PR description, at the first line of the description to link back to the original issue
 - [ ] Include a clear summary of changes made
 - [ ] List all files that were modified with brief descriptions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -87,7 +87,7 @@ When working on an issue:
     - [ ] Metadata `ms.date: <today's date>` with a format of MM/DD/YYYY. If the file already has a `ms.date` metadata, update it to today's date if more than 50 characters are changed in the file.
 
 ### 1. Metadata and Date Requirements
-- [ ] CRITICAL: Set ms.date to the actual current date in MM/DD/YYYY format (GitHub Copilot often uses incorrect future dates)
+- [ ] CRITICAL: Set ms.date to the actual current date in MM/DD/YYYY format.  Do not infer the date based on existing dates in files.  Use today's date.
 - [ ] Add ai-usage: ai-assisted metadata if any AI assistance was used
 - [ ] Place title metadata first, followed by remaining metadata in alphabetical order
 - [ ] Update ms.date if more than 50 characters are changed in existing files
@@ -158,7 +158,16 @@ When working on an issue:
   JSON                   | json          | 2
   Console                | console       | 2
   Text                   | -             | 2
-
+- [ ] Triple-Colon Syntax Requirements:
+  - [ ] NEVER use [!code-csharp[]] syntax - this is incorrect and will cause build errors
+  - [ ] ALWAYS use triple-colon syntax: :::code language="csharp" source="path" id="snippet_name" highlight="lines":::
+  - [ ] NEVER use `name="snippet_name"` attribute - this is unsupported and causes build errors
+  - [ ] ALWAYS use `id="snippet_name"` to reference named snippets
+  - [ ] Use `highlight=` when needed and make sure the line numbers are relative to the snippet content, not absolute file line numbers.
+  - [ ] Example of correct  triple colon syntax with example highlight line number:
+    ```
+    :::code language="csharp" source="~/path/to/file.cs" id="snippet_policy" highlight="3-5,9":::
+    ```
 ### 5. ASP.NET Core Specific Guidelines
 - [ ] Use the latest supported version for examples unless otherwise specified
 - [ ] Title and section header casing is sentence case (capitalize the first word and any proper nouns)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -168,6 +168,12 @@ When working on an issue:
     ```
     :::code language="csharp" source="~/path/to/file.cs" id="snippet_policy" highlight="3-5,9":::
     ```
+- [ ] Code Snippet Folder Structure Requirements:
+  - [ ] For code snippets longer than 6 lines, create proper folder structure: article-name/snippets/version/filename.cs (e.g., cookie/snippets/6.0/Program.cs)
+  - [ ] Create version-specific subfolders: 3.x, 6.0, 8.0, 9.0, etc.
+  - [ ] Use file-relative paths for snippets in same article folder
+  - [ ] Use repository root-relative paths (~/) for shared snippets
+  
 ### 5. ASP.NET Core Specific Guidelines
 - [ ] Use the latest supported version for examples unless otherwise specified
 - [ ] Title and section header casing is sentence case (capitalize the first word and any proper nouns)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,3 +163,9 @@ When working on an issue:
 - [ ] Lead with Microsoft-recommended approaches
 - [ ] Include differences between Minimal API and controller-based approaches when relevant
 - [ ] For middleware content and examples, use the middleware class approach
+
+### 5. PR Description Requirements
+- [ ] ALWAYS include "Fixes #[issue-number]" in the PR description, at the first line of the description to link back to the original issue
+- [ ] Include a clear summary of changes made
+- [ ] List all files that were modified with brief descriptions
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 ---
-author: wadepickett
+author: tdykstra
 ms.author: wpickett
 ms.date: 09-21-2025
 ---

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,15 +22,23 @@ When creating a PR for an issue:
 - [ ] Provide an overview of the project you're working on, including its purpose, goals, and any relevant background information.
 - [ ] Include the folder structure of the repository, including any important directories or files that are relevant to the project.
 
-### 2. Markdown File Naming and Organization
+### 2. Issue Discussion Analysis
+When working on an issue:
+- [ ] **Read the complete issue discussion** - Don't rely solely on the initial issue description
+- [ ] **Prioritize maintainer guidance** - Comments from repository maintainers (especially those with "MEMBER" association) should take precedence over the original issue description
+- [ ] **Look for updated analysis** - Later comments may contain revised understanding, additional context, or modified resolution approaches
+- [ ] **Check for explicit instructions** - Look for phrases like "Action required by GitHub Copilot" or direct "@copilot" mentions that provide specific guidance
+- [ ] **Validate your understanding** - If the discussion seems to contradict the initial issue description, follow the most recent maintainer guidance
+
+### 3. Markdown File Naming and Organization
 - [ ] If you're adding a new Markdown file, it should be named in all lowercase with hyphens separating words. Also, omit any filler words such as "the" or "a" from the file name.
 
-### 3. API References and Verification
+### 4. API References and Verification
   - [ ] Use `<xref:api-doc-ID>` for API cross-references. 
   - [ ] The API documentation ID must be verified and sourced from the official XML documentation in dotnet-api-docs, never just infer API documentation IDs by looking for similar patterns.
   - [ ] If you cannot verify, state that explicitly in your output.
 
-### 4. Links and References
+### 5. Links and References
 - [ ] For cross-references to other articles within the AspNetCore.Docs repository:
   - [ ] Use the xref syntax: `<xref:target-uid>`
   - [ ] The "target-uid" of the xref syntax is obtained from the `uid` property value in the YAML front matter of the article's markdown file

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -173,7 +173,26 @@ When working on an issue:
   - [ ] Create version-specific subfolders: 3.x, 6.0, 8.0, 9.0, etc.
   - [ ] Use file-relative paths for snippets in same article folder
   - [ ] Use repository root-relative paths (~/) for shared snippets
-  
+- [ ] Code Snippet Markers in .cs Files - CRITICAL:
+  - [ ] NEVER use #region snippet_name and #endregion syntax in .cs files
+  - [ ] ALWAYS use // <snippet_name> and // </snippet_name> format (all lowercase)
+  - [ ] Examples of correct .cs file snippet markers:
+    ```csharp
+    // <snippet_policy>
+    var cookiePolicyOptions = new CookiePolicyOptions
+    {
+        MinimumSameSitePolicy = SameSiteMode.Strict,
+    };
+    app.UseCookiePolicy(cookiePolicyOptions);
+    // </snippet_policy>
+    ```
+  - [ ] INCORRECT format to avoid:
+    ```csharp
+    #region snippet_policy
+    // code here
+    #endregion
+    ```
+
 ### 5. ASP.NET Core Specific Guidelines
 - [ ] Use the latest supported version for examples unless otherwise specified
 - [ ] Title and section header casing is sentence case (capitalize the first word and any proper nouns)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,7 @@ When working on an issue:
       
 
 ### 1. Metadata and Date Requirements
-- [ ] CRITICAL: Set ms.date to the actual current date in MM/DD/YYYY format.  Do not infer the date based on existing dates in files.  Use today's date.
+- [ ] CRITICAL: Set ms.date to the actual current date in MM/DD/YYYY format. Do not infer the date based on existing dates in files.  Use today's date.
 - [ ] Add ai-usage: ai-assisted metadata if any AI assistance was used
 - [ ] Place title metadata first, followed by remaining metadata in alphabetical order
 - [ ] Update ms.date if more than 50 characters are changed in existing files

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 ---
 author: wadepickett
 ms.author: wpickett
-ms.date: 08-17-2025
+ms.date: 09-21-2025
 ---
 
 # Copilot Instructions for `dotnet/AspNetCore.Docs`
@@ -85,13 +85,18 @@ When working on an issue:
     - [ ] Metadata `ai-usage: ai-assisted` if any AI assistance was used
     - [ ] Place the title metadata first, followed by the remaining metadata lines in alphabetical order. Example: `title`, `author`, `description`, `monikerRange`, `ms.author`, `ms.custom`, `ms.date`, `uid`, `zone_pivot_groups`
     - [ ] Metadata `ms.date: <today's date>` with a format of MM/DD/YYYY. If the file already has a `ms.date` metadata, update it to today's date if more than 50 characters are changed in the file.
+      
 
 ### 1. Metadata and Date Requirements
 - [ ] CRITICAL: Set ms.date to the actual current date in MM/DD/YYYY format.  Do not infer the date based on existing dates in files.  Use today's date.
 - [ ] Add ai-usage: ai-assisted metadata if any AI assistance was used
 - [ ] Place title metadata first, followed by remaining metadata in alphabetical order
 - [ ] Update ms.date if more than 50 characters are changed in existing files
-    
+  - [ ] When updating ms.date always use <today's date> in the format MM/DD/YYYY.  Examples:
+    - [ ] MM: Two digits, leading zero if needed (01-12)
+    - [ ] DD: Two digits, leading zero if needed (01-31)
+    - [ ] YYYY: Four digits (2025)   
+    - [ ] Example: `ms.date: 08/07/2025`
 ### 2. Version Targeting Common Range Patterns
 - [ ] Fixed Range: `>= aspnetcore-7.0 <= aspnetcore-9.0`
 - [ ] Open Upper Bound: `>= aspnetcore-7.0`
@@ -219,7 +224,14 @@ When working on an issue:
 - [ ] Include differences between Minimal API and controller-based approaches when relevant
 - [ ] For middleware content and examples, use the middleware class approach
 
-### 6. PR Description Requirements
+### 6. Content Writing Guidelines
+- [ ] Introductory paragraph:
+  - [ ] When drafting the first paragraph of any new article, or when significantly updating an existing article:
+  - [ ] Explain why and when the topic matters in practical ASP.NET Core development scenarios.
+  - [ ] Give a concise summary of what the article covers or enables, so readers know what to expect.
+  - [ ] When significantly updating, revise the introductory paragraph to match the new scope and content.
+
+### 7. PR Description Requirements
 - [ ] ALWAYS include "Fixes #[issue-number]" in the PR description, at the first line of the description to link back to the original issue
 - [ ] Include a clear summary of changes made
 - [ ] List all files that were modified with brief descriptions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -97,7 +97,7 @@ When working on an issue:
   - [ ] When updating ms.date always use <today's date> in the format MM/DD/YYYY. Examples:
     - [ ] MM: Two digits, leading zero if needed (01-12)
     - [ ] DD: Two digits, leading zero if needed (01-31)
-    - [ ] YYYY: Four digits (2025)   
+    - [ ] YYYY: Four digits (2025)
     - [ ] Example: `ms.date: 08/07/2025`
 ### 2. Version Targeting Common Range Patterns
 - [ ] Fixed Range: `>= aspnetcore-7.0 <= aspnetcore-9.0`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -192,6 +192,21 @@ When working on an issue:
     // code here
     #endregion
     ```
+- [ ] Code Comments and Localization:
+  - [ ] NEVER add explanatory code comments like `// Configure cookie policy options` in .cs snippet files
+  - [ ] NEVER add comments like `// Add Cookie Policy Middleware` - these prevent proper localization
+  - [ ] Rely on markdown prose before/after code snippets for explanations instead of inline comments
+  - [ ] Only keep comments that are essential to the code's functionality
+- [ ] Common Syntax Errors to Avoid:
+  - [ ] Using `range="5-10"` instead of `id="snippet_name"`
+  - [ ] Using `name="snippet_name"` instead of `id="snippet_name"`
+  - [ ] Mixing old [!code-csharp[]] syntax with new triple-colon syntax
+  - [ ] Using absolute line numbers in highlight="" instead of relative to snippet
+  - [ ] Using #region/#endregion in .cs files instead of // <snippet_name> format
+- [ ] Version-Specific Considerations:
+  - [ ] Create separate snippet files for different .NET versions (3.x, 6.0, 8.0, 9.0+)
+  - [ ] Ensure examples use appropriate syntax for the target version
+  - [ ] Reference the correct version-specific snippet file in markdown
 
 ### 5. ASP.NET Core Specific Guidelines
 - [ ] Use the latest supported version for examples unless otherwise specified

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ When working on an issue:
 - [ ] Add ai-usage: ai-assisted metadata if any AI assistance was used
 - [ ] Place title metadata first, followed by remaining metadata in alphabetical order
 - [ ] Update ms.date if more than 50 characters are changed in existing files
-  - [ ] When updating ms.date always use <today's date> in the format MM/DD/YYYY.  Examples:
+  - [ ] When updating ms.date always use <today's date> in the format MM/DD/YYYY. Examples:
     - [ ] MM: Two digits, leading zero if needed (01-12)
     - [ ] DD: Two digits, leading zero if needed (01-31)
     - [ ] YYYY: Four digits (2025)   


### PR DESCRIPTION
Contributes to:
#35991
#36113

Add new sections collaborated with @tdykstra based on many copilot issues and review handling tests.
Reformat to checkboxes so Copilot stops skipping instructions per current best practice.
Break the original instruction into two documents with a new doc that centers just on code instructions.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/copilot-code-instructions.md](https://github.com/dotnet/AspNetCore.Docs/blob/4bb0234b3ac1e6a79cb1635ec8d95457ebc45984/.github/copilot-code-instructions.md) | [Copilot Code Instructions for `dotnet/AspNetCore.Docs`](https://review.learn.microsoft.com/en-us/aspnet/core/.github/copilot-code-instructions?branch=pr-en-us-36136) |
| [.github/copilot-instructions.md](https://github.com/dotnet/AspNetCore.Docs/blob/4bb0234b3ac1e6a79cb1635ec8d95457ebc45984/.github/copilot-instructions.md) | [.github/copilot-instructions](https://review.learn.microsoft.com/en-us/aspnet/core/.github/copilot-instructions?branch=pr-en-us-36136) |


<!-- PREVIEW-TABLE-END -->