### PR TITLE
Revise Cache Tag Helper documentation attributes

### DIFF
--- a/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
@@ -89,7 +89,7 @@ Example:
 </cache>
 ```
 
-Defaults to 30 seconds if `expires_after` and `expires_on` aren't defined.
+Defaults to 30 seconds if [`expires_after`](#expires-after) and [`expires_on`](#expires-on) aren't defined.
 
 ### `priority`
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
@@ -240,15 +240,17 @@ routes.MapRoute(
 
 `vary-by-user` specifies whether or not the cache resets when the signed-in user (or Context Principal) changes. The current user is also known as the Request Context Principal and can be viewed in a Razor view by referencing `@User.Identity.Name`.
 
-The following example monitors the current logged in user to trigger a cache refresh:
+This attribute defaults to `true` to ensure cache isolation between different users.
+
+The following example disables varying the response by user:
 
 ```cshtml
-<cache vary-by-user="true">
+<cache vary-by-user="false">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </cache>
 ```
 
-Using this attribute maintains the contents in cache through a sign-in and sign-out cycle. When the value is set to `true`, an authentication cycle invalidates the cache for the authenticated user. The cache is invalidated because a new unique cookie value is generated when a user is authenticated. Cache is maintained for the anonymous state when no cookie is present or the cookie has expired. If the user is **not** authenticated, the cache is maintained.
+Using this attribute maintains the contents in cache through a sign-in and sign-out cycle. When the value is `true`, an authentication cycle invalidates the cache for the authenticated user. The cache is invalidated because a new unique cookie value is generated when a user is authenticated. Cache is maintained for the anonymous state when no cookie is present or the cookie has expired. If the user is **not** authenticated, the cache is maintained.
 
 ## Additional resources
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
@@ -89,7 +89,7 @@ Example:
 </cache>
 ```
 
-Defaults to 30 seconds if [`expires_after`](#expires-after) and [`expires_on`](#expires-on) aren't defined.
+Defaults to 30 seconds if [`expires-after`](#expires-after) and [`expires-on`](#expires-on) aren't defined.
 
 ### `priority`
 
@@ -236,7 +236,7 @@ routes.MapRoute(
 
 | Attribute type  | Examples        | Default |
 | --------------- | --------------- | :-----: |
-| Boolean         | `true`, `false` | `false` |
+| Boolean         | `true`, `false` | `true`  |
 
 `vary-by-user` specifies whether or not the cache resets when the signed-in user (or Context Principal) changes. The current user is also known as the Request Context Principal and can be viewed in a Razor view by referencing `@User.Identity.Name`.
 

--- a/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
+++ b/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md
@@ -236,16 +236,14 @@ routes.MapRoute(
 
 | Attribute type  | Examples        | Default |
 | --------------- | --------------- | :-----: |
-| Boolean         | `true`, `false` | `true`  |
+| Boolean         | `true`, `false` | `false`  |
 
 `vary-by-user` specifies whether or not the cache resets when the signed-in user (or Context Principal) changes. The current user is also known as the Request Context Principal and can be viewed in a Razor view by referencing `@User.Identity.Name`.
 
-This attribute defaults to `true` to ensure cache isolation between different users.
-
-The following example disables varying the response by user:
+The following example monitors the current logged in user to trigger a cache refresh:
 
 ```cshtml
-<cache vary-by-user="false">
+<cache vary-by-user="true">
     Current Time Inside Cache Tag Helper: @DateTime.Now
 </cache>
 ```


### PR DESCRIPTION
Fixes #36137

Thanks @mvxproject! 🚀 

Tom, I had a minute here before wrapping things up for the day, so I thought I toss a quick PR in on this Peter Keller article.

* Fix up the items that are called out [here](https://github.com/dotnet/AspNetCore.Docs/issues/36137#issue-3439419075). Adding `vary-by-culture`, which is [supported back to 3.1](https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.cachetaghelperbase.varybyculture).
* Alphabetize the entries.
* Code-fence the headings because they're HTML code.
* Centered the "Default" column.
* Lowercase the word "type" in table column headings.
* I used an em dash for the "Default" for `expires-after` to make sure that no other entry there confuses the reader. However, "None" works, too. Let me know if you prefer "None" or some other value, and I'll change it.

The API is over here ...

https://github.com/dotnet/aspnetcore/blob/main/src/Mvc/Mvc.TagHelpers/src/CacheTagHelperBase.cs

I can't see that Copilot is correct about `vary-by-user`. It looks `false` to me by default, which is what the article states. IDK what it's talking about on its reference to source code 👇.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md](https://github.com/dotnet/AspNetCore.Docs/blob/64797909411653022f60b979d977a0b22b247a85/aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper.md) | [aspnetcore/mvc/views/tag-helpers/built-in/cache-tag-helper](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/built-in/cache-tag-helper?branch=pr-en-us-36142) |


<!-- PREVIEW-TABLE-END -->