### PR TITLE
Fix SetDefaultPolicy being used like SetFallbackPolicy

### DIFF
--- a/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
+++ b/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md
@@ -180,7 +180,7 @@ APIs often need to accommodate access tokens from various issuers. Supporting mu
 
 ### Forcing the bearer authentication
 
-<xref:Microsoft.AspNetCore.Authorization.AuthorizationBuilder.SetDefaultPolicy%2A> can be used to require authentication for all requests even to endpoints without an `[Authorize]` attribute. <xref:Microsoft.AspNetCore.Authorization.AuthorizationBuilder.SetDefaultPolicy%2A> configures the policy used for endpoints with the `[Authorize]` attribute and already defaults to requiring authenticated users. See the [require authenticated users documentation](/aspnet/core/security/authorization/secure-data#require-authenticated-users) for more details.
+<xref:Microsoft.AspNetCore.Authorization.AuthorizationBuilder.SetFallbackPolicy%2A> can be used to require authentication for all requests even to endpoints without an `[Authorize]` attribute. <xref:Microsoft.AspNetCore.Authorization.AuthorizationBuilder.SetDefaultPolicy%2A> configures the policy used for endpoints with the `[Authorize]` attribute and already defaults to requiring authenticated users. See the [require authenticated users documentation](/aspnet/core/security/authorization/secure-data#require-authenticated-users) for more details.
 
 ```csharp
 var requireAuthPolicy = new AuthorizationPolicyBuilder()
@@ -188,7 +188,7 @@ var requireAuthPolicy = new AuthorizationPolicyBuilder()
 	.Build();
 
 builder.Services.AddAuthorizationBuilder()
-	.SetDefaultPolicy(requireAuthPolicy);
+	.SetFallbackPolicy(requireAuthPolicy);
 ```
 
 The <xref:Microsoft.AspNetCore.Authorization.AuthorizeAttribute> attribute can also be used to force the authentication. If multiple schemes are used, the bearer scheme generally needs to be set as the default authentication scheme or specified via `[Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme])`.


### PR DESCRIPTION
The description mistakenly says `SetDefaultPolicy` twice, despite describing the behavior of `SetFallbackPolicy` in the first sentence and then the behavior of `SetDefaultPolicy` in the next sentence. I suppose this is a typo.

What it used to say is false, as changing `SetDefaultPolicy` will never impact endpoints without an `[Authorize]` attribute.

This is especially dangerous, as someone copying the example code may just naively assume their API is already secure without using `[Authorize]`, while it obviously isn't.

Additionally, changed the example below to show how to require authenticated user by default, similar to how it's presented in the linked require-authenticated-users article section.

This was done as the previous example using `SetDefaultFallback` essentially did nothing, as requiring authenticated users is what the default policy does already with nothing set, so the old example is of no use.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/configure-jwt-bearer-authentication.md](https://github.com/dotnet/AspNetCore.Docs/blob/46880d0300af3f12fcc916ee9dfa65295a39e011/aspnetcore/security/authentication/configure-jwt-bearer-authentication.md) | [Configure JWT bearer authentication in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-jwt-bearer-authentication?branch=pr-en-us-36186) |

<!-- PREVIEW-TABLE-END -->