### PR TITLE
Fix a typo in razor-pages-tests.md

### DIFF
--- a/aspnetcore/test/razor-pages-tests.md
+++ b/aspnetcore/test/razor-pages-tests.md
@@ -331,7 +331,7 @@ Another set of unit tests is responsible for tests of page model methods. In the
 | `OnPostDeleteMessageAsync` | Executes `DeleteMessageAsync` to delete a message with the `Id` specified. |
 | `OnPostAnalyzeMessagesAsync` | If one or more messages are in the database, calculates the average number of words per message. |
 
-The page model methods are tested using seven tests in the `IndexPageTests` class (`tests/RazorPagesTestSample.Tests/UnitTests/IndexPageTests.cs`). The tests use the familiar Arrange-Assert-Act pattern. These tests focus on:
+The page model methods are tested using seven tests in the `IndexPageTests` class (`tests/RazorPagesTestSample.Tests/UnitTests/IndexPageTests.cs`). The tests use the familiar Arrange-Act-Assert pattern. These tests focus on:
 
 * Determining if the methods follow the correct behavior when the [ModelState](xref:Microsoft.AspNetCore.Mvc.ModelBinding.ModelStateDictionary) is invalid.
 * Confirming the methods produce the correct <xref:Microsoft.AspNetCore.Mvc.IActionResult>.


### PR DESCRIPTION
Arrange-Act-Assert instead of Arrange-Assert-Act



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/razor-pages-tests.md](https://github.com/dotnet/AspNetCore.Docs/blob/21b3b03a9830f203fb0ce126502e536539eac947/aspnetcore/test/razor-pages-tests.md) | [aspnetcore/test/razor-pages-tests](https://review.learn.microsoft.com/en-us/aspnet/core/test/razor-pages-tests?branch=pr-en-us-36205) |


<!-- PREVIEW-TABLE-END -->