### PR TITLE
Added warning when using Redis to store Data Protection keys

### DIFF
--- a/aspnetcore/security/data-protection/implementation/key-storage-providers.md
+++ b/aspnetcore/security/data-protection/implementation/key-storage-providers.md
@@ -3,7 +3,7 @@ title: Key storage providers in ASP.NET Core
 author: tdykstra
 description: Learn about key storage providers in ASP.NET Core and how to configure key storage locations.
 ms.author: tdykstra
-ms.date: 06/11/2025
+ms.date: 11/07/2025
 uid: security/data-protection/implementation/key-storage-providers
 ---
 <!-- ms.sfi.ropc: t -->


### PR DESCRIPTION
Added a warning about using Redis cache to store Data Protection keys, since Redis doesn't persist data across service restarts by default. Provided links for configuration guidance.

Fixes #36305

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/data-protection/implementation/key-storage-providers.md](https://github.com/dotnet/AspNetCore.Docs/blob/74afd55f8f5580d40873ba6ddb8e5f193a83a0d3/aspnetcore/security/data-protection/implementation/key-storage-providers.md) | [Key storage providers in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/security/data-protection/implementation/key-storage-providers?branch=pr-en-us-36219) |


<!-- PREVIEW-TABLE-END -->