### PR TITLE
Update repository-specific guidelines in instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 ---
 author: tdykstra
 ms.author: wpickett
-ms.date: 09-21-2025
+ms.date: 10-16-2025
 ---
 
 # Copilot Instructions for `dotnet/AspNetCore.Docs`


### PR DESCRIPTION
A quick patch that I don't think rises to the level of requiring an issue.

This came about because Copilot deliberately tried to ***remove*** a contraction from a release notes update ...

https://github.com/dotnet/AspNetCore.Docs/pull/36224#discussion_r2435618526

I edited Copilot's suggested change to put the contraction back.

Cross-ref: [Use contractions](https://learn.microsoft.com/en-us/style-guide/word-choice/use-contractions)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/copilot-instructions.md](https://github.com/dotnet/AspNetCore.Docs/blob/4be7640dde6b6fe1297c6eec75eaf8b6aa776d60/.github/copilot-instructions.md) | [Copilot Instructions for `dotnet/AspNetCore.Docs`](https://review.learn.microsoft.com/en-us/aspnet/core/.github/copilot-instructions?branch=pr-en-us-36225) |


<!-- PREVIEW-TABLE-END -->