### PR TITLE
Update WPF tutorial with target framework guidance

### DIFF
--- a/aspnetcore/blazor/hybrid/tutorials/wpf.md
+++ b/aspnetcore/blazor/hybrid/tutorials/wpf.md
@@ -66,14 +66,14 @@ At the top of the project file, change the SDK to `Microsoft.NET.Sdk.Razor`:
 
 :::moniker range=">= aspnetcore-10.0"
 
-In the project file's existing `<TargetFramework>` property, add a Windows 10 version number:
+In the project file's existing `<TargetFramework>` property, add a Windows 10 or later version number:
 
 ```xml
 <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
 ```
 
 > [!NOTE]
-> The preceding guidance on setting the project's target framework version to target Windows 10 or higher is a result of switching to the new `WebView2CompositionControl`.
+> The preceding guidance on setting the project's target framework version to target Windows 10 or later is a result of switching to the `WebView2CompositionControl` with the release of .NET 10.
 
 :::moniker-end
 


### PR DESCRIPTION
[EDIT by guardrex to add the issue]

Fixes #36228

This pull request updates the Blazor Hybrid WPF tutorial to include new guidance for targeting Windows 10 when using the latest `WebView2CompositionControl`. The change ensures compatibility with recent platform requirements.

Platform targeting update:

* Added instructions for setting the `<TargetFramework>` property to `net10.0-windows10.0.17763.0` in the project file for projects using `Microsoft.NET.Sdk.Razor`, specifically for ASP.NET Core 10.0 and later.
* Included a note explaining that the updated target framework is required due to the switch to `WebView2CompositionControl`.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/tutorials/wpf.md](https://github.com/dotnet/AspNetCore.Docs/blob/01e2db3114518f646928f03ea42fbf058bc5b4c5/aspnetcore/blazor/hybrid/tutorials/wpf.md) | [aspnetcore/blazor/hybrid/tutorials/wpf](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/tutorials/wpf?branch=pr-en-us-36227) |


<!-- PREVIEW-TABLE-END -->