### PR TITLE
[Blazor] Handle Errors - CascadingValue to include IsFixed attribute

### DIFF
--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -555,6 +555,8 @@ The following `ProcessError` component example merely logs errors, but methods o
 
 > [!NOTE]
 > For more information on <xref:Microsoft.AspNetCore.Components.RenderFragment>, see <xref:blazor/components/index#child-content-render-fragments>.
+>
+> <xref:Microsoft.AspNetCore.Components.CascadingValue%601.IsFixed%2A?displayProperty=nameWithType> is used to indicate that a cascading parameter doesn't change after initialization.
 
 :::moniker-end
 
@@ -666,6 +668,8 @@ The following `ProcessError` component passes itself as a [`CascadingValue`](xre
 
 > [!NOTE]
 > For more information on <xref:Microsoft.AspNetCore.Components.RenderFragment>, see <xref:blazor/components/index#child-content-render-fragments>.
+>
+> <xref:Microsoft.AspNetCore.Components.CascadingValue%601.IsFixed%2A?displayProperty=nameWithType> is used to indicate that a cascading parameter doesn't change after initialization.
 
 In the `App` component, wrap the <xref:Microsoft.AspNetCore.Components.Routing.Router> component with the `ProcessError` component. This permits the `ProcessError` component to cascade down to any component of the app where the `ProcessError` component is received as a [`CascadingParameter`](xref:blazor/components/cascading-values-and-parameters#cascadingparameter-attribute).
 


### PR DESCRIPTION
`this` never changes, so `IsFixed="true"` should be used to avoid subscribing to changes (PERF)

https://learn.microsoft.com/en-us/aspnet/core/blazor/performance/rendering?view=aspnetcore-9.0#ensure-cascading-parameters-are-fixed

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/handle-errors.md](https://github.com/dotnet/AspNetCore.Docs/blob/aa0324d6f09d08a246b5d9b5ca15484b10306e81/aspnetcore/blazor/fundamentals/handle-errors.md) | [aspnetcore/blazor/fundamentals/handle-errors](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/handle-errors?branch=pr-en-us-36231) |


<!-- PREVIEW-TABLE-END -->