### PR TITLE
Update wasm-tools installation instructions for .NET 8

### DIFF
--- a/aspnetcore/blazor/webassembly-build-tools-and-aot.md
+++ b/aspnetcore/blazor/webassembly-build-tools-and-aot.md
@@ -32,6 +32,17 @@ The .NET WebAssembly build tools are based on [Emscripten](https://emscripten.or
 > dotnet workload install wasm-tools-net6
 > ```
 
+> [!NOTE]
+> .NET WebAssembly build tools for .NET 8 projects
+>
+> The `wasm-tools` workload installs the build tools for the latest release. However, the current version of the build tools are incompatible with existing projects built with .NET 8. Projects using the build tools that must support both .NET 8 and a later release must use multi-targeting.
+>
+> Use the `wasm-tools-net8` workload for .NET 8 projects when developing apps with the .NET 9 SDK. To install the `wasm-tools-net8` workload, execute the following command from an administrative command shell:
+>
+> ```dotnetcli
+> dotnet workload install wasm-tools-net8
+> ```
+
 ## Ahead-of-time (AOT) compilation
 
 Blazor WebAssembly supports ahead-of-time (AOT) compilation, where you can compile your .NET code directly into WebAssembly. AOT compilation results in runtime performance improvements at the expense of a larger app size.


### PR DESCRIPTION
[EDIT by guardrex to add the issue number]

Fixes #36235

Added note about .NET WebAssembly build tools compatibility and installation instructions for .NET 8 projects.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/webassembly-build-tools-and-aot.md](https://github.com/dotnet/AspNetCore.Docs/blob/b46f26b34bc4260e3f050bee0648d3f34e309078/aspnetcore/blazor/webassembly-build-tools-and-aot.md) | [ASP.NET Core Blazor WebAssembly build tools and ahead-of-time (AOT) compilation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-build-tools-and-aot?branch=pr-en-us-36234) |

<!-- PREVIEW-TABLE-END -->