### PR TITLE
Clarify workload installs by SDK and app targets

### DIFF
--- a/aspnetcore/blazor/webassembly-build-tools-and-aot.md
+++ b/aspnetcore/blazor/webassembly-build-tools-and-aot.md
@@ -29,7 +29,7 @@ To install the build tools as a .NET workload, use ***either*** of the following
   dotnet workload install wasm-tools
   ```
 
-To target a prior .NET release for a given .NET SDK, install the `wasm-tools-net{MAJOR VERSION}` workload:
+To target a prior .NET release with a given .NET SDK, install the `wasm-tools-net{MAJOR VERSION}` workload:
 
 * The `{MAJOR VERSION}` placeholder is replaced with the major version number of the .NET release you want to target (for example, `wasm-tools-net8` for .NET 8).
 * Workloads are installed per .NET SDK. Installing the `wasm-tools` workload for one SDK doesn't make it available to other SDKs on the system.


### PR DESCRIPTION
Fixes #36235

Marek ... This is tricky enough that I think you better look 👀.

❓ ... When we say that the dev should install `wasm-tools-net8` for .NET 9 and .NET 10, shouldn't we also be saying that they run the command in each SDK folder? Otherwise, how would the installer know to use the .NET 9 flavor of the workload versus the .NET 10 flavor of the workload (if I open a command shell at the root) because you said that they differ slightly for each SDK. So, should we say (for the .NET CLI) to install the workload with the command shell opened to the .NET SDK's folder?

Wade, Tom ... 

I only need a single review on this one.

I don't want to create a giant versioning mess for this. Because SDKs are back-compat, I think we're fine just showing them all (versionless) here. I'm going to use my in-article tracking notes each year to add a new section to the list. When I update this at 10.0 GA, I'll leave a new tracking note for 11.0 GA, which I'll address in November, 2026 ... *if I'm still here, of course!* 🤞🍀

WRT the content ... well ... ***I think it makes sense!*** 😆 It's tricky because there are two factors to keep in mind: the .NET SDK and what apps target with the SDK. Marek will have helped by the time you see this, since I'm getting his review first.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/webassembly-build-tools-and-aot.md](https://github.com/dotnet/AspNetCore.Docs/blob/f747a6fa11df120146cb3eb9aa534d592a3e43d3/aspnetcore/blazor/webassembly-build-tools-and-aot.md) | [aspnetcore/blazor/webassembly-build-tools-and-aot](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-build-tools-and-aot?branch=pr-en-us-36243) |


<!-- PREVIEW-TABLE-END -->