### PR TITLE
Improve `bind:get/set` coverage

### DIFF
--- a/aspnetcore/blazor/components/data-binding.md
+++ b/aspnetcore/blazor/components/data-binding.md
@@ -960,11 +960,11 @@ In the following `NestedChild` component, the `NestedGrandchild` component:
 
 Prior to the release of .NET 7, two-way binding across components uses `get`/`set` accessors with a third property that discards the <xref:System.Threading.Tasks.Task> returned by <xref:Microsoft.AspNetCore.Components.EventCallback.InvokeAsync%2A?displayProperty=nameWithType> in its setter. To see an example of this approach for .NET 6 or earlier before `@bind:get`/`@bind:set` modifiers became a framework feature, see [the `NestedChild` component of this section in the .NET 6 version of this article](?view=aspnetcore-6.0&preserve-view=true#bind-across-more-than-two-components).
 
-The reason to avoid directly modifying a component parameter is that it effectively mutates the parent's state from the child component. This can interfere with Blazor's change detection process and trigger extra render cycles because parameters are meant to be *inputs*, they're not meant to be mutable state. In chained scenarios where data is passed among components, directly writing to a component parameter can lead to unintended effects, such as infinite rerenders that hang the app.
+The reason to avoid directly changing the value of a component parameter is that it effectively mutates the parent's state from the child component. This can interfere with Blazor's change detection process and trigger extra render cycles because parameters are meant to be *inputs*, they're not meant to be mutable state. In chained scenarios where data is passed among components, directly writing to a component parameter can lead to unintended effects, such as infinite rerenders that hang the app.
 
 `@bind:get`/`@bind:set` syntax allows you to:
 
-* Avoid creating an extra "middle" property that only exists to forward values and callbacks across chained components.
+* Avoid creating an extra property that only exists to forward values and callbacks across chained components, which was required prior to the release of .NET 7.
 * Intercept and transform values before they're applied.
 * Keep the parameter immutable in the child, while still supporting two-way binding.
 


### PR DESCRIPTION
Fixes #36052

Distilled from Javier's remarks at https://github.com/dotnet/aspnetcore/issues/57962#issuecomment-3254232136.

Tom or Wade: Ready here! This is just mirroring some really nice remarks that Javier made in a PU discussion ☝️ that devs will likely find helpful in understanding why they shouldn't write directly to component parameters, favoring `@bind:get/set` directive attributes instead. This adds a little more juice to the existing section and example on binding across components. I only need one review to get this in.

For reference, here's one of the examples (because you can't see them here with the cross-repo links) ...

https://github.com/dotnet/blazor-samples/blob/main/10.0/BlazorSample_BlazorWebApp/Components/NestedChild.razor



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/data-binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/45aab73b880038e3fada8f7194537f677d00c894/aspnetcore/blazor/components/data-binding.md) | [aspnetcore/blazor/components/data-binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/data-binding?branch=pr-en-us-36250) |


<!-- PREVIEW-TABLE-END -->