### PR TITLE
Add remark on ShowFiles component response stream

### DIFF
--- a/aspnetcore/blazor/images-and-documents.md
+++ b/aspnetcore/blazor/images-and-documents.md
@@ -5,7 +5,7 @@ description: Learn how to display images and documents in ASP.NET Core Blazor ap
 monikerRange: '>= aspnetcore-6.0'
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 11/12/2024
+ms.date: 10/30/2025
 uid: blazor/images-and-documents
 ---
 # Display images and documents in ASP.NET Core Blazor


### PR DESCRIPTION
Fixes #36278

Thanks again, Ondřej! 🎷

This is a companion PR to go with the component fix on https://github.com/dotnet/blazor-samples/pull/599.

I went with your 'combine methods' suggestion, so we now have the following ...

```csharp
private async Task ShowFileAsync(string url, string title)
{
    var absoluteUrl = Navigation.ToAbsoluteUri(url);
    using var response = await Http.GetAsync(absoluteUrl);
    string? contentType = null;

    if (response.Content.Headers.TryGetValues("Content-Type", out var values))
    {
        contentType = values.FirstOrDefault();
    }

    var fileStream = await response.Content.ReadAsStreamAsync();
    var strRef = new DotNetStreamReference(fileStream);

    await JS.InvokeVoidAsync("setSource", "iframe", strRef, contentType, title);
}
```

For reference, the other section on the importance of disposing of `HttpResponseMessage` instances is here ...

https://learn.microsoft.com/aspnet/core/blazor/call-web-api#disposal-of-httprequestmessage-httpresponsemessage-and-httpclient

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/images-and-documents.md](https://github.com/dotnet/AspNetCore.Docs/blob/44de16d5b67a13e5b5ff35f79cd8f9e4ca93c91c/aspnetcore/blazor/images-and-documents.md) | [aspnetcore/blazor/images-and-documents](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/images-and-documents?branch=pr-en-us-36279) |


<!-- PREVIEW-TABLE-END -->