### PR TITLE
Change response from NoContent to NotFound

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -951,7 +951,7 @@ app.MapPatch("/todoitems/{id}", async (long id, TodoContext db) =>
         return TypedResults.Ok(todo);
     }
 
-    return TypedResults.NoContent();
+    return TypedResults.NotFound();
 });
 ```
 


### PR DESCRIPTION
Fixes #36284

Wade/Tom: I'm not updating the article date because this is a tiny code change to just one line of one example.

The reason for the change is that the `MapPatch` method either finds the item to patch, patches it, and returns an Ok (200) response ... ***OR*** ... it doesn't find the item and should return a Not Found (404) response, not a No Content (204) response. I discovered this while working on the Blazor sample updates for 10.0. All of the samples have already been updated with this change.

The method with the status code change on the PR ...

```diff
app.MapPatch("/todoitems/{id}", async (long id, TodoContext db) =>
{
    if (await db.TodoItems.FindAsync(id) is TodoItem todo)
    {
        ... CODE HERE DOES THE PATCH

        return TypedResults.Ok(todo);
    }

-   return TypedResults.NoContent();
+   return TypedResults.NotFound();
});
```