### PR TITLE
Update call-javascript-from-dotnet.md

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -392,7 +392,7 @@ The following component:
 
 :::moniker-end
 
-`TickerChanged` calls the `displayTickerChanged2` method and displays the returned string in the following component.
+`TickerChanged` calls the `displayTickerAlert2` method and displays the returned string in the following component.
 
 :::moniker range=">= aspnetcore-9.0"
 


### PR DESCRIPTION
[EDIT by guardrex to add the issue]

Fixes #36290

Changed the name of the handleTickerChanged1 function to displayTickerAlert1. Because in the code examples this function is called displayTickerAlert1.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md](https://github.com/dotnet/AspNetCore.Docs/blob/c686b08cee95eb27919243f9c5693c2895e19ad8/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md) | [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?branch=pr-en-us-36289) |


<!-- PREVIEW-TABLE-END -->