### PR TITLE
Update call-javascript-from-dotnet.md

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -296,7 +296,10 @@ Provide a `displayTickerAlert2` JS function. The following example returns a str
 
 ### Component (`.razor`) example (`InvokeAsync`)
 
-`TickerChanged` calls the `handleTickerChanged2` method and displays the returned string in the following component.
+The following component:
+
+* Invokes the `displayTickerAlert2` JS function with <xref:Microsoft.JSInterop.JSRuntimeExtensions.InvokeAsync%2A> when selecting a button (**`Set Stock`**).
+* The JS function takes two parameters strictly typed on the C# side — a string and a decimal. If the condition is met, it displays a modal alert box with a specified message and returns a string to the component for display (`text`).
 
 :::moniker range=">= aspnetcore-9.0"
 


### PR DESCRIPTION
Changed the JS function name in the description:
this "handleTickerChanged2" on this "displayTickerAlert2"



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md](https://github.com/dotnet/AspNetCore.Docs/blob/44e4685e88167202057c2caa6aa136f1606f3415/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md) | [Call JavaScript functions from .NET methods in ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?branch=pr-en-us-36291) |

<!-- PREVIEW-TABLE-END -->