### PR TITLE
Update call-javascript-from-dotnet.md

### DIFF
--- a/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
+++ b/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md
@@ -386,7 +386,7 @@ Provide a `displayTickerAlert2` JS function. The following example returns a str
 
 :::moniker-end
 
-`TickerChanged` calls the `handleTickerChanged2` method and displays the returned string in the following component.
+`TickerChanged` calls the `displayTickerAlert2` method and displays the returned string in the following component.
 
 :::moniker range=">= aspnetcore-9.0"
 


### PR DESCRIPTION
Changed the JS function name in the description:
this "handleTickerChanged2" on this "displayTickerAlert2"



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md](https://github.com/dotnet/AspNetCore.Docs/blob/ef27c03def372523c502249c9ecfe368f6192a69/aspnetcore/blazor/javascript-interoperability/call-javascript-from-dotnet.md) | [Call JavaScript functions from .NET methods in ASP.NET Core Blazor](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/javascript-interoperability/call-javascript-from-dotnet?branch=pr-en-us-36292) |

<!-- PREVIEW-TABLE-END -->