### PR TITLE
Fix link for using declaration

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -366,7 +366,7 @@ An <xref:System.Net.Http.HttpRequestMessage> without a body doesn't require expl
   using var request = new HttpRequestMessage(...);
   ```
   
-* [`using` block (all C# releases)](https://learn.microsoft.com/dotnet/csharp/language-reference/keywords/using):
+* [`using` block (all C# releases)](/dotnet/csharp/language-reference/keywords/using):
 
   ```csharp
   using (var request = new HttpRequestMessage(...))


### PR DESCRIPTION
Fixes #36308

Wade or Tom ... I didn't see a great link for `using` declarations. Copilot tried to provide a link that just redirects to the same 404 page that I had here. I can remove the link (on this PR) and flesh out both scenarios with a quick example. I took some modified Copilot suggestions along the way. It's ready for review.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/call-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/e1aa65ad13a454f8dd6a5fe2690ae8838d0d2bce/aspnetcore/blazor/call-web-api.md) | [aspnetcore/blazor/call-web-api](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/call-web-api?branch=pr-en-us-36309) |


<!-- PREVIEW-TABLE-END -->