### PR TITLE
Clarify the Blazor response streaming heading in the What's New doc

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -107,7 +107,7 @@ The following example uses the `HideColumnOptionsAsync` method to close the colu
 }
 ```
 
-### Response streaming is opt-in and how to opt-out
+### HttpClient response streaming enabled by default
 
 In prior Blazor releases, response streaming for <xref:System.Net.Http.HttpClient> requests was opt-in. Now, response streaming is enabled by default.
 


### PR DESCRIPTION
The current heading sounds backwards: response streaming is now enabled by default and is no longer opt-in. Here's my attempt to clarify the heading.