### PR TITLE
[10.0] Improve the location of the Blazor script section

### DIFF
--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -608,7 +608,7 @@ In a Blazor Server app, the Blazor script is located in the `Pages/_Host.cshtml`
 
 :::moniker-end
 
-For a Blazor Web App or a Blazor Server app, the project must contain at least one Razor component file (`.razor`) in order to automatically include the Blazor script when the app is published. If the project doesn't contain at least one Razor component, set the `RequiresAspNetWebAssets` MSBuild property `true` in the app's project file to include the Blazor script:
+For a Blazor Web App or a Blazor Server app, the project must contain at least one Razor component file (`.razor`) in order to automatically include the Blazor script when the app is published. If the project doesn't contain at least one Razor component, set the `RequiresAspNetWebAssets` MSBuild property to `true` in the app's project file to include the Blazor script:
 
 ```xml
 <RequiresAspNetWebAssets>true</RequiresAspNetWebAssets>
@@ -621,6 +621,8 @@ In a Blazor WebAssembly app, the Blazor script content is located in the `wwwroo
 ```html
 <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
 ```
+
+When the app is published, the `{fingerprint}` placeholder is automatically replaced with a unique hash for cache busting.
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #36315

Just need one review on this one.

Updates:

* The versioning is a bit hairy 👹, so I'm going to have a little bit of duplication (a couple of sentences) to avoid version flipping.
* Adding the fingerprinted asset links for the Blazor script.
* Ordering change: Moving the bit on the `RequiresAspNetWebAssets` MSBuild prop UP because it logically follows discussing the server-side Blazor script location.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/project-structure.md](https://github.com/dotnet/AspNetCore.Docs/blob/3450b29e037245aff0443e3364ec0cd820acab60/aspnetcore/blazor/project-structure.md) | [aspnetcore/blazor/project-structure](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/project-structure?branch=pr-en-us-36319) |


<!-- PREVIEW-TABLE-END -->