### PR TITLE
RemoveNotice of Pre-release

### DIFF
--- a/aspnetcore/includes/not-latest-version-without-not-supported-content.md
+++ b/aspnetcore/includes/not-latest-version-without-not-supported-content.md
@@ -4,12 +4,12 @@
 :::moniker-end
 
 <!-- Exclude until .NET 11 preview is added to the version selector collection
-(add tripple colon here)moniker range="> aspnetcore-10.0"
+(add triple colon here)moniker range="> aspnetcore-10.0"
 > [!IMPORTANT]
 > This information relates to a pre-release product that may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
 >
 > For the current release, see the [.NET 10 version of this article](?view=aspnetcore-10.0&preserve-view=true).
-(add tripple colon here)moniker-end
+(add triple colon here)moniker-end
 -->
 
 <!--

--- a/aspnetcore/includes/not-latest-version.md
+++ b/aspnetcore/includes/not-latest-version.md
@@ -8,12 +8,12 @@
 :::moniker-end
 
 <!-- Exclude until .NET 11 preview is added to the version selector collection
-(add tripple colon here) moniker range="> aspnetcore-10.0"
+(add triple colon here) moniker range="> aspnetcore-10.0"
 > [!IMPORTANT]
 > This information relates to a pre-release product that may be substantially modified before it's commercially released. Microsoft makes no warranties, express or implied, with respect to the information provided here.
 >
 > For the current release, see the [.NET 10 version of this article](?view=aspnetcore-10.0&preserve-view=true).
-(add tripple colon here) moniker-end
+(add triple colon here) moniker-end
 -->
 
 <!--


### PR DESCRIPTION
Fixes #36360 

This is a follow up to PR #36355.   There were commented out lines regarding a notice of pre-release that inteneded to be used later when the enxt pre-relase comes along, and while those commented out lines do not show in the build review, they do for some reason in the build for live.

The issue has been identified before as a problem with `:::`  that get read anyway during the process even when commented out per guardrex.  So I removed any occurance of `:::` witin the commented out lines.