### PR TITLE
Fix typo in SignalR tutorial for folder name

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -78,7 +78,7 @@ code -r SignalRChat
 
 The `dotnet new` command creates a new Razor Pages project in the `SignalRChat` folder.
 
-The `code` command opens the `SignalRChat folder in the current instance of Visual Studio Code.
+The `code` command opens the `SignalRChat` folder in the current instance of Visual Studio Code.
 
 [!INCLUDE[](~/includes/vscode-trust-authors-add-assets.md)]
 


### PR DESCRIPTION
Fixed Typo in VSCode command in the Terminal when opening the SignalRChat folder name, the document has `SignalRChat1 instead of `SignalRChat as the folder name.





<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/signalr.md](https://github.com/dotnet/AspNetCore.Docs/blob/c71970dbaa539cf353394911fd9304324e74c48b/aspnetcore/tutorials/signalr.md) | [aspnetcore/tutorials/signalr](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/signalr?branch=pr-en-us-36388) |


<!-- PREVIEW-TABLE-END -->