### PR TITLE
Fix link in rate-limit.md

### DIFF
--- a/aspnetcore/performance/rate-limit.md
+++ b/aspnetcore/performance/rate-limit.md
@@ -5,7 +5,7 @@ ms.author: wpickett
 monikerRange: '>= aspnetcore-7.0'
 description: Learn how limit requests in ASP.NET Core apps
 ms.custom: mvc
-ms.date: 03/05/2025
+ms.date: 11/26/2025
 uid: performance/rate-limit
 ---
 


### PR DESCRIPTION
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->
The link to rate limiting blog from Maarten Balliauw is returning 404 which seems to have changed.

Old link:
https://blog.maartenballiauw.be/post/2022/09/26/aspnet-core-rate-limiting-middleware.html
New link:
https://blog.maartenballiauw.be/posts/2022-09-26-aspnet-core-rate-limiting-middleware/

Edit: also fixed the other link under additional resources section

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/performance/rate-limit.md](https://github.com/dotnet/AspNetCore.Docs/blob/cc0c3c7cd0c491951305ec2b9eabe720a7609cd3/aspnetcore/performance/rate-limit.md) | [Rate limiting middleware in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/rate-limit?branch=pr-en-us-36392) |


<!-- PREVIEW-TABLE-END -->