### PR TITLE
Change ms.topic from 'conceptual' to 'article'

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -44,7 +44,7 @@
       "social_image_url": "/dotnet/media/dotnet-logo.png",
       "feedback_product_url": "https://github.com/dotnet/aspnetcore/blob/main/CONTRIBUTING.md",
       "ms.service": "aspnet-core",
-      "ms.topic": "conceptual",
+      "ms.topic": "article",
       "uhfHeaderId": "MSDocsHeader-AspNet",
       "searchScope": [ "ASP.NET Core" ],
       "zone_pivot_group_filename": "core/zone-pivot-groups.json"


### PR DESCRIPTION
Fixes #36423

The build report is stating that for Line 47 of the `docfx.json` file ...

https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/docfx.json#L47

> The 'ms.topic: conceptual' you used is now deprecated and can no longer be used. We suggest you replace it with 'ms.topic: article'.