### PR TITLE
Fix IOpenApiDocumentProvider injection sample (keyed DI)

### DIFF
--- a/aspnetcore/fundamentals/openapi/using-openapi-documents.md
+++ b/aspnetcore/fundamentals/openapi/using-openapi-documents.md
@@ -5,7 +5,7 @@ description: Learn how to use OpenAPI documents in an ASP.NET Core app.
 ms.author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.custom: mvc
-ms.date: 12/04/2025
+ms.date: 01/13/2026
 uid: fundamentals/openapi/using-openapi-documents
 ---
 # Use openAPI documents
@@ -65,8 +65,8 @@ Enable document generation at build time by setting the following properties in 
 
 ```xml
 <PropertyGroup>
-    <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)</OpenApiDocumentsDirectory>
-    <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
+  <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)</OpenApiDocumentsDirectory>
+  <OpenApiGenerateDocuments>true</OpenApiGenerateDocuments>
 </PropertyGroup>
 ```
 
@@ -102,35 +102,45 @@ The output shows any issues with the OpenAPI document. For example:
 
 ## Support for injecting `IOpenApiDocumentProvider`
 
-You can inject <xref:Microsoft.AspNetCore.OpenApi.IOpenApiDocumentProvider> into your services through dependency injection to access OpenAPI documents programmatically, even outside HTTP request contexts.
+Inject <xref:Microsoft.AspNetCore.OpenApi.IOpenApiDocumentProvider> into services to access OpenAPI documents programmatically, even outside HTTP request contexts. The following example customizes version 2 ("`v2`") of the document with title, version, and description information:
 
 ```csharp
-public class CustomDocumentService
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+public class CustomDocumentService(
+    [FromKeyedServices("v2")] IOpenApiDocumentProvider documentProvider)
 {
-    private readonly IOpenApiDocumentProvider _documentProvider;
-
-    public CustomDocumentService([FromKeyedServices("v1")] IOpenApiDocumentProvider documentProvider)
+    public async Task<OpenApiDocument> GetApiDocumentAsync(
+            CancellationToken cancellationToken = default)
     {
-        _documentProvider = documentProvider;
-    }
+        var document = 
+            await documentProvider.GetOpenApiDocumentAsync(cancellationToken);
 
-    public Task<OpenApiDocument> GetApiDocumentAsync(CancellationToken cancellationToken = default)
-    {
-        return _documentProvider.GetOpenApiDocumentAsync(cancellationToken);
+        document.Info = new OpenApiInfo
+        {
+            Title = "Custom API Title",
+            Version = "v2",
+            Description = "This is a custom API description for version 2."
+        };
+
+        return document;
     }
 }
 ```
 
-Register the service in your DI container. Note that service key "v1" should match the document name passed to `AddOpenApi`:
+Register the service in your DI container. Note that service key should match the document name passed to <xref:Microsoft.Extensions.DependencyInjection.OpenApiServiceCollectionExtensions.AddOpenApi%2A>:
 
 ```csharp
-builder.Services.AddOpenApi("v1");
+builder.AddOpenApi(); // Adds "v1" by default
+builder.AddOpenApi("v2");
 builder.Services.AddScoped<CustomDocumentService>();
 ```
 
 This enables scenarios such as generating client SDKs, validating API contracts in background processes, or exporting documents to external systems.
 
 Support for injecting `IOpenApiDocumentProvider` was introduced in ASP.NET Core in .NET 10. For more information, see [dotnet/aspnetcore #61463](https://github.com/dotnet/aspnetcore/pull/61463).
+
 :::moniker-end
 
 [!INCLUDE[](~/fundamentals/openapi/includes/using-openapi-documents-6-8.md)]


### PR DESCRIPTION
Updates the IOpenApiDocumentProvider example in
`aspnetcore/fundamentals/openapi/using-openapi-documents.md` to:
* Inject the provider as a keyed service using [FromKeyedServices("v1")].
* Call GetOpenApiDocumentAsync with an optional CancellationToken instead of a document name.
* Note that the service key "v1" must match the name passed to AddOpenApi.

The previous sample did not compile (because `GetOpenApiDocumentAsync` does not take a document name parameter) and did not reflect the keyed registration used by `AddOpenApi("v1")`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/using-openapi-documents.md](https://github.com/dotnet/AspNetCore.Docs/blob/a91c7f1ba86ab88b382f321fc897dbd95a925417/aspnetcore/fundamentals/openapi/using-openapi-documents.md) | [aspnetcore/fundamentals/openapi/using-openapi-documents](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/using-openapi-documents?branch=pr-en-us-36426) |


<!-- PREVIEW-TABLE-END -->