### PR TITLE
[11.0 P1] Blazor Web can use `BasePath` component instead of `<base href="">`

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/app-base-path.md
+++ b/aspnetcore/blazor/host-and-deploy/app-base-path.md
@@ -175,6 +175,8 @@ In many hosting scenarios, the relative URL path to the app is the root of the a
 
     The component renders `<base href>` automatically based on the current request path base.
 
+::: moniker-end
+
 :::moniker range="< aspnetcore-11.0"
 
   * Option 1: Use the `<base>` tag to set the app's base path ([location of `<head>` content](xref:blazor/project-structure#location-of-head-and-body-content)):


### PR DESCRIPTION
Doc changes proposal for https://github.com/dotnet/aspnetcore/pull/64590.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/app-base-path.md](https://github.com/dotnet/AspNetCore.Docs/blob/d16fb2d85f7bfb32f609c60e8c9d49a15ec1c13b/aspnetcore/blazor/host-and-deploy/app-base-path.md) | [aspnetcore/blazor/host-and-deploy/app-base-path](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/app-base-path?branch=pr-en-us-36428) |


<!-- PREVIEW-TABLE-END -->