### PR TITLE
Update tutorial for Visual Studio 2026 and .NET 10.0

### DIFF
--- a/aspnetcore/tutorials/min-web-api.md
+++ b/aspnetcore/tutorials/min-web-api.md
@@ -51,20 +51,20 @@ This tutorial creates the following API:
 
 # [Visual Studio](#tab/visual-studio)
 
-* Start Visual Studio 2022 and select **Create a new project**.
+* Start Visual Studio 2026 and select **Create a new project**.
 * In the **Create a new project** dialog:
   * Enter `Empty` in the **Search for templates** search box.
   * Select the **ASP.NET Core Empty** template and select **Next**.
 
-  ![Visual Studio Create a new project](~/tutorials/min-web-api/_static/9.x/create-new-project-empty-vs17.11.0.png)
+  ![Visual Studio Create a new project](~/tutorials/min-web-api/_static/10.x/createaspdotnetempty.png)
 
 * Name the project *TodoApi* and select **Next**.
 * In the **Additional information** dialog:
-  * Select **.NET 9.0**
+  * Select **.NET 10.0**
   * Uncheck **Do not use top-level statements**
   * Select **Create**
 
-  ![Additional information](~/tutorials/min-web-api/_static/9.x/add-info-vs17.11.0.png)
+  ![Additional information](~/tutorials/min-web-api/_static/10.x/choosedotnet10.png)
 
 # [Visual Studio Code](#tab/visual-studio-code)
 


### PR DESCRIPTION
This pull request updates the Visual Studio instructions in the `aspnetcore/tutorials/min-web-api.md` tutorial to reflect the latest version and tooling. The changes ensure that users are guided to use Visual Studio 2026 and .NET 10.0, along with updated screenshots for improved clarity.

Curent Issue: https://github.com/dotnet/AspNetCore.Docs/issues/36466

Original Issue that was moved from the dotnet repo.
Issue: https://github.com/dotnet/docs/issues/50382

Visual Studio version and .NET SDK updates:

* Changed the instructions to use Visual Studio 2026 instead of 2022, and .NET 10.0 instead of .NET 9.0 for project creation.

Screenshot and documentation updates:

* Replaced older screenshots with new images that match Visual Studio 2026 and .NET 10.0, providing more accurate visual guidance for users.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/min-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/dba444da4b2f91930e0ae56d7b62d7a6aa345668/aspnetcore/tutorials/min-web-api.md) | [Tutorial: Create a Minimal API with ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/min-web-api?branch=pr-en-us-36460) |


<!-- PREVIEW-TABLE-END -->