### PR TITLE
Rename AppUser to ApplicationUser in email methods

### DIFF
--- a/aspnetcore/blazor/security/account-confirmation-and-password-recovery.md
+++ b/aspnetcore/blazor/security/account-confirmation-and-password-recovery.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to configure an ASP.NET Core Blazor Web App with email confirmation and password recovery.
 ms.author: wpickett
 monikerRange: '>= aspnetcore-8.0'
-ms.date: 12/09/2025
+ms.date: 11/11/2025
 uid: blazor/security/account-confirmation-and-password-recovery
 ---
 # Account confirmation and password recovery in ASP.NET Core Blazor


### PR DESCRIPTION
Fixes #36473

Thanks again, @FabioPagano! 🚀 

This code came over from the product unit, and I think they were using a derived type in their testing app. We'll switch over to the type from Identity for this.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/account-confirmation-and-password-recovery.md](https://github.com/dotnet/AspNetCore.Docs/blob/131d38bf2937b16303cb2fa55b8cdc4b4f3faf07/aspnetcore/blazor/security/account-confirmation-and-password-recovery.md) | [aspnetcore/blazor/security/account-confirmation-and-password-recovery](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/account-confirmation-and-password-recovery?branch=pr-en-us-36475) |


<!-- PREVIEW-TABLE-END -->