### PR TITLE
Reformat MSBuild property example

### DIFF
--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -5,7 +5,7 @@ description: Learn how to generate and customize OpenAPI documents in an ASP.NET
 ms.author: safia
 monikerRange: '>= aspnetcore-6.0'
 ms.custom: mvc
-ms.date: 09/23/2025
+ms.date: 12/10/2025
 uid: fundamentals/openapi/aspnetcore-openapi
 ---
 # Generate OpenAPI documents
@@ -36,9 +36,7 @@ When generating the OpenAPI document at build time, the OpenAPI version can be s
 
 ```xml
 <!-- Configure build-time OpenAPI generation to produce an OpenAPI 3.1 document -->
-<OpenApiGenerateDocumentsOptions>
-  --openapi-version OpenApi3_1
-</OpenApiGenerateDocumentsOptions>
+<OpenApiGenerateDocumentsOptions>--openapi-version OpenApi3_1</OpenApiGenerateDocumentsOptions>
 ```
 
 ## Package installation


### PR DESCRIPTION
Fixes #36478

Thanks @mligtenberg! 🚀 

Wade ... We're running a hair long here on the code line length (96 chars long on the 85 char limit), but we'll need to make an exception given that breaking the property across multiple lines breaks the app. Martin reports that when broken over multiple lines, the following errors ensue ...

> 15>Microsoft.Extensions.ApiDescription.Server.targets(67,5): Error  : /var/folders/gd/h3gv10p577lc2wg9ll56jfwr0000gn/T/MSBuildTemp/tmpbabec079b1514b63b33a3796c58bae98.exec.cmd: line 3: --openapi-version: command not found
> 15>Microsoft.Extensions.ApiDescription.Server.targets(67,5): Error MSB3073 : The command "dotnet "/.nuget/packages/microsoft.extensions.apidescription.server/10.0.1/build/../tools/dotnet-getdocument.dll" --assembly "xxx.dll" --file-list "obj/xxx.OpenApiFiles.cache" --framework ".NETCoreApp,Version=v10.0" --output "xxx/obj/" --project "xxx" --assets-file "/xxx/obj/project.assets.json" --platform "AnyCPU" 
            --openapi-version OpenApi3_1
        " exited with code 127.

... but when supplied on a single line, all is well. 🌴 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/fa7e9bdaa68c6cfec14282b515b90c42096ac55c/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md) | [aspnetcore/fundamentals/openapi/aspnetcore-openapi](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?branch=pr-en-us-36480) |

<!-- PREVIEW-TABLE-END -->