### PR TITLE
Fix missing _container declaration in snippet

### DIFF
--- a/aspnetcore/fundamentals/middleware/extensibility-third-party-container/samples/2.x/SampleApp/Startup.cs
+++ b/aspnetcore/fundamentals/middleware/extensibility-third-party-container/samples/2.x/SampleApp/Startup.cs
@@ -14,9 +14,9 @@ namespace MiddlewareExtensibilitySample
 {
     public class Startup
     {
+        #region snippet1
         private Container _container = new Container();
 
-        #region snippet1
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_2);

--- a/aspnetcore/fundamentals/middleware/extensibility-third-party-container/samples/3.x/SampleApp/Startup.cs
+++ b/aspnetcore/fundamentals/middleware/extensibility-third-party-container/samples/3.x/SampleApp/Startup.cs
@@ -14,9 +14,9 @@ namespace MiddlewareExtensibilitySample
 {
     public class Startup
     {
+        #region snippet1
         private Container _container = new Container();
 
-        #region snippet1
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddRazorPages();


### PR DESCRIPTION
Fixes #33676

The `Startup.cs` `snippet1` regions for both the `2.x` and `3.x` middleware extensibility samples referenced `_container`, but the field declaration was outside the snippet region.

This moves `#region snippet1` to include the `_container` field so the rendered docs snippet is self-contained and easier to follow.