### PR TITLE
Repair broken links							

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-10/includes/pipe-reader.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/pipe-reader.md
@@ -2,7 +2,7 @@
 
 PR: https://github.com/dotnet/aspnetcore/pull/62895
 
-See https://github.com/dotnet/core/blob/dotnet10-p7-libraries/release-notes/10.0/preview/preview7/libraries.md#pipereader-support-for-json-serializer
+See https://github.com/dotnet/core/blob/main/release-notes/10.0/preview/preview7/libraries.md#pipereader-support-for-json-serializer
 
 MVC, Minimal APIs, and the `HttpRequestJsonExtensions.ReadFromJsonAsync` methods have all been updated to use the new Json+PipeReader support without requiring any code changes from applications.
 

--- a/aspnetcore/security/authentication/social/other-logins.md
+++ b/aspnetcore/security/authentication/social/other-logins.md
@@ -32,8 +32,6 @@ The following list includes common external OAuth authentication providers that 
 
 * [Pinterest](https://www.pinterest.com/login/?next=http%3A%2F%2Fdevsite%2Fapps%2F) ([Instructions](https://developers.pinterest.com/docs/api/overview/?))
 
-* [Pocket](https://getpocket.com/developer/apps/new) ([Instructions](https://getpocket.com/developer/docs/authentication))
-
 * [Flickr](https://www.flickr.com/services/apps/create) ([Instructions](https://www.flickr.com/services/api/auth.oauth.html))
 
 * [Dribbble](https://dribbble.com/signup) ([Instructions](https://developer.dribbble.com))

--- a/aspnetcore/signalr/java-client.md
+++ b/aspnetcore/signalr/java-client.md
@@ -20,7 +20,7 @@ The sample Java console app referenced in this article uses the SignalR Java cli
 
 ## Install the SignalR Java client package
 
-The *signalr-7.0.0* JAR file allows clients to connect to SignalR hubs. To find the latest JAR file version number, see the [Maven search results](https://search.maven.org/search?q=g:com.microsoft.signalr%20AND%20a:signalr).
+The *signalr-7.0.0* JAR file allows clients to connect to SignalR hubs. To find the latest JAR file version number, see the [Maven search results](https://central.sonatype.com/search?q=g:com.microsoft.signalr%20%20a:signalr&smo=true).
 
 If using Gradle, add the following line to the `dependencies` section of your *build.gradle* file:
 

--- a/aspnetcore/signalr/version-differences.md
+++ b/aspnetcore/signalr/version-differences.md
@@ -21,7 +21,7 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 | **Server NuGet package** | [Microsoft.AspNet.SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR/) | None. Included in the [Microsoft.AspNetCore.App](xref:fundamentals/metapackage-app) shared framework. |
 | **Client NuGet packages** | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/)<br>[Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
 | **JavaScript client npm package** | [signalr](https://www.npmjs.com/package/signalr) | [`@microsoft/signalr`](https://www.npmjs.com/package/@microsoft/signalr) |
-| **Java client** | [GitHub Repository](https://github.com/SignalR/java-client) (deprecated)  | Maven package [com.microsoft.signalr](https://search.maven.org/artifact/com.microsoft.signalr/signalr) |
+| **Java client** | [GitHub Repository](https://github.com/SignalR/java-client) (deprecated)  | Maven package [com.microsoft.signalr](https://central.sonatype.com/artifact/com.microsoft.signalr/signalr) |
 | **Server app type** | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |
 | **Supported server platforms** | .NET Framework 4.5 or later | .NET Core 3.0 or later |
 
@@ -34,7 +34,7 @@ ASP.NET Core SignalR isn't compatible with clients or servers for ASP.NET Signal
 | **Server NuGet package** | [Microsoft.AspNet.SignalR](https://www.nuget.org/packages/Microsoft.AspNet.SignalR/) | [Microsoft.AspNetCore.App](https://www.nuget.org/packages/Microsoft.AspNetCore.App/) (.NET Core)<br>[Microsoft.AspNetCore.SignalR](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR/) (.NET Framework) |
 | **Client NuGet packages** | [Microsoft.AspNet.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.Client/)<br>[Microsoft.AspNet.SignalR.JS](https://www.nuget.org/packages/Microsoft.AspNet.SignalR.JS/) | [Microsoft.AspNetCore.SignalR.Client](https://www.nuget.org/packages/Microsoft.AspNetCore.SignalR.Client/) |
 | **JavaScript client npm package** | [signalr](https://www.npmjs.com/package/signalr) | [`@aspnet/signalr`](https://www.npmjs.com/package/@aspnet/signalr) |
-| **Java client** | [GitHub Repository](https://github.com/SignalR/java-client) (deprecated)  | Maven package [com.microsoft.signalr](https://search.maven.org/artifact/com.microsoft.signalr/signalr) |
+| **Java client** | [GitHub Repository](https://github.com/SignalR/java-client) (deprecated)  | Maven package [com.microsoft.signalr](https://central.sonatype.com/artifact/com.microsoft.signalr/signalr) |
 | **Server app type** | ASP.NET (System.Web) or OWIN Self-Host | ASP.NET Core |
 | **Supported server platforms** | .NET Framework 4.5 or later | .NET Framework 4.6.1 or later<br>.NET Core 2.1 or later |
 


### PR DESCRIPTION
This PR repairs 6 broken links in 4 articles

https://dev.azure.com/msft-skilling/Content/_workitems/edit/540856

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/security/authentication/social/other-logins.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0b87e0ca7aec567a14f3515478b50f47e786681/aspnetcore/security/authentication/social/other-logins.md) | [External OAuth authentication providers](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/social/other-logins?branch=pr-en-us-36529) |
| [aspnetcore/signalr/java-client.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0b87e0ca7aec567a14f3515478b50f47e786681/aspnetcore/signalr/java-client.md) | [ASP.NET Core SignalR Java client](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/java-client?branch=pr-en-us-36529) |
| [aspnetcore/signalr/version-differences.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0b87e0ca7aec567a14f3515478b50f47e786681/aspnetcore/signalr/version-differences.md) | [Differences between ASP.NET SignalR and ASP.NET Core SignalR](https://review.learn.microsoft.com/en-us/aspnet/core/signalr/version-differences?branch=pr-en-us-36529) |

<!-- PREVIEW-TABLE-END -->