### PR TITLE
Add CallHelpers reference in test-client documentation

### DIFF
--- a/aspnetcore/grpc/test-client.md
+++ b/aspnetcore/grpc/test-client.md
@@ -48,7 +48,7 @@ The preceding unit test:
 * Mocks `IGreetRepository` and `TesterClient` using [Moq](https://www.nuget.org/packages/Moq).
 * Starts the worker.
 * Verifies `SaveGreeting` is called with the greeting message returned by the mocked `TesterClient`.
-* Uses the [`CallHelpers` from the gRPC examples](https://github.com/grpc/grpc-dotnet/blob/master/examples/Tester/Tests/Client/Helpers/CallHelpers.cs)
+* Uses the [`CallHelpers` from the gRPC examples](https://github.com/grpc/grpc-dotnet/blob/2e283d98f5861e31f8956be0c68aff9a4e29cb0a/examples/Tester/Tests/Client/Helpers/CallHelpers.cs)
 
 ## Additional resources
 


### PR DESCRIPTION
Adds reference to CallHelpers from gRPC examples. Otherwise it's hard to tell that that's not something built-in anywhere.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/grpc/test-client.md](https://github.com/dotnet/AspNetCore.Docs/blob/b101b3ce57b36560e39887f9960076d712634b87/aspnetcore/grpc/test-client.md) | [aspnetcore/grpc/test-client](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/test-client?branch=pr-en-us-36531) |


<!-- PREVIEW-TABLE-END -->