### PR TITLE
Revise SignalR hub path and base path configuration examples - current examples are incomplete

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/app-base-path.md
+++ b/aspnetcore/blazor/host-and-deploy/app-base-path.md
@@ -76,7 +76,7 @@ For the second option, which is the usual approach taken, the app sets the base 
 
 ## Server-side Blazor
 
-Map the SignalR hub of a server-side Blazor app by passing the path to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> in the `Program` file:
+Map the SignalR hub of a server-side Blazor app by passing the path to <xref:Microsoft.AspNetCore.Builder.ComponentEndpointRouteBuilderExtensions.MapBlazorHub%2A> in the `Program` file. The default Blazor hub path is `/_blazor`, and the following example sets the base path of the default hub to `base/path`:
 
 ```csharp
 app.MapBlazorHub("base/path/_blazor");
@@ -101,7 +101,7 @@ app.Map("/base/path", subapp => {
 ```
 
 > [!NOTE]
-> The default path to a Blazor hub is `_blazor` and so your mapped path must end with `/_blazor`
+> The default Blazor hub path is `/_blazor`.
 
 Configure the `<base>` tag, per the guidance in the [Configure the app base path](#configure-the-app-base-path) section.
 


### PR DESCRIPTION
[EDIT by guardrex to add the issue]

Fixes #36549

Updated SignalR hub mapping and base path instructions for server-side Blazor applications.

Based on efforts trying to get this to work in .NET 10, the existing documentation does not work.

`MapBlazorHub` only appears to work when the path ends with `_blazor` 

The code sample for a branched middleware pipeline was incomplete - this change appears to be the minimal implementation to get things working.

`UsePathBase` does not negate the need to set `<base href="..." />`  but the previous docs stated to use **either** not **both** as seems to be required.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/app-base-path.md](https://github.com/dotnet/AspNetCore.Docs/blob/72d3ec17069ec9940dce98bbad8ec1e2be04320f/aspnetcore/blazor/host-and-deploy/app-base-path.md) | [aspnetcore/blazor/host-and-deploy/app-base-path](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/app-base-path?branch=pr-en-us-36541) |


<!-- PREVIEW-TABLE-END -->