### PR TITLE
Remove TBD placeholder comment in best-practices.md

### DIFF
--- a/aspnetcore/fundamentals/best-practices.md
+++ b/aspnetcore/fundamentals/best-practices.md
@@ -4,7 +4,7 @@ author: mjrousos
 description: Tips for maximizing performance and reliability in ASP.NET Core apps.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: tdykstra
-ms.date: 12/20/2022
+ms.date: 12/29/2025
 uid: fundamentals/best-practices
 ---
 # ASP.NET Core Best Practices
@@ -39,7 +39,7 @@ A common performance problem in ASP.NET Core apps is blocking calls that could b
 * **Do** make controller/Razor Page actions asynchronous. The entire call stack is asynchronous in order to benefit from [async/await](/dotnet/csharp/programming-guide/concepts/async/) patterns.
 * **Consider** using message brokers like [Azure Service Bus](/azure/service-bus-messaging/service-bus-messaging-overview) to offload long-running calls
 
-A profiler, such as [PerfView](https://github.com/Microsoft/perfview), can be used to find threads frequently added to the [Thread Pool](/windows/desktop/procthread/thread-pools). The `Microsoft-Windows-DotNETRuntime/ThreadPoolWorkerThread/Start` event indicates a thread added to the thread pool. <!--  For more information, see [async guidance docs](TBD-Link_To_Davifowl_Doc)  -->
+A profiler, such as [PerfView](https://github.com/Microsoft/perfview), can be used to find threads frequently added to the [Thread Pool](/windows/desktop/procthread/thread-pools). The `Microsoft-Windows-DotNETRuntime/ThreadPoolWorkerThread/Start` event indicates a thread added to the thread pool.
 
 ## Return large collections across multiple smaller pages
 


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

**Description**

Remove an outdated placeholder comment that referenced a TBD (To Be Determined) link in the "Avoid blocking calls" section of the ASP.NET Core best practices documentation.

The comment `<!--  For more information, see [async guidance docs](TBD-Link_To_Davifowl_Doc)  -->` was cluttering the file and is no longer needed. This cleans up the documentation without affecting content.

Updated ms.date to 12/29/2025 per repository guidelines for changes exceeding 50 characters.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/best-practices.md](https://github.com/dotnet/AspNetCore.Docs/blob/de0a6243f0098f71e49e895e041909c0265be0ea/aspnetcore/fundamentals/best-practices.md) | [ASP.NET Core Best Practices](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/best-practices?branch=pr-en-us-36550) |

<!-- PREVIEW-TABLE-END -->