### PR TITLE
Add `Priority` metadata

### DIFF
--- a/aspnetcore/fundamentals/static-files.md
+++ b/aspnetcore/fundamentals/static-files.md
@@ -1132,7 +1132,7 @@ Metadata Descriptions:
 
 * **`Cache`**: Specifies the `Cache-Control` header value for the matched content type. This controls browser caching behavior (for example, `max-age=3600, must-revalidate` for media files).
 
-* **`Priority`**: Controls precedence when multiple `StaticWebAssetContentTypeMapping` items match the same file. Higher numeric values take precedence over lower ones. If omitted, the priority defaults to `0`.
+* **`Priority`**: Controls precedence when multiple `StaticWebAssetContentTypeMapping` items match the same file. Higher numeric values take precedence over lower ones. `Priority` is required.
 
 * **`Expression`**: Defines how the fingerprint is inserted into the filename. The default is `#[.{FINGERPRINT}]`, which inserts the fingerprint (`{FINGERPRINT}` placeholder) before the extension.
 


### PR DESCRIPTION
Fixes #36575

Thanks @stasberkov! 🚀 

We forgot to include `Priority` when we added this content on https://github.com/dotnet/AspNetCore.Docs/pull/36117.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/static-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/bddd1f3764654baa3a40112303438e689e6b3580/aspnetcore/fundamentals/static-files.md) | [aspnetcore/fundamentals/static-files](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/static-files?branch=pr-en-us-36577) |


<!-- PREVIEW-TABLE-END -->