### PR TITLE
Revert "[BULK] [Bundle-Security] - Scheduled execution to fix known issues (part 1)"

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -901,7 +901,7 @@ Example:
 ```json
 "DownstreamApi": {
   "BaseUrl": "https://localhost:7277",
-  "Scopes": [ "api://aaaabbbb-0000-cccc-1111-dddd2222eeee/Weather.Get" ]
+  "Scopes": [ "api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get" ]
 }
 ```
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -173,7 +173,7 @@ The following examples use an Application (Client) Id of `11112222-bbbb-3333-ccc
 ME-ID tenant example:
 
 ```csharp
-jwtOptions.Audience = "api://aaaabbbb-0000-cccc-1111-dddd2222eeee";
+jwtOptions.Audience = "api://11112222-bbbb-3333-cccc-4444dddd5555";
 ```
 
 Microsoft Entra External ID tenant:
@@ -259,7 +259,7 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
     {
         configOptions.BaseUrl = "https://localhost:7277";
         configOptions.Scopes = 
-            ["api://aaaabbbb-0000-cccc-1111-dddd2222eeee/Weather.Get"];
+            ["api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get"];
     })
     .AddDistributedTokenCaches();
 ```
@@ -267,7 +267,7 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
 Example:
 
 ```csharp
-List<string> scopes = ["api://aaaabbbb-0000-cccc-1111-dddd2222eeee/Weather.Get"];
+List<string> scopes = ["api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get"];
 ```
 
 ### Configuration for Microsoft Entra External ID
@@ -324,7 +324,7 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
     .AddDownstreamApi("DownstreamApi", configOptions =>
     {
         configOptions.BaseUrl = "https://localhost:7277";
-        configOptions.Scopes = ["api://aaaabbbb-0000-cccc-1111-dddd2222eeee/Weather.Get"];
+        configOptions.Scopes = ["api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get"];
     })
     .AddDistributedTokenCaches();
 ```
@@ -332,7 +332,7 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
 Example:
 
 ```csharp
-List<string> scopes = ["api://aaaabbbb-0000-cccc-1111-dddd2222eeee/Weather.Get"];
+List<string> scopes = ["api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get"];
 ```
 
 :::zone-end
@@ -469,7 +469,7 @@ The following examples use an Application (Client) Id of `11112222-bbbb-3333-ccc
 ME-ID tenant example:
 
 ```csharp
-jwtOptions.Audience = "api://aaaabbbb-0000-cccc-1111-dddd2222eeee";
+jwtOptions.Audience = "api://11112222-bbbb-3333-cccc-4444dddd5555";
 ```
 
 Microsoft Entra External ID tenant:
@@ -548,7 +548,7 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
     .AddDownstreamApi("DownstreamApi", configOptions =>
     {
         configOptions.BaseUrl = "https://localhost:7277";
-        configOptions.Scopes = ["api://aaaabbbb-0000-cccc-1111-dddd2222eeee/Weather.Get"];
+        configOptions.Scopes = ["api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get"];
     })
     .AddDistributedTokenCaches();
 ```
@@ -601,7 +601,7 @@ builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
     .AddDownstreamApi("DownstreamApi", configOptions =>
     {
         configOptions.BaseUrl = "https://localhost:7277";
-        configOptions.Scopes = ["api://aaaabbbb-0000-cccc-1111-dddd2222eeee/Weather.Get"];
+        configOptions.Scopes = ["api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get"];
     })
     .AddDistributedTokenCaches();
 ```
@@ -789,7 +789,7 @@ Example:
 },
 "DownstreamApi": {
   "BaseUrl": "https://localhost:7277",
-  "Scopes": ["api://aaaabbbb-0000-cccc-1111-dddd2222eeee/Weather.Get"]
+  "Scopes": ["api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get"]
 }
 ```
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -193,12 +193,12 @@ jwtOptions.Audience = "{APP ID URI}";
 > [!NOTE]
 > When using Microsoft Entra ID, match the value to just the path of the **Application ID URI** configured when adding the `Weather.Get` scope under **Expose an API** in the Entra or Azure portal. Don't include the scope name, "`Weather.Get`," in the value.
 
-The format of the Audience depends on the type of tenant in use. The following examples for Microsoft Entra ID use a Tenant ID of `contoso` and a Client ID of `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0`.
+The format of the Audience depends on the type of tenant in use. The following examples for Microsoft Entra ID use a Tenant ID of `contoso` and a Client ID of `11112222-bbbb-3333-cccc-4444dddd5555`.
 
 ME-ID tenant App ID URI example:
 
 ```csharp
-jwtOptions.Audience = "api://ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0";
+jwtOptions.Audience = "api://11112222-bbbb-3333-cccc-4444dddd5555";
 ```
 
 AAD B2C tenant App ID URI example:
@@ -258,7 +258,7 @@ The format of the scope depends on the type of tenant in use. In the following e
 ME-ID tenant App ID URI example:
 
 ```csharp
-oidcOptions.Scope.Add("api://ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0/Weather.Get");
+oidcOptions.Scope.Add("api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get");
 ```
 
 AAD B2C tenant App ID URI example:
@@ -541,12 +541,12 @@ jwtOptions.Audience = "{APP ID URI}";
 > [!NOTE]
 > When using Microsoft Entra ID, match the value to just the path of the **Application ID URI** configured when adding the `Weather.Get` scope under **Expose an API** in the Entra or Azure portal. Don't include the scope name, "`Weather.Get`," in the value.
 
-The format of the Audience depends on the type of tenant in use. The following examples for Microsoft Entra ID use a Tenant ID of `contoso` and a Client ID of `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0`.
+The format of the Audience depends on the type of tenant in use. The following examples for Microsoft Entra ID use a Tenant ID of `contoso` and a Client ID of `11112222-bbbb-3333-cccc-4444dddd5555`.
 
 ME-ID tenant App ID URI example:
 
 ```csharp
-jwtOptions.Audience = "api://ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0";
+jwtOptions.Audience = "api://11112222-bbbb-3333-cccc-4444dddd5555";
 ```
 
 AAD B2C tenant App ID URI example:
@@ -888,12 +888,12 @@ jwtOptions.Audience = "{APP ID URI}";
 > [!NOTE]
 > When using Microsoft Entra ID, match the value to just the path of the **Application ID URI** configured when adding the `Weather.Get` scope under **Expose an API** in the Entra or Azure portal. Don't include the scope name, "`Weather.Get`," in the value.
 
-The format of the Audience depends on the type of tenant in use. The following examples for Microsoft Entra ID use a Tenant ID of `contoso` and a Client ID of `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0`.
+The format of the Audience depends on the type of tenant in use. The following examples for Microsoft Entra ID use a Tenant ID of `contoso` and a Client ID of `11112222-bbbb-3333-cccc-4444dddd5555`.
 
 ME-ID tenant App ID URI example:
 
 ```csharp
-jwtOptions.Audience = "api://ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0";
+jwtOptions.Audience = "api://11112222-bbbb-3333-cccc-4444dddd5555";
 ```
 
 AAD B2C tenant App ID URI example:
@@ -1005,7 +1005,7 @@ The format of the scope depends on the type of tenant in use. In the following e
 ME-ID tenant App ID URI example:
 
 ```csharp
-oidcOptions.Scope.Add("api://ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0/Weather.Get");
+oidcOptions.Scope.Add("api://11112222-bbbb-3333-cccc-4444dddd5555/Weather.Get");
 ```
 
 AAD B2C tenant App ID URI example:

--- a/aspnetcore/blazor/security/includes/authorize-client-app.md
+++ b/aspnetcore/blazor/security/includes/authorize-client-app.md
@@ -2,4 +2,4 @@
 > If you don't have the authority to grant admin consent to the tenant in the last step of **API permissions** configuration because consent to use the app is delegated to users, then you must take the following additional steps:
 >
 > * The app must use a [trusted publisher domain](/entra/identity-platform/howto-configure-publisher-domain).
-> * In the **`Server`** app's configuration in the Azure portal, select **Expose an API**. Under **Authorized client applications**, select the button to **Add a client application**. Add the **`Client`** app's Application (client) ID (for example, `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0`).
+> * In the **`Server`** app's configuration in the Azure portal, select **Expose an API**. Under **Authorized client applications**, select the button to **Add a client application**. Add the **`Client`** app's Application (client) ID (for example, `11112222-bbbb-3333-cccc-4444dddd5555`).

--- a/aspnetcore/blazor/security/includes/troubleshoot-wasm.md
+++ b/aspnetcore/blazor/security/includes/troubleshoot-wasm.md
@@ -210,7 +210,7 @@ Example JWT decoded by the tool for an app that authenticates against Azure AAD 
   "exp": 1610059429,
   "nbf": 1610055829,
   "ver": "1.0",
-  "iss": "https://mysiteb2c.b2clogin.com/ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0/v2.0/",
+  "iss": "https://mysiteb2c.b2clogin.com/11112222-bbbb-3333-cccc-4444dddd5555/v2.0/",
   "sub": "aaaaaaaa-0000-1111-2222-bbbbbbbbbbbb",
   "aud": "00001111-aaaa-2222-bbbb-3333cccc4444",
   "nonce": "bbbb0000-cccc-1111-dddd-2222eeee3333",

--- a/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md
@@ -46,7 +46,7 @@ Register an AAD B2C app for the *Server API app*:
 
 Record the following information:
 
-* *Server API app* Application (client) ID (for example, `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0`)
+* *Server API app* Application (client) ID (for example, `00001111-aaaa-2222-bbbb-3333cccc4444`)
 * AAD B2C instance (for example, `https://contoso.b2clogin.com/`, which includes the trailing slash). The instance is the scheme and host of an Azure B2C app registration, which can be found by opening the **Endpoints** window from the **App registrations** page in the Azure portal.
 * Primary/Publisher/Tenant domain (for example, `contoso.onmicrosoft.com`): The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
 
@@ -120,8 +120,8 @@ dotnet new blazorwasm -au IndividualB2C --aad-b2c-instance "{AAD B2C INSTANCE}" 
 | `{PROJECT NAME}` | &mdash; | `BlazorSample` |
 | `{CLIENT APP CLIENT ID}` | Application (client) ID for the **:::no-loc text="Client":::** app | `11112222-bbbb-3333-cccc-4444dddd5555` |
 | `{DEFAULT SCOPE}` | Scope name | `API.Access` |
-| `{SERVER API APP CLIENT ID}` | Application (client) ID for the **:::no-loc text="Server":::** app | `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0` |
-| `{SERVER API APP ID URI GUID}` | Application ID URI GUID | `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0` (GUID ONLY, matches the `{SERVER API APP CLIENT ID}`) |
+| `{SERVER API APP CLIENT ID}` | Application (client) ID for the **:::no-loc text="Server":::** app | `00001111-aaaa-2222-bbbb-3333cccc4444` |
+| `{SERVER API APP ID URI GUID}` | Application ID URI GUID | `00001111-aaaa-2222-bbbb-3333cccc4444` (GUID ONLY, matches the `{SERVER API APP CLIENT ID}`) |
 | `{SIGN UP OR SIGN IN POLICY}` | Sign-up/sign-in user flow | `B2C_1_signupsignin1` |
 | `{TENANT DOMAIN}` | Primary/Publisher/Tenant domain | `contoso.onmicrosoft.com` |
 

--- a/aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id.md
+++ b/aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id.md
@@ -49,7 +49,7 @@ Register an ME-ID app for the *Server API app*:
 
 Record the following information:
 
-* *Server API app* Application (client) ID (for example, `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0`)
+* *Server API app* Application (client) ID (for example, `00001111-aaaa-2222-bbbb-3333cccc4444`)
 * Directory (tenant) ID (for example, `aaaabbbb-0000-cccc-1111-dddd2222eeee`)
 * ME-ID Primary/Publisher/Tenant domain (for example, `contoso.onmicrosoft.com`): The domain is available as the **Publisher domain** in the **Branding** blade of the Azure portal for the registered app.
 
@@ -68,7 +68,7 @@ In **Expose an API**:
 
 Record the following information:
 
-* App ID URI GUID (for example, record `00001111-aaaa-2222-bbbb-3333cccc4444` from the App ID URI of `api://ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0`)
+* App ID URI GUID (for example, record `00001111-aaaa-2222-bbbb-3333cccc4444` from the App ID URI of `api://00001111-aaaa-2222-bbbb-3333cccc4444`)
 * Scope name (for example, `API.Access`)
 
 > [!IMPORTANT]
@@ -125,8 +125,8 @@ dotnet new blazorwasm -au SingleOrg --api-client-id "{SERVER API APP CLIENT ID}"
 | `{PROJECT NAME}` | &mdash; | `BlazorSample` |
 | `{CLIENT APP CLIENT ID}` | Application (client) ID for the **:::no-loc text="Client":::** app | `11112222-bbbb-3333-cccc-4444dddd5555` |
 | `{DEFAULT SCOPE}` | Scope name | `API.Access` |
-| `{SERVER API APP CLIENT ID}` | Application (client) ID for the *Server API app* | `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0` |
-| `{SERVER API APP ID URI GUID}` | Application ID URI GUID | `ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0` (GUID ONLY, matches the `{SERVER API APP CLIENT ID}`) |
+| `{SERVER API APP CLIENT ID}` | Application (client) ID for the *Server API app* | `00001111-aaaa-2222-bbbb-3333cccc4444` |
+| `{SERVER API APP ID URI GUID}` | Application ID URI GUID | `00001111-aaaa-2222-bbbb-3333cccc4444` (GUID ONLY, matches the `{SERVER API APP CLIENT ID}`) |
 | `{TENANT DOMAIN}` | Primary/Publisher/Tenant domain | `contoso.onmicrosoft.com` |
 | `{TENANT ID}` | Directory (tenant) ID | `aaaabbbb-0000-cccc-1111-dddd2222eeee` |
 
@@ -366,7 +366,7 @@ Example default access token scope:
 
 ```csharp
 options.ProviderOptions.DefaultAccessTokenScopes.Add(
-    "api://ffffffff-eeee-dddd-cccc-bbbbbbbbbbb0/API.Access");
+    "api://00001111-aaaa-2222-bbbb-3333cccc4444/API.Access");
 ```
 
 For more information, see the following sections of the *Additional scenarios* article:

--- a/aspnetcore/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery.md
+++ b/aspnetcore/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery.md
@@ -174,7 +174,7 @@ In the preceding example:
 Example:
 
 ```json
-"TenantId": "aaaabbbb-0000-cccc-1111-dddd2222eeee",
+"TenantId": "00001111-aaaa-2222-bbbb-3333cccc4444",
 "VaultUri": "https://contoso.vault.azure.net/"
 ```
 

--- a/aspnetcore/migration/fx-to-core/inc/remote-app-setup.md
+++ b/aspnetcore/migration/fx-to-core/inc/remote-app-setup.md
@@ -34,7 +34,7 @@ To enable the ASP.NET Core app to communicate with the ASP.NET app, it's necessa
 
 You need to configure two configuration values in both applications:
 
-* `RemoteAppApiKey`: A key (required to be parseable as a [GUID](/dotnet/api/system.guid)) that is shared between the two applications. This should be a GUID value like `aaaabbbb-0000-cccc-1111-dddd2222eeee`.
+* `RemoteAppApiKey`: A key (required to be parseable as a [GUID](/dotnet/api/system.guid)) that is shared between the two applications. This should be a GUID value like `12345678-1234-1234-1234-123456789012`.
 * `RemoteAppUri`: The URI of the remote ASP.NET Framework application (only required in the ASP.NET Core application configuration). This should be the full URL where the ASP.NET Framework app is hosted, such as `https://localhost:44300` or `https://myapp.example.com`.
 
 ## Configure ASP.NET Framework Application


### PR DESCRIPTION
Reverts dotnet/AspNetCore.Docs#36595

Must be reverted. Docutune has messed up the carefully curated GUIDs by doing this.

@wadepickett @tdykstra @cmastr ... Would it be possible to get the dummy GUIDs ...

```
11112222-bbbb-3333-cccc-4444dddd5555
00001111-aaaa-2222-bbbb-3333cccc4444
```

... approved for DocuTune so that they don't throw these articles into chaos? It's time consuming (💰) to carefully recalibrate them in the context of the same GUIDs that other parts of the articles are using. I'm already slammed with work, and this can be fixed easily if they would just re-approve those GUIDs :point_up: for use as a dummy values, as they used to pass their checks.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/call-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e30642c9eb02230d9e7dc8c7421fc76616226aa/aspnetcore/blazor/call-web-api.md) | [aspnetcore/blazor/call-web-api](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/call-web-api?branch=pr-en-us-36603) |
| [aspnetcore/blazor/security/blazor-web-app-with-entra.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e30642c9eb02230d9e7dc8c7421fc76616226aa/aspnetcore/blazor/security/blazor-web-app-with-entra.md) | [aspnetcore/blazor/security/blazor-web-app-with-entra](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-entra?branch=pr-en-us-36603) |
| [aspnetcore/blazor/security/blazor-web-app-with-oidc.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e30642c9eb02230d9e7dc8c7421fc76616226aa/aspnetcore/blazor/security/blazor-web-app-with-oidc.md) | [aspnetcore/blazor/security/blazor-web-app-with-oidc](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-oidc?branch=pr-en-us-36603) |
| [aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e30642c9eb02230d9e7dc8c7421fc76616226aa/aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c.md) | [aspnetcore/blazor/security/webassembly/hosted-with-azure-active-directory-b2c](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/hosted-with-azure-active-directory-b2c?branch=pr-en-us-36603) |
| [aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e30642c9eb02230d9e7dc8c7421fc76616226aa/aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id.md) | [aspnetcore/blazor/security/webassembly/hosted-with-microsoft-entra-id](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/hosted-with-microsoft-entra-id?branch=pr-en-us-36603) |
| [aspnetcore/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e30642c9eb02230d9e7dc8c7421fc76616226aa/aspnetcore/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery.md) | [aspnetcore/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/standalone-with-identity/account-confirmation-and-password-recovery?branch=pr-en-us-36603) |
| [aspnetcore/migration/fx-to-core/inc/remote-app-setup.md](https://github.com/dotnet/AspNetCore.Docs/blob/2e30642c9eb02230d9e7dc8c7421fc76616226aa/aspnetcore/migration/fx-to-core/inc/remote-app-setup.md) | [aspnetcore/migration/fx-to-core/inc/remote-app-setup](https://review.learn.microsoft.com/en-us/aspnet/core/migration/fx-to-core/inc/remote-app-setup?branch=pr-en-us-36603) |

<!-- PREVIEW-TABLE-END -->