### PR TITLE
Update license exclusion in docfx.json

### DIFF
--- a/aspnetcore/docfx.json
+++ b/aspnetcore/docfx.json
@@ -3,7 +3,7 @@
     "content": [
       {
         "files": [ "**/*.md", "**/*.yml" ], 
-        "exclude": [ "**/includes/**", "***/license.md", "**/obj/**", "***/readme.md", "**/sample/**", "**/samples/**", "_site/**" ], 
+        "exclude": [ "**/includes/**", "**/license.md", "**/LICENSE.md", "**/obj/**", "**/readme.md", "**/README.md", "**/sample/**", "**/samples/**", "_site/**" ], 
         "group": "group1", 
         "src": "."
       },


### PR DESCRIPTION
Docfx.json: Add exclusion for LICENSE.md jquery files.

- Added upper case LICENSE.md and README.md to the doc build checks exclude list.  

Why: jquery includes the uppercase version now and it was creating errors in the build worflow processes since they were being treated as MS documenation files.