### PR TITLE
Simplify OpenApiGenerateDocumentsOptions examples

### DIFF
--- a/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
+++ b/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md
@@ -276,9 +276,7 @@ By default, the generated OpenAPI document has the same name as the app's projec
 
 ```xml
 <PropertyGroup>
-  <OpenApiGenerateDocumentsOptions>
-    --file-name my-open-api
-  </OpenApiGenerateDocumentsOptions>
+  <OpenApiGenerateDocumentsOptions>--file-name my-open-api</OpenApiGenerateDocumentsOptions>
 </PropertyGroup>
 ```
 
@@ -288,9 +286,7 @@ Some apps may be configured to emit multiple OpenAPI documents. Multiple OpenAPI
 
 ```xml
 <PropertyGroup>
-  <OpenApiGenerateDocumentsOptions>
-    --document-name v2
-  </OpenApiGenerateDocumentsOptions>
+  <OpenApiGenerateDocumentsOptions>--document-name v2</OpenApiGenerateDocumentsOptions>
 </PropertyGroup>
 ```
 


### PR DESCRIPTION
Updated XML formatting for OpenApiGenerateDocumentsOptions.

Using the proposed XML

```xml
<PropertyGroup>
  <OpenApiGenerateDocumentsOptions>
    --file-name my-open-api
  </OpenApiGenerateDocumentsOptions>
</PropertyGroup>
```

will result in

```
D:\.nuget\packages\microsoft.extensions.apidescription.server\10.0.2\build\Microsoft.Extensions.ApiDescription.Server.targets(67,5): error '--file-name' is not recognized as an internal or external command,
    D:\.nuget\packages\microsoft.extensions.apidescription.server\10.0.2\build\Microsoft.Extensions.ApiDescription.Server.targets(67,5): error operable program or batch file.
    D:\.nuget\packages\microsoft.extensions.apidescription.server\10.0.2\build\Microsoft.Extensions.ApiDescription.Server.targets(67,5): error MSB3073:
      The command "dotnet "D:\.nuget\packages\microsoft.extensions.apidescription.server\10.0.2\build\../tools/dotnet-getdocument.dll" --assembly "D:\Temp\Projects\BiometricEngineTests\BiometricEngine.ApiService\b
      in\Debug\net10.0\BiometricEngine.ApiService.dll" --file-list "obj\BiometricEngine.ApiService.OpenApiFiles.cache" --framework ".NETCoreApp,Version=v10.0" --output "D:\Temp\Projects\BiometricEngineTests\contra
      cts" --project "BiometricEngine.ApiService" --assets-file "D:\Temp\Projects\BiometricEngineTests\BiometricEngine.ApiService\obj\project.assets.json" --platform "AnyCPU"
            --file-name weather
          " exited with code 9009.
```

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/aspnetcore-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/59828af586e56a236b0cbf8a7f58c36ae4e88d5d/aspnetcore/fundamentals/openapi/aspnetcore-openapi.md) | [aspnetcore/fundamentals/openapi/aspnetcore-openapi](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/aspnetcore-openapi?branch=pr-en-us-36637) |

<!-- PREVIEW-TABLE-END -->