### PR TITLE
Fix dotenv variable casing in HTTP files example

### DIFF
--- a/aspnetcore/test/http-files.md
+++ b/aspnetcore/test/http-files.md
@@ -447,7 +447,7 @@ And the `.http` file has this content:
 
 ```http
 GET {{HostAddress}}{{Path}}
-X-UserName: {{$dotEnv USERNAME}}
+X-UserName: {{$dotenv USERNAME}}
 ```
 
 The `X-UserName` header will have "userFromDotenv".


### PR DESCRIPTION

<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

Fixes #36559

### Summary
Corrected the casing of the `dotenv` expression in the HTTP files documentation to match the behavior in Visual Studio.

### Details
- Changed `{{$dotEnv USERNAME}}` to `{{$dotenv USERNAME}}`
- This resolves HTTP0012 error when evaluating environment variables

### Testing
Not applicable (documentation-only change)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/http-files.md](https://github.com/dotnet/AspNetCore.Docs/blob/f774639909e51f62c7d0ee11cfd628342acfed6e/aspnetcore/test/http-files.md) | [Use .http files in Visual Studio 2022](https://review.learn.microsoft.com/en-us/aspnet/core/test/http-files?branch=pr-en-us-36651) |

<!-- PREVIEW-TABLE-END -->