### PR TITLE
Clarify wasm-tools Python dependency note

### DIFF
--- a/aspnetcore/blazor/webassembly-build-tools-and-aot.md
+++ b/aspnetcore/blazor/webassembly-build-tools-and-aot.md
@@ -47,7 +47,8 @@ The following list shows which workload to install for each .NET SDK, depending 
   * Targeting .NET 8 requires `wasm-tools-net8`.
 * Using the .NET 8 SDK: Targeting .NET 8 requires `wasm-tools`.
 
-The Emscripten compiler toolchain depends on [LLVM](https://llvm.org/), [Node.js](https://nodejs.org), and [Python](https://www.python.org/), which are installed by default with the .NET WebAssembly build tools workload on Windows and macOS. Python isn't installed for Linux users by default, so Linux users should [download Python for Linux/Unix](https://www.python.org/downloads/source/) and manually install it on their system.
+The Emscripten compiler toolchain depends on [Python](https://www.python.org/), which is bundled by default with the .NET WebAssembly build tools workload on Windows and macOS.
+Python isn't bundled for Linux users, resulting in "unable to find python in $PATH" errors if Python isn't available. Linux users should install Python through their package manager or [download Python for Linux/Unix](https://www.python.org/downloads/source/) and manually install it on their system so that it is available in `$PATH`.
 
 ## Ahead-of-time (AOT) compilation
 


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/AspNetCore.Docs/issues/36597

We don't need to mention LLVM/Nodejs since those are always bundled, it's just Python that is the issue.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/webassembly-build-tools-and-aot.md](https://github.com/dotnet/AspNetCore.Docs/blob/5f23b66392df88a88b89f03a94078acbad2c037b/aspnetcore/blazor/webassembly-build-tools-and-aot.md) | [ASP.NET Core Blazor WebAssembly build tools and ahead-of-time (AOT) compilation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-build-tools-and-aot?branch=pr-en-us-36681) |

<!-- PREVIEW-TABLE-END -->