### PR TITLE
[11.0 P1] Update CSP guidance for inline JS removal

### DIFF
--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -51,7 +51,7 @@ The following directives and sources are commonly used for Blazor apps. Add addi
   * Specify `self` to indicate that the app's origin, including the scheme and port number, is a valid source.
   * In a client-side Blazor app:
     * Specify [`wasm-unsafe-eval`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution) to permit the client-side Blazor Mono runtime to function.
-    * Specify any additional hashes to permit your required *non-framework scripts* to load with [`unsafe-hashes`](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src#unsafe_hashes) and script hashes to permit the inline JavaScript to load.
+    * Specify any additional hashes with the [`unsafe-hashes`](https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/script-src#unsafe_hashes) source expression to permit your required *non-framework inline scripts* to load.
   * In a server-side Blazor app, specify hashes to permit required scripts to load.
 * [`style-src`](https://developer.mozilla.org/docs/Web/HTTP/Headers/Content-Security-Policy/style-src): Indicates valid sources for stylesheets.
   * Specify `self` to indicate that the app's origin, including the scheme and port number, is a valid source.


### PR DESCRIPTION
Fixes #36684
Addresses #36448

Wade or Tom ... Just knocking out the hash guidance now that the inline JS will be going away at 11.0.

I agreed (for the most part) with one of Copilot's suggestions and made a change to address it. I didn't agree with the other suggestion.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/content-security-policy.md](https://github.com/dotnet/AspNetCore.Docs/blob/22d47ea5efc8b82854c63d22743b649a2c043043/aspnetcore/blazor/security/content-security-policy.md) | [aspnetcore/blazor/security/content-security-policy](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/content-security-policy?branch=pr-en-us-36686) |

<!-- PREVIEW-TABLE-END -->