### PR TITLE
Fix component names in authorization policy section

### DIFF
--- a/aspnetcore/blazor/security/blazor-web-app-with-windows-authentication.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-windows-authentication.md
@@ -71,12 +71,12 @@ builder.Services.AddAuthorizationBuilder()
             "S-1-5-113"));   
 ```
 
-The authorization policy is enforced by the `LocalAccountOnly` component.
+The authorization policy is enforced by the `LocalAccount` component.
 
-`Components/Pages/LocalAccountOnly.razor`:
+`Components/Pages/LocalAccount.razor`:
 
 ```razor
-@page "/local-account-only"
+@page "/local-account"
 @using Microsoft.AspNetCore.Authorization
 @attribute [Authorize("LocalAccount")]
 


### PR DESCRIPTION
There is no component named `local-account-only`. Instead, it is named `local-account`.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one: I did not see an issue that addressed this

Fixes (No prior issue number)

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/blazor-web-app-with-windows-authentication.md](https://github.com/dotnet/AspNetCore.Docs/blob/095bd132ddd45662ab6700871737814a1c00f571/aspnetcore/blazor/security/blazor-web-app-with-windows-authentication.md) | [Secure an ASP.NET Core Blazor Web App with Windows Authentication](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-windows-authentication?branch=pr-en-us-36728) |

<!-- PREVIEW-TABLE-END -->