### PR TITLE
Clarify authentication context management in Blazor

### DIFF
--- a/aspnetcore/blazor/security/index.md
+++ b/aspnetcore/blazor/security/index.md
@@ -92,7 +92,7 @@ For more information, see the following resources:
 
 Server-side Blazor apps are configured for security in the same manner as ASP.NET Core apps. For more information, see the articles under <xref:security/index>.
 
-The authentication context is only established when the app starts, which is when the app first [connects to the WebSocket over a SignalR connection](xref:signalr/authn-and-authz) with the client. Authentication can be based on a cookie or some other bearer token, but authentication is managed via the SignalR hub and entirely within the [circuit](xref:blazor/hosting-models#blazor-server). The authentication context is maintained for the lifetime of the circuit. Apps periodically revalidate the user's authentication state every 30 minutes.
+The authentication context is only established when the app starts, which is when the app first [connects to the WebSocket over a SignalR connection](xref:signalr/authn-and-authz) with the client. Authentication can be based on a cookie or some other bearer token, but authentication is managed via the SignalR hub and entirely within the [circuit](xref:blazor/hosting-models#blazor-server). The authentication context is maintained for the lifetime of the connection and is re-evaluated on reconnection.
 
 If the app must capture users for custom services or react to updates to the user, see <xref:blazor/security/additional-scenarios#circuit-handler-to-capture-users-for-custom-services>.
 


### PR DESCRIPTION
Fixes #36744

Wade or Tom ... If you see this before or in lieu of Javier, [his issue](https://github.com/dotnet/AspNetCore.Docs/issues/36744) describes the two problems that we're fixing with this PR.

Postmortem: I think I accidentally misworded this remark (didn't provide enough info) about 30 minutes on the basis of the app using the `IdentityRevalidatingAuthenticationStateProvider` ...

https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/IdentityRevalidatingAuthenticationStateProvider.cs#L18

I think if the sentence called that out that it would be accurate. However, that's covered separately ...

https://learn.microsoft.com/en-us/aspnet/core/blazor/security/?view=aspnetcore-10.0&tabs=visual-studio#additional-security-abstractions

... with links to ref source and the API Browser, where devs will see the `RevalidationInterval` property.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/eee9b8bc2bec08ce76e5136e577b6decfb7b73cc/aspnetcore/blazor/security/index.md) | [aspnetcore/blazor/security/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/index?branch=pr-en-us-36745) |

<!-- PREVIEW-TABLE-END -->