### PR TITLE
Update view-compilation.md with runtime compilation details

### DIFF
--- a/aspnetcore/mvc/views/view-compilation.md
+++ b/aspnetcore/mvc/views/view-compilation.md
@@ -6,7 +6,7 @@ description: Learn how compilation of Razor files occurs in an ASP.NET Core app.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 01/30/2026
+ms.date: 02/06/2026
 uid: mvc/views/view-compilation
 ---
 # Razor file compilation in ASP.NET Core


### PR DESCRIPTION
Clarified the obsolescence of runtime compilation in .NET 10 and its limitations for Razor components and production use.

Fixes #36658,  [this comment in #36722](https://github.com/dotnet/AspNetCore.Docs/pull/36722/files#r2766478942)
Removes bold styling where it was overused.
 
<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/views/view-compilation.md](https://github.com/dotnet/AspNetCore.Docs/blob/3af0c673f757b39fa6b97e21ae366d048ffb9eb2/aspnetcore/mvc/views/view-compilation.md) | [Razor file compilation in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/views/view-compilation?branch=pr-en-us-36749) |


<!-- PREVIEW-TABLE-END -->