### PR TITLE
Update the 'Bind an array' section

### DIFF
--- a/aspnetcore/fundamentals/configuration/index.md
+++ b/aspnetcore/fundamentals/configuration/index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration in ASP.NET Core
+ai-usage: ai-assisted
 author: tdykstra
 description: Learn how to use the Configuration API to configure app settings in an ASP.NET Core app.
 monikerRange: '>= aspnetcore-3.1'
@@ -1320,15 +1321,15 @@ Host.CreateDefaultBuilder(args)
 
 :::moniker-end
 
-The preceding code results in the following configuration key/value pairs:
+The preceding code results in the following bound array:
 
 ```console
 Index: 0 Value: value00
 Index: 1 Value: value10
 Index: 2 Value: value20
 Index: 3 Value: value30
-Index: 3 Value: value40
-Index: 4 Value: value50
+Index: 4 Value: value40
+Index: 5 Value: value50
 ```
 
 ## Custom configuration provider


### PR DESCRIPTION
Fixes #36665

Tom .....

The in-memory config provider is already covered elsewhere in the the article, so we don't need a rehash of that in the *Bind an array* section. What we need to do here is just explain that a missing array value can be supplied to config before the array is bound. I retain the content along those lines with some code updates. Also, this really shouldn't be for just <6.0. I guess at the time (when `Startup.cs` was set aside in favor of doing everything in the `Program` file) the author (Rick?) was going to circle back around with updates for the scenario, and they just didn't get back to it. It turns out that the approach works in all versions of .NET. I've addressed the 6.0 situation (`Startup`/`Program`) with the versioned code examples.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/configuration/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/e127aba6da139d5da1fbb9678ea07af12d5f1434/aspnetcore/fundamentals/configuration/index.md) | [aspnetcore/fundamentals/configuration/index](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/index?branch=pr-en-us-36765) |


<!-- PREVIEW-TABLE-END -->