### PR TITLE
Small change for BasePath component coverage

### DIFF
--- a/aspnetcore/blazor/host-and-deploy/app-base-path.md
+++ b/aspnetcore/blazor/host-and-deploy/app-base-path.md
@@ -141,7 +141,7 @@ Place the `<base>` tag in `<head>` markup ([location of `<head>` content](xref:b
 
 :::moniker range=">= aspnetcore-11.0"
 
-In many hosting scenarios, the relative URL path to the app is the root of the app. When the app runs at `/`, `<BasePath />` renders `<base href="/" />` automatically in [`<head>` content](xref:blazor/project-structure#location-of-head-and-body-content). For any other deployment path, the component emits a `<base>` element that matches the current request's path base.
+In many hosting scenarios, the relative URL path to the app is the root of the app. When the app runs at `/`, the `BasePath` component (`<BasePath />`) renders `<base href="/" />` automatically in [`<head>` content](xref:blazor/project-structure#location-of-head-and-body-content). For any other deployment path, the component emits a `<base>` element that matches the current request's path base.
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #36429

Wade ... I researched where we might need to version in coverage for the new `BasePath` component (>=11.0) for existing `<base>` tag coverage. We're good with the work that was done earlier on #36428! 👍 I only see one tiny NIT change that I'd like to make.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/host-and-deploy/app-base-path.md](https://github.com/dotnet/AspNetCore.Docs/blob/210bfbb00d398a746b8ce724909087cf605adcb6/aspnetcore/blazor/host-and-deploy/app-base-path.md) | [aspnetcore/blazor/host-and-deploy/app-base-path](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/app-base-path?branch=pr-en-us-36766) |

<!-- PREVIEW-TABLE-END -->