### PR TITLE
Configure SignalR hub URL endpoint for loopback hub connections

### DIFF
--- a/aspnetcore/blazor/fundamentals/signalr.md
+++ b/aspnetcore/blazor/fundamentals/signalr.md
@@ -1803,7 +1803,7 @@ In the preceding code, `NavManager` is a <xref:Microsoft.AspNetCore.Components.N
 
 *This section only applies to server-side Blazor apps.*
 
-If HTTP requests in a server-side Blazor app are failing to connect to itself when using <xref:Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri%2A?displayProperty=nameWithType>, you might have a load balancer or proxy that isn't expecting requests from the backend server. In these cases, you can try to change the hub URL that the client is using to connect to the backend server directly.
+If HTTP requests in a server-side Blazor app are failing to connect to itself when using <xref:Microsoft.AspNetCore.Components.NavigationManager.ToAbsoluteUri%2A?displayProperty=nameWithType>, you might have a load balancer or proxy that isn't expecting requests from the backend server. In this scenario, you can try to change the hub URL that the client is using to connect directly to the backend server.
 
 The following example:
 


### PR DESCRIPTION
Fixes #36119

Brennan, Wade ...

* I use "URL" as opposed to "URI" because the API is named "WithUrl" ... "to use HTTP-based transports to connect to the specified URL and transports."
* Removed `UseDefaultCredentials` because it's covered elsewhere in the article and not necessarily germane to the scenario (let me know if I'm incorrect about that, and I'll add it back).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/signalr.md](https://github.com/dotnet/AspNetCore.Docs/blob/394786d0eda4d68444b2b9cd05e6e7dbb9e443f1/aspnetcore/blazor/fundamentals/signalr.md) | [aspnetcore/blazor/fundamentals/signalr](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/signalr?branch=pr-en-us-36769) |


<!-- PREVIEW-TABLE-END -->