### PR TITLE
Fix moniker syntax

### DIFF
--- a/aspnetcore/blazor/project-structure.md
+++ b/aspnetcore/blazor/project-structure.md
@@ -63,11 +63,15 @@ The `Components` folder of the server project holds the app's server-side Razor 
 
 The `Components/Pages` folder of the server project contains the app's routable server-side Razor components. The route for each page is specified using the [`@page`](xref:mvc/views/razor#page) directive.
 
+:::moniker-end
+
 :::moniker range=">= aspnetcore-10.0"
 
 The `NotFound` component (`NotFound.razor`) implements a Not Found page to display when content isn't found for a request path. For more information, see <xref:blazor/fundamentals/navigation#not-found-responses>.
 
 :::moniker-end
+
+:::moniker range=">= aspnetcore-8.0"
 
 The `App` component (`App.razor`) is the root component of the app with HTML `<head>` markup, the `Routes` component, and the Blazor `<script>` tag. The root component is the first component that the app loads.
 


### PR DESCRIPTION
* Add various missing `:::`

Note:

* One moniker is inside another moniker
* The previous monikers, in one instance, had a mismatching section vs correctly prefixed opening and closing tag

Please verify they work correctly now.

https://learn.microsoft.com/en-us/aspnet/core/blazor/project-structure?view=aspnetcore-10.0

<img width="529" height="846" alt="image" src="https://github.com/user-attachments/assets/8360f98a-545b-44fe-a521-99af93732dc8" />


<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/project-structure.md](https://github.com/dotnet/AspNetCore.Docs/blob/c7b391464666b72f7ea984de91f67b48df170745/aspnetcore/blazor/project-structure.md) | [aspnetcore/blazor/project-structure](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/project-structure?branch=pr-en-us-36783) |


<!-- PREVIEW-TABLE-END -->