### PR TITLE
Update JSON Patch package installation command

### DIFF
--- a/aspnetcore/web-api/jsonpatch.md
+++ b/aspnetcore/web-api/jsonpatch.md
@@ -54,7 +54,7 @@ JSON Patch support in ASP.NET Core web API is based on <xref:System.Text.Json> s
 To enable JSON Patch support with <xref:System.Text.Json>, install the [`Microsoft.AspNetCore.JsonPatch.SystemTextJson`](https://www.nuget.org/packages/Microsoft.AspNetCore.JsonPatch.SystemTextJson) NuGet package.
 
 ```dotnetcli
-dotnet add package Microsoft.AspNetCore.JsonPatch.SystemTextJson --prerelease
+dotnet add package Microsoft.AspNetCore.JsonPatch.SystemTextJson
 ```
 
 This package provides a <xref:Microsoft.AspNetCore.JsonPatch.SystemTextJson.JsonPatchDocument%601> class to represent a JSON Patch document for objects of type `T` and custom logic for serializing and deserializing JSON Patch documents using <xref:System.Text.Json>. The key method of the <xref:Microsoft.AspNetCore.JsonPatch.SystemTextJson.JsonPatchDocument%601> class is <xref:Microsoft.AspNetCore.JsonPatch.SystemTextJson.JsonPatchDocument.ApplyTo(System.Object)>, which applies the patch operations to a target object of type `T`.


### PR DESCRIPTION
Removed the '--prerelease' flag from the package installation command.

Contributes to issue #36419

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/web-api/jsonpatch.md](https://github.com/dotnet/AspNetCore.Docs/blob/899df1fdf79e295a6281ac1e6944fd42c409818a/aspnetcore/web-api/jsonpatch.md) | [JSON Patch support in ASP.NET Core web API](https://review.learn.microsoft.com/en-us/aspnet/core/web-api/jsonpatch?branch=pr-en-us-36870) |

<!-- PREVIEW-TABLE-END -->