### PR TITLE
Fixing Windows Scaffold command typo

### DIFF
--- a/aspnetcore/data/ef-rp/intro.md
+++ b/aspnetcore/data/ef-rp/intro.md
@@ -278,7 +278,7 @@ The following packages are automatically installed:
   **On Windows**
 
   ```dotnetcli
-  dotnet aspnet-codegenerator razorpage -m Student -dc ContosoUniversity.Data.SchoolContext -udl -outDir Pages\Students --referenceScriptLibraries -sqlite  
+  dotnet aspnet-codegenerator razorpage -m Student -dc ContosoUniversity.Data.SchoolContext -udl -outDir Pages\Students --referenceScriptLibraries -dbProvider sqlite 
   ```
 
   **On macOS or Linux**


### PR DESCRIPTION
This pull request fixes the Windows Scaffold command for the Razor Pages with Entity Framework Core in ASP.NET Core - Tutorial on page 1 of 8.

Fixes #36875


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/data/ef-rp/intro.md](https://github.com/dotnet/AspNetCore.Docs/blob/41a84a2a1c474e5b2336a8e30bfdcfe8f664696f/aspnetcore/data/ef-rp/intro.md) | [Razor Pages with Entity Framework Core in ASP.NET Core - Tutorial 1 of 8](https://review.learn.microsoft.com/en-us/aspnet/core/data/ef-rp/intro?branch=pr-en-us-36876) |

<!-- PREVIEW-TABLE-END -->