### PR TITLE
Fix moniker syntax for ASP.NET Core documentation

### DIFF
--- a/aspnetcore/fundamentals/configuration/options.md
+++ b/aspnetcore/fundamentals/configuration/options.md
@@ -1396,7 +1396,7 @@ services.AddSingleton<IValidateOptions<KeyOptions2>, KeyOptionsValidation>();
 
 :::moniker-end
 
-:::moniker-range=">= aspnetcore-8.0"
+:::moniker range=">= aspnetcore-8.0"
 
 The following example demonstrates how to log options validation exceptions and display an <xref:Microsoft.Extensions.Options.OptionsValidationException.Message%2A?displayProperty=nameWithType>.
 


### PR DESCRIPTION
# Fix moniker syntax fro ASP.NET Core documentation

I found an invalid moniker syntax in a part of the documentation. 
The syntax was `:::moniker-range`, but in the other sections it was `:::moniker range`. Unfortunately i dont know how i could possibly test if this fixed the issue, but now its according to the other parts of the documentation.


<img width="1189" height="1147" alt="image" src="https://github.com/user-attachments/assets/19318117-7bb0-4b5d-95ad-6150993141a5" />
<img width="1377" height="771" alt="image" src="https://github.com/user-attachments/assets/9ad1957d-3ead-4228-a99b-0704b9f11fe4" />

