### PR TITLE
Fix typo in IOptionsMonitor section link in options.md

### DIFF
--- a/aspnetcore/fundamentals/configuration/options.md
+++ b/aspnetcore/fundamentals/configuration/options.md
@@ -473,7 +473,7 @@ For the preceding code, changes to the JSON configuration in the app settings fi
 
 <xref:Microsoft.Extensions.Options.IOptionsMonitor%601>:
 
-* Covered later in this article in the [Use `IOptionsMonitor` to read updated data](#use-ioptionssnapshot-to-read-updated-data) section.
+* Covered later in this article in the [Use `IOptionsMonitor` to read updated data](#use-ioptionsmonitor-to-read-updated-data) section.
 * Is used to retrieve options and manage options notifications for `TOptions` instances.
 * Is registered as a [singleton service](/dotnet/core/extensions/dependency-injection/service-lifetimes#singleton) and can be injected into any [service lifetime](/dotnet/core/extensions/dependency-injection/service-lifetimes).
 * Supports:


### PR DESCRIPTION
A wrong anchor has been attachted to line `476`: instead of linking to the section in the `IOptionsMonitor` it lead to the section in `IOptionsSnapshot`, due to the incorrect ancor.
* Changed `Covered later in this article in the [Use `IOptionsMonitor` to read updated data](#use-ioptionssnapshot-to-read-updated-data) section.` to `Covered later in this article in the [Use `IOptionsMonitor` to read updated data](#use-ioptionsmonitor-to-read-updated-data) section.`
* Fixes #36896 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/configuration/options.md](https://github.com/dotnet/AspNetCore.Docs/blob/fa9dbc7a6edb76776a48f401d990ff1f41893a13/aspnetcore/fundamentals/configuration/options.md) | [Options pattern in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?branch=pr-en-us-36897) |

<!-- PREVIEW-TABLE-END -->