### PR TITLE
docs: Fix incorrect highlighted line in SignalR documentation

### DIFF
--- a/aspnetcore/tutorials/signalr.md
+++ b/aspnetcore/tutorials/signalr.md
@@ -7,7 +7,7 @@ description: In this tutorial, you create a chat app that uses ASP.NET Core Sign
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
 ms.custom: mvc, engagement-fy23
-ms.date: 01/27/2026
+ms.date: 03/20/2026
 uid: tutorials/signalr
 
 # Customer intent: As a developer, I want to get a quick proof-of-concept app running, so I can get a practical introduction to ASP.NET Core SignalR.


### PR DESCRIPTION

The current SignalR / SignalR with Javascript / [Configure SignalR](https://learn.microsoft.com/en-us/aspnet/core/tutorials/signalr?view=aspnetcore-10.0&WT.mc_id=dotnet-35129-website&tabs=visual-studio#configure-signalr) section, highlights an incorrect line.
The highlighted line currently refers to a line generated in a previous step, rather than the new change required to register the hub endpoint.

This PR updates the highlighted line to match the intended code change, aligning it with the [SignalR with Blazor](https://learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/signalr-blazor?view=aspnetcore-10.0&tabs=visual-studio#add-services-and-an-endpoint-for-the-signalr-hub) tutorial article.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/tutorials/signalr.md](https://github.com/dotnet/AspNetCore.Docs/blob/146eb2a806b9ebf6dbe67180db34eada3ca4f4aa/aspnetcore/tutorials/signalr.md) | [Customer intent: As a developer, I want to get a quick proof-of-concept app running, so I can get a practical introduction to ASP.NET Core SignalR.](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/signalr?branch=pr-en-us-36901) |


<!-- PREVIEW-TABLE-END -->