### PR TITLE
Add example for skipping AllowAnonymous endpoints in OpenAPI docs

### DIFF
--- a/aspnetcore/fundamentals/openapi/customize-openapi.md
+++ b/aspnetcore/fundamentals/openapi/customize-openapi.md
@@ -150,7 +150,7 @@ internal sealed class AuthOperationTransformer : IOpenApiOperationTransformer
 }
 ```
 
-This approach is preferred over document transformers when conditional logic based on endpoint metadata is required.
+Use this approach instead of document transformers when conditional logic based on endpoint metadata is required. This transformer adds security *requirements* per operation and assumes the security *scheme* is already registered at the document level. For an example of registering the Bearer security scheme, see the `BearerSecuritySchemeTransformer` in the [Use document transformers](#use-document-transformers) section.
 
 ## Use schema transformers
 


### PR DESCRIPTION
## Description

Adds a practical example demonstrating how to conditionally apply security requirements in OpenAPI using an `IOpenApiOperationTransformer`.

Specifically, this shows how to skip endpoints decorated with `[AllowAnonymous]`, which is a common real-world scenario not clearly covered in the current documentation.

This complements existing documentation improvements by providing a focused, end-to-end example.

## Related Issue

Fixes #36904
Fixes dotnet/aspnetcore#61264  (Upstream doc issue originally referred to on the product repo)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/openapi/customize-openapi.md](https://github.com/dotnet/AspNetCore.Docs/blob/49449a9bbd935c1ae903ca76b3a437ebf93340ff/aspnetcore/fundamentals/openapi/customize-openapi.md) | [Customize OpenAPI documents](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/customize-openapi?branch=pr-en-us-36902) |


<!-- PREVIEW-TABLE-END -->