### PR TITLE
Remove Web APIs tutorial from toc.yml

### DIFF
--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -414,9 +414,6 @@ items:
           - name: Web apps >>
             displayName: tutorial, razor, razor pages, ui
             href: /training/modules/create-razor-pages-aspnet-core/
-          - name: Web APIs >>
-            displayName: tutorial
-            href: /training/modules/build-web-api-aspnet-core/
           - name: Cloud-native microservices
             items:
               - name: Create and deploy >>


### PR DESCRIPTION
fixes #36941
Removed Web APIs tutorial entry from the table of contents.  It was pointing to an old controller based learn training series.  Minimal API is what should be promoted instead as the starting point.


<img width="656" height="850" alt="image" src="https://github.com/user-attachments/assets/bd317f71-070c-4124-956f-ce4430f87f83" />




<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/toc.yml](https://github.com/dotnet/AspNetCore.Docs/blob/e7d88466e5c325dc9c07f30ba90b5d529043fd36/aspnetcore/toc.yml) | [aspnetcore/toc](https://review.learn.microsoft.com/en-us/aspnet/core/toc?branch=pr-en-us-36942) |

<!-- PREVIEW-TABLE-END -->