### PR TITLE
Add instructions for running the sample app locally

### DIFF
--- a/aspnetcore/blazor/tutorials/movie-database-app/index.md
+++ b/aspnetcore/blazor/tutorials/movie-database-app/index.md
@@ -65,7 +65,7 @@ After executing the preceding command, run the sample using any of the following
   * Select the **Run** button.
   * Use **Debug** > **Start Debugging** from the menu.
   * Press <kbd>F5</kbd>.
-* .NET CLI command shell: Execute the `dotnet watch` (or `dotnet run`) command from the app's folder.
+* .NET CLI command shell: Execute the `dotnet watch` (or `dotnet run`) command from the project's root folder.
 
 ## Article code examples
 


### PR DESCRIPTION
Fixes #36949 

Wade ... Discussed with Dan offline and on the issue. We're going with an instruction over actually putting a copy of the dB in the sample app.

Added instructions for running the sample app locally ...

* An instruction on how to apply the app's migrations.
* An instruction on starting the app using Visual Studio or the .NET CLI.

Not going to get into the weeds with the **Connected Services UI**. That's overkill and too distracting for the *Introduction* of the tutorial. Let's just show the CLI command. They learn about the **Connected Services UI** later in the tutorial.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/tutorials/movie-database-app/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/5ac35ef9f0a61130934d26ce6d10cfe924165055/aspnetcore/blazor/tutorials/movie-database-app/index.md) | [aspnetcore/blazor/tutorials/movie-database-app/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/tutorials/movie-database-app/index?branch=pr-en-us-36952) |


<!-- PREVIEW-TABLE-END -->