### PR TITLE
Add guidance on V1 and V2 STS tokens

### DIFF
--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -140,13 +140,13 @@ The following examples use a Tenant ID of `aaaabbbb-0000-cccc-1111-dddd2222eeee`
 
 If the app is registered in an ME-ID tenant, the authority should match the issuer (`iss`) of the JWT returned by the identity provider.
 
-V1 STS token format:
+V1 STS token endpoint:
 
 ```csharp
 jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee/";
 ```
 
-V2 STS token format:
+V2 STS token endpoint:
 
 ```csharp
 jwtOptions.Authority = "https://login.microsoftonline.com/aaaabbbb-0000-cccc-1111-dddd2222eeee/v2.0";
@@ -446,13 +446,13 @@ The following examples use a Tenant ID of `aaaabbbb-0000-cccc-1111-dddd2222eeee`
 
 If the app is registered in an ME-ID tenant, the authority should match the issuer (`iss`) of the JWT returned by the identity provider.
 
-V1 STS token format:
+V1 STS token endpoint:
 
 ```csharp
 jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee/";
 ```
 
-V2 STS token format:
+V2 STS token endpoint:
 
 ```csharp
 jwtOptions.Authority = "https://login.microsoftonline.com/aaaabbbb-0000-cccc-1111-dddd2222eeee/v2.0";
@@ -1183,12 +1183,12 @@ We also recommend using a shared [Data Protection](xref:security/data-protection
 
 ## STS token version
 
-There are two types of token formats, named Version 1 (V1) and Version 2 (V2). In Azure's security token services (STS), the V1 format uses the `sts.windows.net` domain as the issuer, while the V2 format uses the `login.microsoftonline.com` domain as issuer. V2 supports additional features, such as authenticating personal accounts and OpenID protocols.
+There are two types of token URIs, named Version 1 (V1) and Version 2 (V2). In Azure's security token services (STS), the V1 endpoint uses the `sts.windows.net` domain as the issuer, while the V2 endpoint uses the `login.microsoftonline.com` domain as the issuer. V2 supports additional features, such as authenticating personal accounts and OpenID Connect (OIDC) protocols.
 
 This article and its accompanying sample apps adopt V1 STS tokens. To adopt V2 tokens, make the following changes:
 
 * The STS version must be changed in the apps' registrations in the Azure portal. Set the value of `requestedAccessTokenVersion` to `2` in the apps' manifests, both in the app's registration and the web API's (`MinimalApiJwt`) registration.
-* Use the V2 authority URL format (example: `https://login.microsoftonline.com/{TENANT ID}/v2.0`, where the `{TENANT ID}` placeholder is the tenant ID).
+* Use the V2 authority URL endpoint (example: `https://login.microsoftonline.com/{TENANT ID}/v2.0`, where the `{TENANT ID}` placeholder is the tenant ID).
 * In the web API (`MinimalApiJwt`), explicitly validate the issuer:
 
   ```csharp

--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -1198,12 +1198,25 @@ This article and its accompanying sample apps adopt V1 STS tokens. To adopt V2 t
       // Ensure the issuer ends with /v2.0 if using the V2 endpoint
       ValidIssuer = "https://login.microsoftonline.com/{TENANT ID}/v2.0",
       ValidateAudience = true,
-      ValidAudience = "{WEB API CLIENT ID}",
+      ValidAudiences = new[] { "{WEB API CLIENT ID 1}", "{WEB API CLIENT ID 2}", ... },
       ValidateLifetime = true
   };
   ```
 
-  The `{WEB API CLIENT ID}` placeholder in the preceding example is only the client ID, not the full value passed to the `Audience` property.
+  Instead of setting the <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.ValidAudiences%2A> property, you can specify a single valid audience with <xref:Microsoft.IdentityModel.Tokens.TokenValidationParameters.ValidAudience%2A>:
+  
+  ```csharp
+  ValidAudience = "{WEB API CLIENT ID}",
+  ```
+
+  The `{WEB API CLIENT ID}` placeholders in the preceding examples are ***only the client IDs***, not the full values passed to the `Audience` property.
+
+  To supply a collection of valid audiences in an app that [configures Identity from app settings](#supply-configuration-with-the-json-configuration-provider-app-settings), you can use the following code to obtain the valid audiences configuration:
+
+  ```csharp
+  ValidAudiences = builder.Configuration.GetSection(
+      "Authentication:Schemes:Bearer:ValidAudiences").Get<string[]>(),
+  ```
 
 For more information, see [Access tokens in the Microsoft identity platform: Token formats](/entra/identity-platform/access-tokens#token-formats).
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -1187,7 +1187,7 @@ There are two types of token URIs, named Version 1 (V1) and Version 2 (V2). In A
 
 This article and its accompanying sample apps adopt V1 STS tokens. To adopt V2 tokens, make the following changes:
 
-* The STS version must be changed in the apps' registrations in the Azure portal. Set the value of `requestedAccessTokenVersion` to `2` in the apps' manifests, both in the app's registration and the web API's (`MinimalApiJwt`) registration.
+* The STS version must be changed in the web API's (`MinimalApiJwt`) app registration in the Azure portal. Set the value of `requestedAccessTokenVersion` to `2` in the web API app registration's manifest. Entra issues access tokens in the version requested by the resource (audience) app registration, so this setting on the Blazor Web App's client registration has no effect on the tokens that `MinimalApiJwt` receives and validates.
 * Use the V2 authority URL endpoint (example: `https://login.microsoftonline.com/{TENANT ID}/v2.0`, where the `{TENANT ID}` placeholder is the tenant ID).
 * In the web API (`MinimalApiJwt`), explicitly validate the issuer:
 
@@ -1195,7 +1195,8 @@ This article and its accompanying sample apps adopt V1 STS tokens. To adopt V2 t
   jwtOptions.TokenValidationParameters = new TokenValidationParameters
   {
       ValidateIssuer = true,
-      // Ensure the issuer ends with /v2.0 if using the V2 endpoint
+      // Ensure the issuer ends with /v2.0 if using the V2 endpoint and that
+      // {TENANT ID} is the tenant GUID (matching the token's tid claim), not a domain
       ValidIssuer = "https://login.microsoftonline.com/{TENANT ID}/v2.0",
       ValidateAudience = true,
       ValidAudiences = new[] { "{WEB API CLIENT ID 1}", "{WEB API CLIENT ID 2}", ... },

--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -138,7 +138,7 @@ jwtOptions.Authority = "{AUTHORITY}";
 
 The following examples use a Tenant ID of `aaaabbbb-0000-cccc-1111-dddd2222eeee` and a directory name of `contoso`.
 
-If the app is registered in an ME-ID tenant, the authority should match the issurer (`iss`) of the JWT returned by the identity provider.
+If the app is registered in an ME-ID tenant, the authority should match the issuer (`iss`) of the JWT returned by the identity provider.
 
 V1 STS token format:
 
@@ -444,7 +444,7 @@ jwtOptions.Authority = "{AUTHORITY}";
 
 The following examples use a Tenant ID of `aaaabbbb-0000-cccc-1111-dddd2222eeee` and a directory name of `contoso`.
 
-If the app is registered in an ME-ID tenant, the authority should match the issurer (`iss`) of the JWT returned by the identity provider.
+If the app is registered in an ME-ID tenant, the authority should match the issuer (`iss`) of the JWT returned by the identity provider.
 
 V1 STS token format:
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -143,7 +143,7 @@ If the app is registered in an ME-ID tenant, the authority should match the issu
 V1 STS token format:
 
 ```csharp
-jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
+jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee/";
 ```
 
 V2 STS token format:
@@ -449,7 +449,7 @@ If the app is registered in an ME-ID tenant, the authority should match the issu
 V1 STS token format:
 
 ```csharp
-jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
+jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee/";
 ```
 
 V2 STS token format:
@@ -862,7 +862,7 @@ In the `MinimalApiJwt` project, add the following app settings configuration to 
 "Authentication": {
   "Schemes": {
     "Bearer": {
-      "Authority": "https://sts.windows.net/{TENANT ID (WEB API)}",
+      "Authority": "https://sts.windows.net/{TENANT ID (WEB API)}/",
       "ValidAudiences": ["{APP ID URI (WEB API)}"]
     }
   }
@@ -878,7 +878,7 @@ Update the placeholders in the preceding configuration to match the values that 
 
 Authority formats adopt the following patterns:
 
-* ME-ID tenant type: `https://sts.windows.net/{TENANT ID}`
+* ME-ID tenant type: `https://sts.windows.net/{TENANT ID}/`
 * Microsoft Entra External ID: `https://{DIRECTORY NAME}.ciamlogin.com/{TENANT ID}/v2.0`
 * B2C tenant type: `https://login.microsoftonline.com/{TENANT ID}/v2.0`
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -882,7 +882,7 @@ Authority formats adopt the following patterns:
 * Microsoft Entra External ID: `https://{DIRECTORY NAME}.ciamlogin.com/{TENANT ID}/v2.0`
 * B2C tenant type: `https://login.microsoftonline.com/{TENANT ID}/v2.0`
 
-The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see the [STS token version](#sts-token-version) section.
+The preceding example for the ME-ID tenant type uses the V1 STS token URL format. For guidance on V2 STS tokens, see the [STS token version](#sts-token-version) section.
 
 Audience formats adopt the following patterns (`{CLIENT ID}` is the Client Id of the web API; `{DIRECTORY NAME}` is the directory name, for example, `contoso`):
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-entra.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-entra.md
@@ -138,11 +138,21 @@ jwtOptions.Authority = "{AUTHORITY}";
 
 The following examples use a Tenant ID of `aaaabbbb-0000-cccc-1111-dddd2222eeee` and a directory name of `contoso`.
 
-If the app is registered in an ME-ID tenant, the authority should match the issurer (`iss`) of the JWT returned by the identity provider:
+If the app is registered in an ME-ID tenant, the authority should match the issurer (`iss`) of the JWT returned by the identity provider.
+
+V1 STS token format:
 
 ```csharp
 jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
 ```
+
+V2 STS token format:
+
+```csharp
+jwtOptions.Authority = "https://login.microsoftonline.com/aaaabbbb-0000-cccc-1111-dddd2222eeee/v2.0";
+```
+
+For more information on V2 STS tokens, see the [STS token version](#sts-token-version) section.
 
 If the app is registered in a Microsoft Entra External ID tenant:
 
@@ -434,11 +444,21 @@ jwtOptions.Authority = "{AUTHORITY}";
 
 The following examples use a Tenant ID of `aaaabbbb-0000-cccc-1111-dddd2222eeee` and a directory name of `contoso`.
 
-If the app is registered in an ME-ID tenant, the authority should match the issurer (`iss`) of the JWT returned by the identity provider:
+If the app is registered in an ME-ID tenant, the authority should match the issurer (`iss`) of the JWT returned by the identity provider.
+
+V1 STS token format:
 
 ```csharp
 jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
 ```
+
+V2 STS token format:
+
+```csharp
+jwtOptions.Authority = "https://login.microsoftonline.com/aaaabbbb-0000-cccc-1111-dddd2222eeee/v2.0";
+```
+
+For more information on V2 STS tokens, see the [STS token version](#sts-token-version) section.
 
 If the app is registered in a Microsoft Entra External ID tenant:
 
@@ -849,6 +869,8 @@ In the `MinimalApiJwt` project, add the following app settings configuration to 
 },
 ```
 
+The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see the [STS token version](#sts-token-version) section.
+
 Update the placeholders in the preceding configuration to match the values that the app uses in the `Program` file:
 
 * `{TENANT ID (WEB API)}`: The Tenant Id of the web API.
@@ -859,6 +881,8 @@ Authority formats adopt the following patterns:
 * ME-ID tenant type: `https://sts.windows.net/{TENANT ID}`
 * Microsoft Entra External ID: `https://{DIRECTORY NAME}.ciamlogin.com/{TENANT ID}/v2.0`
 * B2C tenant type: `https://login.microsoftonline.com/{TENANT ID}/v2.0`
+
+The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see the [STS token version](#sts-token-version) section.
 
 Audience formats adopt the following patterns (`{CLIENT ID}` is the Client Id of the web API; `{DIRECTORY NAME}` is the directory name, for example, `contoso`):
 
@@ -1156,6 +1180,32 @@ For more information on how this app secures its weather data, see [Secure data 
 Server-side Blazor Web Apps hosted in a web farm or cluster of machines must adopt [*session affinity*](xref:blazor/fundamentals/signalr#use-session-affinity-sticky-sessions-for-server-side-web-farm-hosting) to maintain Blazor circuits for users of the app.
 
 We also recommend using a shared [Data Protection](xref:security/data-protection/introduction) key ring in production, even when the app uses the Interactive WebAssembly render mode exclusively for client-side rendering (no Blazor circuits).
+
+## STS token version
+
+There are two types of token formats, named Version 1 (V1) and Version 2 (V2). In Azure's security token services (STS), the V1 format uses the `sts.windows.net` domain as the issuer, while the V2 format uses the `login.microsoftonline.com` domain as issuer. V2 supports additional features, such as authenticating personal accounts and OpenID protocols.
+
+This article and its accompanying sample apps adopt V1 STS tokens. To adopt V2 tokens, make the following changes:
+
+* The STS version must be changed in the apps' registrations in the Azure portal. Set the value of `requestedAccessTokenVersion` to `2` in the apps' manifests, both in the app's registration and the web API's (`MinimalApiJwt`) registration.
+* Use the V2 authority URL format (example: `https://login.microsoftonline.com/{TENANT ID}/v2.0`, where the `{TENANT ID}` placeholder is the tenant ID).
+* In the web API (`MinimalApiJwt`), explicitly validate the issuer:
+
+  ```csharp
+  jwtOptions.TokenValidationParameters = new TokenValidationParameters
+  {
+      ValidateIssuer = true,
+      // Ensure the issuer ends with /v2.0 if using the V2 endpoint
+      ValidIssuer = "https://login.microsoftonline.com/{TENANT ID}/v2.0",
+      ValidateAudience = true,
+      ValidAudience = "{WEB API CLIENT ID}",
+      ValidateLifetime = true
+  };
+  ```
+
+  The `{WEB API CLIENT ID}` placeholder in the preceding example is only the client ID, not the full value passed to the `Audience` property.
+
+For more information, see [Access tokens in the Microsoft identity platform: Token formats](/entra/identity-platform/access-tokens#token-formats).
 
 ## Troubleshoot
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -181,6 +181,8 @@ ME-ID tenant Authority example:
 jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
 ```
 
+The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
+
 AAD B2C tenant Authority example:
 
 ```csharp
@@ -529,6 +531,8 @@ ME-ID tenant Authority example:
 jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
 ```
 
+The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
+
 AAD B2C tenant Authority example:
 
 ```csharp
@@ -876,6 +880,8 @@ ME-ID tenant Authority example:
 jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
 ```
 
+The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
+
 AAD B2C tenant Authority example:
 
 ```csharp
@@ -1200,6 +1206,8 @@ In the `MinimalApiJwt` project, add the following app settings configuration to 
 },
 ```
 
+The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
+
 Update the placeholders in the preceding configuration to match the values that the app uses in the `Program` file:
 
 * `{TENANT ID (WEB API)}`: The Tenant Id of the web API.
@@ -1210,6 +1218,8 @@ Authority formats adopt the following patterns:
 * ME-ID tenant type: `https://sts.windows.net/{TENANT ID}`
 * Microsoft Entra External ID: `https://{DIRECTORY NAME}.ciamlogin.com/{TENANT ID}/v2.0`
 * B2C tenant type: `https://login.microsoftonline.com/{TENANT ID}/v2.0`
+
+The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
 
 Audience formats adopt the following patterns (`{CLIENT ID}` is the Client Id of the web API; `{DIRECTORY NAME}` is the directory name, for example, `contoso`):
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -1219,7 +1219,7 @@ Authority formats adopt the following patterns:
 * Microsoft Entra External ID: `https://{DIRECTORY NAME}.ciamlogin.com/{TENANT ID}/v2.0`
 * B2C tenant type: `https://login.microsoftonline.com/{TENANT ID}/v2.0`
 
-The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
+The preceding example for the ME-ID tenant type uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
 
 Audience formats adopt the following patterns (`{CLIENT ID}` is the Client Id of the web API; `{DIRECTORY NAME}` is the directory name, for example, `contoso`):
 

--- a/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
+++ b/aspnetcore/blazor/security/blazor-web-app-with-oidc.md
@@ -178,7 +178,7 @@ The format of the Authority depends on the type of tenant in use. The following 
 ME-ID tenant Authority example:
 
 ```csharp
-jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
+jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee/";
 ```
 
 The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
@@ -528,7 +528,7 @@ The format of the Authority depends on the type of tenant in use. The following 
 ME-ID tenant Authority example:
 
 ```csharp
-jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
+jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee/";
 ```
 
 The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
@@ -877,7 +877,7 @@ The format of the Authority depends on the type of tenant in use. The following 
 ME-ID tenant Authority example:
 
 ```csharp
-jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee";
+jwtOptions.Authority = "https://sts.windows.net/aaaabbbb-0000-cccc-1111-dddd2222eeee/";
 ```
 
 The preceding example uses the V1 STS token URL format. For guidance on V2 STS tokens, see <xref:blazor/security/blazor-web-app-entra#sts-token-version>.
@@ -1199,7 +1199,7 @@ In the `MinimalApiJwt` project, add the following app settings configuration to 
 "Authentication": {
   "Schemes": {
     "Bearer": {
-      "Authority": "https://sts.windows.net/{TENANT ID (WEB API)}",
+      "Authority": "https://sts.windows.net/{TENANT ID (WEB API)}/",
       "ValidAudiences": [ "{APP ID URI (WEB API)}" ]
     }
   }
@@ -1215,7 +1215,7 @@ Update the placeholders in the preceding configuration to match the values that 
 
 Authority formats adopt the following patterns:
 
-* ME-ID tenant type: `https://sts.windows.net/{TENANT ID}`
+* ME-ID tenant type: `https://sts.windows.net/{TENANT ID}/`
 * Microsoft Entra External ID: `https://{DIRECTORY NAME}.ciamlogin.com/{TENANT ID}/v2.0`
 * B2C tenant type: `https://login.microsoftonline.com/{TENANT ID}/v2.0`
 

--- a/aspnetcore/blazor/security/includes/troubleshoot-server.md
+++ b/aspnetcore/blazor/security/includes/troubleshoot-server.md
@@ -181,8 +181,12 @@ app.MapGet("/weather-forecast", (HttpContext context, ILogger<Program> logger) =
 
         try
         {
-            var handler = 
-                new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+                var handler = 
+                    new Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler();
+                var jwtToken = handler.ReadJsonWebToken(token);
+                logger.LogDebug("Audience: {Audience}", 
+                    string.Join(", ", jwtToken.Audiences));
+                logger.LogDebug("Issuer: {Issuer}", jwtToken.Issuer);
             var jwtToken = handler.ReadJwtToken(token);
             logger.LogDebug("Audience: {Audience}", 
                 string.Join(", ", jwtToken.Audiences));

--- a/aspnetcore/blazor/security/includes/troubleshoot-server.md
+++ b/aspnetcore/blazor/security/includes/troubleshoot-server.md
@@ -161,7 +161,7 @@ The following `UserClaims` component can be used directly in apps or serve as th
 
 ### Inspect the access token
 
-Obtaining the access token during development is often helpful when troubleshooting app and Azure configuration problems. In the following example for a weather forecast endpoint, the bearer token and token details are logged when in the DEBUG configuration. You can decode the token using an online JWT token decoder, such as the [Microsoft JWT token decoder](https://jwt.ms/), or log details from the token in C#, as the following example demonstrates.
+Obtaining the access token during development is often helpful when troubleshooting app and Azure configuration problems. In the following example for a weather forecast endpoint, the bearer token and token details are logged only when the app is compiled with the `DEBUG` symbol, which is typically a Debug build. You can decode the token using an online JWT token decoder, such as the [Microsoft JWT token decoder](https://jwt.ms/), or log details from the token in C#, as the following example demonstrates.
 
 > [!CAUTION]
 > In production, avoid logging the token or its contents.
@@ -190,7 +190,7 @@ app.MapGet("/weather-forecast", (HttpContext context, ILogger<Program> logger) =
         }
         catch (Exception ex)
         {
-            logger.LogError("Failed to decode token: {Message}", ex.Message);
+            logger.LogError(ex, "Failed to decode token.");
         }
     }
 #endif

--- a/aspnetcore/blazor/security/includes/troubleshoot-server.md
+++ b/aspnetcore/blazor/security/includes/troubleshoot-server.md
@@ -158,3 +158,51 @@ The following `UserClaims` component can be used directly in apps or serve as th
     }
 }
 ```
+
+### Inspect the access token
+
+Obtaining the access token during development is often helpful when troubleshooting app and Azure configuration problems. In the following example for a weather forecast endpoint, the bearer token and token details are logged when in the DEBUG configuration. You can decode the token using an online JWT token decoder, such as the [Microsoft JWT token decoder](https://jwt.ms/), or log details from the token in C#, as the following example demonstrates.
+
+> [!CAUTION]
+> In production, avoid logging the token or its contents.
+
+```csharp
+app.MapGet("/weather-forecast", (HttpContext context, ILogger<Program> logger) =>
+{
+#if DEBUG
+    var authHeader = context.Request.Headers.Authorization.FirstOrDefault(v => 
+        v != null && 
+        v.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase));
+
+    if (authHeader is not null)
+    {
+        var token = authHeader["Bearer ".Length..].Trim();
+        logger.LogDebug("Token: {Token}", token);
+
+        try
+        {
+            var handler = 
+                new System.IdentityModel.Tokens.Jwt.JwtSecurityTokenHandler();
+            var jwtToken = handler.ReadJwtToken(token);
+            logger.LogDebug("Audience: {Audience}", 
+                string.Join(", ", jwtToken.Audiences));
+            logger.LogDebug("Issuer: {Issuer}", jwtToken.Issuer);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError("Failed to decode token: {Message}", ex.Message);
+        }
+    }
+#endif
+
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return forecast;
+}).RequireAuthorization();
+```


### PR DESCRIPTION
Fixes #36978
Fixes #37030
Fixes #37031

Stephen ...

* The convo that led to this is at the Blazor samples repo: https://github.com/dotnet/blazor-samples/issues/654#issuecomment-4200168336
* TL;DR on that convo (I wrote a 📖🙈😆) ... We spoke years ago about this and decided to just go with V1 tokens. I'm seeing now if we can expand coverage to include guidance on V2 STS tokens.
* IDK if the 🧀 moved (perhaps ME-ID is less flexible on it than AAD of yesteryear), but the ME-ID authority URL requires a trailing slash now. This PR adds it where we show the V1 (`sts.windows.net`) URLs.
* Adding a section on how to get the token (and token details) logged at an endpoint during development. I do ***not*** plan to add the code to the samples, only show it in the article in the *Troubleshoot* section. Thanks, @GC-brian-taylor! 🚀 
* Open questions for the new V2 STS token guidance section ...
  1. I'm currently only showing explicit token issuer validation with `TokenValidationParameters` for the web API (`MinimalApiJwt`). Should I also be doing that in the Blazor app's `Program` file?
  2. In the web API config for `TokenValidationParameters`, why is the `ValidAudience` just the client id and not the full audience passed to `jwtOptions.Audience`? If I try to use the full audience value there, it 💥 with a mismatch error with Azure and explicitly tells me that its just looking for the client id.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/security/blazor-web-app-with-entra.md](https://github.com/dotnet/AspNetCore.Docs/blob/3875b859b97497b810ff9ee7a307d531ec5694a3/aspnetcore/blazor/security/blazor-web-app-with-entra.md) | [aspnetcore/blazor/security/blazor-web-app-with-entra](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-entra?branch=pr-en-us-36979) |
| [aspnetcore/blazor/security/blazor-web-app-with-oidc.md](https://github.com/dotnet/AspNetCore.Docs/blob/3875b859b97497b810ff9ee7a307d531ec5694a3/aspnetcore/blazor/security/blazor-web-app-with-oidc.md) | [aspnetcore/blazor/security/blazor-web-app-with-oidc](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/blazor-web-app-with-oidc?branch=pr-en-us-36979) |


<!-- PREVIEW-TABLE-END -->