### PR TITLE
Update Blazor pause/resume method names

### DIFF
--- a/aspnetcore/blazor/state-management/server.md
+++ b/aspnetcore/blazor/state-management/server.md
@@ -160,17 +160,17 @@ Pausing a circuit stores details about the circuit in client-side browser storag
 
 From a JavaScript event handler:
 
-* Call `Blazor.pause` to pause a circuit.
-* Call `Blazor.resume` to resume a circuit.
+* Call `Blazor.pauseCircuit` to pause a circuit.
+* Call `Blazor.resumeCircuit` to resume a circuit.
 
 The following example assumes that a circuit isn't required for an app that isn't visible:
 
 ```javascript
 window.addEventListener('visibilitychange', () => {
   if (document.visibilityState === 'hidden') {
-    Blazor.pause();
+    Blazor.pauseCircuit();
   } else if (document.visibilityState === 'visible') {
-    Blazor.resume();
+    Blazor.resumeCircuit();
   }
 });
 ```

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -686,7 +686,7 @@ During server-side rendering, Blazor Web Apps can now persist a user's session (
 * Proactive resource management (pausing inactive circuits)
 * [Enhanced navigation](xref:blazor/fundamentals/routing?view=aspnetcore-10.0#enhanced-navigation-and-form-handling)
 
-For more information, see <xref:blazor/state-management/server?view=aspnetcore-10.0#circuit-state-and-prerendering-state-preservation>.
+For more information, see <xref:blazor/state-management/server?view=aspnetcore-10.0>.
 
 ### Hot Reload for Blazor WebAssembly and .NET on WebAssembly
 


### PR DESCRIPTION
Fixes #36982

Thanks @Andrzej-W! 🚀 

Tom or Wade ... This API change wasn't communicated to me last year. I checked the entire repo, and this is the only update that we need WRT API. I'm also pointing the link from the release notes to the entire article because the current bookmark is incorrect and the content spans multiple sections.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/state-management/server.md](https://github.com/dotnet/AspNetCore.Docs/blob/fcbdf0589b176b0b0ec4113ad7e6098bb912ba70/aspnetcore/blazor/state-management/server.md) | [aspnetcore/blazor/state-management/server](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/state-management/server?branch=pr-en-us-36988) |


<!-- PREVIEW-TABLE-END -->