### PR TITLE
Add a link to Not Found coverage

### DIFF
--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -989,7 +989,18 @@ Consider manual render tree builder logic on the same level of complexity and wi
 
 ## Additional resources
 
-:::moniker range=">= aspnetcore-8.0"
+:::moniker range=">= aspnetcore-10.0"
+
+* [Handle caught exceptions outside of a Razor component's lifecycle](xref:blazor/components/sync-context#handle-caught-exceptions-outside-of-a-razor-components-lifecycle)
+* [Not Found responses](xref:blazor/fundamentals/navigation#not-found-responses)
+* <xref:blazor/fundamentals/logging>
+* <xref:fundamentals/error-handling>&dagger;
+* <xref:web-api/index>
+* [Blazor samples GitHub repository (`dotnet/blazor-samples`)](https://github.com/dotnet/blazor-samples) ([how to download](xref:blazor/fundamentals/index#sample-apps))
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-8.0 < aspnetcore-10.0"
 
 * [Handle caught exceptions outside of a Razor component's lifecycle](xref:blazor/components/sync-context#handle-caught-exceptions-outside-of-a-razor-components-lifecycle)
 * <xref:blazor/fundamentals/logging>

--- a/aspnetcore/blazor/fundamentals/handle-errors.md
+++ b/aspnetcore/blazor/fundamentals/handle-errors.md
@@ -964,7 +964,7 @@ Infinite loops during rendering:
 * Causes the rendering process to continue forever.
 * Is equivalent to creating an unterminated loop.
 
-In these scenarios, the Blazor fails and usually attempts to:
+In these scenarios, Blazor fails and usually attempts to:
 
 * Consume as much CPU time as permitted by the operating system, indefinitely.
 * Consume an unlimited amount of memory. Consuming unlimited memory is equivalent to the scenario where an unterminated loop adds entries to a collection on every iteration.


### PR DESCRIPTION
Fixes #37016

Wade or Tom ... Adding a link to the *Additional resources* section of the *Handle errors* article to surface the new (10.0 or later) content on Not Found responses. Not Found responses aren't considered to be unhandled app exceptions. They're considered to be a navigation scenario, so that coverage was placed in the *Navigation* article. However, I'd like to raise awareness of that coverage in the *Handle errors* article in case someone looks for it here.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/handle-errors.md](https://github.com/dotnet/AspNetCore.Docs/blob/641c5cc987d89c9b8df4f3d7a6f0b9e91439951f/aspnetcore/blazor/fundamentals/handle-errors.md) | [aspnetcore/blazor/fundamentals/handle-errors](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/handle-errors?branch=pr-en-us-37017) |


<!-- PREVIEW-TABLE-END -->