### PR TITLE
Document page index handling in QuickGrid

### DIFF
--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -140,6 +140,90 @@ In the running app, page through the items using a rendered `Paginator` componen
 
 QuickGrid renders additional empty rows to fill in the final page of data when used with a `Paginator` component. In .NET 9 or later, empty data cells (`<td></td>`) are added to the empty rows. The empty rows are intended to facilitate rendering the QuickGrid with stable row height and styling across all pages.
 
+To save the page index and return the user to the same page of items from a details page, use the following API:
+
+* <xref:Microsoft.AspNetCore.Components.QuickGrid.PaginationState.CurrentPageIndex%2A?displayProperty=nameWithType>: Gets the current zero-based page index.
+* <xref:Microsoft.AspNetCore.Components.QuickGrid.PaginationState.SetCurrentPageIndexAsync%2A?displayProperty=nameWithType>: Sets the current page index and notifies any associated `QuickGrid` components to fetch and render updated data.
+
+In the following example, the `Details` component receives the page index from the query string in the `Page` property and uses it to form a link back to the `QuickGrid` component's page at `/characters`.
+
+`Details.razor`:
+
+```razor
+@page "/details"
+
+<ul>
+    <li>Character Id for this detail record: @Id</li>
+    <li>QuickGrid page index: @Page</li>
+</ul>
+<div>
+    <a href="@($"/characters?page={Page}")">Back to List</a>
+</div>
+
+@code {
+    [SupplyParameterFromQuery]
+    private int Id { get; set; }
+
+    [SupplyParameterFromQuery]
+    private int Page { get; set; }
+}
+```
+
+The `Characters` component:
+
+* Pages the `QuickGrid` component by calling <xref:Microsoft.AspNetCore.Components.QuickGrid.PaginationState.SetCurrentPageIndexAsync%2A?displayProperty=nameWithType> on component initialization when `Page` has a non-zero value.
+* Opens the preceding `Details` component with the current page index (<xref:Microsoft.AspNetCore.Components.QuickGrid.PaginationState.CurrentPageIndex%2A>) in the query string.
+
+`Characters.razor`:
+
+```razor
+@page "/characters"
+@rendermode InteractiveServer
+@using Microsoft.AspNetCore.Components.QuickGrid
+
+<QuickGrid Items="character" Pagination="pagination">
+    <PropertyColumn Property="@(c => c.Id)" />
+    <PropertyColumn Property="@(c => c.Name)" />
+    <TemplateColumn Context="c">
+        <a href="@($"details?id={c.Id}&page={pagination.CurrentPageIndex}")">
+            Details
+        </a>
+    </TemplateColumn>
+</QuickGrid>
+
+<Paginator State="pagination" />
+
+@code {
+    PaginationState pagination = new PaginationState { ItemsPerPage = 3 };
+
+    private record Character(int Id, string Name);
+
+    private IQueryable<Character> character = new[]
+    {
+        new Character(0, "Ellen Ripley"),
+        new Character(1, "Darth Vader"),
+        new Character(2, "Rick Deckard"),
+        new Character(3, "Sarah Connor"),
+        new Character(4, "Malcolm Reynolds"),
+        new Character(5, "Kara Thrace"),
+        new Character(6, "James Kirk"),
+        new Character(7, "Flash Gordon"),
+        new Character(8, "Max Rockatansky"),
+        new Character(9, "Katniss Everdeen"),
+        new Character(10, "Ellie Sattler"),
+        new Character(11, "Leela")
+    }.AsQueryable();
+
+    [SupplyParameterFromQuery]
+    private int Page { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await pagination.SetCurrentPageIndexAsync(Page);
+    }
+}
+```
+
 ## Apply row styles
 
 Apply styles to rows using [CSS isolation](xref:blazor/components/css-isolation), which can include styling empty rows for `QuickGrid` components that [page data with a `Paginator` component](#page-items-with-a-paginator-component).

--- a/aspnetcore/blazor/components/quickgrid.md
+++ b/aspnetcore/blazor/components/quickgrid.md
@@ -153,7 +153,7 @@ In the following example, the `Details` component receives the page index from t
 @page "/details"
 
 <ul>
-    <li>Character Id for this detail record: @Id</li>
+    <li>Character ID for this detail record: @Id</li>
     <li>QuickGrid page index: @Page</li>
 </ul>
 <div>
@@ -171,7 +171,7 @@ In the following example, the `Details` component receives the page index from t
 
 The `Characters` component:
 
-* Pages the `QuickGrid` component by calling <xref:Microsoft.AspNetCore.Components.QuickGrid.PaginationState.SetCurrentPageIndexAsync%2A?displayProperty=nameWithType> on component initialization when `Page` has a non-zero value.
+* Pages the `QuickGrid` component by calling <xref:Microsoft.AspNetCore.Components.QuickGrid.PaginationState.SetCurrentPageIndexAsync%2A?displayProperty=nameWithType> on component initialization, setting the page index with the value of `Page`.
 * Opens the preceding `Details` component with the current page index (<xref:Microsoft.AspNetCore.Components.QuickGrid.PaginationState.CurrentPageIndex%2A>) in the query string.
 
 `Characters.razor`:
@@ -185,7 +185,7 @@ The `Characters` component:
     <PropertyColumn Property="@(c => c.Id)" />
     <PropertyColumn Property="@(c => c.Name)" />
     <TemplateColumn Context="c">
-        <a href="@($"details?id={c.Id}&page={pagination.CurrentPageIndex}")">
+        <a href="@($"/details?id={c.Id}&page={pagination.CurrentPageIndex}")">
             Details
         </a>
     </TemplateColumn>


### PR DESCRIPTION
Fixes #37019 

Ilona ... A few years ago, a dev asked how to make the manually-built grid of an old Blazor Server EF Core sample return the user to the grid at the ***scroll position***&dagger; where they left. [IIRC, QuickGrid had just come out at the time. The sample that we were discussing didn't use it. We don't even have that sample anymore.]

What I'd like to do in this area is cover ***page index*** management for QuickGrid. At the time, I was too busy to flesh out a page index example, but I reached it for work today. As usual, I want to provide a fully working, cut-'n-paste example. How does this look to you?

&dagger;BTW ... AFAIK, scroll position isn't something that can be tracked/set with a QuickGrid. I know that such a grid can be built that would do something like that, but I don't think that the built-in QuickGrid component has such a feature baked into it. If I'm wrong about that ... if there would be some way to preserve scroll position for coming back from a details page, please let me know. 👂 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/quickgrid.md](https://github.com/dotnet/AspNetCore.Docs/blob/cd737d992c8e3e87e1fffc79762aa0d1422ddc54/aspnetcore/blazor/components/quickgrid.md) | [aspnetcore/blazor/components/quickgrid](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/quickgrid?branch=pr-en-us-37020) |


<!-- PREVIEW-TABLE-END -->