### PR TITLE
Validation article updates

### DIFF
--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -5,7 +5,7 @@ description: Learn about model validation in ASP.NET Core MVC and Razor Pages.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 04/17/2026
+ms.date: 04/28/2026
 uid: mvc/models/validation
 ---
 # Model validation in ASP.NET Core MVC and Razor Pages

--- a/aspnetcore/mvc/models/validation.md
+++ b/aspnetcore/mvc/models/validation.md
@@ -5,7 +5,7 @@ description: Learn about model validation in ASP.NET Core MVC and Razor Pages.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 08/28/2025
+ms.date: 04/17/2026
 uid: mvc/models/validation
 ---
 # Model validation in ASP.NET Core MVC and Razor Pages
@@ -153,7 +153,10 @@ To implement remote validation:
 
    :::code language="csharp" source="~/mvc/models/validation/samples/6.x/ValidationSample/Models/User.cs" id="snippet_Email":::
 
-[Server side validation](#custom-validation) also needs to be implemented for clients that have disabled JavaScript.
+Remote validation:
+
+* Doesn't perform server-side validation after the form is submitted.
+* Doesn't perform client-side checks if the client has disabled JavaScript. If the client-side validation check is required for form processing on the server, always implement separate server-side validation.
 
 ### Additional fields
 
@@ -429,6 +432,7 @@ The preceding approach won't prevent client-side validation of ASP.NET Core Iden
 
 * <xref:System.ComponentModel.DataAnnotations?displayProperty=fullName>
 * [Model Binding](xref:mvc/models/model-binding)
+* <xref:blazor/forms/index>
 
 :::moniker-end
 


### PR DESCRIPTION
Fixes #33239

Tom ... Looking at the items on [the issue](https://github.com/dotnet/AspNetCore.Docs/issues/33239) ...

1. Not a problem any longer. The article section was updated at some point and no longer makes it seem like jQuery is required for [CreditCardAttribute](https://github.com/microsoft/referencesource/blob/main/System.ComponentModel.DataAnnotations/DataAnnotations/CreditCardAttribute.cs), which does its own calcs for the Luhn algorithm.

2. I think we can just cross-link the Blazor *Forms* node landing page. It's something that I hope a dev working with Blazor will find when they're looking at the Blazor node.

3. I still think that passage can be improved. I make a suggestion on this PR for how that text might compose.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/mvc/models/validation.md](https://github.com/dotnet/AspNetCore.Docs/blob/3579e72163b588cd37d172040588a09b4b7e8274/aspnetcore/mvc/models/validation.md) | [aspnetcore/mvc/models/validation](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/models/validation?branch=pr-en-us-37023) |


<!-- PREVIEW-TABLE-END -->