### PR TITLE
Clarify Blazor WASM environment config for >=10.0

### DIFF
--- a/aspnetcore/migration/90-to-100.md
+++ b/aspnetcore/migration/90-to-100.md
@@ -3,7 +3,7 @@ title: Migrate from ASP.NET Core in .NET 9 to ASP.NET Core in .NET 10
 author: wadepickett
 description: Learn how to migrate an ASP.NET Core in .NET 9 to ASP.NET Core in .NET 10.
 ms.author: wpickett
-ms.date: 11/10/2025
+ms.date: 04/22/2026
 uid: migration/90-to-100
 ---
 # Migrate from ASP.NET Core in .NET 9 to ASP.NET Core in .NET 10

--- a/aspnetcore/migration/90-to-100/includes/blazor.md
+++ b/aspnetcore/migration/90-to-100/includes/blazor.md
@@ -6,7 +6,7 @@ For new feature coverage, see <xref:aspnetcore-10>.
 
 *This section only applies to standalone Blazor WebAssembly apps.*
 
-The `Properties/launchSettings.json` file is no longer used to control the environment in standalone Blazor WebAssembly apps.
+The `Blazor-Environment` header and `Properties/launchSettings.json` file (`ASPNETCORE_ENVIRONMENT` environment variable) are no longer used to control the environment in standalone Blazor WebAssembly apps.
 
 Set the environment with the `<WasmApplicationEnvironmentName>` property in the app's project file (`.csproj`).
 

--- a/aspnetcore/release-notes/aspnetcore-10.0.md
+++ b/aspnetcore/release-notes/aspnetcore-10.0.md
@@ -5,7 +5,7 @@ author: wadepickett
 description: Learn about the new features in ASP.NET Core in .NET 10.
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 04/15/2026
+ms.date: 04/22/2026
 uid: aspnetcore-10
 ---
 # What's new in ASP.NET Core in .NET 10

--- a/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-10/includes/blazor.md
@@ -233,7 +233,7 @@ For more information, see <xref:blazor/fundamentals/static-files?view=aspnetcore
 
 ### Set the environment in standalone Blazor WebAssembly apps
 
-The `Properties/launchSettings.json` file is no longer used to control the environment in standalone Blazor WebAssembly apps.
+The `Blazor-Environment` header and `Properties/launchSettings.json` file (`ASPNETCORE_ENVIRONMENT` environment variable) are no longer used to control the environment in standalone Blazor WebAssembly apps.
 
 Starting in .NET 10, set the environment with the `<WasmApplicationEnvironmentName>` property in the app's project file (`.csproj`).
 


### PR DESCRIPTION
Fixes #37042

Thanks for the report, @next-phil! 🚀 ... We'll get this merged and live within a few hours.

Wade, Tom ... Just need one review on this one. In addition to calling out that the `ASPNETCORE_ENVIRONMENT` environment variable via launch settings isn't used any longer as of >=10.0, we'll state that the `Blazor-Environment` header isn't used any longer. The reference coverage in the Blazor node's *Environment* article is good, so we just need to add this for the 10.0 release notes and migration content.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/migration/90-to-100.md](https://github.com/dotnet/AspNetCore.Docs/blob/0e8d54d7f8e4844746acbc51b73ab00b8388b1f1/aspnetcore/migration/90-to-100.md) | [aspnetcore/migration/90-to-100](https://review.learn.microsoft.com/en-us/aspnet/core/migration/90-to-100?branch=pr-en-us-37043) |
| [aspnetcore/release-notes/aspnetcore-10.0.md](https://github.com/dotnet/AspNetCore.Docs/blob/0e8d54d7f8e4844746acbc51b73ab00b8388b1f1/aspnetcore/release-notes/aspnetcore-10.0.md) | [aspnetcore/release-notes/aspnetcore-10.0](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-10.0?branch=pr-en-us-37043) |

<!-- PREVIEW-TABLE-END -->