### PR TITLE
Add link to inspect WebView on Mac Catalyst

### DIFF
--- a/aspnetcore/blazor/hybrid/developer-tools.md
+++ b/aspnetcore/blazor/hybrid/developer-tools.md
@@ -137,4 +137,4 @@ To use Safari developer tools with a macOS app:
 * [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 * [Microsoft Edge Developer Tools overview](/microsoft-edge/devtools-guide-chromium/)
 * [Safari Developer Help](https://support.apple.com/guide/safari-developer/welcome/mac)
-* [Inspect a WebView on Mac Catalyst (Mac Catalyst prior to 13.1 and iOS prior to 16.4)](/dotnet/maui/user-interface/controls/webview?pivots=devices-maccatalyst#inspect-a-webview-on-mac-catalyst)
+* [Inspect a `BlazorWebView` on Mac Catalyst (Mac Catalyst prior to 13.1 and iOS prior to 16.4)](/dotnet/maui/user-interface/controls/webview?pivots=devices-maccatalyst#inspect-a-webview-on-mac-catalyst)

--- a/aspnetcore/blazor/hybrid/developer-tools.md
+++ b/aspnetcore/blazor/hybrid/developer-tools.md
@@ -137,3 +137,4 @@ To use Safari developer tools with a macOS app:
 * [Chrome DevTools](https://developer.chrome.com/docs/devtools/)
 * [Microsoft Edge Developer Tools overview](/microsoft-edge/devtools-guide-chromium/)
 * [Safari Developer Help](https://support.apple.com/guide/safari-developer/welcome/mac)
+* [Inspect a WebView on Mac Catalyst (Mac Catalyst prior to 13.1 and iOS prior to 16.4)](/dotnet/maui/user-interface/controls/webview?pivots=devices-maccatalyst#inspect-a-webview-on-mac-catalyst)


### PR DESCRIPTION
Fixes #31874

This will add a cross-link to the MAUI docs section and briefly remark on the relevant versions. If the dev knows that their versions are beyond those indicated, they shouldn't sweat it.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/hybrid/developer-tools.md](https://github.com/dotnet/AspNetCore.Docs/blob/693ba65c30ea37b4ebb2d1434f7b31277b8fdfc2/aspnetcore/blazor/hybrid/developer-tools.md) | [aspnetcore/blazor/hybrid/developer-tools](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/hybrid/developer-tools?branch=pr-en-us-37055) |


<!-- PREVIEW-TABLE-END -->