### PR TITLE
Remove JsonPatch support mention from APIs doc

### DIFF
--- a/aspnetcore/fundamentals/apis.md
+++ b/aspnetcore/fundamentals/apis.md
@@ -88,7 +88,6 @@ Both API projects refer to the following class:
 * Model binding extensibility (<xref:Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinderProvider>, <xref:Microsoft.AspNetCore.Mvc.ModelBinding.IModelBinder>)
 * Advanced validation features (<xref:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IModelValidator>)
 * [Application parts](xref:mvc/extensibility/app-parts) or the [application model](xref:mvc/controllers/application-model)
-* [JsonPatch](https://www.nuget.org/packages/Microsoft.AspNetCore.JsonPatch/) support
 * [OData](https://www.nuget.org/packages/Microsoft.AspNetCore.OData/) support
 
 Most of these features can be implemented in Minimal APIs with custom solutions, but controllers provide them out of the box.
@@ -151,7 +150,6 @@ Both API projects refer to the following class:
 * Form binding support, including <xref:Microsoft.AspNetCore.Http.IFormFile>
 * Advanced validation features (<xref:Microsoft.AspNetCore.Mvc.ModelBinding.Validation.IModelValidator>)
 * [Application parts](xref:mvc/extensibility/app-parts) or the [application model](xref:mvc/controllers/application-model)
-* [JsonPatch](https://www.nuget.org/packages/Microsoft.AspNetCore.JsonPatch/) support
 * [OData](https://www.nuget.org/packages/Microsoft.AspNetCore.OData/) support
 
 ## See also

--- a/aspnetcore/fundamentals/apis.md
+++ b/aspnetcore/fundamentals/apis.md
@@ -4,7 +4,7 @@ author: JeremyLikness
 description: Learn how to build fast HTTP APIs with ASP.NET Core using Minimal APIs, the recommended approach for new projects.
 ai-usage: ai-assisted
 ms.author: jeliknes
-ms.date: 08/15/2025
+ms.date: 04/30/2026
 monikerRange: '>= aspnetcore-6.0'
 uid: fundamentals/apis
 ---


### PR DESCRIPTION
Contributes to #36419

Removes all version occurances of JsonPatch from "Consider controller-based APIs if you need" list



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/apis.md](https://github.com/dotnet/AspNetCore.Docs/blob/405a273f44d8ad0d7e636ac18618b2500241978c/aspnetcore/fundamentals/apis.md) | [APIs overview](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/apis?branch=pr-en-us-37083) |


<!-- PREVIEW-TABLE-END -->