### PR TITLE
Correct nested Map middleware example

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -228,13 +228,13 @@ var app = builder.Build();
 
 app.Map("/level1", level1App => {
     level1App.Map("/level2a", level2AApp => {
-        app.Run(async context =>
+        level2AApp.Run(async context =>
         {
             await context.Response.WriteAsync("Processing '/level1/level2a'");
         });
     });
     level1App.Map("/level2b", level2BApp => {
-        app.Run(async context =>
+        level2BApp.Run(async context =>
         {
             await context.Response.WriteAsync("Processing '/level1/level2b'");
         });


### PR DESCRIPTION
## Summary

This PR corrects the nested `Map` middleware example.

The example currently calls `app.Run(...)` inside the nested branches. Since `app` is the root application builder, the terminal middleware is registered on the root pipeline instead of the nested branch.

The updated code uses `level2AApp.Run(...)` and `level2BApp.Run(...)`, which matches the intended nested `Map` behavior.

## Validation

Documentation-only change.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/middleware/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/eeaf722b3bbbd4e89a91d8def4608de07ef919ce/aspnetcore/fundamentals/middleware/index.md) | [ASP.NET Core Middleware](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/index?branch=pr-en-us-37120) |

<!-- PREVIEW-TABLE-END -->