### PR TITLE
Improve 'GetUriWithQueryParameter' examples

### DIFF
--- a/aspnetcore/blazor/fundamentals/navigation.md
+++ b/aspnetcore/blazor/fundamentals/navigation.md
@@ -972,14 +972,17 @@ In the following example with a URL of `/search?filter=scifi%20stars&page=3&star
 
 :::moniker range=">= aspnetcore-6.0"
 
-Use <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameter%2A> to add, change, or remove one or more query parameters on the current URL:
+Use <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameter%2A> to add, change, or remove one or more query parameters on the current URL.
 
-```razor
-@inject NavigationManager Navigation
+> [!NOTE]
+> For the following examples throughout this section that call <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameter%2A>, `Navigation` is an injected <xref:Microsoft.AspNetCore.Components.NavigationManager>:
+>
+> ```razor
+> @inject NavigationManager Navigation
+> ```
 
-...
-
-Navigation.GetUriWithQueryParameter("{NAME}", {VALUE})
+```csharp
+Navigation.NavigateTo(Navigation.GetUriWithQueryParameter("{NAME}", {VALUE}));
 ```
 
 For the preceding example:
@@ -995,24 +998,16 @@ For the preceding example:
 
 Call <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameters%2A> to create a URI constructed from <xref:Microsoft.AspNetCore.Components.NavigationManager.Uri> with multiple parameters added, updated, or removed. For each value, the framework uses `value?.GetType()` to determine the runtime type for each query parameter and selects the correct culture-invariant formatting. The framework throws an error for unsupported types.
 
-```razor
-@inject NavigationManager Navigation
-
-...
-
-Navigation.GetUriWithQueryParameters({PARAMETERS})
+```csharp
+Navigation.NavigateTo(Navigation.GetUriWithQueryParameters({PARAMETERS}));
 ```
 
 The `{PARAMETERS}` placeholder is an `IReadOnlyDictionary<string, object>`.
 
 Pass a URI string to <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameters%2A> to generate a new URI from a provided URI with multiple parameters added, updated, or removed. For each value, the framework uses `value?.GetType()` to determine the runtime type for each query parameter and selects the correct culture-invariant formatting. The framework throws an error for unsupported types. Supported types are listed later in this section.
 
-```razor
-@inject NavigationManager Navigation
-
-...
-
-Navigation.GetUriWithQueryParameters("{URI}", {PARAMETERS})
+```csharp
+Navigation.NavigateTo(Navigation.GetUriWithQueryParameters("{URI}", {PARAMETERS}));
 ```
 
 * The `{URI}` placeholder is the URI with or without a query string.
@@ -1042,7 +1037,8 @@ Supported types include:
 ### Replace a query parameter value when the parameter exists
 
 ```csharp
-Navigation.GetUriWithQueryParameter("full name", "Morena Baccarin")
+Navigation.NavigateTo(
+    Navigation.GetUriWithQueryParameter("full name", "Morena Baccarin"));
 ```
 
 Current URL | Generated URL
@@ -1056,7 +1052,8 @@ Current URL | Generated URL
 ### Append a query parameter and value when the parameter doesn't exist
 
 ```csharp
-Navigation.GetUriWithQueryParameter("name", "Morena Baccarin")
+Navigation.NavigateTo(
+    Navigation.GetUriWithQueryParameter("name", "Morena Baccarin"));
 ```
 
 Current URL | Generated URL 
@@ -1068,7 +1065,8 @@ Current URL | Generated URL
 ### Remove a query parameter when the parameter value is `null`
 
 ```csharp
-Navigation.GetUriWithQueryParameter("full name", (string)null)
+Navigation.NavigateTo(
+    Navigation.GetUriWithQueryParameter("full name", (string)null));
 ```
 
 Current URL | Generated URL
@@ -1088,13 +1086,13 @@ In the following example:
 * `eye color` is added or updated to a value of `green`.
 
 ```csharp
-Navigation.GetUriWithQueryParameters(
+Navigation.NavigateTo(Navigation.GetUriWithQueryParameters(
     new Dictionary<string, object?>
     {
         ["name"] = null,
         ["age"] = (int?)25,
         ["eye color"] = "green"
-    })
+    }));
 ```
 
 Current URL | Generated URL
@@ -1114,12 +1112,12 @@ In the following example:
 * `ping` parameters are added or replaced with `35`, `16`, `87` and `240`.
 
 ```csharp
-Navigation.GetUriWithQueryParameters(
+Navigation.NavigateTo(Navigation.GetUriWithQueryParameters(
     new Dictionary<string, object?>
     {
         ["full name"] = "Morena Baccarin",
         ["ping"] = new int?[] { 35, 16, null, 87, 240 }
-    })
+    }));
 ```
 
 Current URL | Generated URL

--- a/aspnetcore/blazor/fundamentals/navigation.md
+++ b/aspnetcore/blazor/fundamentals/navigation.md
@@ -1003,7 +1003,7 @@ Call <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWit
 Navigation.NavigateTo(Navigation.GetUriWithQueryParameters({PARAMETERS}));
 ```
 
-The `{PARAMETERS}` placeholder is an `Dictionary<string, object?>`.
+The `{PARAMETERS}` placeholder is a `Dictionary<string, object?>`.
 
 Pass a URI string to <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameters%2A> to generate a new URI from a provided URI with multiple parameters added, updated, or removed. For each value, the framework uses `value?.GetType()` to determine the runtime type for each query parameter and selects the correct culture-invariant formatting. The framework throws an error for unsupported types. Supported types are listed later in this section.
 
@@ -1012,7 +1012,7 @@ Navigation.NavigateTo(Navigation.GetUriWithQueryParameters("{URI}", {PARAMETERS}
 ```
 
 * The `{URI}` placeholder is the URI with or without a query string.
-* The `{PARAMETERS}` placeholder is an `Dictionary<string, object?>`.
+* The `{PARAMETERS}` placeholder is a `Dictionary<string, object?>`.
 
 Supported types are identical to supported types for route constraints:
 

--- a/aspnetcore/blazor/fundamentals/navigation.md
+++ b/aspnetcore/blazor/fundamentals/navigation.md
@@ -1,5 +1,6 @@
 ---
 title: ASP.NET Core Blazor navigation
+ai-usage: ai-assisted
 author: guardrex
 description: Learn about navigation in Blazor, including how to use the Navigation Manager and NavLink component for navigation.
 monikerRange: '>= aspnetcore-3.1'
@@ -975,7 +976,7 @@ In the following example with a URL of `/search?filter=scifi%20stars&page=3&star
 Use <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameter%2A> to add, change, or remove one or more query parameters on the current URL.
 
 > [!NOTE]
-> For the following examples throughout this section that call <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameter%2A>, `Navigation` is an injected <xref:Microsoft.AspNetCore.Components.NavigationManager>:
+> For the following examples throughout this section that call <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameter%2A> or <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameters%2A>, `Navigation` is an injected <xref:Microsoft.AspNetCore.Components.NavigationManager>:
 >
 > ```razor
 > @inject NavigationManager Navigation
@@ -1002,7 +1003,7 @@ Call <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWit
 Navigation.NavigateTo(Navigation.GetUriWithQueryParameters({PARAMETERS}));
 ```
 
-The `{PARAMETERS}` placeholder is an `IReadOnlyDictionary<string, object>`.
+The `{PARAMETERS}` placeholder is an `Dictionary<string, object?>`.
 
 Pass a URI string to <xref:Microsoft.AspNetCore.Components.NavigationManagerExtensions.GetUriWithQueryParameters%2A> to generate a new URI from a provided URI with multiple parameters added, updated, or removed. For each value, the framework uses `value?.GetType()` to determine the runtime type for each query parameter and selects the correct culture-invariant formatting. The framework throws an error for unsupported types. Supported types are listed later in this section.
 
@@ -1011,7 +1012,7 @@ Navigation.NavigateTo(Navigation.GetUriWithQueryParameters("{URI}", {PARAMETERS}
 ```
 
 * The `{URI}` placeholder is the URI with or without a query string.
-* The `{PARAMETERS}` placeholder is an `IReadOnlyDictionary<string, object>`.
+* The `{PARAMETERS}` placeholder is an `Dictionary<string, object?>`.
 
 Supported types are identical to supported types for route constraints:
 


### PR DESCRIPTION
Fixes #37157

Wade, Tom ... Just need one review to get this in.

Noticed this while working with Daria on the QuickGrid PR, where we needed to use `GetUriWithQueryParameter` in a QuickGrid example.

I'd like to do two things here to improve this batch of examples in the *Navigation* article ...

* Add a NOTE at the top of the `GetUriWithQueryParameter` examples that `Navigation` in the examples is an injected `NavigationManager`. After that NOTE, all of the examples can just be C# calls with a shorter code display.
* Add the `NavigateTo` calls to the `GetUriWithQueryParameter` examples to make them fully functional calls. `GetUriWithQueryParameter` by itself just gets a URI.

WRT Copilot's recommendation to state `Dictionary<string, object?>` for the remark about `GetUriWithQueryParameters` calls, that's true. `IReadOnlyDictionary` isn't the best API to specify because (IIRC) the ***method signature*** is for `IReadOnlyDictionary` ... that's why it was there. If I had focused the sentences on something about the method signature, that probably would've been fine. However, Copilot is correct ... it should indicate what the developer is passing.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/navigation.md](https://github.com/dotnet/AspNetCore.Docs/blob/2073de0027f5ee4beb56cac38f20293fed4f3571/aspnetcore/blazor/fundamentals/navigation.md) | [aspnetcore/blazor/fundamentals/navigation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/navigation?branch=pr-en-us-37158) |


<!-- PREVIEW-TABLE-END -->