### PR TITLE
[Blazor] .NET 11 - xref IOutputCachePolicyProvider

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-11/includes/output-cache-policy-provider.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/output-cache-policy-provider.md
@@ -1,6 +1,6 @@
 ### `IOutputCachePolicyProvider` interface
 
-ASP.NET Core in .NET 11 provides the [IOutputCachePolicyProvider](https://source.dot.net/#Microsoft.AspNetCore.OutputCaching/[IOutputCachePolicyProvider.cs](https://source.dot.net/#Microsoft.AspNetCore.OutputCaching/IOutputCachePolicyProvider.cs)` interface for implementing custom output caching policy selection logic. By using this interface, apps can determine the default base caching policy, check for the existence of named policies, and support advanced scenarios where policies must be resolved dynamically. Examples include loading policies from external configuration sources, databases, or applying tenant-specific caching rules.
+ASP.NET Core in .NET 11 provides the [`IOutputCachePolicyProvider`](xref:Microsoft.AspNetCore.OutputCaching.IOutputCachePolicyProvider) interface for implementing custom output caching policy selection logic. By using this interface, apps can determine the default base caching policy, check for the existence of named policies, and support advanced scenarios where policies must be resolved dynamically. Examples include loading policies from external configuration sources, databases, or applying tenant-specific caching rules.
 
 The following code shows the `IOutputCachePolicyProvider` interface:
 
@@ -11,10 +11,5 @@ public interface IOutputCachePolicyProvider
     ValueTask<IOutputCachePolicy?> GetPolicyAsync(string policyName);
 }
 ```
-
-<!-- 
-UPDATE 11.0 - Add API cross-reference link when available:
-<xref:Microsoft.AspNetCore.OutputCaching.IOutputCachePolicyProvider>
--->
 
 Thank you [@lqlive](https://github.com/lqlive) for this contribution!

--- a/aspnetcore/release-notes/aspnetcore-11/includes/output-cache-policy-provider.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/output-cache-policy-provider.md
@@ -1,6 +1,6 @@
 ### `IOutputCachePolicyProvider` interface
 
-ASP.NET Core in .NET 11 provides the [`IOutputCachePolicyProvider`](xref:Microsoft.AspNetCore.OutputCaching.IOutputCachePolicyProvider) interface for implementing custom output caching policy selection logic. By using this interface, apps can determine the default base caching policy, check for the existence of named policies, and support advanced scenarios where policies must be resolved dynamically. Examples include loading policies from external configuration sources, databases, or applying tenant-specific caching rules.
+ASP.NET Core in .NET 11 provides the <xref:Microsoft.AspNetCore.OutputCaching.IOutputCachePolicyProvider> interface for implementing custom output caching policy selection logic. By using this interface, apps can determine the default base caching policy, check for the existence of named policies, and support advanced scenarios where policies must be resolved dynamically. Examples include loading policies from external configuration sources, databases, or applying tenant-specific caching rules.
 
 The following code shows the `IOutputCachePolicyProvider` interface:
 


### PR DESCRIPTION
Updated the documentation for the IOutputCachePolicyProvider interface to include a cross-reference link.
