### PR TITLE
Improve the PersistentComponentStateSerializer example

### DIFF
--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -372,7 +372,7 @@ public class CustomIntSerializer(ILogger<CustomIntSerializer> logger)
         {
             var remainingText = text.AsSpan(7);
 
-            if (remainingText != "null")
+            if (!remainingText.SequenceEqual("null"))
             {
                 if (int.TryParse(remainingText, out int value))
                 {
@@ -386,7 +386,7 @@ public class CustomIntSerializer(ILogger<CustomIntSerializer> logger)
         }
 
         // Fallback to direct parsing if format is unexpected
-        return int.TryParse(text, out int fallbackValue) ? fallbackValue : 0;
+        return int.TryParse(text, out int? fallbackValue) ? fallbackValue : null;
     }
 }
 ```
@@ -410,16 +410,14 @@ Using the preceding serializer with the `PrerenderedCounter2` component (`Preren
 > [!NOTE]
 > If the app adopts [interactive routing](xref:blazor/fundamentals/routing#static-versus-interactive-routing) and the page is reached via an internal [enhanced navigation](xref:blazor/fundamentals/navigation#enhanced-navigation-and-form-handling), prerendering doesn't occur. Therefore, you must perform a full page reload for the component to see the following output. For more information, see the [Interactive routing and prerendering](#interactive-routing-and-prerendering) section.
 
-```
-info: BlazorSample.Components.Pages.PrerenderedCounter2[0]
-      CurrentCount set to 49
-info: BlazorSample.CustomIntSerializer[0]
-      Persisting value 49 with custom format: CUSTOM:49
-info: BlazorSample.CustomIntSerializer[0]
-      Restoring value from custom format: CUSTOM:49
-info: BlazorSample.Components.Pages.PrerenderedCounter2[0]
-      CurrentCount restored to 49
-```
+> :::no-loc text="info: BlazorSample.Components.Pages.PrerenderedCounter2[0]":::  
+> :::no-loc text="      CurrentCount set to 49":::  
+> :::no-loc text="info: BlazorSample.CustomIntSerializer[0]":::  
+> :::no-loc text="      Persisting value 49 with custom format: CUSTOM:49":::  
+> :::no-loc text="info: BlazorSample.CustomIntSerializer[0]":::  
+> :::no-loc text="      Restoring value from custom format: CUSTOM:49":::  
+> :::no-loc text="info: BlazorSample.Components.Pages.PrerenderedCounter2[0]":::  
+> :::no-loc text="      CurrentCount restored to 49":::
 
 :::moniker-end
 

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -338,6 +338,7 @@ Logging in the following example is for demonstration purposes and isn't normall
 `CustomIntSerializer.cs`:
 
 ```csharp
+using System;
 using System.Buffers;
 using System.Text;
 using Microsoft.AspNetCore.Components;

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -1,5 +1,6 @@
 ---
 title: ASP.NET Core Blazor prerendered state persistence
+ai-usage: ai-assisted
 author: guardrex
 description: Learn how to persist user data (state) in Blazor apps using Blazor's Persistent Component State service.
 monikerRange: '>= aspnetcore-8.0'
@@ -348,7 +349,8 @@ public class CustomIntSerializer(ILogger<CustomIntSerializer> logger)
 {
     public override void Persist(int? value, IBufferWriter<byte> writer)
     {
-        string customFormat = $"CUSTOM:{value}";
+        string customFormat = 
+            value is not null ? $"CUSTOM:{value}" : $"CUSTOM:null";
 
         logger.LogInformation(
             "Persisting value {Value} with custom format: {CustomFormat}", value, 
@@ -366,10 +368,21 @@ public class CustomIntSerializer(ILogger<CustomIntSerializer> logger)
         logger.LogInformation("Restoring value from custom format: {CustomFormat}", 
             text);
 
-        if (text.StartsWith("CUSTOM:", StringComparison.Ordinal) && 
-            int.TryParse(text.AsSpan(7), out int value))
+        if (text.StartsWith("CUSTOM:", StringComparison.Ordinal))
         {
-            return value;
+            var remainingText = text.AsSpan(7);
+
+            if (remainingText != "null")
+            {
+                if (int.TryParse(remainingText, out int value))
+                {
+                    return value;
+                }
+            }
+            else
+            {
+                return null;
+            }
         }
 
         // Fallback to direct parsing if format is unexpected
@@ -398,13 +411,13 @@ Using the preceding serializer with the `PrerenderedCounter2` component (`Preren
 > If the app adopts [interactive routing](xref:blazor/fundamentals/routing#static-versus-interactive-routing) and the page is reached via an internal [enhanced navigation](xref:blazor/fundamentals/navigation#enhanced-navigation-and-form-handling), prerendering doesn't occur. Therefore, you must perform a full page reload for the component to see the following output. For more information, see the [Interactive routing and prerendering](#interactive-routing-and-prerendering) section.
 
 ```
-info: BlazorSample.Components.Pages.Counter[0]
+info: BlazorSample.Components.Pages.PrerenderedCounter2[0]
       CurrentCount set to 49
 info: BlazorSample.CustomIntSerializer[0]
       Persisting value 49 with custom format: CUSTOM:49
 info: BlazorSample.CustomIntSerializer[0]
       Restoring value from custom format: CUSTOM:49
-info: BlazorSample.Components.Pages.Counter[0]
+info: BlazorSample.Components.Pages.PrerenderedCounter2[0]
       CurrentCount restored to 49
 ```
 

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -341,6 +341,7 @@ Logging in the following example is for demonstration purposes and isn't normall
 using System.Buffers;
 using System.Text;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
 
 namespace BlazorSample;
 
@@ -386,7 +387,7 @@ public class CustomIntSerializer(ILogger<CustomIntSerializer> logger)
         }
 
         // Fallback to direct parsing if format is unexpected
-        return int.TryParse(text, out int? fallbackValue) ? fallbackValue : null;
+        return int.TryParse(text, out int fallbackValue) ? fallbackValue : null;
     }
 }
 ```

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -11,7 +11,9 @@ uid: blazor/state-management/prerendered-state-persistence
 ---
 # ASP.NET Core Blazor prerendered state persistence
 
-Without persisting component state, state used during prerendering is lost and must be recreated when the app is fully loaded. If any state is created asynchronously, the UI may flicker as the prerendered UI is replaced when the component is rerendered.
+This article explains how to persist component state across prerendering in Blazor apps using the Persistent Component State service. You'll learn how to use the `[PersistentState]` attribute, the `PersistentComponentState` service directly, and how to create custom serializers for persistent state.
+
+Without persisting component state, state used during prerendering is lost and must be recreated when the app is fully loaded. If any state is created asynchronously, the UI may flicker as the prerendered UI is replaced with temporary loading content and then fully rendered again.
 
 Consider the following `PrerenderedCounter1` counter component. The component sets an initial random counter value during prerendering in [`OnInitialized` lifecycle method](xref:blazor/components/lifecycle#component-initialization-oninitializedasync). When the component then renders interactively, the initial count value is replaced when `OnInitialized` executes a second time.
 

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -328,18 +328,84 @@ When the component executes, `currentCount` is only set once during prerendering
 
 Implement a custom serializer with <xref:Microsoft.AspNetCore.Components.PersistentComponentStateSerializer%601>. Without a registered custom serializer, serialization falls back to the existing JSON serialization.
 
-The custom serializer is registered in the app's `Program` file. In the following example, the `CustomUserSerializer` is registered for the `TUser` type:
+The following example creates a custom serializer for `int?` types that uses a custom format to demonstrate serialization extensibility. The serializer prefixes integer values with "`CUSTOM:`" to clearly distinguish them from JSON serialization.
+
+The serializer executes on nullable and non-nullable types *independently*, so the following serializer doesn't execute on `int` types, only nullable integer types (`int?`) are processed.
+
+Logging in the following example is for demonstration purposes and isn't normally implemented in a production app.
+
+`CustomIntSerializer.cs`:
 
 ```csharp
-builder.Services.AddSingleton<PersistentComponentStateSerializer<TUser>, 
-    CustomUserSerializer>();
+using System.Buffers;
+using System.Text;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorSample;
+
+public class CustomIntSerializer(ILogger<CustomIntSerializer> logger) 
+    : PersistentComponentStateSerializer<int?>
+{
+    public override void Persist(int? value, IBufferWriter<byte> writer)
+    {
+        string customFormat = $"CUSTOM:{value}";
+
+        logger.LogInformation(
+            "Persisting value {Value} with custom format: {CustomFormat}", value, 
+            customFormat);
+
+        byte[] bytes = Encoding.UTF8.GetBytes(customFormat);
+        writer.Write(bytes);
+    }
+
+    public override int? Restore(ReadOnlySequence<byte> data)
+    {
+        byte[] bytes = data.ToArray();
+        string text = Encoding.UTF8.GetString(bytes);
+
+        logger.LogInformation("Restoring value from custom format: {CustomFormat}", 
+            text);
+
+        if (text.StartsWith("CUSTOM:", StringComparison.Ordinal) && 
+            int.TryParse(text.AsSpan(7), out int value))
+        {
+            return value;
+        }
+
+        // Fallback to direct parsing if format is unexpected
+        return int.TryParse(text, out int fallbackValue) ? fallbackValue : 0;
+    }
+}
 ```
 
-The type is automatically persisted and restored with the custom serializer:
+The custom serializer is registered in the app's `Program` file:
 
-```razor
-[PersistentState] 
-public User? CurrentUser { get; set; } = new();
+```csharp
+builder.Services.AddSingleton<PersistentComponentStateSerializer<int?>, 
+    CustomIntSerializer>();
+```
+
+The `int?` type is automatically persisted and restored with the custom serializer:
+
+```csharp
+[PersistentState]
+public int? CurrentCount { get; set; }
+```
+
+Using the preceding serializer with the `PrerenderedCounter2` component (`PrerenderedCounter2.razor`) shown in the [introduction](#aspnet-core-blazor-prerendered-state-persistence) of this article, output similar to the following is logged.
+
+> [!NOTE]
+> If the app adopts [interactive routing](xref:blazor/fundamentals/routing#static-versus-interactive-routing) and the page is reached via an internal [enhanced navigation](xref:blazor/fundamentals/navigation#enhanced-navigation-and-form-handling), prerendering doesn't occur. Therefore, you must perform a full page reload for the component to see the following output. For more information, see the [Interactive routing and prerendering](#interactive-routing-and-prerendering) section.
+
+```
+info: BlazorSample.Components.Pages.Counter[0]
+      CurrentCount set to 49
+info: BlazorSample.CustomIntSerializer[0]
+      Persisting value 49 with custom format: CUSTOM:49
+info: BlazorSample.CustomIntSerializer[0]
+      Restoring value from custom format: CUSTOM:49
+info: BlazorSample.Components.Pages.Counter[0]
+      CurrentCount restored to 49
 ```
 
 :::moniker-end


### PR DESCRIPTION
Fixes #37181

Thanks, @htmlsplash! 🚀

This PR improves the `PersistentComponentStateSerializer` example.

Tom, Wade ... Just need one review on this one, and we don't need to bother Javier. It's taken directly from his framework test at ...

https://github.com/dotnet/aspnetcore/blob/main/src/Components/test/testassets/TestContentPackage/CustomIntSerializer.cs

... with updates to make it for nullable integers (`int?`) and works great as a fully working, cut-'n-paste demo! 🎉 

Note that Copilot suggested the addition of ...

```csharp
using System;
using Microsoft.Extensions.Logging;
```

... which I did add. However, those are in the shared framework. In an app, these namespaces aren't required, but let's go ahead ... no harm ... and the dev can knock them out. If you think the section should remark on this, I can add a sentence or two stating that these namespaces are in the shared framework. IMO, it's probably not necessary.




<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/state-management/prerendered-state-persistence.md](https://github.com/dotnet/AspNetCore.Docs/blob/23073f45611f5434e3821e5a92ce77a7bf080f21/aspnetcore/blazor/state-management/prerendered-state-persistence.md) | [aspnetcore/blazor/state-management/prerendered-state-persistence](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/state-management/prerendered-state-persistence?branch=pr-en-us-37184) |


<!-- PREVIEW-TABLE-END -->