### PR TITLE
Revert "docs(blazor): clarify ValidationSummary default CSS class and class-merging behavior"

### DIFF
--- a/aspnetcore/blazor/forms/validation.md
+++ b/aspnetcore/blazor/forms/validation.md
@@ -1042,7 +1042,7 @@ The <xref:Microsoft.AspNetCore.Components.Forms.ValidationMessage%601> component
 <ValidationMessage For="@(() => Model!.MaximumAccommodation)" />
 ```
 
-The <xref:Microsoft.AspNetCore.Components.Forms.ValidationMessage%601> and <xref:Microsoft.AspNetCore.Components.Forms.ValidationSummary> components support arbitrary attributes. Any attribute that doesn't match a component parameter is added to the generated `<div>` or `<ul>` element.
+The <xref:Microsoft.AspNetCore.Components.Forms.ValidationMessage%601> and <xref:Microsoft.AspNetCore.Components.Forms.ValidationSummary> components support arbitrary attributes. Any attribute that doesn't match a component parameter is added to the generated `<div>` or `<ul>` element. If a class attribute is supplied, its value replaces the component's default CSS class.
 
 Control the style of validation messages in the app's stylesheet (`wwwroot/css/app.css` or `wwwroot/css/site.css`). The default `validation-message` class sets the text color of validation messages to red:
 

--- a/aspnetcore/blazor/forms/validation.md
+++ b/aspnetcore/blazor/forms/validation.md
@@ -1042,7 +1042,7 @@ The <xref:Microsoft.AspNetCore.Components.Forms.ValidationMessage%601> component
 <ValidationMessage For="@(() => Model!.MaximumAccommodation)" />
 ```
 
-The <xref:Microsoft.AspNetCore.Components.Forms.ValidationMessage%601> and <xref:Microsoft.AspNetCore.Components.Forms.ValidationSummary> components support arbitrary attributes. Any attribute that doesn't match a component parameter is added to the generated `<div>` or `<ul>` element. `ValidationSummary` applies the `validation-errors` CSS class to the generated `<ul>` element by default. When a `class` attribute is supplied, the provided class value is combined with the default class.
+The <xref:Microsoft.AspNetCore.Components.Forms.ValidationMessage%601> and <xref:Microsoft.AspNetCore.Components.Forms.ValidationSummary> components support arbitrary attributes. Any attribute that doesn't match a component parameter is added to the generated `<div>` or `<ul>` element.
 
 Control the style of validation messages in the app's stylesheet (`wwwroot/css/app.css` or `wwwroot/css/site.css`). The default `validation-message` class sets the text color of validation messages to red:
 


### PR DESCRIPTION
Reverts dotnet/AspNetCore.Docs#37191.

I'm sorry Luke, I didn't have time to read what copilot did here and it's not correct. I will do it manually now.

According to https://github.com/dotnet/aspnetcore/pull/43928#issuecomment-1420501679 the behavior reported in https://github.com/dotnet/aspnetcore/issues/43860 is by design.

Closes https://github.com/dotnet/aspnetcore/issues/43860.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/validation.md](https://github.com/dotnet/AspNetCore.Docs/blob/29de4c9df3dde68d620e87e9b3bf8dcf836f96b4/aspnetcore/blazor/forms/validation.md) | [aspnetcore/blazor/forms/validation](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/validation?branch=pr-en-us-37195) |


<!-- PREVIEW-TABLE-END -->