### PR TITLE
Update ms.product to ms.service in index.yml

### DIFF
--- a/aspnetcore/index.yml
+++ b/aspnetcore/index.yml
@@ -7,7 +7,7 @@ brand: aspnet
 metadata:
   title: ASP.NET documentation
   description: Learn to use ASP.NET Core to create web apps and services that are fast, secure, cross-platform, and cloud-based. Browse tutorials, sample code, fundamentals, API reference and more.
-  ms.product: aspnet
+  ms.service: aspnet-core
   ms.topic: hub-page
   author: wadepickett
   ms.author: wpickett


### PR DESCRIPTION
Fixes #37200

Replaced meta data `ms.product: aspnet` which we no longer use, with `ms.service: aspnet-core`.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/index.yml](https://github.com/dotnet/AspNetCore.Docs/blob/9f404f0939c236e09806fa0618e8c07231286367/aspnetcore/index.yml) | [highlightedContent section (optional)](https://review.learn.microsoft.com/en-us/aspnet/core/index?branch=pr-en-us-37199) |

<!-- PREVIEW-TABLE-END -->