### PR TITLE
[11.0 P5] Document client-side culture handling in Blazor

### DIFF
--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -190,7 +190,7 @@ A data file is included to make timezone information correct. If the app doesn't
 
 ## Client-side prerendering in a Blazor Web App preserves the server's culture
 
-By default, client-side prerendering on the server (`.Client` project in a Blazor Web App) persists the server's <xref:System.Globalization.CultureInfo.CurrentCulture> and <xref:System.Globalization.CultureInfo.CurrentUICulture> into component state and applies them on the client before satellite assemblies load. This ensures that the client renders with the same culture as the server.
+By default, client-side prerendering on the server (`.Client` project in a Blazor Web App) persists the server's <xref:System.Globalization.CultureInfo.CurrentCulture> and <xref:System.Globalization.CultureInfo.CurrentUICulture> into component state and applies them on the client before satellite assemblies load.
 
 Apps that require the client to choose a culture independently of the server can opt out with `WebAssemblyComponentsOptions.UseCultureFromServer` in the Blazor Web App's `Program` file:
 

--- a/aspnetcore/blazor/globalization-localization.md
+++ b/aspnetcore/blazor/globalization-localization.md
@@ -184,6 +184,26 @@ A data file is included to make timezone information correct. If the app doesn't
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-11.0"
+
+<!-- UPDATE 11.0 - API Browser cross-link -->
+
+## Client-side prerendering in a Blazor Web App preserves the server's culture
+
+By default, client-side prerendering on the server (`.Client` project in a Blazor Web App) persists the server's <xref:System.Globalization.CultureInfo.CurrentCulture> and <xref:System.Globalization.CultureInfo.CurrentUICulture> into component state and applies them on the client before satellite assemblies load. This ensures that the client renders with the same culture as the server.
+
+Apps that require the client to choose a culture independently of the server can opt out with `WebAssemblyComponentsOptions.UseCultureFromServer` in the Blazor Web App's `Program` file:
+
+```csharp
+builder.Services.AddRazorComponents()
+    .AddInteractiveWebAssemblyComponents(options =>
+    {
+        options.UseCultureFromServer = false;
+    });
+```
+
+:::moniker-end
+
 ## Demonstration component
 
 The following `CultureExample1` component can be used to demonstrate Blazor globalization and localization concepts covered by this article.


### PR DESCRIPTION
Fixes #37214

Daria ... I'll added the blurb on this to the ASP.NET Core release notes on #37206, which is the PR that focuses on QuickGrid updates.

Note that this content is phrased a bit differently in Blazor docs than how Copilot phrased it in the .NET Core release notes: The Blazor docs typically only use "Blazor WebAssembly" to discuss *standalone* Blazor WebAssembly. When referring to the Blazor WebAssembly rendering of a BWA, the docs usually use language about the CSR of a BWA and mention the `.Client` project. You'll see on the diff how I've normally handled it. I'm 👂 for your feedback on it.

I'm not sure if the section [*Dynamically set the culture in a Blazor Web App by user preference*](https://learn.microsoft.com/aspnet/core/blazor/globalization-localization#dynamically-set-the-culture-in-a-blazor-web-app-by-user-preference) requires changes. That approach is focused on using local storage to save/load the culture, and the cookie is updated on the server after a client-side culture change is made. You should look tho to see if you think any changes are needed. Since it currently uses a controller on the backend, I just opened [Swap a Minimal API for the CultureController (`dotnet/AspNetCore.Docs` #37216)](https://github.com/dotnet/AspNetCore.Docs/issues/37216) to convert that part to a Minimal API. *I'll get on that very soon!* 🏃‍♂️ 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/globalization-localization.md](https://github.com/dotnet/AspNetCore.Docs/blob/6d6f3463a0276e5761d6d4ae4dfe3c8fe1744a30/aspnetcore/blazor/globalization-localization.md) | [aspnetcore/blazor/globalization-localization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/globalization-localization?branch=pr-en-us-37215) |

<!-- PREVIEW-TABLE-END -->