### PR TITLE
Update links to use HTML anchor tags

### DIFF
--- a/aspnetcore/tutorials/getting-started-with-swashbuckle/includes/getting-started-with-swashbuckle8.md
+++ b/aspnetcore/tutorials/getting-started-with-swashbuckle/includes/getting-started-with-swashbuckle8.md
@@ -11,11 +11,11 @@
 
 There are three main components to Swashbuckle:
 
-* [Swashbuckle.AspNetCore.Swagger](https://www.nuget.org/packages/Swashbuckle.AspNetCore.Swagger/): a Swagger object model and middleware to expose `SwaggerDocument` objects as JSON endpoints.
+* <a href="https://www.nuget.org/packages/Swashbuckle.AspNetCore.Swagger/" target="_blank" rel="noopener noreferrer">Swashbuckle.AspNetCore.Swagger</a>: a Swagger object model and middleware to expose `SwaggerDocument` objects as JSON endpoints.
 
-* [Swashbuckle.AspNetCore.SwaggerGen](https://www.nuget.org/packages/Swashbuckle.AspNetCore.SwaggerGen/): a Swagger generator that builds `SwaggerDocument` objects directly from your routes, controllers, and models. It's typically combined with the Swagger endpoint middleware to automatically expose Swagger JSON.
+* <a href="https://www.nuget.org/packages/Swashbuckle.AspNetCore.SwaggerGen/" target="_blank" rel="noopener noreferrer">Swashbuckle.AspNetCore.SwaggerGen</a>: a Swagger generator that builds `SwaggerDocument` objects directly from your routes, controllers, and models. It's typically combined with the Swagger endpoint middleware to automatically expose Swagger JSON.
 
-* [Swashbuckle.AspNetCore.SwaggerUI](https://www.nuget.org/packages/Swashbuckle.AspNetCore.SwaggerUI/): an embedded version of the Swagger UI tool. It interprets Swagger JSON to build a rich, customizable experience for describing the web API functionality. It includes built-in test harnesses for the public methods.
+* <a href="https://www.nuget.org/packages/Swashbuckle.AspNetCore.SwaggerUI/" target="_blank" rel="noopener noreferrer">Swashbuckle.AspNetCore.SwaggerUI</a>: an embedded version of the Swagger UI tool. It interprets Swagger JSON to build a rich, customizable experience for describing the web API functionality. It includes built-in test harnesses for the public methods.
 
 ## Package installation
 


### PR DESCRIPTION
Changed the links to use HTML anchor tags so that they would open in a new tab instead.