### PR TITLE
Document UseOutputCache ordering relative to auth middleware

### DIFF
--- a/aspnetcore/fundamentals/middleware/index.md
+++ b/aspnetcore/fundamentals/middleware/index.md
@@ -6,7 +6,7 @@ description: Learn about ASP.NET Core middleware and the request pipeline.
 monikerRange: '>= aspnetcore-3.0'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 02/04/2026
+ms.date: 06/09/2026
 uid: fundamentals/middleware/index
 ---
 # ASP.NET Core Middleware
@@ -1153,7 +1153,7 @@ All |
 [HTTP Strict Transport Security (HSTS)](xref:security/enforcing-ssl#http-strict-transport-security-protocol-hsts) | Security enhancement middleware that adds a special response header. | All | Before responses are sent and after middleware that modify requests. Examples: Forwarded Headers, URL Rewriting.
 [MVC](xref:mvc/overview) | Processes requests with MVC/Razor Pages. | RP/MVC | Terminal if a request matches a route.
 [OWIN](xref:fundamentals/owin) | Interop with OWIN-based apps, servers, and middleware. | RP/MVC | Terminal if the OWIN Middleware fully processes the request.
-[Output Caching](xref:performance/caching/output) | Provides support for caching responses based on configuration. | RP/MVC | Before middleware that require caching. <xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A> and <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A> must come before <xref:Microsoft.AspNetCore.Builder.OutputCacheApplicationBuilderExtensions.UseOutputCache%2A>.
+[Output Caching](xref:performance/caching/output) | Provides support for caching responses based on configuration. | RP/MVC | Before middleware that require caching. <xref:Microsoft.AspNetCore.Builder.EndpointRoutingApplicationBuilderExtensions.UseRouting%2A>, <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A>, <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthentication%2A>, and <xref:Microsoft.AspNetCore.Builder.AuthorizationAppBuilderExtensions.UseAuthorization%2A> must come before <xref:Microsoft.AspNetCore.Builder.OutputCacheApplicationBuilderExtensions.UseOutputCache%2A>.
 [Response Caching](xref:performance/caching/middleware) | Provides support for caching responses. This requires client participation to work. Use output caching for complete server control. | RP/MVC | Before middleware that require caching. <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A> must come before <xref:Microsoft.AspNetCore.Builder.ResponseCachingExtensions.UseResponseCaching%2A>. Response caching isn't typically beneficial for UI apps, such as Razor Pages, because browsers generally set request headers that prevent caching. [Output caching](xref:performance/caching/output) benefits UI apps.
 [Request Decompression](xref:fundamentals/middleware/request-decompression) | Provides support for decompressing requests. | All | Before middleware that read the request body.
 [Response Compression](xref:performance/response-compression) | Provides support for compressing responses. | All | Before middleware that require compression.

--- a/aspnetcore/performance/caching/output.md
+++ b/aspnetcore/performance/caching/output.md
@@ -5,7 +5,7 @@ description: Learn how to configure and use output caching middleware in ASP.NET
 monikerRange: '>= aspnetcore-7.0'
 ms.author: tdykstra
 ms.custom: mvc
-ms.date: 05/01/2026
+ms.date: 06/09/2026
 uid: performance/caching/output
 
 # customer intent: As an ASP.NET developer, I want to configure output caching middleware in ASP.NET Core, so I can use output caching in my apps.
@@ -32,13 +32,14 @@ Add the output caching middleware to the service collection by calling the <xref
 
 Add the middleware to the request processing pipeline by calling the <xref:Microsoft.AspNetCore.Builder.OutputCacheApplicationBuilderExtensions.UseOutputCache%2A> method. For example:
 
-:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="snippet_use" highlight="5":::
+:::code language="csharp" source="~/performance/caching/output/samples/7.x/Program.cs" id="snippet_use" highlight="6":::
 
 Calling the `AddOutputCache`and `UseOutputCache` methods doesn't start caching behavior, it makes caching available. To make the app cache responses, caching must be configured as described in the following sections.
 
 > [!NOTE]
 > * In apps that use [Cross-Origin Requests (CORS) middleware](xref:security/cors), the `UseOutputCache` method must be called after the <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A> method.
 > * In Razor Pages apps and apps with controllers, the `UseOutputCache` method must be called after the `UseRouting` method.
+> * In apps that use [authentication](xref:security/authentication/index) or [authorization](xref:security/authorization/introduction), the `UseOutputCache` method must be called after the <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthentication%2A> and <xref:Microsoft.AspNetCore.Builder.AuthorizationAppBuilderExtensions.UseAuthorization%2A> methods. Otherwise, the output caching middleware can serve content cached for unauthorized users instead of content for authorized users.
 
 ## Configure one endpoint or page
 

--- a/aspnetcore/performance/caching/output/includes/output7.md
+++ b/aspnetcore/performance/caching/output/includes/output7.md
@@ -13,6 +13,7 @@ Add the middleware to the request processing pipeline by calling <xref:Microsoft
 > [!NOTE]
 > * In apps that use [CORS middleware](xref:security/cors), `UseOutputCache` must be called after <xref:Microsoft.AspNetCore.Builder.CorsMiddlewareExtensions.UseCors%2A>.
 > * In Razor Pages apps and apps with controllers, `UseOutputCache` must be called after `UseRouting`.
+> * In apps that use [authentication](xref:security/authentication/index) or [authorization](xref:security/authorization/introduction), `UseOutputCache` must be called after <xref:Microsoft.AspNetCore.Builder.AuthAppBuilderExtensions.UseAuthentication%2A> and <xref:Microsoft.AspNetCore.Builder.AuthorizationAppBuilderExtensions.UseAuthorization%2A>. Otherwise, the output caching middleware can serve content cached for unauthorized users instead of content for authorized users.
 > * Calling `AddOutputCache`and `UseOutputCache` doesn't start caching behavior, it makes caching available. Caching response data must be configured as shown in the following sections.
 
 ## Configure one endpoint or page

--- a/aspnetcore/performance/caching/output/samples/7.x/Program.cs
+++ b/aspnetcore/performance/caching/output/samples/7.x/Program.cs
@@ -74,8 +74,8 @@ public class Program
 
         // Configure the HTTP request pipeline.
         app.UseHttpsRedirection();
-        app.UseOutputCache();
         app.UseAuthorization();
+        app.UseOutputCache();
         //</snippet_use>
 
 

--- a/aspnetcore/performance/caching/output/samples/9.x/OCControllers/Program.cs
+++ b/aspnetcore/performance/caching/output/samples/9.x/OCControllers/Program.cs
@@ -90,8 +90,8 @@ public class Program
         }
 
         app.UseHttpsRedirection();
-        app.UseOutputCache();
         app.UseAuthorization();
+        app.UseOutputCache();
 
         app.MapControllers();
         


### PR DESCRIPTION
## Description

The output caching middleware docs explain that `UseOutputCache` must come after `UseRouting` and `UseCors`, but say nothing about authentication or authorization. When `UseOutputCache` runs before `UseAuthentication`/`UseAuthorization`, cached responses can be served to users who shouldn't see them.

This PR adds that ordering guidance and fixes the existing code samples, which placed `UseOutputCache()` before `UseAuthorization()`.

## Changes

* `performance/caching/output.md` and the `output7.md` include: added a bullet to the existing NOTE explaining `UseOutputCache` must be called after `UseAuthentication` and `UseAuthorization`, otherwise the middleware can serve content cached for unauthorized users instead of content for authorized users.
* `fundamentals/middleware/index.md`: updated the Output Caching row in the middleware order table to include `UseAuthentication` and `UseAuthorization` in the list of middleware that must come before `UseOutputCache`.
* `output/samples/7.x/Program.cs` and `output/samples/9.x/OCControllers/Program.cs`: swapped the order so `UseAuthorization()` is called before `UseOutputCache()`. Updated the `highlight` line number in `output.md` accordingly.
* Bumped `ms.date` on the two affected articles.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/middleware/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/24736718da35a8878ecd53d8e7bc60de04f8b4cf/aspnetcore/fundamentals/middleware/index.md) | [ASP.NET Core Middleware](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/middleware/index?branch=pr-en-us-37248) |
| [aspnetcore/performance/caching/output.md](https://github.com/dotnet/AspNetCore.Docs/blob/24736718da35a8878ecd53d8e7bc60de04f8b4cf/aspnetcore/performance/caching/output.md) | [Output caching middleware in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/performance/caching/output?branch=pr-en-us-37248) |

<!-- PREVIEW-TABLE-END -->