### PR TITLE
Document C# union types in ASP.NET Core (.NET 11)

### DIFF
--- a/aspnetcore/fundamentals/minimal-apis/unions.md
+++ b/aspnetcore/fundamentals/minimal-apis/unions.md
@@ -118,7 +118,7 @@ public sealed class PetClassifier : JsonTypeClassifierFactory<UnionPet>
 
 ## Minimal APIs
 
-Unions work as request body parameters and as return types in both the runtime path (`RequestDelegateFactory`) and the source-generated path (Request Delegate Generator). Behavior is identical across both.
+Unions work as request body parameters and as return types in both the runtime path (`RequestDelegateFactory`) and the source-generated [Request Delegate Generator (RDG)](xref:fundamentals/aot/rdg). Behavior is identical across both.
 
 ```csharp
 var builder = WebApplication.CreateBuilder(args);
@@ -140,20 +140,18 @@ app.MapGet("/pet", () => new UnionPet(new Cat("Whiskers")));
 app.Run();
 ```
 
-Additional supported scenarios include:
+Unions compose with the usual Minimal API return types. For example, a union can be returned asynchronously, wrapped in a nullable, or handed back through <xref:Microsoft.AspNetCore.Http.TypedResults>:
 
-* `Task<TUnion>` and `ValueTask<TUnion>` return types.
-* A nullable union wrapper (`TUnion?`) and unions that include a nullable case, such as `union UnionNullableIntString(int?, string)`.
-* A union returned through <xref:Microsoft.AspNetCore.Http.TypedResults> or `Results<TResult1, TResult2>` wrappers.
-* A union used as a property of another model (an envelope), and `IAsyncEnumerable<TUnion>` streaming, which serializes the active case per item.
-* A union body inside an `[AsParameters]` container, where the union binds from the body and sibling properties bind from the route or query.
-* `ConfigureHttpJsonOptions` is honored for union serialization and deserialization.
+```csharp
+app.MapGet("/maybe", () => new UnionNullableIntString(null));                  // null
+app.MapGet("/typed", () => TypedResults.Ok(new UnionPet(new Cat("Whiskers"))));
+```
 
-For an unambiguous union, an empty request body and content negotiation behave the same as for any other JSON body parameter: a non-JSON content type returns `415 Unsupported Media Type`.
+A union can also be a property of another model, an item streamed from an `IAsyncEnumerable<T>`, or the body slot of an `[AsParameters]` container. Union serialization also respects options configured through `ConfigureHttpJsonOptions`.
 
-## MVC controllers and Razor Pages
+## MVC controllers
 
-Unions flow through the STJ input and output formatters, so controllers and Razor Pages support them as action parameters and return types, including `Task<TUnion>` and `ValueTask<TUnion>` results:
+Unions flow through the STJ input and output formatters, so controllers support them as action parameters and return types, including `Task<TUnion>` and `ValueTask<TUnion>` results:
 
 ```csharp
 [ApiController]
@@ -209,6 +207,18 @@ Unions are supported only with `JsonHubProtocol`. The MessagePack and Newtonsoft
 The OpenAPI document represents a union as an [`anyOf`](https://spec.openapis.org/oas/latest#composition-and-inheritance-polymorphism) schema, with one entry per case type:
 
 ```json
+"Cat": {
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" }
+  }
+},
+"Dog": {
+  "type": "object",
+  "properties": {
+    "breed": { "type": "string" }
+  }
+},
 "UnionIntString": {
   "anyOf": [
     { "type": "integer", "format": "int32" },
@@ -224,7 +234,7 @@ The OpenAPI document represents a union as an [`anyOf`](https://spec.openapis.or
 }
 ```
 
-Because a union case has no discriminator and is structurally identical to the standalone type, each case schema reuses the standalone component name, such as `Cat` and `Dog`. This differs from polymorphic types, whose derived schemas are lifted to prefixed component names because they carry a `$type` discriminator.
+Because a union case has no discriminator and is structurally identical to the standalone type, each case schema reuses the standalone component name. The `Cat` and `Dog` schemas referenced by `UnionPet` are the same components that a standalone `Cat` or `Dog` endpoint produces. This differs from polymorphic types, whose derived schemas are lifted to prefixed component names because they carry a `$type` discriminator.
 
 An endpoint can also produce multiple response types for the same status code and content type. <xref:Microsoft.AspNetCore.Mvc.ApiExplorer> preserves every declared response type, and the generated document emits an `anyOf` schema when several types share a content type:
 
@@ -247,7 +257,7 @@ Union support requires `System.Text.Json`. Binding sources that *don't* route th
 
 These sources bind a string token to a target type without JSON parsing, so there's no reliable way to choose a union case. Even for STJ, most ambiguous unions require a custom classifier, and a single query value such as `?id=42` provides no way to know whether to bind `int`, `string`, `Guid`, or another case. Because of this ambiguity, unions are intentionally not supported in these binding sources.
 
-Use unions only as JSON request and response bodies. For non-body parameters, use a concrete type or a discriminated representation that the binding source can parse unambiguously.
+Parameter binding for unions from non-body sources is still being explored. If you have a scenario that needs it, the team is gathering feedback on the [union parameter binding issue](https://github.com/dotnet/aspnetcore/issues/66648).
 
 ## Unions compared to polymorphism
 

--- a/aspnetcore/fundamentals/minimal-apis/unions.md
+++ b/aspnetcore/fundamentals/minimal-apis/unions.md
@@ -29,8 +29,8 @@ public union UnionPet(Cat, Dog);
 STJ serializes a union value *transparently*. The union wrapper is unpacked and only the active case is written, using that case's own JSON contract. There's no envelope object, no `$type` field, and no discriminator of any kind:
 
 ```csharp
-JsonSerializer.Serialize<UnionIntString>(new UnionIntString(42));      // 42
-JsonSerializer.Serialize<UnionIntString>(new UnionIntString("hello")); // "hello"
+JsonSerializer.Serialize(new UnionIntString(42));      // 42
+JsonSerializer.Serialize(new UnionIntString("hello")); // "hello"
 ```
 
 This is a deliberate difference from polymorphic serialization with <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute>, which writes a `$type` discriminator. Unions have no natural discriminator, so none is emitted. For more information, see [Unions compared to polymorphism](#unions-compared-to-polymorphism).
@@ -188,8 +188,8 @@ public class ChatHub : Hub
     // Union stream items (server → client).
     public async IAsyncEnumerable<UnionIntString> Stream()
     {
-        yield return new UnionIntString(1);
-        yield return new UnionIntString("two");
+        yield return 1;
+        yield return "two";
     }
 }
 ```

--- a/aspnetcore/fundamentals/minimal-apis/unions.md
+++ b/aspnetcore/fundamentals/minimal-apis/unions.md
@@ -51,7 +51,7 @@ Because there's no discriminator on the wire, STJ recovers the case type from th
 Selection is O(1) and requires no read-ahead. A union whose cases map to distinct token kinds, such as `UnionBoolString(bool, string)`, deserializes without any extra configuration.
 
 > [!IMPORTANT]
-> Minimal APIs and MVC serialize and deserialize HTTP JSON using web defaults (<xref:System.Text.Json.JsonSerializerDefaults>.Web), which enable `JsonNumberHandling.AllowReadingFromString`. This lets a numeric case be read from a JSON `String` token, so the `String` token becomes compatible with *both* numeric cases and `string`. As a result, a union that pairs a numeric case with a `string` case—such as `UnionIntString(int, string)`—is ambiguous on the `String` token for HTTP JSON binding. A `Number` payload binds to the numeric case, but a `String` payload returns `400 Bad Request` unless the union supplies a classifier. This differs from plain `System.Text.Json` and from SignalR's `JsonHubProtocol`, which don't enable `AllowReadingFromString` and deserialize the same union without a classifier.
+> Minimal APIs and MVC serialize and deserialize HTTP JSON using web defaults (<xref:System.Text.Json.JsonSerializerDefaults>.Web), which enable `JsonNumberHandling.AllowReadingFromString`. This lets a numeric case be read from a JSON `String` token, so the `String` token becomes compatible with *both* numeric cases and `string`. As a result, a union that pairs a numeric case with a `string` case—such as `UnionIntString(int, string)`—is ambiguous on the `String` token for HTTP JSON binding. A `Number` payload binds to the numeric case, but a `String` payload returns `400 Bad Request` unless the union supplies a classifier. This differs from plain `System.Text.Json` and from SignalR's `JsonHubProtocol`, which deserialize the same union without a classifier.
 
 ### Ambiguous unions require a classifier
 
@@ -80,7 +80,8 @@ public sealed class PetClassifier : JsonTypeClassifierFactory<UnionPet>
     public override JsonTypeClassifier CreateJsonClassifier(
         JsonTypeClassifierContext context, JsonSerializerOptions options)
     {
-        // The delegate receives a defensive copy of the reader.
+        // The delegate receives a defensive copy of the reader, so advancing it
+        // here doesn't affect the reader used for deserialization.
         return static (ref Utf8JsonReader reader) =>
         {
             if (reader.TokenType is not JsonTokenType.StartObject)
@@ -88,22 +89,19 @@ public sealed class PetClassifier : JsonTypeClassifierFactory<UnionPet>
                 return null;
             }
 
-            var clone = reader;
-            clone.Read();
-            while (clone.TokenType is JsonTokenType.PropertyName)
+            while (reader.Read() && reader.TokenType is JsonTokenType.PropertyName)
             {
-                if (clone.ValueTextEquals("name") || clone.ValueTextEquals("Name"))
+                if (reader.ValueTextEquals("name") || reader.ValueTextEquals("Name"))
                 {
                     return typeof(Cat);
                 }
-                if (clone.ValueTextEquals("breed") || clone.ValueTextEquals("Breed"))
+                if (reader.ValueTextEquals("breed") || reader.ValueTextEquals("Breed"))
                 {
                     return typeof(Dog);
                 }
 
-                clone.Read();
-                clone.Skip();
-                clone.Read();
+                reader.Read(); // Move to the property value.
+                reader.Skip(); // Skip the value.
             }
 
             return null; // No case identified; deserialization fails.
@@ -198,7 +196,7 @@ public class ChatHub : Hub
 
 On the read path, the parameter, return, or stream-item `Type` resolved from the invocation binder drives the union converter, including any `[JsonUnion]` classifier. On the write path, the active case is serialized with no envelope or discriminator.
 
-Unlike HTTP JSON binding, `JsonHubProtocol` doesn't enable `JsonNumberHandling.AllowReadingFromString`, so a union such as `UnionIntString(int, string)` round-trips both the `int` and `string` cases without a classifier. Object-cased unions, such as `UnionPet(Cat, Dog)`, are still ambiguous on read and require a classifier.
+Unlike HTTP JSON binding in Minimal APIs and MVC, `JsonHubProtocol` doesn't treat a JSON `String` token as ambiguous for numeric cases, so a union such as `UnionIntString(int, string)` round-trips both the `int` and `string` cases without a classifier. Object-cased unions, such as `UnionPet(Cat, Dog)`, are still ambiguous on read and require a classifier.
 
 Unions are supported only with `JsonHubProtocol`. The MessagePack and Newtonsoft.Json hub protocols don't support unions, because their underlying serializers have no union support.
 

--- a/aspnetcore/fundamentals/minimal-apis/unions.md
+++ b/aspnetcore/fundamentals/minimal-apis/unions.md
@@ -48,22 +48,26 @@ Because there's no discriminator on the wire, STJ recovers the case type from th
 | `StartArray` | Arrays and collections |
 | `Null` | `null` |
 
-Selection is O(1) and requires no read-ahead. A union such as `UnionIntString(int, string)` works out of the box because `int` is the only case compatible with `Number` and `string` is the only case compatible with `String`.
+Selection is O(1) and requires no read-ahead. A union whose cases map to distinct token kinds, such as `UnionBoolString(bool, string)`, deserializes without any extra configuration.
+
+> [!IMPORTANT]
+> Minimal APIs and MVC serialize and deserialize HTTP JSON using web defaults (<xref:System.Text.Json.JsonSerializerDefaults>.Web), which enable `JsonNumberHandling.AllowReadingFromString`. This lets a numeric case be read from a JSON `String` token, so the `String` token becomes compatible with *both* numeric cases and `string`. As a result, a union that pairs a numeric case with a `string` case—such as `UnionIntString(int, string)`—is ambiguous on the `String` token for HTTP JSON binding. A `Number` payload binds to the numeric case, but a `String` payload returns `400 Bad Request` unless the union supplies a classifier. This differs from plain `System.Text.Json` and from SignalR's `JsonHubProtocol`, which don't enable `AllowReadingFromString` and deserialize the same union without a classifier.
 
 ### Ambiguous unions require a classifier
 
-When two or more cases map to the same token kind, the first-token rule can't pick a case. These unions are *ambiguous*:
+A union is ambiguous when more than one case can match the same JSON payload. Ambiguity arises in two ways:
 
-```csharp
-public union UnionIntShort(int, short);              // both → Number
-public union UnionDateTimeString(DateTime, string);  // both → String
-public union UnionPet(Cat, Dog);                     // both → StartObject (records)
-```
+* **Cases that share a JSON token kind.** The source generator reports these at compile time with diagnostic `SYSLIB1227`:
 
-For ambiguous unions:
+  ```csharp
+  public union UnionIntShort(int, short);              // both → Number
+  public union UnionDateTimeString(DateTime, string);  // both → String
+  public union UnionPet(Cat, Dog);                     // both → StartObject (records)
+  ```
 
-* The source generator emits diagnostic `SYSLIB1227` at compile time.
-* At runtime, deserializing an ambiguous union without a classifier fails. In Minimal APIs and MVC, this surfaces as an HTTP `400 Bad Request`.
+* **A numeric case paired with a `string` case in Minimal APIs or MVC**, such as `UnionIntString(int, string)`. There's no compile-time diagnostic, but a JSON `String` payload is ambiguous at runtime under web defaults, as described in the preceding note.
+
+When deserialization of an ambiguous union fails, Minimal APIs and MVC return `400 Bad Request`.
 
 To resolve the ambiguity, attach a custom `JsonTypeClassifier` with the `[JsonUnion]` attribute. The classifier inspects the JSON and returns the case type to bind. Serialization is unaffected by a classifier, because the active case is always known when writing.
 
@@ -120,10 +124,16 @@ Unions work as request body parameters and as return types in both the runtime p
 var builder = WebApplication.CreateBuilder(args);
 var app = builder.Build();
 
-// Union as a request body.
+// Request body: UnionBoolString is unambiguous (bool vs string),
+// so it binds without a classifier.
+app.MapPost("/flag", (UnionBoolString flag) => flag);
+
+// Request body: UnionPet is object-cased, so it needs the classifier
+// shown earlier to bind from a body.
 app.MapPost("/pet", ([FromBody] UnionPet pet) => TypedResults.Ok(pet));
 
-// Union as a return type — only the active case is serialized.
+// Return types: only the active case is serialized, and no classifier
+// is needed to write.
 app.MapGet("/value", () => new UnionIntString(42));      // 42
 app.MapGet("/pet", () => new UnionPet(new Cat("Whiskers")));
 
@@ -152,7 +162,7 @@ Unions flow through the STJ input and output formatters, so controllers and Razo
 public class PetsController : ControllerBase
 {
     [HttpPost]
-    public UnionPet Echo([FromBody] UnionPet value) => value;
+    public UnionBoolString Echo([FromBody] UnionBoolString value) => value;
 
     [HttpGet("{kind}")]
     public UnionIntString Primitive(string kind) => kind switch
@@ -189,6 +199,8 @@ public class ChatHub : Hub
 ```
 
 On the read path, the parameter, return, or stream-item `Type` resolved from the invocation binder drives the union converter, including any `[JsonUnion]` classifier. On the write path, the active case is serialized with no envelope or discriminator.
+
+Unlike HTTP JSON binding, `JsonHubProtocol` doesn't enable `JsonNumberHandling.AllowReadingFromString`, so a union such as `UnionIntString(int, string)` round-trips both the `int` and `string` cases without a classifier. Object-cased unions, such as `UnionPet(Cat, Dog)`, are still ambiguous on read and require a classifier.
 
 Unions are supported only with `JsonHubProtocol`. The MessagePack and Newtonsoft.Json hub protocols don't support unions, because their underlying serializers have no union support.
 

--- a/aspnetcore/fundamentals/minimal-apis/unions.md
+++ b/aspnetcore/fundamentals/minimal-apis/unions.md
@@ -1,0 +1,256 @@
+---
+title: Use C# union types in ASP.NET Core
+author: DeagleGross
+description: Learn how C# union types are supported as JSON request and response bodies in ASP.NET Core Minimal APIs, MVC, SignalR, and OpenAPI.
+monikerRange: '>= aspnetcore-11.0'
+ms.author: wpickett
+ms.date: 06/17/2026
+uid: fundamentals/minimal-apis/unions
+ai-usage: ai-assisted
+---
+# Use C# union types in ASP.NET Core
+
+C# union types, introduced as a language feature in .NET 11, let a single type represent a value that's exactly one of a fixed set of case types. Unions are a frequently requested feature for modeling APIs that accept or return one of several shapes, such as a success payload or an error payload. This article explains where ASP.NET Core supports unions, how they're serialized, and the cases that require extra configuration.
+
+ASP.NET Core support for unions builds entirely on [`System.Text.Json` (STJ) union support](https://github.com/dotnet/runtime/issues/127299). As a result, unions are supported only where STJ is the serializer: the **JSON request body** (input) and the **JSON response body** (output). Unions aren't supported for non-body binding sources, such as query strings, route values, headers, and form fields. For more information, see [Where unions aren't supported](#where-unions-arent-supported).
+
+For background on the language feature, see the [C# unions proposal](https://github.com/dotnet/csharplang/blob/main/proposals/unions.md).
+
+## How unions are serialized
+
+A union type is declared with the `union` keyword and a list of case types:
+
+```csharp
+public union UnionIntString(int, string);
+
+public record Cat(string Name);
+public record Dog(string Breed);
+public union UnionPet(Cat, Dog);
+```
+
+STJ serializes a union value *transparently*. The union wrapper is unpacked and only the active case is written, using that case's own JSON contract. There's no envelope object, no `$type` field, and no discriminator of any kind:
+
+```csharp
+JsonSerializer.Serialize<UnionIntString>(new UnionIntString(42));      // 42
+JsonSerializer.Serialize<UnionIntString>(new UnionIntString("hello")); // "hello"
+```
+
+This is a deliberate difference from polymorphic serialization with <xref:System.Text.Json.Serialization.JsonPolymorphicAttribute>, which writes a `$type` discriminator. Unions have no natural discriminator, so none is emitted. For more information, see [Unions compared to polymorphism](#unions-compared-to-polymorphism).
+
+### Deserialization uses the first JSON token
+
+Because there's no discriminator on the wire, STJ recovers the case type from the JSON value itself by inspecting the *first token* and selecting the single case whose declared type is compatible with that token kind. The mapping is fixed:
+
+| <xref:System.Text.Json.JsonTokenType> | Compatible case types |
+| --- | --- |
+| `Number` | Numeric primitives, such as `int`, `long`, `double`, and `decimal` |
+| `String` | `string`, `DateTime`, `DateTimeOffset`, `Guid`, `TimeSpan`, `Uri`, `char`, `byte[]`, and enums |
+| `True` / `False` | `bool` |
+| `StartObject` | Objects and dictionaries |
+| `StartArray` | Arrays and collections |
+| `Null` | `null` |
+
+Selection is O(1) and requires no read-ahead. A union such as `UnionIntString(int, string)` works out of the box because `int` is the only case compatible with `Number` and `string` is the only case compatible with `String`.
+
+### Ambiguous unions require a classifier
+
+When two or more cases map to the same token kind, the first-token rule can't pick a case. These unions are *ambiguous*:
+
+```csharp
+public union UnionIntShort(int, short);              // both → Number
+public union UnionDateTimeString(DateTime, string);  // both → String
+public union UnionPet(Cat, Dog);                     // both → StartObject (records)
+```
+
+For ambiguous unions:
+
+* The source generator emits diagnostic `SYSLIB1227` at compile time.
+* At runtime, deserializing an ambiguous union without a classifier fails. In Minimal APIs and MVC, this surfaces as an HTTP `400 Bad Request`.
+
+To resolve the ambiguity, attach a custom `JsonTypeClassifier` with the `[JsonUnion]` attribute. The classifier inspects the JSON and returns the case type to bind. Serialization is unaffected by a classifier, because the active case is always known when writing.
+
+```csharp
+[JsonUnion(TypeClassifier = typeof(PetClassifier))]
+public union UnionPet(Cat, Dog);
+
+public sealed class PetClassifier : JsonTypeClassifierFactory<UnionPet>
+{
+    public override JsonTypeClassifier CreateJsonClassifier(
+        JsonTypeClassifierContext context, JsonSerializerOptions options)
+    {
+        // The delegate receives a defensive copy of the reader.
+        return static (ref Utf8JsonReader reader) =>
+        {
+            if (reader.TokenType is not JsonTokenType.StartObject)
+            {
+                return null;
+            }
+
+            var clone = reader;
+            clone.Read();
+            while (clone.TokenType is JsonTokenType.PropertyName)
+            {
+                if (clone.ValueTextEquals("name") || clone.ValueTextEquals("Name"))
+                {
+                    return typeof(Cat);
+                }
+                if (clone.ValueTextEquals("breed") || clone.ValueTextEquals("Breed"))
+                {
+                    return typeof(Dog);
+                }
+
+                clone.Read();
+                clone.Skip();
+                clone.Read();
+            }
+
+            return null; // No case identified; deserialization fails.
+        };
+    }
+}
+```
+
+> [!NOTE]
+> `JsonUnionAttribute`, `JsonTypeClassifier`, and `JsonTypeClassifierFactory<T>` are new `System.Text.Json` APIs in .NET 11. For the complete classifier design, including multi-type classifiers registered through <xref:System.Text.Json.JsonSerializerOptions>, see [System.Text.Json union type support](https://github.com/dotnet/runtime/issues/127299).
+<!-- TODO: Replace GitHub link with <xref:> IDs once the .NET 11 System.Text.Json union APIs are published to dotnet-api-docs. -->
+
+## Minimal APIs
+
+Unions work as request body parameters and as return types in both the runtime path (`RequestDelegateFactory`) and the source-generated path (Request Delegate Generator). Behavior is identical across both.
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+// Union as a request body.
+app.MapPost("/pet", ([FromBody] UnionPet pet) => TypedResults.Ok(pet));
+
+// Union as a return type — only the active case is serialized.
+app.MapGet("/value", () => new UnionIntString(42));      // 42
+app.MapGet("/pet", () => new UnionPet(new Cat("Whiskers")));
+
+app.Run();
+```
+
+Additional supported scenarios include:
+
+* `Task<TUnion>` and `ValueTask<TUnion>` return types.
+* A nullable union wrapper (`TUnion?`) and unions that include a nullable case, such as `union UnionNullableIntString(int?, string)`.
+* A union returned through <xref:Microsoft.AspNetCore.Http.TypedResults> or `Results<TResult1, TResult2>` wrappers.
+* A union used as a property of another model (an envelope), and `IAsyncEnumerable<TUnion>` streaming, which serializes the active case per item.
+* A union body inside an `[AsParameters]` container, where the union binds from the body and sibling properties bind from the route or query.
+* `ConfigureHttpJsonOptions` is honored for union serialization and deserialization.
+
+For an unambiguous union, an empty request body and content negotiation behave the same as for any other JSON body parameter: a non-JSON content type returns `415 Unsupported Media Type`.
+
+## MVC controllers and Razor Pages
+
+Unions flow through the STJ input and output formatters, so controllers and Razor Pages support them as action parameters and return types, including `Task<TUnion>` and `ValueTask<TUnion>` results:
+
+```csharp
+[ApiController]
+[Route("[controller]/[action]")]
+[Produces("application/json")]
+public class PetsController : ControllerBase
+{
+    [HttpPost]
+    public UnionPet Echo([FromBody] UnionPet value) => value;
+
+    [HttpGet("{kind}")]
+    public UnionIntString Primitive(string kind) => kind switch
+    {
+        "value" => new UnionIntString(42),
+        "string" => new UnionIntString("hi"),
+        _ => default,
+    };
+}
+```
+
+The same serialization rules apply: only the active case is written, and ambiguous unions need a classifier to deserialize.
+
+## SignalR
+
+`JsonHubProtocol` forwards reads and writes to `System.Text.Json`, so unions work as hub method parameters, return values, and stream items without any extra configuration:
+
+```csharp
+public class ChatHub : Hub
+{
+    // Union argument (client → server).
+    public Task Send(UnionIntString message) => Clients.All.SendAsync("Receive", message);
+
+    // Union return value (server → client).
+    public UnionPet GetPet() => new UnionPet(new Cat("Whiskers"));
+
+    // Union stream items (server → client).
+    public async IAsyncEnumerable<UnionIntString> Stream()
+    {
+        yield return new UnionIntString(1);
+        yield return new UnionIntString("two");
+    }
+}
+```
+
+On the read path, the parameter, return, or stream-item `Type` resolved from the invocation binder drives the union converter, including any `[JsonUnion]` classifier. On the write path, the active case is serialized with no envelope or discriminator.
+
+Unions are supported only with `JsonHubProtocol`. The MessagePack and Newtonsoft.Json hub protocols don't support unions, because their underlying serializers have no union support.
+
+## OpenAPI
+
+The OpenAPI document represents a union as an [`anyOf`](https://spec.openapis.org/oas/latest#composition-and-inheritance-polymorphism) schema, with one entry per case type:
+
+```json
+"UnionIntString": {
+  "anyOf": [
+    { "type": "integer", "format": "int32" },
+    { "type": "string" }
+  ]
+},
+"UnionPet": {
+  "type": "object",
+  "anyOf": [
+    { "$ref": "#/components/schemas/Cat" },
+    { "$ref": "#/components/schemas/Dog" }
+  ]
+}
+```
+
+Because a union case has no discriminator and is structurally identical to the standalone type, each case schema reuses the standalone component name, such as `Cat` and `Dog`. This differs from polymorphic types, whose derived schemas are lifted to prefixed component names because they carry a `$type` discriminator.
+
+An endpoint can also produce multiple response types for the same status code and content type. <xref:Microsoft.AspNetCore.Mvc.ApiExplorer> preserves every declared response type, and the generated document emits an `anyOf` schema when several types share a content type:
+
+```csharp
+app.MapGet("/any-of", () => Results.Ok())
+    .Produces<UnionPet>(StatusCodes.Status200OK, "application/json")
+    .Produces<Clinic>(StatusCodes.Status200OK, "application/json");
+```
+
+The same support applies to MVC controllers that declare multiple <xref:Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute> attributes for one status code and content type.
+
+## Where unions aren't supported
+
+Union support requires `System.Text.Json`. Binding sources that *don't* route through STJ don't support unions:
+
+* Query string values
+* Route values
+* Header values
+* Form fields
+
+These sources bind a string token to a target type without JSON parsing, so there's no reliable way to choose a union case. Even for STJ, most ambiguous unions require a custom classifier, and a single query value such as `?id=42` provides no way to know whether to bind `int`, `string`, `Guid`, or another case. Because of this ambiguity, unions are intentionally not supported in these binding sources.
+
+Use unions only as JSON request and response bodies. For non-body parameters, use a concrete type or a discriminated representation that the binding source can parse unambiguously.
+
+## Unions compared to polymorphism
+
+Unions and `[JsonPolymorphic]` hierarchies solve related but distinct problems:
+
+* **Polymorphism** writes a `$type` discriminator on the wire and matches incoming JSON by that discriminator. Use it when the JSON is self-describing and you want a tagged representation.
+* **Unions** write no discriminator and match incoming JSON structurally by the first token, or through a custom classifier. Use them to model a closed set of case types without changing the wire format.
+
+A union case type can itself be polymorphic. When a derived instance of a `[JsonPolymorphic]` case is returned, the polymorphic contract still emits its `$type` discriminator for that case's payload.
+
+## Additional resources
+
+* [System.Text.Json union type support (dotnet/runtime)](https://github.com/dotnet/runtime/issues/127299)
+* [C# unions language proposal (dotnet/csharplang)](https://github.com/dotnet/csharplang/blob/main/proposals/unions.md)
+* <xref:fundamentals/minimal-apis/parameter-binding>
+* <xref:fundamentals/minimal-apis/responses>

--- a/aspnetcore/fundamentals/minimal-apis/unions.md
+++ b/aspnetcore/fundamentals/minimal-apis/unions.md
@@ -12,9 +12,7 @@ ai-usage: ai-assisted
 
 C# union types, introduced as a language feature in .NET 11, let a single type represent a value that's exactly one of a fixed set of case types. Unions are a frequently requested feature for modeling APIs that accept or return one of several shapes, such as a success payload or an error payload. This article explains where ASP.NET Core supports unions, how they're serialized, and the cases that require extra configuration.
 
-ASP.NET Core support for unions builds entirely on [`System.Text.Json` (STJ) union support](https://github.com/dotnet/runtime/issues/127299). As a result, unions are supported only where STJ is the serializer: the **JSON request body** (input) and the **JSON response body** (output). Unions aren't supported for non-body binding sources, such as query strings, route values, headers, and form fields. For more information, see [Where unions aren't supported](#where-unions-arent-supported).
-
-For background on the language feature, see the [C# unions proposal](https://github.com/dotnet/csharplang/blob/main/proposals/unions.md).
+ASP.NET Core support for unions builds entirely on union support in [`System.Text.Json`](/dotnet/standard/serialization/system-text-json/overview) (STJ). As a result, unions are supported only where STJ is the serializer: the **JSON request body** (input) and the **JSON response body** (output). Unions aren't supported for non-body binding sources, such as query strings, route values, headers, and form fields. For more information, see [Where unions aren't supported](#where-unions-arent-supported).
 
 ## How unions are serialized
 
@@ -111,8 +109,8 @@ public sealed class PetClassifier : JsonTypeClassifierFactory<UnionPet>
 ```
 
 > [!NOTE]
-> `JsonUnionAttribute`, `JsonTypeClassifier`, and `JsonTypeClassifierFactory<T>` are new `System.Text.Json` APIs in .NET 11. For the complete classifier design, including multi-type classifiers registered through <xref:System.Text.Json.JsonSerializerOptions>, see [System.Text.Json union type support](https://github.com/dotnet/runtime/issues/127299).
-<!-- TODO: Replace GitHub link with <xref:> IDs once the .NET 11 System.Text.Json union APIs are published to dotnet-api-docs. -->
+> `JsonUnionAttribute`, `JsonTypeClassifier`, and `JsonTypeClassifierFactory<T>` are new `System.Text.Json` APIs in .NET 11. A classifier can also be registered for multiple union types through <xref:System.Text.Json.JsonSerializerOptions>.
+<!-- TODO: Add <xref:> links for the .NET 11 System.Text.Json union APIs (JsonUnionAttribute, JsonTypeClassifier, JsonTypeClassifierFactory<T>) once published to dotnet-api-docs. -->
 
 ## Minimal APIs
 
@@ -250,7 +248,7 @@ A union case type can itself be polymorphic. When a derived instance of a `[Json
 
 ## Additional resources
 
-* [System.Text.Json union type support (dotnet/runtime)](https://github.com/dotnet/runtime/issues/127299)
-* [C# unions language proposal (dotnet/csharplang)](https://github.com/dotnet/csharplang/blob/main/proposals/unions.md)
+* [JSON serialization and deserialization in .NET](/dotnet/standard/serialization/system-text-json/overview)
+* [How to serialize polymorphic types with System.Text.Json](/dotnet/standard/serialization/system-text-json/polymorphism)
 * <xref:fundamentals/minimal-apis/parameter-binding>
 * <xref:fundamentals/minimal-apis/responses>

--- a/aspnetcore/fundamentals/unions.md
+++ b/aspnetcore/fundamentals/unions.md
@@ -54,7 +54,7 @@ Because there's no discriminator on the wire, STJ recovers the case type from th
 Selection is O(1) and requires no read-ahead. A union whose cases map to distinct token kinds, such as `UnionBoolString(bool, string)`, deserializes without any extra configuration.
 
 > [!IMPORTANT]
-> Minimal APIs and MVC serialize and deserialize HTTP JSON using web defaults (<xref:System.Text.Json.JsonSerializerDefaults>.Web), which enable `JsonNumberHandling.AllowReadingFromString`. This lets a numeric case be read from a JSON `String` token, so the `String` token becomes compatible with *both* numeric cases and `string`. As a result, a union that pairs a numeric case with a `string` case—such as `UnionIntString(int, string)`—is ambiguous on the `String` token for HTTP JSON binding. A `Number` payload binds to the numeric case, but a `String` payload returns `400 Bad Request` unless the union supplies a classifier. This differs from plain `System.Text.Json` and from SignalR's `JsonHubProtocol`, which deserialize the same union without a classifier.
+> Minimal APIs and MVC serialize and deserialize HTTP JSON using <xref:System.Text.Json.JsonSerializerDefaults.Web?displayProperty=nameWithType>, which enables `JsonNumberHandling.AllowReadingFromString`. This lets a numeric case be read from a JSON `String` token, so the `String` token becomes compatible with *both* numeric cases and `string`. As a result, a union that pairs a numeric case with a `string` case—such as `UnionIntString(int, string)`—is ambiguous on the `String` token for HTTP JSON binding. A `Number` payload binds to the numeric case, but a `String` payload returns `400 Bad Request` unless the union supplies a classifier. This differs from plain `System.Text.Json` and from SignalR's `JsonHubProtocol`, which deserialize the same union without a classifier.
 
 ### Ambiguous unions require a classifier
 
@@ -199,7 +199,7 @@ public class ChatHub : Hub
 
 On the read path, the parameter, return, or stream-item `Type` resolved from the invocation binder drives the union converter, including any `[JsonUnion]` classifier. On the write path, the active case is serialized with no envelope or discriminator.
 
-Unlike HTTP JSON binding in Minimal APIs and MVC, `JsonHubProtocol` doesn't treat a JSON `String` token as ambiguous for numeric cases, so a union such as `UnionIntString(int, string)` round-trips both the `int` and `string` cases without a classifier. Object-cased unions, such as `UnionPet(Cat, Dog)`, are still ambiguous on read and require a classifier.
+Unlike HTTP JSON binding in Minimal APIs and MVC, `JsonHubProtocol` doesn't treat a JSON `String` token as ambiguous for numeric cases, so a union such as `UnionIntString(int, string)` round-trips both the `int` and `string` cases without a classifier. Unions whose cases share the `StartObject` token, such as `UnionPet(Cat, Dog)`, are still ambiguous on read and require a classifier.
 
 Unions are supported only with `JsonHubProtocol`. The MessagePack and Newtonsoft.Json hub protocols don't support unions, because their underlying serializers have no union support.
 
@@ -279,12 +279,17 @@ The OpenAPI document represents a union as an [`anyOf`](https://spec.openapis.or
 
 Because a union case has no discriminator and is structurally identical to the standalone type, each case schema reuses the standalone component name. The `Cat` and `Dog` schemas referenced by `UnionPet` are the same components that a standalone `Cat` or `Dog` endpoint produces. This differs from polymorphic types, whose derived schemas are lifted to prefixed component names because they carry a `$type` discriminator.
 
-An endpoint can also produce multiple response types for the same status code and content type. <xref:Microsoft.AspNetCore.Mvc.ApiExplorer> preserves every declared response type, and the generated document emits an `anyOf` schema when several types share a content type:
+An endpoint can also produce multiple response types for the same status code and content type. The <xref:Microsoft.AspNetCore.Mvc.ApiExplorer?displayProperty=fullName> namespace preserves every declared response type, and the generated document emits an `anyOf` schema when several types share a content type:
 
 ```csharp
 app.MapGet("/any-of", () => Results.Ok())
     .Produces<UnionPet>(StatusCodes.Status200OK, "application/json")
-    .Produces<Clinic>(StatusCodes.Status200OK, "application/json");
+    .Produces<UnionDinosaur>(StatusCodes.Status200OK, "application/json");
+    
+public record Tyrannosaurus(string Name, double BiteForceNewtons);
+public record Triceratops(string Name, int HornCount);
+public record Velociraptor(string Name, double TopSpeedKmh);
+public union UnionDinosaur(Tyrannosaurus, Triceratops, Velociraptor);
 ```
 
 The same support applies to MVC controllers that declare multiple <xref:Microsoft.AspNetCore.Mvc.ProducesResponseTypeAttribute> attributes for one status code and content type.

--- a/aspnetcore/fundamentals/unions.md
+++ b/aspnetcore/fundamentals/unions.md
@@ -1,18 +1,18 @@
 ---
 title: Use C# union types in ASP.NET Core
 author: DeagleGross
-description: Learn how C# union types are supported as JSON request and response bodies in ASP.NET Core Minimal APIs, MVC, SignalR, and OpenAPI.
+description: Learn how C# union types are supported through System.Text.Json in ASP.NET Core Minimal APIs, MVC, SignalR, Blazor, and OpenAPI.
 monikerRange: '>= aspnetcore-11.0'
 ms.author: wpickett
-ms.date: 06/17/2026
-uid: fundamentals/minimal-apis/unions
+ms.date: 06/19/2026
+uid: fundamentals/unions
 ai-usage: ai-assisted
 ---
 # Use C# union types in ASP.NET Core
 
 C# union types, introduced as a language feature in .NET 11, let a single type represent a value that's exactly one of a fixed set of case types. Unions are a frequently requested feature for modeling APIs that accept or return one of several shapes, such as a success payload or an error payload. This article explains where ASP.NET Core supports unions, how they're serialized, and the cases that require extra configuration.
 
-ASP.NET Core support for unions builds entirely on union support in [`System.Text.Json`](/dotnet/standard/serialization/system-text-json/overview) (STJ). As a result, unions are supported only where STJ is the serializer: the **JSON request body** (input) and the **JSON response body** (output). Unions aren't supported for non-body binding sources, such as query strings, route values, headers, and form fields. For more information, see [Where unions aren't supported](#where-unions-arent-supported).
+ASP.NET Core support for unions builds entirely on union support in [`System.Text.Json`](/dotnet/standard/serialization/system-text-json/overview) (STJ). As a result, unions are supported only where STJ is the serializer: the **JSON request body** (input) and the **JSON response body** (output). The same STJ foundation also enables unions in SignalR's `JsonHubProtocol` and in Blazor's JavaScript interop, persisted component state, and prerendered component parameters. Unions aren't supported for non-body binding sources, such as query strings, route values, headers, and form fields. For more information, see [Where unions aren't supported](#where-unions-arent-supported).
 
 ## How unions are serialized
 
@@ -200,6 +200,48 @@ Unlike HTTP JSON binding in Minimal APIs and MVC, `JsonHubProtocol` doesn't trea
 
 Unions are supported only with `JsonHubProtocol`. The MessagePack and Newtonsoft.Json hub protocols don't support unions, because their underlying serializers have no union support.
 
+## Blazor
+
+Blazor works with unions in two ways, depending on whether a value stays in-process or crosses a serialization boundary. In-process component parameters are assigned directly and need no serialization, while JavaScript interop, persisted component state, and prerendered parameters serialize unions with `System.Text.Json` and follow the same rules described earlier in this article.
+
+### Component parameters
+
+A component parameter is set by direct assignment when a component is rendered from Razor markup or through `RenderTreeBuilder.AddComponentParameter`. In-process rendering doesn't serialize parameters, so a union parameter works with no extra configuration:
+
+```razor
+<PetCard Pet="@(new UnionPet(new Cat("Whiskers")))" />
+```
+
+```csharp
+public class PetCard : ComponentBase
+{
+    [Parameter]
+    public UnionPet Pet { get; set; }
+}
+```
+
+### JavaScript interop
+
+JavaScript interop through <xref:Microsoft.JSInterop.IJSRuntime> serializes arguments and return values with `System.Text.Json`, so a union can be passed to and returned from JavaScript. The first-token dispatch and classifier rules described earlier apply:
+
+```csharp
+// .NET to JavaScript: the argument is serialized to JSON.
+await JS.InvokeVoidAsync("savePet", new UnionPet(new Cat("Whiskers")));
+
+// JavaScript to .NET: the return value is deserialized into the union.
+var pet = await JS.InvokeAsync<UnionPet>("loadPet");
+```
+
+A `[JSInvokable]` .NET method that JavaScript calls uses the same serialization path for its parameters and return value.
+
+### Persisted component state
+
+<xref:Microsoft.AspNetCore.Components.PersistentComponentState> serializes state with `System.Text.Json`, so a union round-trips through `PersistAsJson` and `TryTakeFromJson`, including a union whose active case is `null`.
+
+### Prerendering
+
+When a component is prerendered with Blazor Server or Blazor WebAssembly, its parameters are serialized into the component marker with `System.Text.Json` and deserialized when the component initializes on the client. Unions are supported across this boundary, including a union whose active case serializes to JSON `null`, such as a `UnionNullableIntString` that holds a null `int?`.
+
 ## OpenAPI
 
 The OpenAPI document represents a union as an [`anyOf`](https://spec.openapis.org/oas/latest#composition-and-inheritance-polymorphism) schema, with one entry per case type:
@@ -254,6 +296,8 @@ Union support requires `System.Text.Json`. Binding sources that *don't* route th
 * Form fields
 
 These sources bind a string token to a target type without JSON parsing, so there's no reliable way to choose a union case. Even for STJ, most ambiguous unions require a custom classifier, and a single query value such as `?id=42` provides no way to know whether to bind `int`, `string`, `Guid`, or another case. Because of this ambiguity, unions are intentionally not supported in these binding sources.
+
+In Blazor, the same limitation applies to component parameters supplied from non-body sources, including `[SupplyParameterFromQuery]` and form binding with `[SupplyParameterFromForm]`. These bind string or form values without JSON parsing, so they don't support unions.
 
 Parameter binding for unions from non-body sources is still being explored. If you have a scenario that needs it, the team is gathering feedback on the [union parameter binding issue](https://github.com/dotnet/aspnetcore/issues/66648).
 

--- a/aspnetcore/fundamentals/unions.md
+++ b/aspnetcore/fundamentals/unions.md
@@ -129,8 +129,8 @@ var app = builder.Build();
 // so it binds without a classifier.
 app.MapPost("/flag", (UnionBoolString flag) => flag);
 
-// Request body: UnionPet is object-cased, so it needs the classifier
-// shown earlier to bind from a body.
+// Request body: UnionPet's cases are both objects (StartObject token),
+// so it needs the classifier shown earlier to bind from a body.
 app.MapPost("/pet", ([FromBody] UnionPet pet) => TypedResults.Ok(pet));
 
 // Return types: only the active case is serialized, and no classifier

--- a/aspnetcore/fundamentals/unions.md
+++ b/aspnetcore/fundamentals/unions.md
@@ -21,6 +21,8 @@ A union type is declared with the `union` keyword and a list of case types:
 
 ```csharp
 public union UnionIntString(int, string);
+public union UnionBoolString(bool, string);
+public union UnionNullableIntString(int?, string);
 
 public record Cat(string Name);
 public record Dog(string Breed);

--- a/aspnetcore/fundamentals/unions.md
+++ b/aspnetcore/fundamentals/unions.md
@@ -8,6 +8,7 @@ ms.date: 06/19/2026
 uid: fundamentals/unions
 ai-usage: ai-assisted
 ---
+
 # Use C# union types in ASP.NET Core
 
 C# union types, introduced as a language feature in .NET 11, let a single type represent a value that's exactly one of a fixed set of case types. Unions are a frequently requested feature for modeling APIs that accept or return one of several shapes, such as a success payload or an error payload. This article explains where ASP.NET Core supports unions, how they're serialized, and the cases that require extra configuration.

--- a/aspnetcore/release-notes/aspnetcore-11.md
+++ b/aspnetcore/release-notes/aspnetcore-11.md
@@ -36,6 +36,8 @@ This section describes new features for Minimal APIs.
 
 [!INCLUDE[](~/release-notes/aspnetcore-11/includes/endpoint-filters-binding-failures-preview4.md)]
 
+[!INCLUDE[](~/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md)]
+
 ## OpenAPI
 
 This section describes new features for OpenAPI.

--- a/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
@@ -2,13 +2,13 @@
 
 ASP.NET Core supports C# union types, a .NET 11 language feature, as JSON request bodies and response bodies. Support builds on `System.Text.Json` union serialization, so it applies to Minimal APIs, MVC controllers, Razor Pages, and SignalR's `JsonHubProtocol`.
 
-A union value serializes transparently—only the active case is written, with no envelope or `$type` discriminator. On deserialization, `System.Text.Json` selects the case from the first JSON token. Ambiguous unions, whose cases map to the same token kind, require a custom `JsonTypeClassifier` attached with `[JsonUnion]`.
+A union value serializes transparently—only the active case is written, with no envelope or `$type` discriminator. On deserialization, `System.Text.Json` selects the case from the first JSON token. Ambiguous unions, whose cases can't be distinguished from a single token, require a custom `JsonTypeClassifier` attached with `[JsonUnion]`. Because Minimal APIs and MVC bind HTTP JSON using web defaults, a numeric case paired with a `string` case is ambiguous on a JSON string and also needs a classifier.
 
 ```csharp
 public union UnionIntString(int, string);
 
-app.MapPost("/value", (UnionIntString value) => value);
-app.MapGet("/value", () => new UnionIntString(42)); // serializes as: 42
+// Returns the active case only: 42
+app.MapGet("/value", () => new UnionIntString(42));
 ```
 
 OpenAPI documents represent a union as an `anyOf` schema with one entry per case type. Unions are supported only where `System.Text.Json` is the serializer, so they aren't supported for query, route, header, or form binding.

--- a/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
@@ -1,0 +1,17 @@
+### C# union types as JSON request and response bodies
+
+ASP.NET Core supports [C# union types](https://github.com/dotnet/csharplang/blob/main/proposals/unions.md), a .NET 11 language feature, as JSON request bodies and response bodies. Support builds on `System.Text.Json` union serialization, so it applies to Minimal APIs, MVC controllers, Razor Pages, and SignalR's `JsonHubProtocol`.
+
+A union value serializes transparently—only the active case is written, with no envelope or `$type` discriminator. On deserialization, `System.Text.Json` selects the case from the first JSON token. Ambiguous unions, whose cases map to the same token kind, require a custom `JsonTypeClassifier` attached with `[JsonUnion]`.
+
+```csharp
+public union UnionIntString(int, string);
+
+app.MapPost("/value", (UnionIntString value) => value);
+app.MapGet("/value", () => new UnionIntString(42)); // serializes as: 42
+```
+
+OpenAPI documents represent a union as an `anyOf` schema with one entry per case type. Unions are supported only where `System.Text.Json` is the serializer, so they aren't supported for query, route, header, or form binding.
+
+For more information, see [Use C# union types in ASP.NET Core](xref:fundamentals/minimal-apis/unions).
+<!-- TODO: System.Text.Json union APIs (JsonUnionAttribute, JsonTypeClassifier) are new in .NET 11; update to <xref:> once published to dotnet-api-docs. -->

--- a/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
@@ -13,5 +13,5 @@ app.MapGet("/value", () => new UnionIntString(42));
 
 OpenAPI documents represent a union as an `anyOf` schema with one entry per case type. Unions are supported only where `System.Text.Json` is the serializer, so they aren't supported for query, route, header, or form binding.
 
-For more information, see [Use C# union types in ASP.NET Core](xref:fundamentals/minimal-apis/unions).
+For more information, see [Use C# union types in ASP.NET Core](xref:fundamentals/unions).
 <!-- TODO: System.Text.Json union APIs (JsonUnionAttribute, JsonTypeClassifier) are new in .NET 11; update to <xref:> once published to dotnet-api-docs. -->

--- a/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
@@ -1,6 +1,6 @@
 ### C# union types as JSON request and response bodies
 
-ASP.NET Core supports [C# union types](https://github.com/dotnet/csharplang/blob/main/proposals/unions.md), a .NET 11 language feature, as JSON request bodies and response bodies. Support builds on `System.Text.Json` union serialization, so it applies to Minimal APIs, MVC controllers, Razor Pages, and SignalR's `JsonHubProtocol`.
+ASP.NET Core supports C# union types, a .NET 11 language feature, as JSON request bodies and response bodies. Support builds on `System.Text.Json` union serialization, so it applies to Minimal APIs, MVC controllers, Razor Pages, and SignalR's `JsonHubProtocol`.
 
 A union value serializes transparently—only the active case is written, with no envelope or `$type` discriminator. On deserialization, `System.Text.Json` selects the case from the first JSON token. Ambiguous unions, whose cases map to the same token kind, require a custom `JsonTypeClassifier` attached with `[JsonUnion]`.
 

--- a/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md
@@ -1,6 +1,6 @@
 ### C# union types as JSON request and response bodies
 
-ASP.NET Core supports C# union types, a .NET 11 language feature, as JSON request bodies and response bodies. Support builds on `System.Text.Json` union serialization, so it applies to Minimal APIs, MVC controllers, Razor Pages, and SignalR's `JsonHubProtocol`.
+ASP.NET Core supports C# union types, a .NET 11 language feature, as JSON request bodies and response bodies. Support builds on `System.Text.Json` union serialization, so it applies to Minimal APIs, MVC controllers, and SignalR's `JsonHubProtocol`.
 
 A union value serializes transparently—only the active case is written, with no envelope or `$type` discriminator. On deserialization, `System.Text.Json` selects the case from the first JSON token. Ambiguous unions, whose cases can't be distinguished from a single token, require a custom `JsonTypeClassifier` attached with `[JsonUnion]`. Because Minimal APIs and MVC bind HTTP JSON using web defaults, a numeric case paired with a `string` case is ambiguous on a JSON string and also needs a classifier.
 

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -1162,6 +1162,8 @@ items:
         uid: fundamentals/minimal-apis/parameter-binding
       - name: Create responses
         uid: fundamentals/minimal-apis/responses
+      - name: C# union types
+        uid: fundamentals/minimal-apis/unions
       - name: Filters
         uid: fundamentals/minimal-apis/min-api-filters
       - name: Unit and integration tests

--- a/aspnetcore/toc.yml
+++ b/aspnetcore/toc.yml
@@ -478,6 +478,8 @@ items:
         uid: fundamentals/startup
       - name: Dependency injection (services)
         uid: fundamentals/dependency-injection
+      - name: C# union types
+        uid: fundamentals/unions
       - name: Native AOT
         items:
           - name: Overview
@@ -1162,8 +1164,6 @@ items:
         uid: fundamentals/minimal-apis/parameter-binding
       - name: Create responses
         uid: fundamentals/minimal-apis/responses
-      - name: C# union types
-        uid: fundamentals/minimal-apis/unions
       - name: Filters
         uid: fundamentals/minimal-apis/min-api-filters
       - name: Unit and integration tests


### PR DESCRIPTION
Fixes dotnet/aspnetcore#67096

## Summary

Documents C# union types (a .NET 11 language feature) in ASP.NET Core. Union support is built entirely on `System.Text.Json` (STJ), so it applies wherever STJ is the serializer: JSON request bodies (input) and JSON response bodies (output), plus SignalR's `JsonHubProtocol` and Blazor's JavaScript interop, persisted component state, and prerendered component parameters. The docs also clearly state where unions are **not** supported (query, route, header, and form binding) and why.

Content is based on the implementation and verification PRs linked from the epic dotnet/aspnetcore#64599:

* dotnet/aspnetcore#66951 - Minimal APIs (`RequestDelegateFactory` + Request Delegate Generator)
* dotnet/aspnetcore#67001 - OpenAPI / ApiExplorer (`anyOf` schemas)
* dotnet/aspnetcore#67005 - MVC controllers / Razor Pages (STJ formatters)
* dotnet/aspnetcore#67125 - SignalR (`JsonHubProtocol`)
* dotnet/aspnetcore#67296 - Blazor (component parameters, JavaScript interop, persisted state, prerendering)
* dotnet/aspnetcore#65650 - multiple `Produces` per status code/content-type
* STJ design: dotnet/runtime#127299

## Files changed

* **Added** `aspnetcore/fundamentals/unions.md` - new conceptual article covering serialization (no discriminator, first-token dispatch), ambiguous unions and custom `JsonTypeClassifier`, Minimal APIs, MVC/Razor Pages, SignalR, Blazor, OpenAPI, unsupported binding sources, and unions vs polymorphism.
* **Added** `aspnetcore/release-notes/aspnetcore-11/includes/csharp-unions-preview-6.md` - What's New include summarizing the feature and linking to the article.
* **Modified** `aspnetcore/release-notes/aspnetcore-11.md` - wires the include into the Minimal APIs section.
* **Modified** `aspnetcore/toc.yml` - adds the new article under Fundamentals.

## Notes

The article was relocated from `aspnetcore/fundamentals/minimal-apis/unions.md` to `aspnetcore/fundamentals/unions.md` (uid `fundamentals/minimal-apis/unions` -> `fundamentals/unions`). Union support is cross-cutting across Minimal APIs, MVC, SignalR, Blazor, and OpenAPI, so the article doesn't belong under the Minimal APIs node. No redirect is added because the article is new in this PR and hasn't been published, so the original URL was never live.

The new .NET 11 STJ union APIs (`JsonUnionAttribute`, `JsonTypeClassifier`, `JsonTypeClassifierFactory<T>`) aren't yet published to dotnet-api-docs, so they use code style with `TODO` comments to convert to `<xref:>` once available.


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/unions.md](https://github.com/dotnet/AspNetCore.Docs/blob/2edf8bfe3af369e6a2d6566106cea3d57c2ec8eb/aspnetcore/fundamentals/unions.md) | [Use C# union types in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/unions?branch=pr-en-us-37261) |
| [aspnetcore/release-notes/aspnetcore-11.md](https://github.com/dotnet/AspNetCore.Docs/blob/2edf8bfe3af369e6a2d6566106cea3d57c2ec8eb/aspnetcore/release-notes/aspnetcore-11.md) | [What's new in ASP.NET Core in .NET 11](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-11?branch=pr-en-us-37261) |
| [aspnetcore/toc.yml](https://github.com/dotnet/AspNetCore.Docs/blob/2edf8bfe3af369e6a2d6566106cea3d57c2ec8eb/aspnetcore/toc.yml) | [aspnetcore/toc](https://review.learn.microsoft.com/en-us/aspnet/core/toc?branch=pr-en-us-37261) |


<!-- PREVIEW-TABLE-END -->