### PR TITLE
[11.0 P6] Docs for virtualize updates

### DIFF
--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -284,7 +284,7 @@ The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> com
 
 ### `InitialItemIndex` parameter
 
-Set `InitialItemIndex` to open the list at a specific item index on first interactive render. This is a one-shot parameter—changes after first render are ignored. Out-of-range values are clamped.
+Set `InitialIndex` to open the list at a specific item index on the first interactive render. This is a one-shot parameter—changes after first render are ignored. Out-of-range values are clamped.
 
 ```razor
 <Virtualize Items="allFlights" Context="flight" InitialItemIndex="500">

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -274,6 +274,50 @@ The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> com
 
 :::moniker-end
 
+:::moniker range=">= aspnetcore-10.0"
+
+## Scroll to a specific item
+
+The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> component provides two ways to control scroll position: `InitialItemIndex` for the first render and `ScrollToItemAsync` for programmatic scrolling after the component is rendered.
+
+### `InitialItemIndex` parameter
+
+Set `InitialItemIndex` to open the list at a specific item index on first interactive render. This is a one-shot parameter—changes after first render are ignored. Out-of-range values are clamped.
+
+```razor
+<Virtualize Items="allFlights" Context="flight" InitialItemIndex="500">
+    <FlightSummary @key="flight.FlightId" Details="@flight.Summary" />
+</Virtualize>
+```
+
+### `ScrollToItemAsync` method
+
+Call `ScrollToItemAsync` to programmatically scroll to an item after first render. The scroll is instant (no animation). The method returns a `Task` that completes when the target item is aligned to the top of the viewport. Cancellation is supported via `CancellationToken`.
+
+If multiple calls occur, the last call wins—earlier calls complete normally but only the final target is honored. If the user scrolls during a programmatic scroll, the user's scroll takes precedence. Calling before first interactive render throws an <xref:System.InvalidOperationException>.
+
+```razor
+<Virtualize Items="allFlights" Context="flight" @ref="virtualizeComponent">
+    <FlightSummary @key="flight.FlightId" Details="@flight.Summary" />
+</Virtualize>
+
+<button @onclick="ScrollToFlight">Go to flight 200</button>
+
+@code {
+    private Virtualize<Flight>? virtualizeComponent;
+
+    private async Task ScrollToFlight()
+    {
+        if (virtualizeComponent is not null)
+        {
+            await virtualizeComponent.ScrollToItemAsync(200);
+        }
+    }
+}
+```
+
+:::moniker-end
+
 :::moniker range=">= aspnetcore-11.0"
 
 ## Control viewport scroll position behavior when items are dynamically added

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -274,7 +274,9 @@ The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> com
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-10.0"
+:::moniker range=">= aspnetcore-11.0"
+
+<!-- UPDATE 11.0 - API Browser cross-links -->
 
 ## Scroll to a specific item
 

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -312,7 +312,7 @@ If multiple calls occur, the last call wins—earlier calls complete normally bu
     {
         if (virtualizeComponent is not null)
         {
-            await virtualizeComponent.ScrollToItemAsync(200);
+            await virtualizeComponent.ScrollToIndexAsync(200);
         }
     }
 }

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -294,7 +294,7 @@ Set `InitialIndex` to open the list at a specific item index on the first intera
 
 ### `ScrollToItemAsync` method
 
-Call `ScrollToItemAsync` to programmatically scroll to an item after first render. The scroll is instant (no animation). The method returns a `Task` that completes when the target item is aligned to the top of the viewport. Cancellation is supported via `CancellationToken`.
+Call `ScrollToIndexAsync` to programmatically scroll to an item after the first render. The scroll is instant (no animation). The method returns a <xref:System.Threading.Tasks.Task> that completes when the target item is aligned to the top of the viewport. Cancellation is supported via a <xref:System.Threading.CancellationToken>.
 
 If multiple calls occur, the last call wins—earlier calls complete normally but only the final target is honored. If the user scrolls during a programmatic scroll, the user's scroll takes precedence. Calling before the first interactive render throws an <xref:System.InvalidOperationException>.
 

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -280,7 +280,7 @@ The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> com
 
 ## Scroll to a specific item
 
-The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> component provides two ways to control scroll position: `InitialItemIndex` for the first render and `ScrollToItemAsync` for programmatic scrolling after the component is rendered.
+The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> component provides two ways to control scroll position: `InitialIndex` for the first render and `ScrollToIndexAsync` for programmatic scrolling after the component is rendered.
 
 ### `InitialItemIndex` parameter
 

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -327,20 +327,20 @@ If multiple calls occur, the last call wins—earlier calls complete normally bu
 Assign a `VirtualizeAnchorMode` value to the `AnchorMode` parameter to control how the viewport behaves at list edges when items are dynamically added:
 
 * `None`: No edge pinning. The viewport stays at the current scroll position regardless of item changes.
-* `Beginning`: Pins the viewport to the beginning of the list. When the user is at a scroll position near the top of the list and new items arrive at the beginning, the viewport stays at the top showing the newest items. For example, this pinning behavior is useful for a news feed user experience.
+* `Start`: Pins the viewport to the start of the list. When the user is at a scroll position near the top of the list and new items arrive at the start, the viewport stays at the top showing the newest items. For example, this pinning behavior is useful for a news feed user experience.
 * `End`: Pins the viewport to the end of the list. When the user is at a scroll position near the bottom of the list and new items arrive at the end, the viewport auto-scrolls to show them. If the user has scrolled away, auto-scroll disengages until they return to the bottom. For example, this pinning behavior is useful for a chat or logging user experience.
 
-The following example pins the viewport to the beginning of a virtualized flight list:
+The following example pins the viewport to the start of a virtualized flight list:
 
 ```razor
 <div style="height:500px;overflow-y:scroll">
-    <Virtualize Items="allFlights" Context="flight" AnchorMode="Beginning">
+    <Virtualize Items="allFlights" Context="flight" AnchorMode="Start">
         <FlightSummary @key="flight.FlightId" Details="@flight.Summary" />
     </Virtualize>
 </div>
 ```
 
-Modes can be combined. For example, assigning `Beginning | End` pins both edges. Combining `None` with other modes is supported but doesn't change the combined value.
+Modes can be combined. For example, assigning `Start | End` pins both edges. Combining `None` with other modes is supported but doesn't change the combined value.
 
 `Virtualize.ItemComparer` gets or sets a comparer used to detect whether items were prepended or appended when using class-typed items with an <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601.ItemsProvider%2A> (for more information, see the [Item provider delegate](#item-provider-delegate) section).
 
@@ -351,7 +351,7 @@ The comparer determines if the first loaded item changed between provider calls,
                    I thought that it wouldn't need it. -->
 
 ```razor
-<Virtualize ItemsProvider="LoadFlights" AnchorMode="Beginning" 
+<Virtualize ItemsProvider="LoadFlights" AnchorMode="Start" 
     ItemComparer="itemComparer">
     ...
 </Virtualize>

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -282,7 +282,7 @@ The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> com
 
 The <xref:Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize%601> component provides two ways to control scroll position: `InitialIndex` for the first render and `ScrollToIndexAsync` for programmatic scrolling after the component is rendered.
 
-### `InitialItemIndex` parameter
+### `InitialIndex` parameter
 
 Set `InitialIndex` to open the list at a specific item index on the first interactive render. This is a one-shot parameter—changes after first render are ignored. Out-of-range values are clamped.
 

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -296,7 +296,7 @@ Set `InitialIndex` to open the list at a specific item index on the first intera
 
 Call `ScrollToItemAsync` to programmatically scroll to an item after first render. The scroll is instant (no animation). The method returns a `Task` that completes when the target item is aligned to the top of the viewport. Cancellation is supported via `CancellationToken`.
 
-If multiple calls occur, the last call wins—earlier calls complete normally but only the final target is honored. If the user scrolls during a programmatic scroll, the user's scroll takes precedence. Calling before first interactive render throws an <xref:System.InvalidOperationException>.
+If multiple calls occur, the last call wins—earlier calls complete normally but only the final target is honored. If the user scrolls during a programmatic scroll, the user's scroll takes precedence. Calling before the first interactive render throws an <xref:System.InvalidOperationException>.
 
 ```razor
 <Virtualize Items="allFlights" Context="flight" @ref="virtualizeComponent">


### PR DESCRIPTION
1) Programmatic scroll got added in https://github.com/dotnet/aspnetcore/pull/66753 an is renamed after review in https://github.com/dotnet/aspnetcore/pull/67312.

2) `AnchorMode` also has a pending rename in https://github.com/dotnet/aspnetcore/pull/67313, we are changing `Beginning` -> `Start`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/virtualization.md](https://github.com/dotnet/AspNetCore.Docs/blob/cc734f39e6eca7af16ee2441f7fd85229f5b3b57/aspnetcore/blazor/components/virtualization.md) | [aspnetcore/blazor/components/virtualization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/virtualization?branch=pr-en-us-37270) |


<!-- PREVIEW-TABLE-END -->