### PR TITLE
Add RCL coverage with class lib deltas and details

### DIFF
--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -62,7 +62,7 @@ The following characteristics distinguish an RCL from an ASP.NET Core class libr
 
 :::moniker range=">= aspnetcore-5.0"
 
-* The project file (`.csproj`) includes the `SupportedPlatform` property for the `browser` platform. For more information, see the [Client-side browser compatibility analyzer](#client-side-browser-compatibility-analyzer) section.
+* An RCL's project file (`.csproj`) includes the `SupportedPlatform` property for the `browser` platform. For more information, see the [Client-side browser compatibility analyzer](#client-side-browser-compatibility-analyzer) section.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/components/class-libraries.md
+++ b/aspnetcore/blazor/components/class-libraries.md
@@ -1,11 +1,12 @@
 ---
 title: Consume ASP.NET Core Razor components from a Razor class library (RCL)
+ai-usage: ai-assisted
 author: guardrex
 description: Discover how components can be included in Blazor apps from an external Razor class library (RCL).
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 11/11/2025
+ms.date: 07/02/2026
 uid: blazor/components/class-libraries
 ---
 # Consume ASP.NET Core Razor components from a Razor class library (RCL)
@@ -53,6 +54,20 @@ Just as components are regular .NET types, components provided by an RCL are nor
 
 ---
 
+## How an RCL is different from an ASP.NET Core class library
+
+The following characteristics distinguish an RCL from an ASP.NET Core class library:
+
+* An RCL uses the `Microsoft.NET.Sdk.Razor` SDK, while an ordinary class library project uses the `Microsoft.NET.Sdk` SDK. The `Microsoft.NET.Sdk.Razor` SDK builds the library with custom MSBuild tooling specifically designed to compile, build, and package Razor files (`.cshtml`) and Razor component files (`.razor`).
+
+:::moniker range=">= aspnetcore-5.0"
+
+* The project file (`.csproj`) includes the `SupportedPlatform` property for the `browser` platform. For more information, see the [Client-side browser compatibility analyzer](#client-side-browser-compatibility-analyzer) section.
+
+:::moniker-end
+
+* An RCL references the [`Microsoft.AspNetCore.Components.Web` NuGet package](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.Web) and usually relies on an Imports file (`_Imports.razor`) with an `@using` statement for the <xref:Microsoft.AspNetCore.Components.Web?displayProperty=fullName> namespace. The package provides web-specific infrastructure, HTML element abstractions, and event handling bindings required to run Blazor apps inside a web browser.
+
 ## Consume a Razor component from an RCL
 
 To consume components from an RCL in another project, use either of the following approaches:
@@ -60,7 +75,7 @@ To consume components from an RCL in another project, use either of the followin
 * Use the full component type name, which includes the RCL's namespace.
 * Individual components can be added by name without the RCL's namespace if Razor's [`@using`](xref:mvc/views/razor#using) directive declares the RCL's namespace. Use the following approaches:
   * Add the `@using` directive to individual components.
-  * include the `@using` directive in the top-level `_Imports.razor` file to make the library's components available to an entire project. Add the directive to an `_Imports.razor` file at any level to apply the namespace to a single component or set of components within a folder. When an `_Imports.razor` file is used, individual components don't require an `@using` directive for the RCL's namespace.
+  * Include the `@using` directive in the top-level `_Imports.razor` file to make the library's components available to an entire project. Add the directive to an `_Imports.razor` file at any level to apply the namespace to a single component or set of components within a folder. When an `_Imports.razor` file is used, individual components don't require an `@using` directive for the RCL's namespace.
 
 In the following examples, `ComponentLibrary` is an RCL containing the `Component1` component. The `Component1` component is an example component automatically added to an RCL created from the RCL project template that isn't created to support pages and views.
 

--- a/aspnetcore/blazor/components/event-handling.md
+++ b/aspnetcore/blazor/components/event-handling.md
@@ -5,7 +5,7 @@ description: Learn about Blazor's event handling features, including event argum
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
 ms.custom: mvc
-ms.date: 11/11/2025
+ms.date: 07/02/2026
 uid: blazor/components/event-handling
 ---
 # ASP.NET Core Blazor event handling
@@ -13,6 +13,8 @@ uid: blazor/components/event-handling
 [!INCLUDE[](~/includes/not-latest-version.md)]
 
 This article explains Blazor's event handling features, including event argument types, event callbacks, and managing default browser events.
+
+The [`Microsoft.AspNetCore.Components.Web` NuGet package](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.Web) (<xref:Microsoft.AspNetCore.Components.Web?displayProperty=fullName> namespace) contains types for supplying information about browser events to the Blazor framework. Blazor apps target the package implicitly, while [Razor class libraries](xref:blazor/components/class-libraries) include an explicit package reference in the library's project file (`.csproj`).
 
 ## Delegate event handlers
 


### PR DESCRIPTION
Fixes #37288

Thanks @RiRiSharp! 🚀 ... I ended up ........

* Adding a section near the top of the Blazor node's *Class lib* (RCL) article on the differences between an RCL and ordinary class lib, which includes info on the package and the namespace.
* Adding a blurb at the top of the *Event handling* article on the package's role with a cross-link to the class lib article.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/blazor/components/class-libraries.md](https://github.com/dotnet/AspNetCore.Docs/blob/f968692e1ec40fbb24933d4e10164322e3a02b3f/aspnetcore/blazor/components/class-libraries.md) | [aspnetcore/blazor/components/class-libraries](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/class-libraries?branch=pr-en-us-37305) |
| [aspnetcore/blazor/components/event-handling.md](https://github.com/dotnet/AspNetCore.Docs/blob/f968692e1ec40fbb24933d4e10164322e3a02b3f/aspnetcore/blazor/components/event-handling.md) | [aspnetcore/blazor/components/event-handling](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/event-handling?branch=pr-en-us-37305) |


<!-- PREVIEW-TABLE-END -->