### PR TITLE
BULK fix broken link

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-9/includes/produces-problem.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/produces-problem.md
@@ -22,4 +22,4 @@ Prior to .NET 9, constructing [Problem](/dotnet/api/microsoft.aspnetcore.http.ty
 
 :::code language="csharp" source="~/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs" id="snippet_2" :::
 
-Thanks to GitHub user [joegoldman2](https://github.com/joegoldman2) for this contribution!
+Thanks to GitHub user joegoldman2 for this contribution!

--- a/aspnetcore/release-notes/aspnetcore-9/includes/produces-problem.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/produces-problem.md
@@ -22,4 +22,4 @@ Prior to .NET 9, constructing [Problem](/dotnet/api/microsoft.aspnetcore.http.ty
 
 :::code language="csharp" source="~/fundamentals/openapi/samples/9.x/ProducesProblem/Program.cs" id="snippet_2" :::
 
-Thanks to GitHub user joegoldman2 for this contribution!
+Thanks to Joseph Goldman for this contribution!


### PR DESCRIPTION
BrokenLinks from 6/24/2026 Content Quality report
See work item https://dev.azure.com/msft-skilling/Content/_workitems/edit/593149
No substitute found, removing link
<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->