### PR TITLE
Add a note about dashes and underscores in header names

### DIFF
--- a/aspnetcore/fundamentals/servers/yarp/header-guidelines.md
+++ b/aspnetcore/fundamentals/servers/yarp/header-guidelines.md
@@ -4,7 +4,7 @@ title: YARP HTTP header guidelines
 description: Learn about YARP HTTP header guidelines.
 author: wadepickett
 ms.author: wpickett
-ms.date: 04/03/2025
+ms.date: 07/13/2026
 ms.topic: concept-article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted
@@ -12,6 +12,9 @@ ai-usage: ai-assisted
 # YARP HTTP header guidelines
 
 Headers are a very important part of processing HTTP requests and each have their own semantics and considerations. Most headers are proxied by default, though some used to control how the request is delivered are automatically adjusted or removed by the proxy. The connections between the client and the proxy and between the proxy and the destination are independent. Therefore, headers that affect the connection and transport must be filtered. Many headers contain information like domain names, paths, or other details that may be affected when a reverse proxy is included in the application architecture. The following is a collection of guidelines about how specific headers might be impacted and what to do about them.
+
+> [!NOTE]
+> YARP doesn't normalize dashes (`-`) and underscores (`_`) in header names. They're treated as different characters, so a name such as `my-header` doesn't match a request header named `my_header`.
 
 ## YARP header filtering
 

--- a/aspnetcore/fundamentals/servers/yarp/header-routing.md
+++ b/aspnetcore/fundamentals/servers/yarp/header-routing.md
@@ -4,7 +4,7 @@ title: YARP Header Based Routing
 description: YARP Header Based Routing
 author: wadepickett
 ms.author: wpickett
-ms.date: 2/6/2025
+ms.date: 07/13/2026
 ms.topic: concept-article
 content_well_notification: AI-contribution
 ai-usage: ai-assisted
@@ -282,6 +282,9 @@ var routes = new[]
 ### Name
 
 The header name to check for on the request. A non-empty value is required. This field is case-insensitive per the HTTP RFCs.
+
+> [!NOTE]
+> YARP doesn't normalize dashes (`-`) and underscores (`_`) in header names. They're treated as different characters, so a name such as `my-header` doesn't match a request header named `my_header`.
 
 ### Values
 


### PR DESCRIPTION
Adds an extra note to YARP docs

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/fundamentals/servers/yarp/header-guidelines.md](https://github.com/dotnet/AspNetCore.Docs/blob/09e844ccabe658f25ffdf35efa196bc9d3ee5b0a/aspnetcore/fundamentals/servers/yarp/header-guidelines.md) | [YARP HTTP header guidelines](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/yarp/header-guidelines?branch=pr-en-us-37337) |
| [aspnetcore/fundamentals/servers/yarp/header-routing.md](https://github.com/dotnet/AspNetCore.Docs/blob/09e844ccabe658f25ffdf35efa196bc9d3ee5b0a/aspnetcore/fundamentals/servers/yarp/header-routing.md) | [YARP Header Based Routing](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/yarp/header-routing?branch=pr-en-us-37337) |

<!-- PREVIEW-TABLE-END -->