### PR TITLE
Fix the learn issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/customer-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/customer-feedback.yml
@@ -9,11 +9,12 @@ body:
     attributes:
       value: Describe the issue in the following text box. Add as much detail as needed to help us resolve the issue.
   - type: textarea
-    id: feedback
+    id: userfeedback
     validations:
       required: true
     attributes:
       label: Description
+      placeholder: Describe your problem or suggestion
   - type: markdown
     attributes:
       value: "## 🚧 Article information 🚧"


### PR DESCRIPTION
Fixes the problem with how GitHub Issues now enforces query string values in fields.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [.github/ISSUE_TEMPLATE/customer-feedback.yml](https://github.com/dotnet/AspNetCore.Docs/blob/a067d17d06539636b9335e837e67378fb1280567/.github/ISSUE_TEMPLATE/customer-feedback.yml) | [.github/ISSUE_TEMPLATE/customer-feedback](https://review.learn.microsoft.com/en-us/aspnet/core/.github/ISSUE_TEMPLATE/customer-feedback?branch=pr-en-us-37341) |

<!-- PREVIEW-TABLE-END -->