### PR TITLE
[11.0 P7] Rename ConfigureHostApplicationBuilder to ConfigureWebApplicationBuilder

### DIFF
--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -228,7 +228,7 @@ There are various ways to supply test-specific configurations to the running web
 
     Using this approach, the configuration source added via `ConfigureAppConfiguration` is preserved, but it's only available after the web application is built. If you try to access the configuration before `WebApplicationBuilder.Build` is called, the configurations will not be available.
 
-3. Starting in .NET 11 Preview 6, you can override a new `ConfigureHostApplicationBuilder` method as follows:
+3. Starting in .NET 11 Preview 6, you can override a new `ConfigureWebApplicationBuilder` method as follows:
 
     ```csharp
     private static readonly KeyValuePair<string, string?>[] s_inMemorySettings = new KeyValuePair<string, string?>[]
@@ -236,14 +236,14 @@ There are various ways to supply test-specific configurations to the running web
         new("TestConfigKey", "TestConfigValue"),
     };
 
-    protected override void ConfigureHostApplicationBuilder(IHostApplicationBuilder hostApplicationBuilder)
+    protected override void ConfigureWebApplicationBuilder(IHostApplicationBuilder hostApplicationBuilder)
     {
         hostApplicationBuilder.Configuration.AddInMemoryCollection(s_inMemorySettings);
-        base.ConfigureHostApplicationBuilder(hostApplicationBuilder);
+        base.ConfigureWebApplicationBuilder(hostApplicationBuilder);
     }
     ```
 
-    Using this approach, the configuration source added via `ConfigureHostApplicationBuilder` is preserved, and is also available immediately after `WebApplication.CreateBuilder` returns.
+    Using this approach, the configuration source added via `ConfigureWebApplicationBuilder` is preserved, and is also available immediately after `WebApplication.CreateBuilder` returns.
 
 ## Customize the client with WithWebHostBuilder
 

--- a/aspnetcore/test/integration-tests.md
+++ b/aspnetcore/test/integration-tests.md
@@ -228,7 +228,7 @@ There are various ways to supply test-specific configurations to the running web
 
     Using this approach, the configuration source added via `ConfigureAppConfiguration` is preserved, but it's only available after the web application is built. If you try to access the configuration before `WebApplicationBuilder.Build` is called, the configurations will not be available.
 
-3. Starting in .NET 11 Preview 6, you can override a new `ConfigureWebApplicationBuilder` method as follows:
+3. Starting in .NET 11 Preview 7, you can override a new `ConfigureWebApplicationBuilder` method as follows:
 
     ```csharp
     private static readonly KeyValuePair<string, string?>[] s_inMemorySettings = new KeyValuePair<string, string?>[]


### PR DESCRIPTION
Reacts to product change in https://github.com/dotnet/aspnetcore/pull/67917

This will be ready to merge when the PR is merged and gets released in Preview 7 (if merged on time)

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| 📄 File | 🔗 Preview link |
|:--|:--|
| [aspnetcore/test/integration-tests.md](https://github.com/dotnet/AspNetCore.Docs/blob/04dfba065050bf4b4bf5a4676e9ed1133524a3b3/aspnetcore/test/integration-tests.md) | [Integration tests in ASP.NET Core](https://review.learn.microsoft.com/en-us/aspnet/core/test/integration-tests?branch=pr-en-us-37352) |


<!-- PREVIEW-TABLE-END -->