### PR TITLE
Update xref links in views.md to unblock merge to live

### DIFF
--- a/aspnetcore/mvc/security/authorization/views.md
+++ b/aspnetcore/mvc/security/authorization/views.md
@@ -19,7 +19,7 @@ A developer often wants to show, hide, or otherwise modify a UI based on the cur
 
 To inject the authorization service into every view, place the `@inject` directive in the `Views/_ViewImports.cshtml` file. For more information, see <xref:mvc/views/dependency-injection>.
 
-Use the injected authorization service to invoke <xref:Microsoft.AspNetCore.Authorization.IAuthorizationService.AuthorizeAsync%2A?displayProperty=nameWithType> in exactly the same way an app would check authorization during [resource-based authorization](xref:security/authorization/resource-based#use-imperative-authorization):
+Use the injected authorization service to invoke <xref:Microsoft.AspNetCore.Authorization.IAuthorizationService.AuthorizeAsync%2A?displayProperty=nameWithType> in exactly the same way an app would check authorization during [resource-based authorization](xref:mvc/security/authorization/resource-based#use-imperative-authorization):
 
 ```razor
 @if ((await AuthService.AuthorizeAsync(User, "PolicyName")).Succeeded)
@@ -28,7 +28,7 @@ Use the injected authorization service to invoke <xref:Microsoft.AspNetCore.Auth
 }
 ```
 
-In some cases, the resource is the view model. Invoke <xref:Microsoft.AspNetCore.Authorization.IAuthorizationService.AuthorizeAsync%2A> in exactly the same way the app would check authorization during [resource-based authorization](xref:security/authorization/resource-based#use-imperative-authorization). The model is passed as a resource for the policy's evaluation:
+In some cases, the resource is the view model. Invoke <xref:Microsoft.AspNetCore.Authorization.IAuthorizationService.AuthorizeAsync%2A> in exactly the same way the app would check authorization during [resource-based authorization](xref:mvc/security/authorization/resource-based#use-imperative-authorization). The model is passed as a resource for the policy's evaluation:
 
 ```razor
 @if ((await AuthService.AuthorizeAsync(User, Model, Operations.Edit)).Succeeded)


### PR DESCRIPTION
Fixing broken link on main so we can re-merge to main and fix merge to live block on #37372

Two problems combined:

- The uid is out of date. The resource-based article was itself renamed to mvc/security/authorization/resource-based (I confirmed its front matter: uid: mvc/security/authorization/resource-based). So xref:security/authorization/resource-based no longer resolves. 
- The anchor #use-imperative-authorization does exist on that target (## Use imperative authorization), so once the uid is corrected the bookmark is valid.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->