### PR TITLE
Fix environment variable name for HTTPS port

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -72,7 +72,7 @@ The following code calls the <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuild
 The preceding highlighted code:
 
 * Uses the default <xref:Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionOptions.RedirectStatusCode?displayProperty=nameWithType> property with the <xref:Microsoft.AspNetCore.Http.StatusCodes.Status307TemporaryRedirect> code.
-* Uses the default <xref:Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionOptions.HttpsPort?displayProperty=nameWithType> property (passing null), unless overridden by the `ASPNETCORE_HTTPS_PORT` environment variable or <xref:Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>.
+* Uses the default <xref:Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionOptions.HttpsPort?displayProperty=nameWithType> property (passing null), unless overridden by the `ASPNETCORE_HTTPS_PORTS` environment variable or <xref:Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>.
 
 The recommended approach is to use temporary redirects rather than permanent redirects. Link caching can cause unstable behavior in development environments. If you prefer to send a permanent redirect status code when the app is in a non-`Development` environment, see the [Configure permanent redirects in production](#configure-permanent-redirects-in-production) section. Use [HSTS](#hsts) to signal to clients that only secure resource requests should be sent to the app (only in production).
 
@@ -88,7 +88,7 @@ Specify the HTTPS port by using any of the following approaches:
 * Set [HttpsRedirectionOptions.HttpsPort](#options).
 * Set the `https_port` [host setting](xref:fundamentals/host/generic-host#https-port):
    * In host configuration.
-   * By setting the `ASPNETCORE_HTTPS_PORT` environment variable.
+   * By setting the `ASPNETCORE_HTTPS_PORTS` environment variable.
    * By adding a top-level entry in the _appsettings.json_ file:
 
       [!code-json[](enforcing-ssl/sample-snapshot/6.x/appsettings.json?highlight=2)]


### PR DESCRIPTION
According to other documentation the proper environment variable name is `APSNETCORE_HTTPS_PORTS`(c.f. https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-10.0#specify-ports-only)

I also tested this on a .NET app, `APSNETCORE_HTTPS_PORT` does not tell the app do anything, `APSNETCORE_HTTPS_PORTS` opened the app with https support.

However, the app used .NET 8.0, so this might have changed in newer versions, but then the documentation at https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-10.0#specify-ports-only would need an update.