### PR TITLE
Revert "Fix environment variable name for HTTPS port"

### DIFF
--- a/aspnetcore/security/enforcing-ssl.md
+++ b/aspnetcore/security/enforcing-ssl.md
@@ -72,7 +72,7 @@ The following code calls the <xref:Microsoft.AspNetCore.Builder.HttpsPolicyBuild
 The preceding highlighted code:
 
 * Uses the default <xref:Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionOptions.RedirectStatusCode?displayProperty=nameWithType> property with the <xref:Microsoft.AspNetCore.Http.StatusCodes.Status307TemporaryRedirect> code.
-* Uses the default <xref:Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionOptions.HttpsPort?displayProperty=nameWithType> property (passing null), unless overridden by the `ASPNETCORE_HTTPS_PORTS` environment variable or <xref:Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>.
+* Uses the default <xref:Microsoft.AspNetCore.HttpsPolicy.HttpsRedirectionOptions.HttpsPort?displayProperty=nameWithType> property (passing null), unless overridden by the `ASPNETCORE_HTTPS_PORT` environment variable or <xref:Microsoft.AspNetCore.Hosting.Server.Features.IServerAddressesFeature>.
 
 The recommended approach is to use temporary redirects rather than permanent redirects. Link caching can cause unstable behavior in development environments. If you prefer to send a permanent redirect status code when the app is in a non-`Development` environment, see the [Configure permanent redirects in production](#configure-permanent-redirects-in-production) section. Use [HSTS](#hsts) to signal to clients that only secure resource requests should be sent to the app (only in production).
 
@@ -88,7 +88,7 @@ Specify the HTTPS port by using any of the following approaches:
 * Set [HttpsRedirectionOptions.HttpsPort](#options).
 * Set the `https_port` [host setting](xref:fundamentals/host/generic-host#https-port):
    * In host configuration.
-   * By setting the `ASPNETCORE_HTTPS_PORTS` environment variable.
+   * By setting the `ASPNETCORE_HTTPS_PORT` environment variable.
    * By adding a top-level entry in the _appsettings.json_ file:
 
       [!code-json[](enforcing-ssl/sample-snapshot/6.x/appsettings.json?highlight=2)]


### PR DESCRIPTION
Reverts dotnet/AspNetCore.Docs#37386

The env vars that were changed in the *Enforcing SSL* article should be left as-is. They set the `https_port` configuration key for HTTPS redirection middleware, which I only discovered after Copilot reminded me ... but in passing, note that these are so closely named that they're confusing. The dev who sent the PR was confused, and I was confused when I first looked. We'll revert those updates here before the changes go live.

I think we have some updates to make to address the confusion. I'll take up my recommendations with you on new issue (and PR) shortly.