### PR TITLE
Update signalr-trimming-aot.md with HubMethodName guidance

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-9/includes/signalr-trimming-aot.md
+++ b/aspnetcore/release-notes/aspnetcore-9/includes/signalr-trimming-aot.md
@@ -25,5 +25,6 @@ The preceding example produces a native Windows executable of 10 MB and a Linux 
   * This follows the same approach as Minimal APIs.
 * On the SignalR server, Hub method parameters of type `IAsyncEnumerable<T>` and `ChannelReader<T>` where `T` is a ValueType (`struct`) aren't supported. Using these types results in a runtime exception at startup in development and in the published app. For more information, see [SignalR: Using IAsyncEnumerable&lt;T&gt; and ChannelReader&lt;T&gt; with ValueTypes in native AOT (`dotnet/aspnetcore` #56179)](https://github.com/dotnet/aspnetcore/issues/56179).
 * [Strongly typed hubs](xref:signalr/hubs#use-strongly-typed-hubs) aren't supported with Native AOT (`PublishAot`). Using strongly typed hubs with Native AOT will result in warnings during build and publish, and a runtime exception. Using strongly typed hubs with trimming (`PublishedTrimmed`) is supported.
+  * Make sure to copy the names from `[HubMethodName(...)]` applied to the strongly typed hub interface methods into the `SendAsync` calls.
 * Only `Task`, `Task<T>`, `ValueTask`, or `ValueTask<T>` are supported for async return types.
 


### PR DESCRIPTION
Added note about copying names from HubMethodName to SendAsync calls.

See https://github.com/dotnet/aspnetcore/issues/68059#issuecomment-5115967258