### PR TITLE
Remove ServerCertificateCustomValidationCallback from timeout samples.

### DIFF
--- a/aspnetcore/grpc/troubleshoot.md
+++ b/aspnetcore/grpc/troubleshoot.md
@@ -217,11 +217,11 @@ System.OperationCanceledException: The request was canceled due to the configure
 
 There are a couple of ways to fix this error. The first is to configure <xref:System.Net.Http.HttpClient.Timeout?displayProperty=nameWithType> to a larger value. <xref:System.Threading.Timeout.InfiniteTimeSpan?displayProperty=nameWithType> disables the timeout:
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_CallTimeoutHttpClient&highlight=5)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_CallTimeoutHttpClient&highlight=3)]
 
 Alternatively, avoid creating `HttpClient` and set `GrpcChannel.HttpHandler` instead:
 
-[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_CallTimeoutSetGrpcChannel&highlight=6)]
+[!code-csharp[](~/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs?name=snippet_CallTimeoutSetGrpcChannel&highlight=4)]
 
 :::moniker-end
 

--- a/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
+++ b/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs
@@ -209,8 +209,6 @@ using GrpcGreeterClient;
 
 // <snippet_CallTimeoutHttpClient>
 var handler = new HttpClientHandler();
-handler.ServerCertificateCustomValidationCallback = 
-    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
 var httpClient = new HttpClient(handler) { Timeout = Timeout.InfiniteTimeSpan };
 var channel = GrpcChannel.ForAddress("https://localhost:5001",
@@ -231,8 +229,6 @@ using GrpcGreeterClient;
 
 // <snippet_CallTimeoutSetGrpcChannel>
 var handler = new HttpClientHandler();
-handler.ServerCertificateCustomValidationCallback = 
-    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
 
 var channel = GrpcChannel.ForAddress("https://localhost:5001",
     new GrpcChannelOptions { HttpHandler = handler });


### PR DESCRIPTION
Fixes #37431

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/grpc/troubleshoot.md](https://github.com/dotnet/AspNetCore.Docs/blob/b44cffa54dc837cf6c2a5cc3613db9fd981365e8/aspnetcore/grpc/troubleshoot.md) | [aspnetcore/grpc/troubleshoot](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-11.0&branch=pr-en-us-37432) |
| [aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs](https://github.com/dotnet/AspNetCore.Docs/blob/b44cffa54dc837cf6c2a5cc3613db9fd981365e8/aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs) | [aspnetcore/grpc/troubleshoot/sample/8.0/GrpcGreeterClient/Program.cs](https://review.learn.microsoft.com/en-us/aspnet/core/grpc/troubleshoot?view=aspnetcore-11.0&branch=pr-en-us-37432) |

<!-- PREVIEW-TABLE-END -->