### PR TITLE
Improve Blazor named/typed HTTP client coverage

### DIFF
--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -289,18 +289,18 @@ builder.Services.AddScoped(sp =>
 
 ## Named `HttpClient` with `IHttpClientFactory`
 
-*The guidance in this section applies to using a named <xref:System.Net.Http.HttpClient> in the `.Client` project of a Blazor Web App or in prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
+*The guidance in this section applies to using a named <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
 
-<xref:System.Net.Http.IHttpClientFactory> services and the configuration of a named <xref:System.Net.Http.HttpClient> are supported for classes and Razor components in the `.Client` project of a Blazor Web App and for prerendered client-side components in a Blazor Web App.
+<xref:System.Net.Http.IHttpClientFactory> services and the configuration of a named <xref:System.Net.Http.HttpClient> are supported for classes and Razor components in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components in a Blazor Web App.
 
 > [!NOTE]
 > An alternative to using a named <xref:System.Net.Http.HttpClient> from an <xref:System.Net.Http.IHttpClientFactory> is to use a typed <xref:System.Net.Http.HttpClient>. For more information, see the [Typed `HttpClient`](#typed-httpclient) section.
 
-Add the [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http) NuGet package to the `.Client` project.
+Add the [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http) NuGet package to the project.
 
 [!INCLUDE[](~/includes/package-reference.md)]
 
-In the `Program` file of the `.Client` project, register HTTP client services, giving a name to the client. In the following example, the name is `WebAPI`:
+In the `Program` file of the project, register HTTP client services, giving a name to the client. In the following example, the name is `WebAPI`:
 
 ```csharp
 builder.Services.AddHttpClient("WebAPI", client => 
@@ -375,14 +375,14 @@ For a working demonstration in a client app based on calling Microsoft Graph wit
 
 ## Typed `HttpClient`
 
-*The guidance in this section applies to using a typed <xref:System.Net.Http.HttpClient> in the `.Client` project of a Blazor Web App or in prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
+*The guidance in this section applies to using a typed <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
 
-Typed <xref:System.Net.Http.HttpClient> uses one or more of the app's <xref:System.Net.Http.HttpClient> instances, default or named, to return data from one or more web API endpoints. Typed clients are supported for classes and Razor components in the `.Client` project of a Blazor Web App and for prerendered client-side components in a Blazor Web App.
+Typed <xref:System.Net.Http.HttpClient> uses one or more of the app's <xref:System.Net.Http.HttpClient> instances, default or named, to return data from one or more web API endpoints. Typed clients are supported for classes and Razor components in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components in a Blazor Web App.
 
 > [!NOTE]
 > An alternative to using a typed <xref:System.Net.Http.HttpClient> is to use a named <xref:System.Net.Http.HttpClient> from an <xref:System.Net.Http.IHttpClientFactory>. For more information, see the [Named `HttpClient` with `IHttpClientFactory`](#named-httpclient-with-ihttpclientfactory) section.
 
-Add the [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http) NuGet package to the `.Client` project.
+Add the [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http) NuGet package to the project.
 
 [!INCLUDE[](~/includes/package-reference.md)]
 
@@ -402,7 +402,7 @@ public class ForecastHttpClient(HttpClient http)
 }
 ```
 
-In the `Program` file of the `.Client` project:
+In the `Program` file of the project:
 
 ```csharp
 builder.Services.AddHttpClient<ForecastHttpClient>(client => 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -289,7 +289,7 @@ builder.Services.AddScoped(sp =>
 
 ## Named `HttpClient` with `IHttpClientFactory`
 
-*The guidance in this section applies to using a named <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
+*The guidance in this section applies to using a named <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App or a Blazor Server app, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
 
 <xref:System.Net.Http.IHttpClientFactory> services and the configuration of a named <xref:System.Net.Http.HttpClient> are supported for classes and Razor components in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components in a Blazor Web App.
 
@@ -375,7 +375,7 @@ For a working demonstration in a client app based on calling Microsoft Graph wit
 
 ## Typed `HttpClient`
 
-*The guidance in this section applies to using a typed <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
+*The guidance in this section applies to using a typed <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App or a Blazor Server app, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
 
 Typed <xref:System.Net.Http.HttpClient> uses one or more of the app's <xref:System.Net.Http.HttpClient> instances, default or named, to return data from one or more web API endpoints. Typed clients are supported for classes and Razor components in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components in a Blazor Web App.
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -289,7 +289,7 @@ builder.Services.AddScoped(sp =>
 
 ## Named `HttpClient` with `IHttpClientFactory`
 
-*The guidance in this section applies to using a named <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App or a Blazor Server app, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
+*The guidance in this section applies to using a named <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps (for example, when you use an HTTP client only in the server project of a Blazor Web App or in a Blazor Server app), see <xref:fundamentals/http-requests#review-consumption-patterns>.*
 
 <xref:System.Net.Http.IHttpClientFactory> services and the configuration of a named <xref:System.Net.Http.HttpClient> are supported for classes and Razor components in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components in a Blazor Web App.
 
@@ -375,7 +375,7 @@ For a working demonstration in a client app based on calling Microsoft Graph wit
 
 ## Typed `HttpClient`
 
-*The guidance in this section applies to using a typed <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App or a Blazor Server app, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
+*The guidance in this section applies to using a typed <xref:System.Net.Http.HttpClient> in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps (for example, when you use an HTTP client only in the server project of a Blazor Web App or in a Blazor Server app), see <xref:fundamentals/http-requests#review-consumption-patterns>.*
 
 Typed <xref:System.Net.Http.HttpClient> uses one or more of the app's <xref:System.Net.Http.HttpClient> instances, default or named, to return data from one or more web API endpoints. Typed clients are supported for classes and Razor components in a Blazor WebAssembly app, the `.Client` project of a Blazor Web App, and for prerendered client-side components in a Blazor Web App.
 

--- a/aspnetcore/blazor/call-web-api.md
+++ b/aspnetcore/blazor/call-web-api.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to call a web API from Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 12/18/2025
+ms.date: 08/14/2026
 uid: blazor/call-web-api
 ---
 # Call a web API from ASP.NET Core Blazor
@@ -289,16 +289,18 @@ builder.Services.AddScoped(sp =>
 
 ## Named `HttpClient` with `IHttpClientFactory`
 
-<xref:System.Net.Http.IHttpClientFactory> services and the configuration of a named <xref:System.Net.Http.HttpClient> are supported.
+*The guidance in this section applies to using a named <xref:System.Net.Http.HttpClient> in the `.Client` project of a Blazor Web App or in prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
+
+<xref:System.Net.Http.IHttpClientFactory> services and the configuration of a named <xref:System.Net.Http.HttpClient> are supported for classes and Razor components in the `.Client` project of a Blazor Web App and for prerendered client-side components in a Blazor Web App.
 
 > [!NOTE]
 > An alternative to using a named <xref:System.Net.Http.HttpClient> from an <xref:System.Net.Http.IHttpClientFactory> is to use a typed <xref:System.Net.Http.HttpClient>. For more information, see the [Typed `HttpClient`](#typed-httpclient) section.
 
-Add the [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http) NuGet package to the app.
+Add the [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http) NuGet package to the `.Client` project.
 
 [!INCLUDE[](~/includes/package-reference.md)]
 
-In the `Program` file of a client project:
+In the `Program` file of the `.Client` project, register HTTP client services, giving a name to the client. In the following example, the name is `WebAPI`:
 
 ```csharp
 builder.Services.AddHttpClient("WebAPI", client => 
@@ -373,12 +375,14 @@ For a working demonstration in a client app based on calling Microsoft Graph wit
 
 ## Typed `HttpClient`
 
-Typed <xref:System.Net.Http.HttpClient> uses one or more of the app's <xref:System.Net.Http.HttpClient> instances, default or named, to return data from one or more web API endpoints.
+*The guidance in this section applies to using a typed <xref:System.Net.Http.HttpClient> in the `.Client` project of a Blazor Web App or in prerendered client-side components of a Blazor Web App. For general guidance on HTTP client patterns in ASP.NET Core apps, focusing on only using an HTTP client in the server project of a Blazor Web App, see <xref:fundamentals/http-requests#review-consumption-patterns>.*
+
+Typed <xref:System.Net.Http.HttpClient> uses one or more of the app's <xref:System.Net.Http.HttpClient> instances, default or named, to return data from one or more web API endpoints. Typed clients are supported for classes and Razor components in the `.Client` project of a Blazor Web App and for prerendered client-side components in a Blazor Web App.
 
 > [!NOTE]
 > An alternative to using a typed <xref:System.Net.Http.HttpClient> is to use a named <xref:System.Net.Http.HttpClient> from an <xref:System.Net.Http.IHttpClientFactory>. For more information, see the [Named `HttpClient` with `IHttpClientFactory`](#named-httpclient-with-ihttpclientfactory) section.
 
-Add the [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http) NuGet package to the app.
+Add the [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http) NuGet package to the `.Client` project.
 
 [!INCLUDE[](~/includes/package-reference.md)]
 
@@ -398,7 +402,7 @@ public class ForecastHttpClient(HttpClient http)
 }
 ```
 
-In the `Program` file of a client project:
+In the `Program` file of the `.Client` project:
 
 ```csharp
 builder.Services.AddHttpClient<ForecastHttpClient>(client => 


### PR DESCRIPTION
Fixes #37475

Wade, Tom ... Just need one review on this one.

I want the sections on named and typed HTTP clients to clarify that they mostly apply to Blazor WebAssembly, the `.Client` project (assembly) of a Blazor Web App (BWA), and prerendered client-side components of a BWA. We should direct readers to the main doc set coverage via a cross-link for purely server-side use in BWAs and older Blazor Server apps. In the purely server-side case, it's the same coverage as for any ASP.NET Core app.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/blazor/call-web-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/3c19c41f35cbd00b583596943b2003b3603fd5b5/aspnetcore/blazor/call-web-api.md) | [aspnetcore/blazor/call-web-api](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/call-web-api?view=aspnetcore-11.0&branch=pr-en-us-37480) |


<!-- PREVIEW-TABLE-END -->