### PR TITLE
Add authorization ordering guidance to the URL rewriting article

### DIFF
--- a/aspnetcore/fundamentals/url-rewriting.md
+++ b/aspnetcore/fundamentals/url-rewriting.md
@@ -1,11 +1,12 @@
 ---
 title: URL rewriting middleware in ASP.NET Core
+ai-usage: ai-assisted
 author: wadepickett
 description: Learn about URL rewriting and redirecting with URL rewriting middleware in ASP.NET Core applications.
 monikerRange: '>= aspnetcore-2.1'
 ms.author: wpickett
 ms.custom: sfi-image-nochange
-ms.date: 07/06/2026
+ms.date: 08/17/2026
 uid: fundamentals/url-rewriting
 ---
 # URL rewriting middleware in ASP.NET Core
@@ -86,6 +87,34 @@ Establish URL rewrite and redirect rules by creating an instance of the [Rewrite
 [!code-csharp[](url-rewriting/samples/6.x/SampleApp/Program.cs?name=snippet1&highlight=7-24)]
 
 In the preceding code, [`MethodRules`](https://github.com/dotnet/AspNetCore.Docs/blob/main/aspnetcore/fundamentals/url-rewriting/samples/6.x/SampleApp/RewriteRules.cs) is a user defined class. See [`RewriteRules.cs`](#rrr) in this article for more information.
+
+### Authorization and URL rewriting
+
+When a rule changes the request path, routing evaluates the new path and can select a different endpoint than the one that matched the original path. Authorization must run for the endpoint that's finally selected. Otherwise, the authorization requirements of that endpoint aren't applied.
+
+An app that calls `UseRewriter` and protects any endpoint with authorization must add the authentication and authorization middleware explicitly, and must add it after `UseRewriter`:
+
+```csharp
+app.UseRewriter(options);
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+When the app calls `UseRouting` explicitly, use the following order:
+
+```csharp
+app.UseRewriter(options);
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+```
+
+Both of the following configurations evaluate authorization against the endpoint selected for the original path rather than the rewritten path:
+
+* Relying on the authentication and authorization middleware that's added automatically when the corresponding services are registered, without calling `UseAuthentication` and `UseAuthorization`.
+* Calling `UseAuthentication` and `UseAuthorization` before `UseRewriter`.
+
+Always run the latest supported patch release.
 
 ### Redirect non-www to www
 


### PR DESCRIPTION
Related to dotnet/aspnetcore#68581

## Summary

Adds an `Authorization and URL rewriting` section to the URL rewriting article.

When a rewrite rule changes the request path, routing evaluates the new path and can select a different endpoint than the one that matched the original path. The article previously showed `app.UseRewriter(...)` without any routing or authorization middleware in its samples, and gave no guidance on where authentication and authorization belong relative to the rewriter.

The new section states the requirement explicitly: an app that calls `UseRewriter` and protects any endpoint with authorization must add the authentication and authorization middleware itself, after `UseRewriter`. It also names the two configurations that evaluate authorization against the pre-rewrite endpoint.

## Modified files

- `aspnetcore/fundamentals/url-rewriting.md` - adds the `Authorization and URL rewriting` section after the `Extension and options` sample; adds `ai-usage: ai-assisted` and updates `ms.date`.
