### PR TITLE
Fix typo

### DIFF
--- a/aspnetcore/blazor/fundamentals/index.md
+++ b/aspnetcore/blazor/fundamentals/index.md
@@ -131,7 +131,7 @@ Articles in the *Fundamentals* node make reference to the concept of *render mod
 
 For the early references in this node of articles to render mode concepts, merely note the following at this time:
 
-Every component in a Blazor Web App adopts a *render mode* to determine the hosting model that it uses, where it's rendered, and whether or not it's rendered statically on the server, rendered with for user interactivity on the server, or rendered for user interactivity on the client (usually with prerendering on the server).
+Every component in a Blazor Web App adopts a *render mode* to determine the hosting model that it uses, where it's rendered, and whether or not it's rendered statically on the server, rendered for user interactivity on the server, or rendered for user interactivity on the client (usually with prerendering on the server).
 
 Blazor Server and Blazor WebAssembly apps for ASP.NET Core releases prior to .NET 8 remain fixated on *hosting model* concepts, not render modes. Render modes are conceptually applied to Blazor Web Apps in .NET 8 or later.
 


### PR DESCRIPTION
It appears both `with` and `for` were both leftover from an editing process. This edit chooses `for` to match the final clause, `rendered for user interactivity on the client`

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/blazor/fundamentals/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/f991f3f39515514dcc53c80f4012b6943885ee45/aspnetcore/blazor/fundamentals/index.md) | [aspnetcore/blazor/fundamentals/index](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/fundamentals/index?view=aspnetcore-11.0&branch=pr-en-us-37490) |

<!-- PREVIEW-TABLE-END -->