### PR TITLE
Improve description of `AllowUpdates`

### DIFF
--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -488,16 +488,14 @@ protected override async Task OnInitializedAsync()
 :::moniker range=">= aspnetcore-11.0"
 
 > [!NOTE]
-> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't
-control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) or [tab inactivity](xref:#automatic-circuit-pause-on-tab-inactivity).
+> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) or [tab inactivity](xref:#automatic-circuit-pause-on-tab-inactivity).
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-10.0 < aspnetcore-11.0"
 
 > [!NOTE]
-> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't
-control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence).
+> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -488,7 +488,7 @@ protected override async Task OnInitializedAsync()
 :::moniker range=">= aspnetcore-11.0"
 
 > [!NOTE]
-> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) or [tab inactivity](xref:#automatic-circuit-pause-on-tab-inactivity).
+> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) or [tab inactivity](xref:blazor/state-management/server#automatic-circuit-pause-on-tab-inactivity).
 
 :::moniker-end
 

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -5,7 +5,7 @@ author: guardrex
 description: Learn how to persist user data (state) in Blazor apps using Blazor's Persistent Component State service.
 monikerRange: '>= aspnetcore-8.0'
 ms.author: wpickett
-ms.date: 08/18/2026
+ms.date: 08/20/2026
 uid: blazor/state-management/prerendered-state-persistence
 ---
 # ASP.NET Core Blazor prerendered state persistence
@@ -488,14 +488,22 @@ protected override async Task OnInitializedAsync()
 :::moniker range=">= aspnetcore-11.0"
 
 > [!NOTE]
-> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) or [tab inactivity](xref:blazor/state-management/server#automatic-circuit-pause-on-tab-inactivity).
+> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether the current property value is captured by [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) when the circuit pauses, including an automatic pause caused by [tab inactivity](xref:blazor/state-management/server#automatic-circuit-pause-on-tab-inactivity).
 
 :::moniker-end
 
 :::moniker range=">= aspnetcore-10.0 < aspnetcore-11.0"
 
 > [!NOTE]
-> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence).
+> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether the current property value is captured by [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) when the circuit pauses.
+
+
+doesn't control whether property mutations are captured when a circuit pauses due to .
+
+
+doesn't control whether the current property value is captured by [circuit state persistance] when circuit pauses.
+
+
 
 :::moniker-end
 

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -497,14 +497,6 @@ protected override async Task OnInitializedAsync()
 > [!NOTE]
 > <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't control whether the current property value is captured by [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) when the circuit pauses.
 
-
-doesn't control whether property mutations are captured when a circuit pauses due to .
-
-
-doesn't control whether the current property value is captured by [circuit state persistance] when circuit pauses.
-
-
-
 :::moniker-end
 
 :::moniker range=">= aspnetcore-10.0"

--- a/aspnetcore/blazor/state-management/prerendered-state-persistence.md
+++ b/aspnetcore/blazor/state-management/prerendered-state-persistence.md
@@ -5,7 +5,7 @@ author: guardrex
 description: Learn how to persist user data (state) in Blazor apps using Blazor's Persistent Component State service.
 monikerRange: '>= aspnetcore-8.0'
 ms.author: wpickett
-ms.date: 08/03/2026
+ms.date: 08/18/2026
 uid: blazor/state-management/prerendered-state-persistence
 ---
 # ASP.NET Core Blazor prerendered state persistence
@@ -471,7 +471,7 @@ Blazor supports handling persistent component state during [enhanced navigation]
 
 By default, persistent component state is only loaded by interactive components when they're initially loaded on the page. This prevents important state, such as data in an edited webform, from being overwritten if additional enhanced navigation events to the same page occur after the component is loaded.
 
-If the data is read-only and doesn't change frequently, opt-in to allow updates during enhanced navigation by setting `AllowUpdates = true` on the [`[PersistentState]` attribute](xref:Microsoft.AspNetCore.Components.PersistentStateAttribute). This is useful for scenarios such as displaying cached data that's expensive to fetch but doesn't change often. The following example demonstrates the use of `AllowUpdates` for weather forecast data:
+If the data is read-only and doesn't change frequently, opt-in to allow updates during enhanced navigation by setting <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A> to `true` on the [`[PersistentState]` attribute](xref:Microsoft.AspNetCore.Components.PersistentStateAttribute). This is useful for scenarios such as displaying cached data that's expensive to fetch but doesn't change often, such as weather forecast data in the following example:
 
 ```csharp
 [PersistentState(AllowUpdates = true)]
@@ -482,6 +482,26 @@ protected override async Task OnInitializedAsync()
     Forecasts ??= await ForecastService.GetForecastAsync();
 }
 ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-11.0"
+
+> [!NOTE]
+> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't
+control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) or [tab inactivity](xref:#automatic-circuit-pause-on-tab-inactivity).
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-10.0 < aspnetcore-11.0"
+
+> [!NOTE]
+> <xref:Microsoft.AspNetCore.Components.PersistentStateAttribute.AllowUpdates%2A?displayProperty=nameWithType> doesn't
+control whether property mutations are captured when a circuit pauses due to [circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence).
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-10.0"
 
 To skip restoring state during prerendering, set `RestoreBehavior` to `SkipInitialValue`:
 

--- a/aspnetcore/blazor/state-management/server.md
+++ b/aspnetcore/blazor/state-management/server.md
@@ -5,7 +5,7 @@ author: guardrex
 description: Learn how to persist user data (state) in server-side Blazor apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 07/23/2026
+ms.date: 08/18/2026
 uid: blazor/state-management/server
 ---
 # ASP.NET Core Blazor server-side state management
@@ -254,7 +254,7 @@ For elements without Blazor bindings (for example, `<canvas>`, WebRTC connection
 > <span>@SelectedFileName</span>
 >
 > @code {
->     [PersistentState(AllowUpdates = true)]
+>     [PersistentState]
 >     public string? SelectedFileName { get; set; }
 >
 >     private async Task HandleFileSelected(ChangeEventArgs e)


### PR DESCRIPTION
Fixes #37483

Ilona ... I opened a framework API summary change for this at https://github.com/dotnet/aspnetcore/pull/68618. I need help interpreting and selecting the best language for Dan's remark over here ...

> Add a short note near the first AllowUpdates example explaining that it doesn't control whether later mutations are captured when a circuit pauses.

I'd like to specify that we're talking about property mutations and not use the word "later" unless we end up specifying when "later" is, so my draft goes like this ...

For >=11.0 ...

> `PersistentStateAttribute.AllowUpdates` doesn't control whether property mutations are captured when a circuit pauses due to \[circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence) or \[tab inactivity](xref:#automatic-circuit-pause-on-tab-inactivity).

For >=10 and <11.0 ...

> `PersistentStateAttribute.AllowUpdates` doesn't control whether property mutations are captured when a circuit pauses due to \[circuit state persistence](xref:blazor/state-management/server#circuit-state-persistence).

We could also work further with the word "control" as well. Should it state something more like ...

> `PersistentStateAttribute.AllowUpdates` doesn't result in capturing property mutations while a circuit pauses due to ...

If correct, such a change clarifies what "control" means in the original sentence.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/blazor/state-management/prerendered-state-persistence.md](https://github.com/dotnet/AspNetCore.Docs/blob/96896951a36eb2c328f6df4b7dfd9ef74cc4ad3c/aspnetcore/blazor/state-management/prerendered-state-persistence.md) | [aspnetcore/blazor/state-management/prerendered-state-persistence](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/state-management/prerendered-state-persistence?view=aspnetcore-11.0&branch=pr-en-us-37494) |
| [aspnetcore/blazor/state-management/server.md](https://github.com/dotnet/AspNetCore.Docs/blob/96896951a36eb2c328f6df4b7dfd9ef74cc4ad3c/aspnetcore/blazor/state-management/server.md) | [aspnetcore/blazor/state-management/server](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/state-management/server?view=aspnetcore-11.0&branch=pr-en-us-37494) |


<!-- PREVIEW-TABLE-END -->