### PR TITLE
[11.0 P6] Blazor CSP guidance updates

### DIFF
--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -550,6 +550,7 @@ CSP violations are avoided because `Virtualize` components:
 
 * Render calculated spacer and placeholder heights as numeric values in `data-blazor-virtualize-reserved-height` attributes.
 * When required, render the trailing spacer's vertical offset as a numeric value in a `data-blazor-virtualize-loop-breaker-transform` attribute to hide the spacer.
+
 A JS [`MutationObserver`](https://developer.mozilla.org/docs/Web/API/MutationObserver) validates the attribute values and applies them via the [CSS Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model) as pixel-based `height` and `transform` styles.
 
 :::moniker-end

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -542,18 +542,31 @@ In the preceding example, the document root is used as the scroll container, so 
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-11.0"
-
 ## Content Security Policy (CSP) compliance
 
-The `Virtualize` component renders dynamic inline `style` attributes on its spacer elements because spacer heights are calculated at runtime based on scroll position, item count, and average item size, which change on every scroll interaction.
+:::moniker range=">= aspnetcore-11.0"
 
-To avoid CSP violations, render CSS height in a `data-blazor-virtualize-reserved-height` attribute instead of a `style` attribute, which makes the rendered component compatible with strict [Content Security Policy (CSP)](https://developer.mozilla.org/docs/Web/HTTP/Guides/CSP) configurations.
+CSP violations are avoided because `Virtualize` components:
+
+* Render CSS styles in a `data-blazor-style` attribute instead of a `style` attribute.
+* Use a JS [`MutationObserver`](https://developer.mozilla.org/docs/Web/API/MutationObserver) to read the attribute's value and apply each declaration via the [CSS Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model): `element.style.setProperty(name, value)`.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-11.0"
+
+The `Virtualize` component renders dynamic inline `style` attributes on its spacer elements because spacer heights are calculated at runtime based on scroll position, item count, and average item size, which change on every scroll interaction. To avoid CSP violations, render CSS height in a `data-blazor-virtualize-reserved-height` attribute instead of a `style` attribute, which makes the rendered component compatible with strict [Content Security Policy (CSP)](https://developer.mozilla.org/docs/Web/HTTP/Guides/CSP) configurations.
 
 In the following example, the height is set to 3,400 pixels:
 
 ```razor
 <div data-blazor-virtualize-reserved-height="3400" aria-hidden="true"></div>
 ```
+
+:::moniker-end
+
+:::moniker range="< aspnetcore-7.0"
+
+The `Virtualize` component renders dynamic inline `style` attributes on its spacer elements because spacer heights are calculated at runtime based on scroll position, item count, and average item size, which change on every scroll interaction. Apps are required to relax `style-src` with `'unsafe-inline'` to allow inline styles for the component to function.
 
 :::moniker-end

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to use component virtualization in ASP.NET Core Blazor apps.
 monikerRange: '>= aspnetcore-5.0'
 ms.author: wpickett
-ms.date: 07/14/2026
+ms.date: 08/18/2026
 uid: blazor/components/virtualization
 ---
 # ASP.NET Core Razor component virtualization
@@ -542,7 +542,7 @@ In the preceding example, the document root is used as the scroll container, so 
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-7.0"
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-11.0"
 
 ## Content Security Policy (CSP) compliance
 

--- a/aspnetcore/blazor/components/virtualization.md
+++ b/aspnetcore/blazor/components/virtualization.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to use component virtualization in ASP.NET Core Blazor apps.
 monikerRange: '>= aspnetcore-5.0'
 ms.author: wpickett
-ms.date: 08/18/2026
+ms.date: 08/26/2026
 uid: blazor/components/virtualization
 ---
 # ASP.NET Core Razor component virtualization
@@ -548,8 +548,9 @@ In the preceding example, the document root is used as the scroll container, so 
 
 CSP violations are avoided because `Virtualize` components:
 
-* Render CSS styles in a `data-blazor-style` attribute instead of a `style` attribute.
-* Use a JS [`MutationObserver`](https://developer.mozilla.org/docs/Web/API/MutationObserver) to read the attribute's value and apply each declaration via the [CSS Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model): `element.style.setProperty(name, value)`.
+* Render calculated spacer and placeholder heights as numeric values in `data-blazor-virtualize-reserved-height` attributes.
+* When required, render the trailing spacer's vertical offset as a numeric value in a `data-blazor-virtualize-loop-breaker-transform` attribute to hide the spacer.
+A JS [`MutationObserver`](https://developer.mozilla.org/docs/Web/API/MutationObserver) validates the attribute values and applies them via the [CSS Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model) as pixel-based `height` and `transform` styles.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -4,7 +4,7 @@ author: guardrex
 description: Learn how to use a Content Security Policy (CSP) with ASP.NET Core Blazor apps to help protect against Cross-Site Scripting (XSS) attacks.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 11/11/2025
+ms.date: 08/18/2026
 uid: blazor/security/content-security-policy
 ---
 # Enforce a Content Security Policy for ASP.NET Core Blazor
@@ -298,6 +298,12 @@ For Blazor Server apps:
 
 > [!NOTE]
 > The preceding SHA256 hash is for demonstration purposes. You may need to calculate a new hash for your CSP.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-7.0 < aspnetcore-11.0"
+
+If the app uses one or more `Virtualize` components, they render dynamic inline `style` attributes on their spacer elements because spacer heights are calculated at runtime based on scroll position, item count, and average item size, which change on every scroll interaction. For guidance on how to avoid CSP violations for `Virtualize` components, see <xref:blazor/components/virtualization#content-security-policy-csp-compliance>.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -303,7 +303,7 @@ For Blazor Server apps:
 
 :::moniker range=">= aspnetcore-5.0 < aspnetcore-11.0"
 
-If the app uses one or more `Virtualize` components, they render dynamic inline `style` attributes on their spacer elements because spacer heights are calculated at runtime based on scroll position, item count, and average item size, which change on every scroll interaction. Strict CSP configurations that don't allow inline styles can block these `style` attributes and prevent virtualization from working. If you can't upgrade to ASP.NET Core 11.0 or later (where `Virtualize` is CSP-compliant), you may need to relax `style-src` to allow inline styles for the component to function. For more information, see <xref:blazor/components/virtualization#content-security-policy-csp-compliance>.
+If the app uses one or more `Virtualize` components, they render dynamic inline `style` attributes on their spacer elements because spacer heights are calculated at runtime based on scroll position, item count, and average item size, which change on every scroll interaction. Strict CSP configurations that don't allow inline styles block these `style` attributes and prevent virtualization from working. If you can't upgrade to ASP.NET Core 11.0 or later (where `Virtualize` is CSP-compliant), see <xref:blazor/components/virtualization#content-security-policy-csp-compliance>.
 
 :::moniker-end
 

--- a/aspnetcore/blazor/security/content-security-policy.md
+++ b/aspnetcore/blazor/security/content-security-policy.md
@@ -301,9 +301,9 @@ For Blazor Server apps:
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-7.0 < aspnetcore-11.0"
+:::moniker range=">= aspnetcore-5.0 < aspnetcore-11.0"
 
-If the app uses one or more `Virtualize` components, they render dynamic inline `style` attributes on their spacer elements because spacer heights are calculated at runtime based on scroll position, item count, and average item size, which change on every scroll interaction. For guidance on how to avoid CSP violations for `Virtualize` components, see <xref:blazor/components/virtualization#content-security-policy-csp-compliance>.
+If the app uses one or more `Virtualize` components, they render dynamic inline `style` attributes on their spacer elements because spacer heights are calculated at runtime based on scroll position, item count, and average item size, which change on every scroll interaction. Strict CSP configurations that don't allow inline styles can block these `style` attributes and prevent virtualization from working. If you can't upgrade to ASP.NET Core 11.0 or later (where `Virtualize` is CSP-compliant), you may need to relax `style-src` to allow inline styles for the component to function. For more information, see <xref:blazor/components/virtualization#content-security-policy-csp-compliance>.
 
 :::moniker-end
 

--- a/aspnetcore/release-notes/aspnetcore-11.md
+++ b/aspnetcore/release-notes/aspnetcore-11.md
@@ -4,7 +4,7 @@ ai-usage: ai-assisted
 author: wadepickett
 description: Learn about the new features in ASP.NET Core in .NET 11.
 ms.author: wpickett
-ms.date: 08/13/2026
+ms.date: 08/26/2026
 uid: aspnetcore-11
 ---
 # What's new in ASP.NET Core in .NET 11

--- a/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
@@ -177,7 +177,7 @@ For more information, see the following resources:
 
   Now, CSP violations are avoided because `Virtualize` components:
 
-  * Render CSS styles in a `data-blazor-style` attribute instead of a `style` attribute.
+  * Render CSS styles in a `data-blazor-virtualize-reserved-height` attribute instead of a `style` attribute.
   * Use a JS [`MutationObserver`](https://developer.mozilla.org/docs/Web/API/MutationObserver) to read the attribute's value and apply each declaration via the [CSS Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model): `element.style.setProperty(name, value)`.
 
 ### New service defaults library project template for Blazor WebAssembly apps

--- a/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
@@ -177,8 +177,8 @@ For more information, see the following resources:
 
   Now, CSP violations are avoided because `Virtualize` components:
 
-  * Render CSS styles in a `data-blazor-virtualize-reserved-height` attribute instead of a `style` attribute.
-  * Use a JS [`MutationObserver`](https://developer.mozilla.org/docs/Web/API/MutationObserver) to read the attribute's value and apply each declaration via the [CSS Object Model (CSSOM)](https://developer.mozilla.org/docs/Web/API/CSS_Object_Model): `element.style.setProperty(name, value)`.
+  * Render calculated spacer and placeholder heights as numeric values in `data-blazor-virtualize-reserved-height` attributes.
+  * When required, render the trailing spacer's vertical offset as a numeric value in a `data-blazor-virtualize-loop-breaker-transform` attribute to hide the spacer.
 
 ### New service defaults library project template for Blazor WebAssembly apps
 


### PR DESCRIPTION
Fixes #37339

Looks like we need a little work on the CSP section of the *Virtualization* article and to add a (missed 🙈) remark about the `Virtualize` component to the CSP article (that drops out at 11.0).

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/blazor/components/virtualization.md](https://github.com/dotnet/AspNetCore.Docs/blob/184fc5fd86d4a964bc043a4d9e5f25cca0c987cf/aspnetcore/blazor/components/virtualization.md) | [aspnetcore/blazor/components/virtualization](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/components/virtualization?view=aspnetcore-11.0&branch=pr-en-us-37495) |
| [aspnetcore/blazor/security/content-security-policy.md](https://github.com/dotnet/AspNetCore.Docs/blob/184fc5fd86d4a964bc043a4d9e5f25cca0c987cf/aspnetcore/blazor/security/content-security-policy.md) | [aspnetcore/blazor/security/content-security-policy](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/content-security-policy?view=aspnetcore-11.0&branch=pr-en-us-37495) |
| [aspnetcore/release-notes/aspnetcore-11.md](https://github.com/dotnet/AspNetCore.Docs/blob/184fc5fd86d4a964bc043a4d9e5f25cca0c987cf/aspnetcore/release-notes/aspnetcore-11.md) | [aspnetcore/release-notes/aspnetcore-11](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-11?view=aspnetcore-11.0&branch=pr-en-us-37495) |
| [aspnetcore/release-notes/aspnetcore-11/includes/blazor.md](https://github.com/dotnet/AspNetCore.Docs/blob/184fc5fd86d4a964bc043a4d9e5f25cca0c987cf/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md) | [aspnetcore/release-notes/aspnetcore-11/includes/blazor](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-11?view=aspnetcore-11.0&branch=pr-en-us-37495) |


<!-- PREVIEW-TABLE-END -->