### PR TITLE
Add OAuth 2.0 for Browser-Based Applications standard to OIDC doc

### DIFF
--- a/aspnetcore/security/authentication/configure-oidc-web-authentication.md
+++ b/aspnetcore/security/authentication/configure-oidc-web-authentication.md
@@ -381,5 +381,6 @@ For more information, see <xref:blazor/security/blazor-web-app-oidc>.
 
 * [OpenID Connect 1.0](https://openid.net/specs/openid-connect-core-1_0-final.html)
 * [Proof Key for Code Exchange by OAuth Public Clients](https://datatracker.ietf.org/doc/html/rfc7636)
+* [OAuth 2.0 for Browser-Based Applications](https://datatracker.ietf.org/doc/html/rfc10017)
 * [The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
 * [OAuth 2.0 Pushed Authorization Requests (PAR) RFC 9126](https://datatracker.ietf.org/doc/html/rfc9126)


### PR DESCRIPTION
Add the OAuth 2.0 for Browser-Based Applications standard reference to the OIDC documentation. 

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/security/authentication/configure-oidc-web-authentication.md](https://github.com/dotnet/AspNetCore.Docs/blob/401875ee210db183ab915ea905889e3e3225ec2b/aspnetcore/security/authentication/configure-oidc-web-authentication.md) | [aspnetcore/security/authentication/configure-oidc-web-authentication](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/configure-oidc-web-authentication?view=aspnetcore-11.0&branch=pr-en-us-37514) |

<!-- PREVIEW-TABLE-END -->