### PR TITLE
Add note on constructor parameter precedence in binding

### DIFF
--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -123,6 +123,8 @@ Binding supports:
 
 You can also use the [`[DataMember]`](xref:System.Runtime.Serialization.DataMemberAttribute) and [`[IgnoreDataMember]`](xref:System.Runtime.Serialization.IgnoreDataMemberAttribute) attributes to customize model binding. Use these attributes to rename properties, ignore properties, and mark properties as required.
 
+When binding a type with constructor parameters, if a constructor parameter matches a property by name, the constructor parameter takes precedence. The mapper uses the property’s explicit `DataMember.Name`, if present, as the form field name, but otherwise ignores the property’s mapping attributes. Constructor parameters are always required.
+
 ## Additional binding options
 
 Additional model binding options are available from <xref:Microsoft.AspNetCore.Components.Endpoints.RazorComponentsServiceOptions> when calling <xref:Microsoft.Extensions.DependencyInjection.RazorComponentsServiceCollectionExtensions.AddRazorComponents%2A>:


### PR DESCRIPTION
Clarified behavior of constructor parameters in model binding.



<!--
# Instructions

When creating a new PR, please reference the issue number if there is one:

Fixes #Issue_Number

The "Fixes #nnn" syntax in the PR description allows GitHub to automatically close the issue when this PR is merged.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/888e20756e570e829f1f24d14c449a953a60c305/aspnetcore/blazor/forms/binding.md) | [aspnetcore/blazor/forms/binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?view=aspnetcore-11.0&branch=pr-en-us-37523) |

<!-- PREVIEW-TABLE-END -->