### PR TITLE
Document MVC and form-mapping differences

### DIFF
--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -1,10 +1,11 @@
 ---
 title: ASP.NET Core Blazor forms binding
+ai-usage: ai-assisted
 author: guardrex
 description: Learn how to use binding in Blazor forms.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 11/11/2025
+ms.date: 08/24/2026
 uid: blazor/forms/binding
 ---
 # ASP.NET Core Blazor forms binding
@@ -121,9 +122,14 @@ Binding supports:
 * Types with constructors
 * Enums
 
+## Form-mapping attributes
+
 You can also use the [`[DataMember]`](xref:System.Runtime.Serialization.DataMemberAttribute) and [`[IgnoreDataMember]`](xref:System.Runtime.Serialization.IgnoreDataMemberAttribute) attributes to customize model binding. Use these attributes to rename properties, ignore properties, and mark properties as required.
 
 When binding a type with constructor parameters, if a constructor parameter matches a property by name, the constructor parameter takes precedence. The mapper uses the property’s explicit `DataMember.Name`, if present, as the form field name, but otherwise ignores the property’s mapping attributes. Constructor parameters are always required.
+
+> [!WARNING]
+> Blazor form mapping with [`[SupplyParameterFromForm]`](xref:Microsoft.AspNetCore.Components.SupplyParameterFromFormAttribute) doesn't use MVC model binding. Attributes in the `Microsoft.AspNetCore.Mvc.ModelBinding` namespace, such as [`[BindNever]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindNeverAttribute) and [`[BindRequired]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindRequiredAttribute), aren't supported. Don't use these attributes to prevent overposting. Instead, use a dedicated form model, view model, or data transfer object (DTO) that includes only the properties users are allowed to modify. For more information, see [Mitigate overposting attacks](xref:blazor/forms/index#mitigate-overposting-attacks).
 
 ## Additional binding options
 

--- a/aspnetcore/blazor/forms/binding.md
+++ b/aspnetcore/blazor/forms/binding.md
@@ -122,14 +122,9 @@ Binding supports:
 * Types with constructors
 * Enums
 
-## Form-mapping attributes
-
 You can also use the [`[DataMember]`](xref:System.Runtime.Serialization.DataMemberAttribute) and [`[IgnoreDataMember]`](xref:System.Runtime.Serialization.IgnoreDataMemberAttribute) attributes to customize model binding. Use these attributes to rename properties, ignore properties, and mark properties as required.
 
 When binding a type with constructor parameters, if a constructor parameter matches a property by name, the constructor parameter takes precedence. The mapper uses the property’s explicit `DataMember.Name`, if present, as the form field name, but otherwise ignores the property’s mapping attributes. Constructor parameters are always required.
-
-> [!WARNING]
-> Blazor form mapping with [`[SupplyParameterFromForm]`](xref:Microsoft.AspNetCore.Components.SupplyParameterFromFormAttribute) doesn't use MVC model binding. Attributes in the `Microsoft.AspNetCore.Mvc.ModelBinding` namespace, such as [`[BindNever]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindNeverAttribute) and [`[BindRequired]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindRequiredAttribute), aren't supported. Don't use these attributes to prevent overposting. Instead, use a dedicated form model, view model, or data transfer object (DTO) that includes only the properties users are allowed to modify. For more information, see [Mitigate overposting attacks](xref:blazor/forms/index#mitigate-overposting-attacks).
 
 ## Additional binding options
 
@@ -235,6 +230,8 @@ The following `NamedFormsWithScope` component uses the library's `HelloFormFromL
 ## Supply a parameter from the form (`[SupplyParameterFromForm]`)
 
 The `[SupplyParameterFromForm]` attribute indicates that the value of the associated property should be supplied from the form data for the form. Data in the request that matches the name of the property is bound to the property. Inputs based on `InputBase<TValue>` generate form value names that match the names Blazor uses for model binding. Unlike component parameter properties (`[Parameter]`), properties annotated with `[SupplyParameterFromForm]` aren't required to be marked `public`.
+
+Blazor form mapping with [`[SupplyParameterFromForm]`](xref:Microsoft.AspNetCore.Components.SupplyParameterFromFormAttribute) doesn't use MVC model binding. Attributes in the <xref:Microsoft.AspNetCore.Mvc.ModelBinding?displayProperty=fullName> namespace, such as [`[BindNever]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindNeverAttribute) and [`[BindRequired]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindRequiredAttribute), aren't supported. Don't use these attributes to prevent overposting. Instead, use a dedicated form model, view model, or data transfer object (DTO) that includes only the properties users are allowed to modify. For more information, see [Mitigate overposting attacks](xref:blazor/forms/index#mitigate-overposting-attacks).
 
 You can specify the following form binding parameters to the [`[SupplyParameterFromForm]` attribute](xref:Microsoft.AspNetCore.Components.SupplyParameterFromFormAttribute):
 

--- a/aspnetcore/fundamentals/minimal-apis/includes/parameter-binding8-10.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/parameter-binding8-10.md
@@ -254,7 +254,7 @@ Binding is supported for:
 * Complex types, for example, `Todo` or `Project`
 
 > [!WARNING]
-> Complex-type form mapping with [`[FromForm]`](xref:Microsoft.AspNetCore.Mvc.FromFormAttribute) in Minimal APIs doesn't use MVC model binding. Attributes in the `Microsoft.AspNetCore.Mvc.ModelBinding` namespace, such as [`[BindNever]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindNeverAttribute) and [`[BindRequired]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindRequiredAttribute), aren't supported. Don't use these attributes to prevent overposting. Instead, use a dedicated input model or data transfer object (DTO) that includes only the properties clients are allowed to modify.
+> Complex-type form mapping with [`[FromForm]`](xref:Microsoft.AspNetCore.Mvc.FromFormAttribute) in Minimal APIs doesn't use MVC model binding. Attributes in the <xref:Microsoft.AspNetCore.Mvc.ModelBinding?displayProperty=fullName> namespace, such as [`[BindNever]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindNeverAttribute) and [`[BindRequired]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindRequiredAttribute), aren't supported. Don't use these attributes to prevent overposting. Instead, use a dedicated input model or data transfer object (DTO) that includes only the properties clients are allowed to modify.
 
 The following code shows:
 

--- a/aspnetcore/fundamentals/minimal-apis/includes/parameter-binding8-10.md
+++ b/aspnetcore/fundamentals/minimal-apis/includes/parameter-binding8-10.md
@@ -253,6 +253,9 @@ Binding is supported for:
 * Collections, for example [List](/dotnet/api/system.collections.generic.list-1) and [Dictionary](/dotnet/api/system.collections.generic.dictionary-2)
 * Complex types, for example, `Todo` or `Project`
 
+> [!WARNING]
+> Complex-type form mapping with [`[FromForm]`](xref:Microsoft.AspNetCore.Mvc.FromFormAttribute) in Minimal APIs doesn't use MVC model binding. Attributes in the `Microsoft.AspNetCore.Mvc.ModelBinding` namespace, such as [`[BindNever]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindNeverAttribute) and [`[BindRequired]`](xref:Microsoft.AspNetCore.Mvc.ModelBinding.BindRequiredAttribute), aren't supported. Don't use these attributes to prevent overposting. Instead, use a dedicated input model or data transfer object (DTO) that includes only the properties clients are allowed to modify.
+
 The following code shows:
 
 * A minimal endpoint that binds a multi-part form input to a complex object.
@@ -264,7 +267,7 @@ In the preceding code:
 
 * The target parameter ***must*** be annotated with the [`[FromForm]`](xref:Microsoft.AspNetCore.Mvc.FromFormAttribute) attribute to disambiguate from parameters that should be read from the JSON body.
 * Binding from complex or collection types is ***not*** supported for Minimal APIs that are compiled with the Request Delegate Generator.
-* The markup shows an additional hidden input with a name of `isCompleted` and a value of `false`. If the `isCompleted` checkbox is checked when the form is submitted, both values `true` and `false` are submitted as values. If the checkbox is unchecked, only the hidden input value `false` is submitted. The ASP.NET Core model-binding process reads only the first value when binding to a `bool` value, which results in `true` for checked checkboxes and `false` for unchecked checkboxes.
+* The markup shows an additional hidden input with a name of `isCompleted` and a value of `false`. If the `isCompleted` checkbox is checked when the form is submitted, both values `true` and `false` are submitted as values. If the checkbox is unchecked, only the hidden input value `false` is submitted. The ASP.NET Core form-mapping process reads only the first value when binding to a `bool` value, which results in `true` for checked checkboxes and `false` for unchecked checkboxes.
   
 An example of the form data submitted to the preceding endpoint looks as follows:
 

--- a/aspnetcore/fundamentals/minimal-apis/parameter-binding.md
+++ b/aspnetcore/fundamentals/minimal-apis/parameter-binding.md
@@ -1,12 +1,12 @@
 ---
 title: Parameter binding in Minimal API applications
-ai-usage: ai-assisted
 author: wadepickett
 description: Learn how parameters are populated before invoking minimal route handlers.
-monikerRange: '>= aspnetcore-7.0'
 ms.author: wpickett
-ms.date: 08/24/2026
+monikerRange: '>= aspnetcore-7.0'
+ms.date: 07/16/2026
 uid: fundamentals/minimal-apis/parameter-binding
+ai-usage: ai-assisted
 ---
 
 # Parameter Binding in Minimal API apps

--- a/aspnetcore/fundamentals/minimal-apis/parameter-binding.md
+++ b/aspnetcore/fundamentals/minimal-apis/parameter-binding.md
@@ -1,12 +1,12 @@
 ---
 title: Parameter binding in Minimal API applications
+ai-usage: ai-assisted
 author: wadepickett
 description: Learn how parameters are populated before invoking minimal route handlers.
-ms.author: wpickett
 monikerRange: '>= aspnetcore-7.0'
-ms.date: 07/16/2026
+ms.author: wpickett
+ms.date: 08/24/2026
 uid: fundamentals/minimal-apis/parameter-binding
-ai-usage: ai-assisted
 ---
 
 # Parameter Binding in Minimal API apps


### PR DESCRIPTION
Documents that Minimal API and Blazor form mapping don't honor MVC model-binding attributes such as `[BindNever]` and `[BindRequired]`.

## Summary

- Adds warnings next to complex form-mapping guidance for Minimal APIs and Blazor.
- Recommends dedicated input models or DTOs to mitigate overposting.
- Clarifies form-mapping terminology in the Minimal API guidance.

## Files changed

- `aspnetcore/fundamentals/minimal-apis/includes/parameter-binding8-10.md`: Documents unsupported MVC model-binding attributes and the recommended mitigation.
- `aspnetcore/fundamentals/minimal-apis/parameter-binding.md`: Updates article metadata.
- `aspnetcore/blazor/forms/binding.md`: Adds discoverable form-mapping attribute guidance and links to the existing overposting guidance.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/blazor/forms/binding.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0defdfa426c4cf9de899bd4636b7aa64f6ea79c/aspnetcore/blazor/forms/binding.md) | [aspnetcore/blazor/forms/binding](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/forms/binding?view=aspnetcore-11.0&branch=pr-en-us-37529) |
| [aspnetcore/fundamentals/minimal-apis/includes/parameter-binding8-10.md](https://github.com/dotnet/AspNetCore.Docs/blob/c0defdfa426c4cf9de899bd4636b7aa64f6ea79c/aspnetcore/fundamentals/minimal-apis/includes/parameter-binding8-10.md) | [aspnetcore/fundamentals/minimal-apis/includes/parameter-binding8-10](https://review.learn.microsoft.com/en-us/aspnet/core/fundamentals/minimal-apis/parameter-binding?view=aspnetcore-11.0&branch=pr-en-us-37529) |


<!-- PREVIEW-TABLE-END -->