### PR TITLE
Align passkey guidance with the .NET 11 Blazor template

### DIFF
--- a/aspnetcore/security/authentication/passkeys/blazor.md
+++ b/aspnetcore/security/authentication/passkeys/blazor.md
@@ -190,6 +190,7 @@ dotnet ef database update
 Add the following model classes to the project in the `Components/Account` folder and update the `BlazorWebCSharp._1.Components.Account` namespace to match the app (for example: `Contoso.Components.Account`):
 
 * [`Components/Account/PasskeyInputModel.cs`](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/PasskeyInputModel.cs): Holds the JSON passkey credential for passkey sign-in operations (`Login` component) and adding passkeys (`Passkeys` component).
+
 * [`Components/Account/PasskeyOperation.cs`](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/PasskeyOperation.cs): Defines the authentication action to be performed (`PassKeySubmit` component), either registering a new passkey (`Create`/0) or authenticating with an existing passkey (`Request`/1).
 
 :::moniker range=">= aspnetcore-11.0"

--- a/aspnetcore/security/authentication/passkeys/blazor.md
+++ b/aspnetcore/security/authentication/passkeys/blazor.md
@@ -1,10 +1,11 @@
 ---
 title: Implement passkeys in ASP.NET Core Blazor Web Apps
+ai-usage: ai-assisted
 author: guardrex
 description: Learn how to implement passkeys authentication in ASP.NET Core Blazor Web Apps.
 ms.author: wpickett
 monikerRange: '>= aspnetcore-10.0'
-ms.date: 10/30/2025
+ms.date: 08/31/2026
 uid: security/authentication/passkeys/blazor
 zone_pivot_groups: implementation
 ---
@@ -191,6 +192,12 @@ Add the following model classes to the project in the `Components/Account` folde
 * [`Components/Account/PasskeyInputModel.cs`](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/PasskeyInputModel.cs): Holds the JSON passkey credential for passkey sign-in operations (`Login` component) and adding passkeys (`Passkeys` component).
 * [`Components/Account/PasskeyOperation.cs`](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/PasskeyOperation.cs): Defines the authentication action to be performed (`PassKeySubmit` component), either registering a new passkey (`Create`/0) or authenticating with an existing passkey (`Request`/1).
 
+:::moniker range=">= aspnetcore-11.0"
+
+* [`Components/Account/PasskeyAuthenticators.cs`](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/PasskeyAuthenticators.cs): Maps Authenticator Attestation GUIDs (AAGUIDs) to friendly display names, so a new passkey from a known authenticator is named automatically instead of prompting the user.
+
+:::moniker-end
+
 ## Create the `PasskeySubmit` component
 
 Add the following `PasskeySubmit` component to handle passkey operations:
@@ -207,25 +214,13 @@ Add the following JavaScript file to handle WebAuthn API interactions:
 
 Update the `IdentityComponentsEndpointRouteBuilderExtensions.cs` file (or create the file if it doesn't exist and call `MapAdditionalIdentityEndpoints` in the [`Program` file](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Program.cs#L129-L130)) to include the passkey-specific endpoints:
 
-[`/PasskeyCreationOptions` and `/PasskeyRequestOptions` endpoints](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs#L53-L90)
+[`/PasskeyCreationOptions` and `/PasskeyRequestOptions` endpoints](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/IdentityComponentsEndpointRouteBuilderExtensions.cs#L80-L132)
 
 ## Update the Login page
 
 Replace the existing `Login` component with the following component and update the `BlazorWebCSharp._1.Data` namespace to match the app (for example: `Contoso.Components.Account.Data`):
 
 [`Components/Account/Pages/Login.razor`](https://github.com/dotnet/aspnetcore/blob/main/src/ProjectTemplates/Web.ProjectTemplates/content/BlazorWeb-CSharp/BlazorWebCSharp.1/Components/Account/Pages/Login.razor)
-
-## Add a redirect method to the `IdentityRedirectManager` class
-
-Add the following method to the `IdentityRedirectManager` class in `Components/Account/IdentityRedirectManager.cs`:
-
-```csharp
-public void RedirectToInvalidUser(
-    UserManager<ApplicationUser> userManager, HttpContext context) =>
-        RedirectToWithStatus("Account/InvalidUser",
-            $"Error: Unable to load user with ID '{userManager.GetUserId(context.User)}'.",
-            context);
-```
 
 ## Create passkey management pages for adding and renaming passkeys
 
@@ -254,13 +249,13 @@ In `Components/Account/Shared/ManageNavMenu.razor`, add the following [`NavLink`
 In the `App` component (`Components/App.razor`), locate the [Blazor script](xref:blazor/project-structure#location-of-the-blazor-script) tag:
 
 ```razor
-<script src="_framework/blazor.web.js"></script>
+<script src="@Assets["_framework/blazor.web.js"]"></script>
 ```
 
 Immediately after the Blazor script tag, add a reference to the `PasskeySubmit` JavaScript module:
 
 ```razor
-<script src="Components/Account/Shared/PasskeySubmit.razor.js" type="module"></script>
+<script src="@Assets["Components/Account/Shared/PasskeySubmit.razor.js"]" type="module"></script>
 ```
 
 :::zone-end
@@ -282,7 +277,7 @@ After a passkey is registered:
 1. Sign out of the app.
 1. On the login page, enter your email address.
 1. Select **Log in with a passkey**.
-4. Follow the browser's prompts to authenticate with your passkey.
+1. Follow the browser's prompts to authenticate with your passkey.
 1. Navigate to `Account/Manage/Passkeys` to add, rename, or delete passkeys.
 1. If the passkey supports passkey autofill (conditional UI) for login, test the passkey autofill feature by selecting the email input field when you have saved passkeys.
 

--- a/aspnetcore/security/authentication/passkeys/blazor.md
+++ b/aspnetcore/security/authentication/passkeys/blazor.md
@@ -5,7 +5,7 @@ author: guardrex
 description: Learn how to implement passkeys authentication in ASP.NET Core Blazor Web Apps.
 ms.author: wpickett
 monikerRange: '>= aspnetcore-10.0'
-ms.date: 08/31/2026
+ms.date: 09/01/2026
 uid: security/authentication/passkeys/blazor
 zone_pivot_groups: implementation
 ---

--- a/aspnetcore/security/authentication/passkeys/index.md
+++ b/aspnetcore/security/authentication/passkeys/index.md
@@ -5,7 +5,7 @@ author: guardrex
 description: Discover how to enable Web Authentication API (WebAuthn) passkeys in ASP.NET Core apps.
 ms.author: wpickett
 monikerRange: '>= aspnetcore-10.0'
-ms.date: 08/07/2026
+ms.date: 08/31/2026
 uid: security/authentication/passkeys/index
 ---
 # Enable Web Authentication API (WebAuthn) passkeys
@@ -453,6 +453,8 @@ After registration is initiated, the browser must obtain creation options from t
 
 From the browser's perspective, this step involves making an HTTP request to the server:
 
+:::moniker range="< aspnetcore-11.0"
+
 ```javascript
 async function createCredential(headers, signal) {
   // Step 2: Request creation options from the server
@@ -468,6 +470,27 @@ async function createCredential(headers, signal) {
   return await navigator.credentials.create({ publicKey: options, signal });
 }
 ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-11.0"
+
+```javascript
+async function createCredential(signal) {
+  // Step 2: Request creation options from the server
+  const optionsResponse = 
+    await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
+    {
+      method: 'POST',
+      signal,
+    });
+  const optionsJson = await optionsResponse.json();
+  const options = PublicKeyCredential.parseCreationOptionsFromJSON(optionsJson);
+  return await navigator.credentials.create({ publicKey: options, signal });
+}
+```
+
+:::moniker-end
 
 The application should define an endpoint that generates these options:
 
@@ -522,6 +545,8 @@ The <xref:Microsoft.AspNetCore.Identity.IdentityPasskeyOptions.UserVerificationR
 
 With the creation options available, the client-side JavaScript passes the options to the WebAuthn API to create a new credential:
 
+:::moniker range="< aspnetcore-11.0"
+
 ```javascript
 async function createCredential(headers, signal) {
   // Step 4: Parse the options and request a new credential from the authenticator
@@ -538,6 +563,27 @@ async function createCredential(headers, signal) {
 }
 ```
 
+:::moniker-end
+
+:::moniker range=">= aspnetcore-11.0"
+
+```javascript
+async function createCredential(signal) {
+  // Step 4: Parse the options and request a new credential from the authenticator
+  const optionsResponse = 
+    await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
+    {
+      method: 'POST',
+      signal,
+    });
+  const optionsJson = await optionsResponse.json();
+  const options = PublicKeyCredential.parseCreationOptionsFromJSON(optionsJson);
+  return await navigator.credentials.create({ publicKey: options, signal });
+}
+```
+
+:::moniker-end
+
 The `parseCreationOptionsFromJSON` function converts the JSON response into the format expected by the WebAuthn API, and `navigator.credentials.create()` initiates the credential creation process with the authenticator.
 
 ### Step 5: Authenticator interaction
@@ -547,6 +593,8 @@ At this point, the browser communicates with the authenticator to create the cre
 ### Step 6: Credential submission
 
 After the authenticator creates the credential, the browser must send the credential back to the server for verification and storage. The credential must be serialized to JSON before submission:
+
+:::moniker range="< aspnetcore-11.0"
 
 ```javascript
 async function createCredential(headers, signal) {
@@ -564,6 +612,28 @@ async function createCredential(headers, signal) {
   return await navigator.credentials.create({ publicKey: options, signal });
 }
 ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-11.0"
+
+```javascript
+async function createCredential(signal) {
+  // Step 6: The credential is returned from navigator.credentials.create()
+  // and is serialized to JSON for submission to the server
+  const optionsResponse = 
+    await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
+    {
+      method: 'POST',
+      signal,
+    });
+  const optionsJson = await optionsResponse.json();
+  const options = PublicKeyCredential.parseCreationOptionsFromJSON(optionsJson);
+  return await navigator.credentials.create({ publicKey: options, signal });
+}
+```
+
+:::moniker-end
 
 In the Blazor Web App template, the returned credential is automatically serialized and submitted through a form, but the exact submission mechanism varies by application.
 
@@ -643,6 +713,8 @@ Users typically initiate passkey authentication through a dedicated button or li
 
 The browser requests authentication options from the server to begin the authentication process. These options include a list of acceptable credentials and a new challenge to be signed:
 
+:::moniker range="< aspnetcore-11.0"
+
 ```javascript
 async function requestCredential(email, mediation, headers, signal) {
   // Step 2: Request authentication options from the server
@@ -658,6 +730,27 @@ async function requestCredential(email, mediation, headers, signal) {
   return await navigator.credentials.get({ publicKey: options, mediation, signal });
 }
 ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-11.0"
+
+```javascript
+async function requestCredential(email, mediation, signal) {
+  // Step 2: Request authentication options from the server
+  const optionsResponse = 
+    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
+    {
+      method: 'POST',
+      signal,
+    });
+  const optionsJson = await optionsResponse.json();
+  const options = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJson);
+  return await navigator.credentials.get({ publicKey: options, mediation, signal });
+}
+```
+
+:::moniker-end
 
 The <xref:Microsoft.AspNetCore.Identity.SignInManager%601.MakePasskeyRequestOptionsAsync%2A> method generates these options. When you provide a specific user, it includes only that user's credentials in the allow list. When called without a user, it generates options suitable for conditional UI or username-less authentication:
 
@@ -684,6 +777,8 @@ The server generates authentication options using the same <xref:Microsoft.AspNe
 
 The client-side JavaScript passes the authentication options to the WebAuthn API to request an assertion from the authenticator:
 
+:::moniker range="< aspnetcore-11.0"
+
 ```javascript
 async function requestCredential(email, mediation, headers, signal) {
   // Step 4: Parse the options and request an assertion from the authenticator
@@ -700,6 +795,27 @@ async function requestCredential(email, mediation, headers, signal) {
 }
 ```
 
+:::moniker-end
+
+:::moniker range=">= aspnetcore-11.0"
+
+```javascript
+async function requestCredential(email, mediation, signal) {
+  // Step 4: Parse the options and request an assertion from the authenticator
+  const optionsResponse = 
+    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
+    {
+      method: 'POST',
+      signal,
+    });
+  const optionsJson = await optionsResponse.json();
+  const options = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJson);
+  return await navigator.credentials.get({ publicKey: options, mediation, signal });
+}
+```
+
+:::moniker-end
+
 The `navigator.credentials.get()` call initiates the authentication process with the authenticator, which prompts the user for verification.
 
 ### Step 5: Authenticator verification
@@ -709,6 +825,8 @@ The authenticator verifies the user's identity and signs the challenge with the 
 ### Step 6: Assertion submission
 
 After the authenticator creates the signed assertion, the browser serializes it to JSON and submits it to the server:
+
+:::moniker range="< aspnetcore-11.0"
 
 ```javascript
 async function requestCredential(email, mediation, headers, signal) {
@@ -726,6 +844,28 @@ async function requestCredential(email, mediation, headers, signal) {
   return await navigator.credentials.get({ publicKey: options, mediation, signal });
 }
 ```
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-11.0"
+
+```javascript
+async function requestCredential(email, mediation, signal) {
+  // Step 6: The assertion is returned from navigator.credentials.get()
+  // and is serialized to JSON for submission to the server
+  const optionsResponse = 
+    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
+    {
+      method: 'POST',
+      signal,
+    });
+  const optionsJson = await optionsResponse.json();
+  const options = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJson);
+  return await navigator.credentials.get({ publicKey: options, mediation, signal });
+}
+```
+
+:::moniker-end
 
 The submission mechanism varies by app but typically involves either a form submission or an API call.
 
@@ -752,6 +892,12 @@ The <xref:Microsoft.AspNetCore.Identity.SignInManager%601.PasskeySignInAsync%2A>
 * Update the signature counter to prevent replay attacks.
 
 If all checks pass, the method signs in the user and returns a `SignInResult` indicating success.
+
+:::moniker range=">= aspnetcore-11.0"
+
+The method distinguishes between a recoverable user action and an app error. If the passkey session state is missing or expired, for example because the user took too long to respond to the authenticator, the method returns <xref:Microsoft.AspNetCore.Identity.SignInResult.Failed?displayProperty=nameWithType>. Calling the method without a preceding call to <xref:Microsoft.AspNetCore.Identity.SignInManager%601.MakePasskeyRequestOptionsAsync%2A> throws an <xref:System.InvalidOperationException>, because that indicates a problem in the app rather than something the user can retry.
+
+:::moniker-end
 
 For scenarios requiring more control, you can use <xref:Microsoft.AspNetCore.Identity.SignInManager%601.PerformPasskeyAssertionAsync%2A> directly to validate the assertion without immediately signing in the user:
 

--- a/aspnetcore/security/authentication/passkeys/index.md
+++ b/aspnetcore/security/authentication/passkeys/index.md
@@ -5,7 +5,7 @@ author: guardrex
 description: Discover how to enable Web Authentication API (WebAuthn) passkeys in ASP.NET Core apps.
 ms.author: wpickett
 monikerRange: '>= aspnetcore-10.0'
-ms.date: 08/31/2026
+ms.date: 09/01/2026
 uid: security/authentication/passkeys/index
 ---
 # Enable Web Authentication API (WebAuthn) passkeys
@@ -597,18 +597,9 @@ After the authenticator creates the credential, the browser must send the creden
 :::moniker range=">= aspnetcore-11.0"
 
 ```javascript
-async function createCredential(signal) {
-  // Step 6: The credential is returned from navigator.credentials.create()
-  // and is serialized to JSON for submission to the server
-  const optionsResponse = 
-    await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
-    {
-      method: 'POST',
-      signal,
-    });
-  const optionsJson = await optionsResponse.json();
-  const options = PublicKeyCredential.parseCreationOptionsFromJSON(optionsJson);
-  return await navigator.credentials.create({ publicKey: options, signal });
+async function createCredentialJson(signal) {
+  const credential = await createCredential(signal);
+  return JSON.stringify(credential);
 }
 ```
 
@@ -617,19 +608,9 @@ async function createCredential(signal) {
 :::moniker range="< aspnetcore-11.0"
 
 ```javascript
-async function createCredential(headers, signal) {
-  // Step 6: The credential is returned from navigator.credentials.create()
-  // and is serialized to JSON for submission to the server
-  const optionsResponse = 
-    await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
-    {
-      method: 'POST',
-      headers,
-      signal,
-    });
-  const optionsJson = await optionsResponse.json();
-  const options = PublicKeyCredential.parseCreationOptionsFromJSON(optionsJson);
-  return await navigator.credentials.create({ publicKey: options, signal });
+async function createCredentialJson(headers, signal) {
+  const credential = await createCredential(headers, signal);
+  return JSON.stringify(credential);
 }
 ```
 
@@ -719,7 +700,7 @@ The browser requests authentication options from the server to begin the authent
 async function requestCredential(email, mediation, signal) {
   // Step 2: Request authentication options from the server
   const optionsResponse = 
-    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
+    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${encodeURIComponent(email)}`,
     {
       method: 'POST',
       signal,
@@ -738,7 +719,7 @@ async function requestCredential(email, mediation, signal) {
 async function requestCredential(email, mediation, headers, signal) {
   // Step 2: Request authentication options from the server
   const optionsResponse = 
-    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
+    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${encodeURIComponent(email)}`,
     {
       method: 'POST',
       headers,
@@ -783,7 +764,7 @@ The client-side JavaScript passes the authentication options to the WebAuthn API
 async function requestCredential(email, mediation, signal) {
   // Step 4: Parse the options and request an assertion from the authenticator
   const optionsResponse = 
-    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
+    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${encodeURIComponent(email)}`,
     {
       method: 'POST',
       signal,
@@ -802,7 +783,7 @@ async function requestCredential(email, mediation, signal) {
 async function requestCredential(email, mediation, headers, signal) {
   // Step 4: Parse the options and request an assertion from the authenticator
   const optionsResponse = 
-    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
+    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${encodeURIComponent(email)}`,
     {
       method: 'POST',
       headers,
@@ -829,18 +810,9 @@ After the authenticator creates the signed assertion, the browser serializes it 
 :::moniker range=">= aspnetcore-11.0"
 
 ```javascript
-async function requestCredential(email, mediation, signal) {
-  // Step 6: The assertion is returned from navigator.credentials.get()
-  // and is serialized to JSON for submission to the server
-  const optionsResponse = 
-    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
-    {
-      method: 'POST',
-      signal,
-    });
-  const optionsJson = await optionsResponse.json();
-  const options = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJson);
-  return await navigator.credentials.get({ publicKey: options, mediation, signal });
+async function requestCredentialJson(email, mediation, signal) {
+  const credential = await requestCredential(email, mediation, signal);
+  return JSON.stringify(credential);
 }
 ```
 
@@ -849,19 +821,9 @@ async function requestCredential(email, mediation, signal) {
 :::moniker range="< aspnetcore-11.0"
 
 ```javascript
-async function requestCredential(email, mediation, headers, signal) {
-  // Step 6: The assertion is returned from navigator.credentials.get()
-  // and is serialized to JSON for submission to the server
-  const optionsResponse = 
-    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
-    {
-      method: 'POST',
-      headers,
-      signal,
-    });
-  const optionsJson = await optionsResponse.json();
-  const options = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJson);
-  return await navigator.credentials.get({ publicKey: options, mediation, signal });
+async function requestCredentialJson(email, mediation, headers, signal) {
+  const credential = await requestCredential(email, mediation, headers, signal);
+  return JSON.stringify(credential);
 }
 ```
 

--- a/aspnetcore/security/authentication/passkeys/index.md
+++ b/aspnetcore/security/authentication/passkeys/index.md
@@ -895,7 +895,7 @@ If all checks pass, the method signs in the user and returns a `SignInResult` in
 
 :::moniker range=">= aspnetcore-11.0"
 
-The method distinguishes between a recoverable user action and an app error. If the passkey session state is missing or expired, for example because the user took too long to respond to the authenticator, the method returns <xref:Microsoft.AspNetCore.Identity.SignInResult.Failed?displayProperty=nameWithType>. Calling the method without a preceding call to <xref:Microsoft.AspNetCore.Identity.SignInManager%601.MakePasskeyRequestOptionsAsync%2A> throws an <xref:System.InvalidOperationException>, because that indicates a problem in the app rather than something the user can retry.
+The method distinguishes between a recoverable user action and an app error. If the passkey session state is missing or expired, for example because the user took too long to respond to the authenticator, the method returns <xref:Microsoft.AspNetCore.Identity.SignInResult.Failed?displayProperty=nameWithType>. Calling the method without a preceding call to <xref:Microsoft.AspNetCore.Identity.SignInManager%601.MakePasskeyRequestOptionsAsync%2A> throws an <xref:System.InvalidOperationException> because that indicates a problem in the app rather than something the user can retry.
 
 :::moniker-end
 

--- a/aspnetcore/security/authentication/passkeys/index.md
+++ b/aspnetcore/security/authentication/passkeys/index.md
@@ -453,16 +453,15 @@ After registration is initiated, the browser must obtain creation options from t
 
 From the browser's perspective, this step involves making an HTTP request to the server:
 
-:::moniker range="< aspnetcore-11.0"
+:::moniker range=">= aspnetcore-11.0"
 
 ```javascript
-async function createCredential(headers, signal) {
+async function createCredential(signal) {
   // Step 2: Request creation options from the server
   const optionsResponse = 
     await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
     {
       method: 'POST',
-      headers,
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -473,15 +472,16 @@ async function createCredential(headers, signal) {
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-11.0"
+:::moniker range="< aspnetcore-11.0"
 
 ```javascript
-async function createCredential(signal) {
+async function createCredential(headers, signal) {
   // Step 2: Request creation options from the server
   const optionsResponse = 
     await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
     {
       method: 'POST',
+      headers,
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -545,16 +545,15 @@ The <xref:Microsoft.AspNetCore.Identity.IdentityPasskeyOptions.UserVerificationR
 
 With the creation options available, the client-side JavaScript passes the options to the WebAuthn API to create a new credential:
 
-:::moniker range="< aspnetcore-11.0"
+:::moniker range=">= aspnetcore-11.0"
 
 ```javascript
-async function createCredential(headers, signal) {
+async function createCredential(signal) {
   // Step 4: Parse the options and request a new credential from the authenticator
   const optionsResponse = 
     await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
     {
       method: 'POST',
-      headers,
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -565,15 +564,16 @@ async function createCredential(headers, signal) {
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-11.0"
+:::moniker range="< aspnetcore-11.0"
 
 ```javascript
-async function createCredential(signal) {
+async function createCredential(headers, signal) {
   // Step 4: Parse the options and request a new credential from the authenticator
   const optionsResponse = 
     await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
     {
       method: 'POST',
+      headers,
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -594,6 +594,26 @@ At this point, the browser communicates with the authenticator to create the cre
 
 After the authenticator creates the credential, the browser must send the credential back to the server for verification and storage. The credential must be serialized to JSON before submission:
 
+:::moniker range=">= aspnetcore-11.0"
+
+```javascript
+async function createCredential(signal) {
+  // Step 6: The credential is returned from navigator.credentials.create()
+  // and is serialized to JSON for submission to the server
+  const optionsResponse = 
+    await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
+    {
+      method: 'POST',
+      signal,
+    });
+  const optionsJson = await optionsResponse.json();
+  const options = PublicKeyCredential.parseCreationOptionsFromJSON(optionsJson);
+  return await navigator.credentials.create({ publicKey: options, signal });
+}
+```
+
+:::moniker-end
+
 :::moniker range="< aspnetcore-11.0"
 
 ```javascript
@@ -605,26 +625,6 @@ async function createCredential(headers, signal) {
     {
       method: 'POST',
       headers,
-      signal,
-    });
-  const optionsJson = await optionsResponse.json();
-  const options = PublicKeyCredential.parseCreationOptionsFromJSON(optionsJson);
-  return await navigator.credentials.create({ publicKey: options, signal });
-}
-```
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-11.0"
-
-```javascript
-async function createCredential(signal) {
-  // Step 6: The credential is returned from navigator.credentials.create()
-  // and is serialized to JSON for submission to the server
-  const optionsResponse = 
-    await fetchWithErrorHandling('/Account/PasskeyCreationOptions', 
-    {
-      method: 'POST',
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -713,16 +713,15 @@ Users typically initiate passkey authentication through a dedicated button or li
 
 The browser requests authentication options from the server to begin the authentication process. These options include a list of acceptable credentials and a new challenge to be signed:
 
-:::moniker range="< aspnetcore-11.0"
+:::moniker range=">= aspnetcore-11.0"
 
 ```javascript
-async function requestCredential(email, mediation, headers, signal) {
+async function requestCredential(email, mediation, signal) {
   // Step 2: Request authentication options from the server
   const optionsResponse = 
     await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
     {
       method: 'POST',
-      headers,
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -733,15 +732,16 @@ async function requestCredential(email, mediation, headers, signal) {
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-11.0"
+:::moniker range="< aspnetcore-11.0"
 
 ```javascript
-async function requestCredential(email, mediation, signal) {
+async function requestCredential(email, mediation, headers, signal) {
   // Step 2: Request authentication options from the server
   const optionsResponse = 
     await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
     {
       method: 'POST',
+      headers,
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -777,16 +777,15 @@ The server generates authentication options using the same <xref:Microsoft.AspNe
 
 The client-side JavaScript passes the authentication options to the WebAuthn API to request an assertion from the authenticator:
 
-:::moniker range="< aspnetcore-11.0"
+:::moniker range=">= aspnetcore-11.0"
 
 ```javascript
-async function requestCredential(email, mediation, headers, signal) {
+async function requestCredential(email, mediation, signal) {
   // Step 4: Parse the options and request an assertion from the authenticator
   const optionsResponse = 
     await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
     {
       method: 'POST',
-      headers,
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -797,15 +796,16 @@ async function requestCredential(email, mediation, headers, signal) {
 
 :::moniker-end
 
-:::moniker range=">= aspnetcore-11.0"
+:::moniker range="< aspnetcore-11.0"
 
 ```javascript
-async function requestCredential(email, mediation, signal) {
+async function requestCredential(email, mediation, headers, signal) {
   // Step 4: Parse the options and request an assertion from the authenticator
   const optionsResponse = 
     await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
     {
       method: 'POST',
+      headers,
       signal,
     });
   const optionsJson = await optionsResponse.json();
@@ -826,6 +826,26 @@ The authenticator verifies the user's identity and signs the challenge with the 
 
 After the authenticator creates the signed assertion, the browser serializes it to JSON and submits it to the server:
 
+:::moniker range=">= aspnetcore-11.0"
+
+```javascript
+async function requestCredential(email, mediation, signal) {
+  // Step 6: The assertion is returned from navigator.credentials.get()
+  // and is serialized to JSON for submission to the server
+  const optionsResponse = 
+    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
+    {
+      method: 'POST',
+      signal,
+    });
+  const optionsJson = await optionsResponse.json();
+  const options = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJson);
+  return await navigator.credentials.get({ publicKey: options, mediation, signal });
+}
+```
+
+:::moniker-end
+
 :::moniker range="< aspnetcore-11.0"
 
 ```javascript
@@ -837,26 +857,6 @@ async function requestCredential(email, mediation, headers, signal) {
     {
       method: 'POST',
       headers,
-      signal,
-    });
-  const optionsJson = await optionsResponse.json();
-  const options = PublicKeyCredential.parseRequestOptionsFromJSON(optionsJson);
-  return await navigator.credentials.get({ publicKey: options, mediation, signal });
-}
-```
-
-:::moniker-end
-
-:::moniker range=">= aspnetcore-11.0"
-
-```javascript
-async function requestCredential(email, mediation, signal) {
-  // Step 6: The assertion is returned from navigator.credentials.get()
-  // and is serialized to JSON for submission to the server
-  const optionsResponse = 
-    await fetchWithErrorHandling(`/Account/PasskeyRequestOptions?username=${email}`, 
-    {
-      method: 'POST',
       signal,
     });
   const optionsJson = await optionsResponse.json();


### PR DESCRIPTION
Documents dotnet/aspnetcore#65343, dotnet/aspnetcore#65752, dotnet/aspnetcore#67539 and dotnet/aspnetcore#67589.

The passkey articles had drifted from the Blazor Web App template, so a .NET 11 reader following them copies the .NET 10 flow.

### Versioned JavaScript

The .NET 10 samples stay as they are. The .NET 11 versions drop the `headers` argument, which the template stopped sending in dotnet/aspnetcore#67589 when it moved to the fetch-metadata CSRF middleware. Those endpoints are still validated, just by the middleware instead of a token header, so nothing loses protection here.

### The rest

- The `RedirectToInvalidUser` snippet doesn't compile any more, because dotnet/aspnetcore#65752 removed `RedirectToWithStatus` from the template. .NET 10 already ships the method, so the section was wrong in both versions. Dropped it.
- Added `PasskeyAuthenticators.cs` to the model classes list, missing since dotnet/aspnetcore#65343.
- Documented that `PasskeySignInAsync` returns `SignInResult.Failed` on expired session state instead of throwing, per dotnet/aspnetcore#67539.
- Fixed a source link whose line range had moved.

Two things I left out on purpose: the creation options URL moving to `/Account/Manage/`, and `PasskeyOperation` gaining `Reauthenticate`. Both are .NET 12 only, and there's no `aspnetcore-12.0` moniker yet, so gated content would render for nobody.

One fix outside the drift: the "locate the Blazor script tag" snippet was missing `@Assets[...]`, which is wrong in every version.

Checked every sample against `release/10.0`, `release/11.0` and `main`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/security/authentication/passkeys/blazor.md](https://github.com/dotnet/AspNetCore.Docs/blob/036980142d0ea7585e77e7a45b6b80b801e8d8e9/aspnetcore/security/authentication/passkeys/blazor.md) | [Learn preview](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/passkeys/blazor?view=aspnetcore-11.0&branch=pr-en-us-37559) |
| [aspnetcore/security/authentication/passkeys/index.md](https://github.com/dotnet/AspNetCore.Docs/blob/036980142d0ea7585e77e7a45b6b80b801e8d8e9/aspnetcore/security/authentication/passkeys/index.md) | [Learn preview](https://review.learn.microsoft.com/en-us/aspnet/core/security/authentication/passkeys/index?view=aspnetcore-11.0&branch=pr-en-us-37559) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/332f35cd-658d-4914-0f85-907e40ee89f0/202609011119263271-37559/BuildReport?accessString=6a2f1ab3db214351cc2a03603e3d010402a7597c9afe8babf7ec23207dbfd2dc)