### PR TITLE
Change anchor element to link to HelloWorld controller

### DIFF
--- a/aspnetcore/tutorials/first-mvc-app/adding-view.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-view.md
@@ -97,11 +97,9 @@ Replace the content of the `Views/Shared/_Layout.cshtml` file with the following
 The preceding markup made the following changes:
 
 * Three occurrences of `MvcMovie` to `Movie App`.
-* The anchor element `<a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">MvcMovie</a>` to `<a class="navbar-brand" asp-controller="Movies" asp-action="Index">Movie App</a>`.
+* The anchor element `<a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">MvcMovie</a>` to `<a class="navbar-brand" asp-area="" asp-controller="HelloWorld" asp-action="Index">Movie App</a>`.
 
 In the preceding markup, the `asp-area=""` [anchor Tag Helper attribute](xref:mvc/views/tag-helpers/builtin-th/anchor-tag-helper) and attribute value was omitted because this app isn't using [Areas](xref:mvc/controllers/areas).
-
-**Note**: The `Movies` controller hasn't been implemented. At this point, the `Movie App` link isn't functional.
 
 Save the changes and select the **Privacy** link. Notice how the title on the browser tab displays **Privacy Policy - Movie App** instead of **Privacy Policy - MvcMovie**
 

--- a/aspnetcore/tutorials/first-mvc-app/adding-view/includes/adding-view9.md
+++ b/aspnetcore/tutorials/first-mvc-app/adding-view/includes/adding-view9.md
@@ -83,11 +83,9 @@ Replace the content of the `Views/Shared/_Layout.cshtml` file with the following
 The preceding markup made the following changes:
 
 * Three occurrences of `MvcMovie` to `Movie App`.
-* The anchor element `<a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">MvcMovie</a>` to `<a class="navbar-brand" asp-controller="Movies" asp-action="Index">Movie App</a>`.
+* The anchor element `<a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">MvcMovie</a>` to `<a class="navbar-brand" asp-area="" asp-controller="HelloWorld" asp-action="Index">Movie App</a>`.
 
 In the preceding markup, the `asp-area=""` [anchor Tag Helper attribute](xref:mvc/views/tag-helpers/builtin-th/anchor-tag-helper) and attribute value was omitted because this app isn't using [Areas](xref:mvc/controllers/areas).
-
-**Note**: The `Movies` controller hasn't been implemented. At this point, the `Movie App` link isn't functional.
 
 Save the changes and select the **Privacy** link. Notice how the title on the browser tab displays **Privacy Policy - Movie App** instead of **Privacy Policy - MvcMovie**
 


### PR DESCRIPTION
Updated the anchor element in the markup to link to the HelloWorld controller instead of the Movies controller. Removed note about the Movies controller not being implemented.

**Originally, the text below the code said:**

    The preceding markup made the following changes:
    -     Three occurrences of MvcMovie to Movie App.
    -     The anchor element `<a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">MvcMovie</a>` to `<a class="navbar-brand" asp-controller="Movies" asp-action="Index">Movie App</a>`.

**But the line of code referred by the second point was:**
    `<a class="navbar-brand" asp-area="" asp-controller="HelloWorld" asp-action="Index">Movie App</a>`
**and not:**
    `<a class="navbar-brand" asp-controller="Movies" asp-action="Index">Movie App</a>`

**Hence the text below the code must say:**

    The preceding markup made the following changes:
    -     Three occurrences of MvcMovie to Movie App.
    -     The anchor element `<a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">MvcMovie</a>` to `<a class="navbar-brand" asp-area="" asp-controller="HelloWorld" asp-action="Index">Movie App</a>`.

**And hence it is also necessary that the below line be removed from the documentation (Since there is no "Movie App" link , i.e. asp-controller="Movies", in the code as of now. Instead, the link in the code is of "HelloWorld", i.e. asp-controller="HelloWorld", which has already been implemented):**

    Note: The Movies controller hasn't been implemented. At this point, the Movie App link isn't functional.

<!--
# Instructions

When creating a new PR, reference the originating issue on the first line of the description:

* Issue in this repository (dotnet/AspNetCore.Docs): use a closing keyword so GitHub auto-closes the issue when this PR is merged:

  Fixes #Issue_Number

* Issue in another repository: use a non-closing, fully-qualified reference so it links without closing the other repository's issue:

  Contributes to owner/repo#Issue_Number

Notes:

* If this PR only partially addresses an issue in this repository, use "Contributes to #Issue_Number" instead of "Fixes" so the issue stays open.
* Never use a bare "#Issue_Number" for an issue in another repository; the bare form resolves to an issue of that number in this repository and links to the wrong issue. Always use the "owner/repo#Issue_Number" form for cross-repository references.

NOTE: This is a comment; please type your descriptions above or below it.
-->

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/tutorials/first-mvc-app/adding-view.md](https://github.com/dotnet/AspNetCore.Docs/blob/366d9bfe01f25952e3fd315ea2156385d9945eb3/aspnetcore/tutorials/first-mvc-app/adding-view.md) | [Learn preview](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-view?view=aspnetcore-11.0&branch=pr-en-us-37597) |
| [aspnetcore/tutorials/first-mvc-app/adding-view/includes/adding-view9.md](https://github.com/dotnet/AspNetCore.Docs/blob/366d9bfe01f25952e3fd315ea2156385d9945eb3/aspnetcore/tutorials/first-mvc-app/adding-view/includes/adding-view9.md) | [Learn preview](https://review.learn.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/adding-view?view=aspnetcore-11.0&branch=pr-en-us-37597) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/332f35cd-658d-4914-0f85-907e40ee89f0/202609082211340564-37597/BuildReport?accessString=c867e3e685c7374adfc50ec12a3cb7fdf067aa63a8553639c212ea484e716320)