### PR TITLE
Document custom IApiDescriptionProvider in MVC application model

### DIFF
--- a/aspnetcore/mvc/controllers/application-model.md
+++ b/aspnetcore/mvc/controllers/application-model.md
@@ -217,3 +217,53 @@ The application model exposes an <xref:Microsoft.AspNetCore.Mvc.ApplicationModel
 [!code-csharp[](./application-model/sample/src/AppModelSample/Conventions/EnableApiExplorerApplicationConvention.cs)]
 
 Using this approach (and additional conventions if required), API visibility is enabled or disabled at any level within an app.
+
+### Custom API description providers with `IApiDescriptionProvider`
+
+ASP.NET Core uses <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider> implementations to discover endpoints and generate <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription> metadata during app startup. OpenAPI and Swagger generators inspect these `ApiDescription` instances when producing API documentation.
+
+Implement <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider> to programmatically inspect or modify `ApiDescription` instances produced by the framework:
+
+* <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider.OnProvidersExecuting%2A>: Executes in ascending order of the <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider.Order> property to construct `ApiDescription` metadata for discovered endpoints.
+* <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider.OnProvidersExecuted%2A>: Executes in reverse order after all providers have executed, allowing customization or enrichment of generated `ApiDescription` instances.
+
+The following example demonstrates a custom `IApiDescriptionProvider` that adds custom metadata properties to discovered API descriptions:
+
+```csharp
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+public class CustomApiDescriptionProvider : IApiDescriptionProvider
+{
+    // Execute after the framework's default ApiDescriptionProvider (Order = -1000)
+    public int Order => 0;
+
+    public void OnProvidersExecuting(ApiDescriptionProviderContext context)
+    {
+        // No action required during initial execution phase
+    }
+
+    public void OnProvidersExecuted(ApiDescriptionProviderContext context)
+    {
+        foreach (var apiDescription in context.Results)
+        {
+            // Enrich or modify ApiDescription metadata
+            apiDescription.Properties["CustomMetadata"] = "CustomValue";
+        }
+    }
+}
+```
+
+Register the custom provider with dependency injection using <xref:Microsoft.Extensions.DependencyInjection.Extensions.ServiceCollectionDescriptorExtensions.TryAddEnumerable%2A> in `Program.cs`:
+
+```csharp
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.TryAddEnumerable(
+    ServiceDescriptor.Transient<IApiDescriptionProvider, CustomApiDescriptionProvider>());
+
+var app = builder.Build();
+```

--- a/aspnetcore/mvc/controllers/application-model.md
+++ b/aspnetcore/mvc/controllers/application-model.md
@@ -3,7 +3,7 @@ title: Work with the application model in ASP.NET Core
 author: tdykstra
 description: Learn how to read and manipulate the application model to modify how MVC elements behave in ASP.NET Core.
 ms.author: tdykstra
-ms.date: 04/05/2021
+ms.date: 09/05/2026
 uid: mvc/controllers/application-model
 ---
 # Work with the application model in ASP.NET Core

--- a/aspnetcore/mvc/controllers/application-model.md
+++ b/aspnetcore/mvc/controllers/application-model.md
@@ -3,7 +3,7 @@ title: Work with the application model in ASP.NET Core
 author: tdykstra
 description: Learn how to read and manipulate the application model to modify how MVC elements behave in ASP.NET Core.
 ms.author: tdykstra
-ms.date: 09/05/2026
+ms.date: 09/06/2026
 uid: mvc/controllers/application-model
 ---
 # Work with the application model in ASP.NET Core

--- a/aspnetcore/mvc/controllers/application-model.md
+++ b/aspnetcore/mvc/controllers/application-model.md
@@ -220,7 +220,18 @@ Using this approach (and additional conventions if required), API visibility is 
 
 ### Custom API description providers with `IApiDescriptionProvider`
 
-ASP.NET Core uses <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider> implementations to discover endpoints and generate <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription> metadata during app startup. OpenAPI and Swagger generators inspect these `ApiDescription` instances when producing API documentation.
+:::moniker range=">= aspnetcore-9.0"
+
+Starting with .NET 9, ASP.NET Core includes built-in OpenAPI document generation in the [`Microsoft.AspNetCore.OpenApi`](https://www.nuget.org/packages/Microsoft.AspNetCore.OpenApi) package. To programmatically inspect or modify the generated OpenAPI output, use document, operation, and schema transformers rather than implementing <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider> directly. For more information, see <xref:fundamentals/openapi/aspnetcore-openapi>.
+
+:::moniker-end
+
+:::moniker range=">= aspnetcore-6.0 < aspnetcore-9.0"
+
+> [!NOTE]
+> <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider> is an advanced extensibility point intended for framework and library authors. Most apps don't need to implement it. Starting with .NET 9, use the built-in OpenAPI document, operation, and schema transformers to customize generated API documentation. For more information, see <xref:fundamentals/openapi/aspnetcore-openapi>.
+
+ASP.NET Core uses <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider> implementations to discover endpoints and generate <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescription> metadata. Tools such as Swashbuckle and NSwag inspect these `ApiDescription` instances when producing API documentation.
 
 Implement <xref:Microsoft.AspNetCore.Mvc.ApiExplorer.IApiDescriptionProvider> to programmatically inspect or modify `ApiDescription` instances produced by the framework:
 
@@ -267,3 +278,5 @@ builder.Services.TryAddEnumerable(
 
 var app = builder.Build();
 ```
+
+:::moniker-end


### PR DESCRIPTION
…8465)



<!--
# Instructions

When creating a new PR, reference the originating issue on the first line of the description:

* Issue in this repository (dotnet/AspNetCore.Docs): use a closing keyword so GitHub auto-closes the issue when this PR is merged:

  Fixes #Issue_Number

* Issue in another repository: use a non-closing, fully-qualified reference so it links without closing the other repository's issue:

  Contributes to owner/repo#Issue_Number

Notes:

* If this PR only partially addresses an issue in this repository, use "Contributes to #Issue_Number" instead of "Fixes" so the issue stays open.
* Never use a bare "#Issue_Number" for an issue in another repository; the bare form resolves to an issue of that number in this repository and links to the wrong issue. Always use the "owner/repo#Issue_Number" form for cross-repository references.

NOTE: This is a comment; please type your descriptions above or below it.
-->
Fixes #8465

## Description

`IApiDescriptionProvider` implementations construct `ApiDescription` metadata for `ApiExplorerModel`, which OpenAPI/Swagger doc generators rely upon. Previously, `aspnetcore/mvc/controllers/application-model.md` explained application model conventions and `ApiExplorerModel`, but lacked documentation on custom `IApiDescriptionProvider` implementations.

This PR adds a `### Custom API description providers with IApiDescriptionProvider` subsection under `## Use ApiExplorer to document an app` in `aspnetcore/mvc/controllers/application-model.md`.

## Changes

- Documented `IApiDescriptionProvider` and its execution order methods (`OnProvidersExecuting` and `OnProvidersExecuted`).
- Provided a C# example demonstrating a custom `IApiDescriptionProvider` that enriches `ApiDescription` instances with custom metadata.
- Demonstrated registering `IApiDescriptionProvider` implementations in DI using `builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IApiDescriptionProvider, ...>())`.

<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/mvc/controllers/application-model.md](https://github.com/dotnet/AspNetCore.Docs/blob/6f4c643f8e069678ce6377989d6ca8476c528af1/aspnetcore/mvc/controllers/application-model.md) | [Learn preview](https://review.learn.microsoft.com/en-us/aspnet/core/mvc/controllers/application-model?view=aspnetcore-11.0&branch=pr-en-us-37601) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/332f35cd-658d-4914-0f85-907e40ee89f0/202609061246030281-37601/BuildReport?accessString=ddebc5bb90a3910c68834181bd2f6441250932321d9ac474b21ce025906ed8d7)