### PR TITLE
Blazor RC1 coverage

### DIFF
--- a/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
@@ -889,6 +889,13 @@ For more information, see <xref:blazor/state-management/cacheview-component?view
 
 ## Blazor Server circuits update after authentication refresh
 
-Interactive Server components can now receive the refreshed `ClaimsPrincipal` without reconnecting the circuit ([dotnet/aspnetcore #68221](https://github.com/dotnet/aspnetcore/pull/68221)). The Blazor component hub and client enable authentication refresh automatically, so no additional configuration is required ([dotnet/aspnetcore #68593](https://github.com/dotnet/aspnetcore/pull/68593)).
+Interactive Server components can now receive the refreshed `ClaimsPrincipal` without reconnecting the circuit. The Blazor component hub and client enable authentication refresh automatically, so no additional configuration is required.
 
-After the connection refreshes its authentication, Blazor updates the authentication state and raises `AuthenticationStateChanged`. Components that consume `AuthenticationStateProvider`, including `AuthorizeView`, re-render using the refreshed identity and claims. This behavior is useful when a user's roles or permissions change during an active circuit, or when a component needs to reload user-specific content after claims are refreshed. The UI can reflect the new authentication state without forcing the user to reconnect or reload the page.
+After the connection refreshes its authentication, Blazor updates the authentication state and raises `AuthenticationStateChanged`. Components that consume `AuthenticationStateProvider`, including `AuthorizeView`, rerender using the refreshed identity and claims. This behavior is useful when a user's roles or permissions change during an active circuit or when a component should reload user-specific content after claims are refreshed. The UI can reflect the new authentication state without forcing the user to reconnect or reload the page.
+
+For more information, see the following resources:
+
+* [[Blazor] Propagate SignalR authentication refresh to server circuits (`dotnet/aspnetcore` #68221)](https://github.com/dotnet/aspnetcore/pull/68221)
+* [[release/11.0-rc1] Harden SignalR authentication refresh (`dotnet/aspnetcore` #68593)](https://github.com/dotnet/aspnetcore/pull/68593))
+
+Please don't comment on closed issues and PRs. If you have feedback on this feature, please open a new issue on the `dotnet/aspnetcore` GitHub repository.

--- a/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
@@ -896,6 +896,6 @@ After the connection refreshes its authentication, Blazor updates the authentica
 For more information, see the following resources:
 
 * [[Blazor] Propagate SignalR authentication refresh to server circuits (`dotnet/aspnetcore` #68221)](https://github.com/dotnet/aspnetcore/pull/68221)
-* [[release/11.0-rc1] Harden SignalR authentication refresh (`dotnet/aspnetcore` #68593)](https://github.com/dotnet/aspnetcore/pull/68593))
+* [[release/11.0-rc1] Harden SignalR authentication refresh (`dotnet/aspnetcore` #68593)](https://github.com/dotnet/aspnetcore/pull/68593)
 
 Please don't comment on closed issues and PRs. If you have feedback on this feature, please open a new issue on the `dotnet/aspnetcore` GitHub repository.

--- a/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
@@ -590,35 +590,33 @@ Hosted services are started when the app starts and stopped when it shuts down, 
 
 ### Configure Blazor client behavior from the server
 
-<!-- UPDATE 11.0 - We need reference article coverage for this. 
-                   I'll open an issue and try to resolve it by
-                   EOD. -->
+<!-- UPDATE 11.0 - We need reference article coverage for this. I'll get to it soon! -->
 
 Blazor apps can now configure client-side startup behavior from the server in C# when mapping Razor components instead of hand-writing `Blazor.start` JavaScript. `WithBrowserOptions` sets options that the server serializes into the rendered page and the Blazor script applies in the browser, across the Server, WebAssembly, and Auto render modes. The options cover the client log level, interactive Server reconnection, whether enhanced navigation preserves the DOM, and a WebAssembly runtime's environment name, culture, and environment variables:
 
 ```csharp
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode()
+    .AddInteractiveWebAssemblyRenderMode()
     .WithBrowserOptions(options =>
     {
         options.LogLevel = LogLevel.Warning;
-        options.Server.ReconnectionMaxRetries = 10;
-        options.Server.ReconnectionRetryInterval = TimeSpan.FromSeconds(1.5);
-        options.Ssr.PreserveDom = true;
-        options.WebAssembly.EnvironmentName = "Staging";
-        options.WebAssembly.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = 
+        options.InteractiveServer.ReconnectionMaxRetries = 10;
+        options.InteractiveServer.ReconnectionRetryInterval = TimeSpan.FromSeconds(1.5);
+        options.StaticServer.PreserveDom = true;
+        options.InteractiveWebAssembly.EnvironmentName = "Staging";
+        options.InteractiveWebAssembly.EnvironmentVariables["OTEL_EXPORTER_OTLP_ENDPOINT"] = 
             "https://localhost:4318";
     });
 ```
 
 You can also set the options from a component with `<ConfigureBrowser>` or read the resolved options from `HttpContext` with `GetBrowserOptions()`.
 
-The API was introduced in Preview 4 and reshaped in Preview 6 to follow options conventions. If you adopted the earlier shape, `WithBrowserConfiguration` is now `WithBrowserOptions`, `BrowserConfiguration` is now `BrowserOptions`, `ServerBrowserOptions` is now `InteractiveServerBrowserOptions`, `SsrBrowserOptions.DisableDomPreservation` is now `PreserveDom` (with the opposite meaning), and `CircuitInactivityTimeoutMs` is now `CircuitInactivityTimeout` (a `TimeSpan`).
-
 For more information, see the following resources:
 
 * [API Proposal: BrowserOptions for server-to-client configuration (`dotnet/aspnetcore` #66393)](https://github.com/dotnet/aspnetcore/issues/66393)
 * [Reshape BrowserConfiguration API per review (BrowserOptions) while preserving the JS wire format (`dotnet/aspnetcore` #67337)](https://github.com/dotnet/aspnetcore/pull/67337)
+* [Reshape BrowserOptions server-to-client configuration API per review (`dotnet/aspnetcore` #67918)](https://github.com/dotnet/aspnetcore/pull/67918)
 
 Please don't comment on closed issues and PRs. Open a new issue to provide feedback on this API.
 
@@ -888,3 +886,9 @@ The new `CacheView` component caches the rendered output of a Razor component su
 ```
 
 For more information, see <xref:blazor/state-management/cacheview-component?view=aspnetcore-11.0>.
+
+## Blazor Server circuits update after authentication refresh
+
+Interactive Server components can now receive the refreshed `ClaimsPrincipal` without reconnecting the circuit ([dotnet/aspnetcore #68221](https://github.com/dotnet/aspnetcore/pull/68221)). The Blazor component hub and client enable authentication refresh automatically, so no additional configuration is required ([dotnet/aspnetcore #68593](https://github.com/dotnet/aspnetcore/pull/68593)).
+
+After the connection refreshes its authentication, Blazor updates the authentication state and raises `AuthenticationStateChanged`. Components that consume `AuthenticationStateProvider`, including `AuthorizeView`, re-render using the refreshed identity and claims. This behavior is useful when a user's roles or permissions change during an active circuit, or when a component needs to reload user-specific content after claims are refreshed. The UI can reflect the new authentication state without forcing the user to reconnect or reload the page.

--- a/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
+++ b/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md
@@ -887,7 +887,7 @@ The new `CacheView` component caches the rendered output of a Razor component su
 
 For more information, see <xref:blazor/state-management/cacheview-component?view=aspnetcore-11.0>.
 
-## Blazor Server circuits update after authentication refresh
+### Blazor Server circuits update after authentication refresh
 
 Interactive Server components can now receive the refreshed `ClaimsPrincipal` without reconnecting the circuit. The Blazor component hub and client enable authentication refresh automatically, so no additional configuration is required.
 


### PR DESCRIPTION
Addresses #36448

Wade ... If we merge this first, it will get sucked in by the date change for the release notes on your PR.

Also note that I need to get some reference coverage into place. I'll take care of that tomorrow morning. For now, let's just get the release notes done. I spent six hours today working on the *Startup* coverage, and I'm toast 🧠🔥😄 for the day.  

Note @ilonatommy that I haven't placed any coverage for *Experimental Blazor AI components for agentic user interfaces*. I can place coverage on that whenever the PU pulls the trigger.



<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/release-notes/aspnetcore-11/includes/blazor.md](https://github.com/dotnet/AspNetCore.Docs/blob/4e417a8905e3a62d75fc2cb5474ca919dc0d3464/aspnetcore/release-notes/aspnetcore-11/includes/blazor.md) | [Learn preview](https://review.learn.microsoft.com/en-us/aspnet/core/release-notes/aspnetcore-11?view=aspnetcore-11.0&branch=pr-en-us-37610) |


<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/332f35cd-658d-4914-0f85-907e40ee89f0/202609081843360866-37610/BuildReport?accessString=765e83556854496f4f4783226b3f70f0f30b937fca3ad850ce7c3f9df5afeabb)