### PR TITLE
Graph SDK/API v6 for Blazor WASM updates

### DIFF
--- a/aspnetcore/blazor/security/webassembly/graph-api.md
+++ b/aspnetcore/blazor/security/webassembly/graph-api.md
@@ -1,10 +1,11 @@
 ---
 title: Use Graph API with ASP.NET Core Blazor WebAssembly
+ai-usage: ai-assisted
 author: guardrex
 description: Learn how to use the Microsoft Graph SDK/API with Blazor WebAssembly apps.
 monikerRange: '>= aspnetcore-3.1'
 ms.author: wpickett
-ms.date: 11/11/2025
+ms.date: 09/09/2026
 uid: blazor/security/webassembly/graph-api
 zone_pivot_groups: blazor-graph-api
 ---
@@ -46,7 +47,7 @@ The examples in this article take advantage of new .NET/C# features. When using 
 
 :::zone pivot="graph-sdk-5"
 
-*The following guidance applies to Microsoft Graph v5.*
+*The following guidance applies to Microsoft Graph v5 or later.*
 
 The Microsoft Graph SDK for use in Blazor apps is called the *Microsoft Graph .NET Client Library*.
 
@@ -66,6 +67,9 @@ The Graph SDK examples require the following package references in the standalon
 * [`Microsoft.Authentication.WebAssembly.Msal`](https://www.nuget.org/packages/Microsoft.Authentication.WebAssembly.Msal)
 * [`Microsoft.Extensions.Http`](https://www.nuget.org/packages/Microsoft.Extensions.Http)
 * [`Microsoft.Graph`](https://www.nuget.org/packages/Microsoft.Graph)
+
+> [!NOTE]
+> The [`Microsoft.Authentication.WebAssembly.Msal` package](https://www.nuget.org/packages/Microsoft.Authentication.WebAssembly.Msal) transitively adds the [`Microsoft.AspNetCore.Components.WebAssembly.Authentication` package](https://www.nuget.org/packages/Microsoft.AspNetCore.Components.WebAssembly.Authentication) to the app.
 
 [!INCLUDE[](~/includes/package-reference.md)]
 
@@ -433,7 +437,10 @@ When testing with the Graph SDK locally, we recommend using a new InPrivate/inco
 
 :::zone pivot="graph-sdk-4"
 
-*The following guidance applies to Microsoft Graph v4. If you're upgrading an app from SDK v4 to v5, see the [Microsoft Graph .NET SDK v5 changelog and upgrade guide](https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/main/docs/upgrade-to-v5.md).*
+*The following guidance applies to Microsoft Graph v4. If you're upgrading an app from SDK v4 to v5 or later, see the following resources:*
+
+* *[Microsoft Graph .NET SDK v5 changelog and upgrade guide](https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/main/docs/upgrade-to-v5.md)*
+* *[Microsoft Graph .NET SDK releases (`microsoftgraph/msgraph-sdk-dotnet` GitHub repository)](https://github.com/microsoftgraph/msgraph-sdk-dotnet/releases) (see the 6.0.0 breaking changes remarks)*
 
 The Microsoft Graph SDK for use in Blazor apps is called the *Microsoft Graph .NET Client Library*.
 

--- a/aspnetcore/zone-pivot-groups.yml
+++ b/aspnetcore/zone-pivot-groups.yml
@@ -45,7 +45,7 @@ groups:
     - id: graph-sdk-4
       title: Graph SDK v4
     - id: graph-sdk-5
-      title: Graph SDK v5
+      title: Graph SDK v5 or later
     - id: named-client-graph-api
       title: Named HttpClient with Graph API
 - id: blazor-multiple-hosted-wasm-apps


### PR DESCRIPTION
Fixes #37598

Wade ... 🎉 Our v5 coverage is solid for v6, so all we need to do here is touch a few points where "v5" text is used, changing it to state "v5 or later." All was tested locally with Graph SDK 6.6.0 (latest stable release), and it all ...

## ✨ *Just Works!*&trade; ✨🍻


<img width="529" height="308" alt="graph1" src="https://github.com/user-attachments/assets/7f4b3c0a-f61c-4c75-9ca7-f2a1d4c9521f" />

<img width="710" height="509" alt="graph2" src="https://github.com/user-attachments/assets/a6cc525d-e2da-4182-a036-f046c19fbf16" />


<!-- PREVIEW-TABLE-START -->

---

#### Internal previews

| File | Preview link |
|:--|:--|
| [aspnetcore/blazor/security/webassembly/graph-api.md](https://github.com/dotnet/AspNetCore.Docs/blob/270f916443cb446dab7a5ee08c1f187b0fa75599/aspnetcore/blazor/security/webassembly/graph-api.md) | [Learn preview](https://review.learn.microsoft.com/en-us/aspnet/core/blazor/security/webassembly/graph-api?view=aspnetcore-11.0&branch=pr-en-us-37615) |
| [aspnetcore/zone-pivot-groups.yml](https://github.com/dotnet/AspNetCore.Docs/blob/270f916443cb446dab7a5ee08c1f187b0fa75599/aspnetcore/zone-pivot-groups.yml) | [Learn preview](https://review.learn.microsoft.com/en-us/aspnet/core/zone-pivot-groups.json?view=aspnetcore-11.0&branch=pr-en-us-37615) |

<!-- PREVIEW-TABLE-END -->

[Build report](https://buildapi.docs.microsoft.com/Output/PullRequest/332f35cd-658d-4914-0f85-907e40ee89f0/202609091738598929-37615/BuildReport?accessString=fd507defc27d1b374d38f1907c859ae239834bf527e8abb0f8abbd3388300352)